### PR TITLE
Moves symlinks to cache directory

### DIFF
--- a/app/models/blog/symlinks.js
+++ b/app/models/blog/symlinks.js
@@ -12,13 +12,13 @@ if (!process.env.BLOT_DIRECTORY)
 var fs = require("fs-extra");
 var localPath = require("helper").localPath;
 var async = require("async");
-var HOSTS = process.env.BLOT_DIRECTORY + "/data/hosts";
+var HOSTS = process.env.BLOT_DIRECTORY + "/cache";
 
 // add and remove should be a list of hosts, e.g.
 // ['example.blot.im', 'example.com']
 module.exports = function(blogID, add, remove, callback) {
   var blogFolder = localPath(blogID, "/").slice(0, -1);
-  var staticFolder = process.env.BLOT_DIRECTORY + "/static/" + blogID;
+  var staticFolder = config.blog_static_files_dir + "/" + blogID;
 
   async.parallel([addSymlinks, removeSymlinks], callback);
 

--- a/app/models/blog/symlinks.js
+++ b/app/models/blog/symlinks.js
@@ -21,7 +21,7 @@ module.exports = function(blogID, add, remove, callback) {
   var blogFolder = localPath(blogID, "/").slice(0, -1);
   var staticFolder = config.blog_static_files_dir + "/" + blogID;
 
-  async.parallel([addSymlinks, removeSymlinks], callback);
+  async.series([removeSymlinks, addSymlinks], callback);
 
   function addSymlinks(done) {
     var links = [];

--- a/app/models/blog/symlinks.js
+++ b/app/models/blog/symlinks.js
@@ -1,5 +1,5 @@
 // The purpose of this module is to set up a number of symlinks between the blogs
-// folder stored againsts its ID, e.g. blogs/XYZ and its host, e.g. data/hosts/example.com
+// folder stored againsts its ID, e.g. blogs/XYZ and its host, e.g. /cache/example.com
 // This is designed to allow NGINX to serve static content without a way to lookup the
 // blog by ID, and will take load off the Node.js server
 

--- a/app/models/blog/symlinks.js
+++ b/app/models/blog/symlinks.js
@@ -12,7 +12,8 @@ if (!process.env.BLOT_DIRECTORY)
 var fs = require("fs-extra");
 var localPath = require("helper").localPath;
 var async = require("async");
-var HOSTS = process.env.BLOT_DIRECTORY + "/cache";
+var config = require("config");
+var HOSTS = config.cache_directory;
 
 // add and remove should be a list of hosts, e.g.
 // ['example.blot.im', 'example.com']

--- a/app/models/blog/tests/set.js
+++ b/app/models/blog/tests/set.js
@@ -2,7 +2,7 @@ describe("Blog.set", function() {
   var set = require("../set");
   var config = require("config");
   var fs = require("fs-extra");
-  var HOSTS = process.env.BLOT_DIRECTORY + "/data/hosts";
+  var HOSTS = config.cache_directory;
 
   // Create a test blog before each spec
   global.test.blog();

--- a/config/nginx/blot-blogs.conf
+++ b/config/nginx/blot-blogs.conf
@@ -14,11 +14,11 @@ root /;
 # use $request_uri if you want the query string also
 # use $uri if you don't want the query string
 set $permanent_cache /cache/$host/$scheme/permanent$request_uri;
-set $permanent_static /var/www/blot/data/hosts/$host/static$request_uri;
+set $permanent_static /cache/$host/static$request_uri;
 
 set $temporary_cache /cache/$host/$scheme/temporary$request_uri;
 set $temporary_cache_index /cache/$host/$scheme/temporary$request_uri/index.html;
-set $temporary_blog_folder /var/www/blot/data/hosts/$host/folder$request_uri;
+set $temporary_blog_folder /cache/$host/folder$request_uri;
 
 location / {
   add_header 'Cache-Hit' 'true-permanent' always;

--- a/scripts/state/load.js
+++ b/scripts/state/load.js
@@ -25,11 +25,6 @@ function main(label, callback) {
 
     fs.emptyDirSync(DATA_DIRECTORY);
     fs.ensureDirSync(directory + "/data");
-    // There is some bug or weird behaviour with the latest
-    // version of fs-extra which errors out when you copy the
-    // symlinks inside the hosts folder. Since in local development
-    // this isn't essential, we wipe that folder first.
-    fs.removeSync(directory + "/data/hosts");
     fs.copySync(directory + "/data", DATA_DIRECTORY);
 
     fs.emptyDirSync(BLOG_FOLDERS_DIRECTORY);


### PR DESCRIPTION
- [x] Symlinks should never have been in data directory
- [x] Remove data/hosts check from scripts
- [ ] Re-run script to create symlinks
- [ ] Wipe contents of `data/hosts` on server
