### PR TITLE
Handles indentation inside pre-formatted Markdown blocks

### DIFF
--- a/app/build/converters/markdown/tests/index.js
+++ b/app/build/converters/markdown/tests/index.js
@@ -27,6 +27,9 @@ describe("markdown converter", function() {
         fs.readFile(__dirname + path +'.html', 'utf-8', function(err, expected){
 
           expect(err).toBe(null);
+
+          if (html !== expected) fs.outputFileSync(__dirname + path + '.expected.html', html);
+
           expect(html).toEqual(expected);
 
           callback();
@@ -38,7 +41,8 @@ describe("markdown converter", function() {
   it("handles return characters", from('/return-character.txt'));
   it("converts basic markdown", from('/basic-post.txt'));
   it("converts a list", from('/list.txt'));
-  
+  it("handles pre-formatted indentation", from('/pre-formatted-indents.txt'));
+
   // These are disabled because Travis uses an old version of Pandoc
   // I need to update Travis' pandoc.
   xit("does not obfuscate an email address", from('/email-addresses.txt'));

--- a/app/build/converters/markdown/tests/pre-formatted-indents.txt
+++ b/app/build/converters/markdown/tests/pre-formatted-indents.txt
@@ -3,11 +3,9 @@
   Preserve this indent
 </li>
 ```
-
 <p>
     Don't preserve this indent because Pandoc would turn it into a code block
 </p>
-
 ```
 <b>
     Preserve this indent

--- a/app/build/converters/markdown/tests/pre-formatted-indents.txt
+++ b/app/build/converters/markdown/tests/pre-formatted-indents.txt
@@ -1,0 +1,15 @@
+```
+<li>
+  Preserve this line's indent
+</li>
+```
+
+<p>
+    Don't preserve this line's indent because Pandoc would turn it into a code block...
+</p>
+
+```
+<b>
+    Preserve this line's indent
+</b>
+```

--- a/app/build/converters/markdown/tests/pre-formatted-indents.txt
+++ b/app/build/converters/markdown/tests/pre-formatted-indents.txt
@@ -4,7 +4,7 @@
 </li>
 ```
 <p>
-    Don't preserve this indent because Pandoc would turn it into a code block
+    Do not preserve this indent because Pandoc would turn it into a code block
 </p>
 ```
 <b>

--- a/app/build/converters/markdown/tests/pre-formatted-indents.txt
+++ b/app/build/converters/markdown/tests/pre-formatted-indents.txt
@@ -1,15 +1,15 @@
 ```
 <li>
-  Preserve this line's indent
+  Preserve this indent
 </li>
 ```
 
 <p>
-    Don't preserve this line's indent because Pandoc would turn it into a code block...
+    Don't preserve this indent because Pandoc would turn it into a code block
 </p>
 
 ```
 <b>
-    Preserve this line's indent
+    Preserve this indent
 </b>
 ```

--- a/app/build/converters/markdown/tests/pre-formatted-indents.txt.html
+++ b/app/build/converters/markdown/tests/pre-formatted-indents.txt.html
@@ -2,7 +2,7 @@
   Preserve this indent
 &lt;/li&gt;</code></pre>
 <p>
-Don’t preserve this indent because Pandoc would turn it into a code block
+Do not preserve this indent because Pandoc would turn it into a code block
 </p>
 <pre><code>&lt;b&gt;
     Preserve this indent

--- a/app/build/converters/markdown/tests/pre-formatted-indents.txt.html
+++ b/app/build/converters/markdown/tests/pre-formatted-indents.txt.html
@@ -1,9 +1,9 @@
 <pre><code>&lt;li&gt;
-  Preserve this line&#39;s indent
+  Preserve this indent
 &lt;/li&gt;</code></pre>
 <p>
-Don’t preserve this line’s indent because Pandoc would turn it into a code block…
+Don’t preserve this indent because Pandoc would turn it into a code block
 </p>
 <pre><code>&lt;b&gt;
-    Preserve this line&#39;s indent
+    Preserve this indent
 &lt;/b&gt;</code></pre>

--- a/app/build/converters/markdown/tests/pre-formatted-indents.txt.html
+++ b/app/build/converters/markdown/tests/pre-formatted-indents.txt.html
@@ -1,0 +1,9 @@
+<pre><code>&lt;li&gt;
+  Preserve this line&#39;s indent
+&lt;/li&gt;</code></pre>
+<p>
+Don’t preserve this line’s indent because Pandoc would turn it into a code block…
+</p>
+<pre><code>&lt;b&gt;
+    Preserve this line&#39;s indent
+&lt;/b&gt;</code></pre>


### PR DESCRIPTION
Pandoc is very strict and treats indents inside HTML blocks as code blocks. This is correct but bad user experience. For instance Pandoc converts this:

```
<table>
    <td>[Hey!](/goo)</td>
</table>
```

Into:

```html
<table>
<pre><code><td>[Hey!](/goo)</td></code></pre>
</table>
```

This is technically correct but not desirable behaviour. We want to mix HTML and Markdown in the same file. So I wrote a function to collapse the indentation for the contents of an HTML tag. [More discussion of this issue](https://github.com/jgm/pandoc/issues/1841)

---

- [x] Fix a bug in the indent-stripping function so that it will no longer remove the indents for pre formatted text.