### PR TITLE
Fixes issue with foreign characters on the git client

### DIFF
--- a/app/clients/git/sync.js
+++ b/app/clients/git/sync.js
@@ -79,6 +79,11 @@ module.exports = function sync(blogID, callback) {
                   "diff",
                   "--name-status",
                   "--no-renames",
+                  // The 'z' flag will output paths 
+                  // in UTF-8 format, instead of octal
+                  // Without this flag, files with foreign 
+                  // characters are not synced to Blot.
+                  "-z",
                   headBeforePull + ".." + headAfterPull
                 ],
                 function(err, res) {
@@ -98,10 +103,12 @@ module.exports = function sync(blogID, callback) {
                     // A = added, M = modified, D = deleted
                     // Blot only needs to know about changes...
                     if (
-                      ["A", "M", "D"].indexOf(line[0]) > -1 &&
-                      line[1] === "\t"
+                      ["A", "M", "D"].indexOf(line[0]) > -1
                     ) {
-                      modified.push(line.slice(2));
+                      // The end of the line contains a null byte
+                      // The start of the line is either A M or D
+                      // and then a null byte.
+                      modified.push(line.slice(2, -1));
                     } else {
                       debug("Nothing found for line:", line);
                     }

--- a/app/clients/git/tests/write.js
+++ b/app/clients/git/tests/write.js
@@ -38,4 +38,23 @@ describe("write", function() {
       });
     });
   });
+
+  it("writes a file with foreign characters", function(done) {
+    var repoDirectory = this.repoDirectory;
+    var git = Git(repoDirectory).silent(true);
+    var path = "/こんにちは世界.txt";
+    var content = "こんにちは世界!";
+    var blogID = this.blog.id;
+
+    write(blogID, path, content, function(err) {
+      if (err) return done.fail(err);
+
+      git.pull(function(err) {
+        if (err) return done.fail(err);
+
+        expect(fs.readFileSync(repoDirectory + path, "utf-8")).toEqual(content);
+        done();
+      });
+    });
+  });
 });

--- a/app/dashboard/routes/folder/determinePath.js
+++ b/app/dashboard/routes/folder/determinePath.js
@@ -9,6 +9,13 @@ module.exports = function determinePath(req, res, next) {
   if (dir === "/") res.locals.folder.root = true;
 
   dir = decodeURIComponent(dir);
+  	
+  // Fixes an encoding bug I don't properly understand
+  // "ブ".length => 1
+  // "ブ".length => 2
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
+  dir = dir.normalize('NFC');
+
   req.dir = dir;
   res.locals.folder.redirect = req.path;
 


### PR DESCRIPTION
A file named the following would not generate a blog post:

こんにちは世界.txt

Why? Because by default, `git diff` will print non-ASCII file names in quoted octal notation, i.e. "\nnn\nnn..."

