### PR TITLE
Fixes summary bug

### DIFF
--- a/app/build/prepare/summary.js
+++ b/app/build/prepare/summary.js
@@ -4,7 +4,18 @@ var puncs = "?.!:,".split("");
 var MAX_LENGTH = 150;
 var he = require("he");
 
+// since the summary is often used
+// {{}} which is encoded by mustache
+// we have to decode it in advance
+// because the HTML has already been
+// decoded by pandoc...!
+function normalize (str) {
+  return he.decode(str).replace(/\s/g, " ").trim()
+}
+
 function summary($, title) {
+  var summary;
+
   // We ignore the text content of
   // these tags for the summary
   // we only care about the content
@@ -20,13 +31,11 @@ function summary($, title) {
     $(this).append(" ");
   });
 
-  debug("title:", title);
-
-  var summary = $(":root").text();
+  title = normalize(title)
+  summary = normalize($(":root").text())
 
   if (summary.length > MAX_LENGTH) {
     summary = summary.slice(0, MAX_LENGTH);
-
     summary = summary.trim();
 
     // and go to last whole word
@@ -51,13 +60,6 @@ function summary($, title) {
     summary = summary.slice(1) || "";
 
   summary = summary.trim();
-
-  // since the summary is often used
-  // {{}} which is encoded by mustache
-  // we have to decode it in advance
-  // because the HTML has already been
-  // decoded by pandoc...!
-  summary = he.decode(summary);
 
   return summary;
 }

--- a/app/build/prepare/tests/index.js
+++ b/app/build/prepare/tests/index.js
@@ -29,7 +29,7 @@ describe("prepare", function() {
     prepare(entry);
 
     expect(entry.title).toEqual("");
-    expect(entry.summary).toEqual("Hey there.");
+    expect(entry.summary).toEqual("Hey there");
   });
 
   it("will not remove non-h1 title tags from the body", function() {

--- a/app/build/prepare/tests/summary.js
+++ b/app/build/prepare/tests/summary.js
@@ -41,10 +41,10 @@ describe("summary", function() {
   it("handles html entities in the title", function() {
     expect(
       this.summary({
-        html: "<p>Supercharge Your Workflow with&nbsp;Sync.com</p><p>Foo</p>",
-        title: "Supercharge Your Workflow with Sync.com"
+        html: "<p>Ad&nbsp;Fontes</p><p>Lucili</p>",
+        title: "Ad Fontes"
       })
-    ).toEqual("Foo");
+    ).toEqual("Lucili");
   });
 
   it("does not contain the text of the title", function() {

--- a/app/build/prepare/tests/summary.js
+++ b/app/build/prepare/tests/summary.js
@@ -38,6 +38,15 @@ describe("summary", function() {
     ).toEqual("Hello");
   });
 
+  it("handles html entities in the title", function() {
+    expect(
+      this.summary({
+        html: "<p>Supercharge Your Workflow with&nbsp;Sync.com</p><p>Foo</p>",
+        title: "Supercharge Your Workflow with Sync.com"
+      })
+    ).toEqual("Foo");
+  });
+
   it("does not contain the text of the title", function() {
     expect(
       this.summary({


### PR DESCRIPTION
- Handles non-breaking spaces in HTML posts
- Generally normalizes whitespace to prevent the title entering the summary