### PR TITLE
Disables Mustache escaping on blogs

### DIFF
--- a/app/blog/render/main.js
+++ b/app/blog/render/main.js
@@ -2,6 +2,15 @@ var Mustache = require("mustache");
 var helper = require("helper");
 var ensure = helper.ensure;
 
+// Disables Mustache's escaping so {{html}} is now the same as {{{html}}}
+// Why does Mustache offer escaping by default? It's to prevent HTML
+// injection, e.g. a screename "<script>alert()</script>" would cause
+// undesired JavaScript to run. Since you can only ever control your own
+// site, this behaviour is less useful for Blot. In fact, it's caused a 
+// number of confusing issues. For example, Mustache escapes slashes by
+// default, which break a number of URL parsers and feed readers.
+Mustache.escape = function(text) {return text;};
+
 var ERROR = require("./error");
 var OVERFLOW = "Maximum call stack size exceeded";
 


### PR DESCRIPTION
If applied, this PR would disable Mustache's default escaping function and return the value of all properties in the blog renderer as-is.

---

For example, right now if you render this template:

```
{{html}}
```

with this view:

```json
{ "html": "<p>Hello, world</p>" }
```

you receive this result:

```
&lt;p&gt;Hello, world&lt;/p&gt;
```

To return the unescaped, original value of `html` directly you must use three-staches in your template, e.g.:

```
{{{html}}}
```

If applied, this PR would disable Mustache's default escaping function and return the value of all properties in the blog renderer as-is, i.e. `{{html}}` and `{{{html}}}` would be equivalent.

---

Questions to answer:

- Why does Mustache escape values by default?
  - To prevent XSS? 
- Why does disabling Mustache escaping help Blot's customers?
  - Would have fixed #1 and a whole load of customer support emails, confusion
  - Would make documentation and templates much simpler to explain 
- What are the costs?
- Are there any security risks?

---

Festina lente