### PR TITLE
Fix bug in summary generator

### DIFF
--- a/app/build/converters/webloc/index.js
+++ b/app/build/converters/webloc/index.js
@@ -1,4 +1,4 @@
-var debug = require("debug")("blot:models:entry:build");
+var debug = require("debug")("blot:build");
 var fs = require('fs');
 var bplist = require('./bplist');
 var helper = require('helper');

--- a/app/build/prepare/index.js
+++ b/app/build/prepare/index.js
@@ -83,7 +83,10 @@ function Prepare(entry) {
   debug(entry.path, "Generated  title", entry.title);
 
   debug(entry.path, "Generating summary");
-  entry.summary = Summary($, metadata.title || entry.title);
+  // We pass in the metadata title in case it exists to prevent
+  // a bug which surfaces when the file contains title metadata
+  // and 
+  entry.summary = Summary($, entry.metadata.title || entry.title);
   debug(entry.path, "Generated  summary");
 
   debug(entry.path, "Generating teasers");

--- a/app/build/prepare/index.js
+++ b/app/build/prepare/index.js
@@ -83,7 +83,7 @@ function Prepare(entry) {
   debug(entry.path, "Generated  title", entry.title);
 
   debug(entry.path, "Generating summary");
-  entry.summary = Summary($, entry.title);
+  entry.summary = Summary($, metadata.title || entry.title);
   debug(entry.path, "Generated  summary");
 
   debug(entry.path, "Generating teasers");

--- a/app/build/prepare/index.js
+++ b/app/build/prepare/index.js
@@ -1,4 +1,4 @@
-var debug = require('debug')('blot:models:entry:build:prepare');
+var debug = require('debug')('blot:build:prepare');
 var _ = require("lodash");
 var helper = require('helper');
 var falsy = helper.falsy;
@@ -73,9 +73,13 @@ function Prepare(entry) {
   // the plain path because some clients, like Dropbox, send the case
   // sensitive name with the update. So we form a temporary variable,
   // pathWithCaseSensitiveName to use to generate a title...
-  var pathWithCaseSensitiveName = require('path').dirname(entry.path) + '/' + entry.name;
+  var pathWithCaseSensitiveName = '';
 
-  debug(entry.path, "Generating title from", entry.name);
+  if (entry.path && entry.name) {
+    pathWithCaseSensitiveName = require('path').dirname(entry.path) + '/' + entry.name;
+  }
+
+  debug(entry.path, "Generating title from", pathWithCaseSensitiveName);
   var parsedTitle = Title($, pathWithCaseSensitiveName);
   entry.title = parsedTitle.title;
   entry.titleTag = parsedTitle.tag;
@@ -85,8 +89,9 @@ function Prepare(entry) {
   debug(entry.path, "Generating summary");
   // We pass in the metadata title in case it exists to prevent
   // a bug which surfaces when the file contains title metadata
-  // and 
-  entry.summary = Summary($, entry.metadata.title || entry.title);
+  var title = entry.title;
+  if (type(entry.metadata.title, Model.title)) title = entry.metadata.title;
+  entry.summary = Summary($, title || '');
   debug(entry.path, "Generated  summary");
 
   debug(entry.path, "Generating teasers");

--- a/app/build/prepare/summary.js
+++ b/app/build/prepare/summary.js
@@ -58,43 +58,4 @@ function summary ($, title) {
   return summary;
 }
 
-var cheerio = require('cheerio');
-var assert = require('assert');
-
-function is (html, expected, title) {
-
-  var $ = cheerio.load(html, {decodeEntities: false});
-  var output = summary($, title || '');
-
-  try {
-    assert(output === expected);
-  } catch (e) {
-    console.log('INPUT', html);
-    console.log('OUTPUT', output);
-    console.log('EXPECTED', expected);
-  }
-
-}
-
-var longWord = 'helloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo';
-
-
-is('<p>H</p>', 'H');
-
-// Handle inline elements nicely
-is('<span>H</span><a href="">ello</a>', 'Hello');
-
-// Check spaces are inserted between paragraphs
-is('<p>H</p><p>E</p>', 'H E');
-
-// Check blot ignores the title text
-is('<p>Hello</p><p>there</p>', 'there', 'Hello');
-
-// Check long results are trimmed to words
-is('<p>Hello there ' + longWord + '.</p>', 'Hello there');
-
-// Check the result is decoded
-is('<p>Hello & foo</p><p>there</p>', 'Hello & foo there');
-is('<p>Hello &amp; & foo</p><p>there</p>', 'Hello & & foo there');
-
 module.exports = summary;

--- a/app/build/prepare/summary.js
+++ b/app/build/prepare/summary.js
@@ -1,3 +1,5 @@
+var debug = require('debug')('blot:build:prepare:summary');
+
 var puncs = '?.!:,'.split('');
 var MAX_LENGTH = 150;
 var he = require('he');
@@ -16,6 +18,8 @@ function summary ($, title) {
   $('p, blockquote').each(function(){
     $(this).append(' ');
   });
+
+  debug('title:', title);
 
   var summary = $(':root').text();
 

--- a/app/build/prepare/teaser.js
+++ b/app/build/prepare/teaser.js
@@ -1,4 +1,4 @@
-var debug = require('debug')('blot:models:entry:build:prepare:teaser');
+var debug = require('debug')('blot:build:prepare:teaser');
 // Some of these characters are different, though they look the same...
 // Lines 5 - 24 should be removed, if I work out how to consolidate
 // escaped chars?

--- a/app/build/prepare/tests/index.js
+++ b/app/build/prepare/tests/index.js
@@ -1,0 +1,31 @@
+fdescribe("prepare", function() {
+
+  var prepare = require('../index');
+
+  beforeEach(function(){
+    this.entry = {
+      path: '',
+      size: 123,
+      html: '',
+      updated: 123,
+      draft: true,
+      metadata: {}
+    };
+  });
+
+
+  it("returns an empty title, summary and teaser when the file is empty", function(){
+
+    var entry = this.entry;
+
+    entry.html = '<p>Hey there.</p>';
+    entry.metadata = {
+        title: ''
+      };
+
+    prepare(entry);
+
+    expect(entry.title).toEqual('');
+    expect(entry.summary).toEqual('Hey there.');
+  });
+});

--- a/app/build/prepare/tests/index.js
+++ b/app/build/prepare/tests/index.js
@@ -1,4 +1,4 @@
-fdescribe("prepare", function() {
+describe("prepare", function() {
   var prepare = require("../index");
 
   beforeEach(function() {

--- a/app/build/prepare/tests/index.js
+++ b/app/build/prepare/tests/index.js
@@ -1,31 +1,44 @@
 fdescribe("prepare", function() {
+  var prepare = require("../index");
 
-  var prepare = require('../index');
-
-  beforeEach(function(){
+  beforeEach(function() {
     this.entry = {
-      path: '',
+      path: "",
       size: 123,
-      html: '',
+      html: "",
       updated: 123,
       draft: true,
       metadata: {}
     };
   });
 
-
-  it("returns an empty title, summary and teaser when the file is empty", function(){
-
+  // This was the result of a rather niche bug, caused by files like this:
+  // Title:
+  // Hello world!
+  // Blot was generating an empty title *and* an empty empty summary, since
+  // 'Hello world!' was in the auto-generated title but not the metadata
+  // title. The summary generated is now passed the metadata title too...
+  it("includes what would become the title, in the summary, if the title is set to empty in the file's metadata", function() {
     var entry = this.entry;
 
-    entry.html = '<p>Hey there.</p>';
+    entry.html = "<p>Hey there.</p>";
     entry.metadata = {
-        title: ''
-      };
+      title: ""
+    };
 
     prepare(entry);
 
-    expect(entry.title).toEqual('');
-    expect(entry.summary).toEqual('Hey there.');
+    expect(entry.title).toEqual("");
+    expect(entry.summary).toEqual("Hey there.");
+  });
+
+  it("generates an empty title when given an empty file", function() {
+    var entry = this.entry;
+
+    entry.html = "";
+    
+    prepare(entry);
+
+    expect(entry.title).toEqual("");
   });
 });

--- a/app/build/prepare/tests/summary.js
+++ b/app/build/prepare/tests/summary.js
@@ -1,0 +1,76 @@
+describe("summary", function() {
+  var cheerio = require("cheerio");
+  var summary = require("../summary");
+
+  beforeEach(function() {
+    this.summary = function(input) {
+      var $ = cheerio.load(input.html, {
+        decodeEntities: false,
+        withDomLvl1: false // this may cause issues?
+      });
+
+      return summary($, input.title || "");
+    };
+  });
+
+  it("is empty when HTML is empty", function() {
+    expect(
+      this.summary({
+        title: "",
+        html: ""
+      })
+    ).toEqual("");
+  });
+
+  it("is the text of the first paragraph", function() {
+    expect(
+      this.summary({
+        html: "<p>H</p>"
+      })
+    ).toEqual("H");
+  });
+
+  it("contains text inside inline elements", function() {
+    expect(
+      this.summary({
+        html: "<p>H<b>ell</b>o</p>"
+      })
+    ).toEqual("Hello");
+  });
+
+  it("does not contain the text of the title", function() {
+    expect(
+      this.summary({
+        html: "<p>Hello</p><p>World</p>",
+        title: "Hello"
+      })
+    ).toEqual("World");
+  });
+
+  // Not sure if I like this behaviour
+  it("has spaces between seperate paragraphs", function() {
+    expect(
+      this.summary({
+        html: "<p>Hello</p><p>World</p>",
+        title: "Hello"
+      })
+    ).toEqual("World");
+  });
+
+  it("will not contain or truncate long words", function() {
+    expect(
+      this.summary({
+        html: "<p>Hello there helloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo.</p>"
+      })
+    ).toEqual("Hello there");
+  });
+
+  it("decodes HTML entities", function() {
+    expect(
+      this.summary({
+        html: "<p>Hello & &amp; foo</p><p>there</p>"
+      })
+    ).toEqual("Hello & & foo there");
+  });
+
+});

--- a/app/build/single.js
+++ b/app/build/single.js
@@ -1,4 +1,4 @@
-var debug = require("debug")("blot:models:entry:build:single");
+var debug = require("debug")("blot:build:single");
 var Metadata = require("./metadata");
 var Dependencies = require("./dependencies");
 var helper = require("helper");


### PR DESCRIPTION
Input:

```
Title:

Hello world!
```

Output:
```json
{
  "title": "",
  "summary": "",
  ...
}
```

Expected:
```json
{
  "title": "",
  "summary": "Hello world!",
  ...
}
```


Thanks Josh for reporting this.