### PR TITLE
Fixed issue with image cache modifying contents of blog folder

### DIFF
--- a/app/models/entry/build/plugins/image/optimize.js
+++ b/app/models/entry/build/plugins/image/optimize.js
@@ -1,9 +1,12 @@
 var helper = require('helper');
 var ensure = helper.ensure;
-
+var fs = require('fs-extra');
 var upload = helper.upload;
 var resize = require('./resize');
 var minify = require('./minify');
+var basename = require('path').basename;
+var uuid = require('uuid/v4');
+var join = require('path').join;
 
 module.exports = function (blogID, path, callback) {
 
@@ -11,29 +14,43 @@ module.exports = function (blogID, path, callback) {
     .and(path, 'string')
     .and(callback, 'function');
 
-  resize(path, function(err, info){
+  var tmpPath = join(helper.tempDir(),uuid(),basename(path));
+
+  // We need to make a copy to avoid potentially modifying
+  // a file in the user's folder.
+  fs.copy(path, tmpPath, function(err){
 
     if (err) return callback(err);
 
-    minify(path, function(err){
+    resize(tmpPath, function(err, info){
 
       if (err) return callback(err);
 
-      var options = {
-        blogID: blogID,
-        folder: 'image-cache'
-      };
-
-      upload(path, options, function(err, url){
+      minify(tmpPath, function(err){
 
         if (err) return callback(err);
 
-        callback(null, {
-          url: url,
-          width: info.width,
-          height: info.height
+        var options = {
+          blogID: blogID,
+          folder: 'image-cache'
+        };
+
+        upload(tmpPath, options, function(err, url){
+
+          if (err) return callback(err);
+
+          fs.remove(tmpPath, function(err){
+
+            if (err) return callback(err);
+            
+            callback(null, {
+              url: url,
+              width: info.width,
+              height: info.height
+            });
+          });
         });
       });
     });
-  });
+  });  
 };


### PR DESCRIPTION
This was due to unexpected behaviour in the transformer module, which prevents Blot from minifying or caching the same image multiple times. I assumed that it invoked the transformation function with a temporary path to a copy of an image in a blog's folder. This was not the case, and so the minification and resize processes were applied to the image itself.