### PR TITLE
Remove rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "reds": "^0.2.5",
     "remarkable": "^1.6.0",
     "request": "^2.72.0",
-    "rimraf": "^2.2.8",
     "sharp": "^0.21.1",
     "simple-git": "^1.102.0",
     "stripe": "^2.9.0",


### PR DESCRIPTION
rimraf is now unused, it has been replaced by fs-extra's remove method.