### PR TITLE
Slightly less strict metadata

### DIFF
--- a/app/build/metadata.js
+++ b/app/build/metadata.js
@@ -2,7 +2,7 @@ var debug = require("debug")("blot:build:metadata");
 var helper = require("helper");
 var ensure = helper.ensure;
 
-var alphaNumericRegEx = /^([a-zA-Z0-9 ]+)$/;
+var alphaNumericRegEx = /^([a-zA-Z0-9\-_ ]+)$/;
 
 function Metadata(html) {
   ensure(html, "string");

--- a/app/build/tests/metadata.js
+++ b/app/build/tests/metadata.js
@@ -64,11 +64,19 @@ describe("metadata parser", function() {
   });
 
   it("allows a maximum of one space in the metadata key", function() {
-    expect(Metadata(["Author last name: Jason"].join("\n")).metadata).toEqual({});
+    expect(Metadata(["And he called: Jason"].join("\n")).metadata).toEqual({});
+  });
+
+  it("allows dashes in the metadata key", function() {
+    expect(Metadata(["Is-Social: Yes"].join("\n")).metadata).toEqual({'Is-Social': 'Yes'});
+  });
+
+  it("allows underscores in the metadata key", function() {
+    expect(Metadata(["Is_Social: Yes"].join("\n")).metadata).toEqual({'Is_Social': 'Yes'});
   });
 
   it("disallows punctuation in the metadata key", function() {
-    expect(Metadata(["Au-thor: Jason"].join("\n")).metadata).toEqual({});
+    expect(Metadata(["Lo! Said: Jason"].join("\n")).metadata).toEqual({});
   });
 
   it("handles pure metadata", function() {

--- a/app/build/tests/metadata.js
+++ b/app/build/tests/metadata.js
@@ -68,11 +68,11 @@ describe("metadata parser", function() {
   });
 
   it("allows dashes in the metadata key", function() {
-    expect(Metadata(["Is-Social: Yes"].join("\n")).metadata).toEqual({'Is-Social': 'Yes'});
+    expect(Metadata(["Is-Social: Yes"].join("\n")).metadata).toEqual({'is-social': 'Yes'});
   });
 
   it("allows underscores in the metadata key", function() {
-    expect(Metadata(["Is_Social: Yes"].join("\n")).metadata).toEqual({'Is_Social': 'Yes'});
+    expect(Metadata(["Is_Social: Yes"].join("\n")).metadata).toEqual({'is_social': 'Yes'});
   });
 
   it("disallows punctuation in the metadata key", function() {


### PR DESCRIPTION
Will allow dashes and underscores in metadata keys:

```
is_public: Yes
```

