### PR TITLE
Fix link for redirecting an ignored 404

### DIFF
--- a/app/dashboard/views/settings/404s.html
+++ b/app/dashboard/views/settings/404s.html
@@ -20,7 +20,7 @@
       {{/list}}
 
 
-      <Br /><br />
+      <br><br>
       {{#has_ignored}}{{^ignored.length}}
       <p>
         <a href="?ignored=true">Show ignored 404s</a>
@@ -35,9 +35,9 @@
 
       {{#ignored}}
       <hr>
-      <form style="display:block;float:right;z-index:10;margin:0 1em" method='post' action='?_csrf={{csrftoken}}'>
+      <form style="display:block;float:right;z-index:10;" method='post' action='?_csrf={{csrftoken}}'>
         <button class="button small" name="unignore" value="{{url}}">Unignore</button>
-        <a href="/preferences#{{url}}">Redirect</a>
+        <a class="link" href="/settings/urls/redirects#{{url}}" style="text-decoration:none">Redirect</a>
       </form>
       <p><a href="{{blog.url}}{{url}}"><code>{{url}}</code></a></p>
       {{/ignored}}


### PR DESCRIPTION
Update to to new URL for redirects: ignored 404s had the old one. Also, small tweaks to match style of unignored 404 redirect/ignore form.