### PR TITLE
Ignore image captions in summary

### DIFF
--- a/app/build/prepare/summary.js
+++ b/app/build/prepare/summary.js
@@ -16,13 +16,15 @@ function normalize (str) {
 function summary($, title) {
   var summary;
 
+debug($.html());
+  
   // We ignore the text content of
   // these tags for the summary
   // we only care about the content
   // of parapgraph tags for summaries
   // but these could sneak in
   $(
-    "pre, code, .katex, script, object, iframe, style, h1, h2, h3, h4, h5, h6"
+    "pre, code, .katex, script, object, iframe, style, h1, h2, h3, h4, h5, h6, img + .caption"
   ).remove();
 
   // add a space before the end of
@@ -60,6 +62,8 @@ function summary($, title) {
     summary = summary.slice(1) || "";
 
   summary = summary.trim();
+
+  debug(summary);
 
   return summary;
 }

--- a/app/build/tests/index.js
+++ b/app/build/tests/index.js
@@ -83,6 +83,26 @@ describe("build", function() {
     });
   });
 
+  it("will not include caption text in summaries", function(done) {
+      var path = "/Hello world.txt";
+      var contents = "# Hello\n\n![Image caption](file.jpg)\n\nWorld";
+
+      fs.outputFileSync(this.blogDirectory + path, contents);
+
+      let blog = {...this.blog};
+      blog.plugins.imageCaption.enabled = true;
+
+      build(blog, path, {}, function(err, entry) {
+        if (err) return done.fail(err);
+
+        // verify a thumbnail was generated from the image
+        expect(entry.summary).toEqual("World");
+
+        done();
+      });
+    });
+
+
   it("will not cache image an image using the static query string", function(done) {
     var path = "/Hello world.txt";
     var contents = "<img src='" + this.origin + "/public.jpg?static=1'>";


### PR DESCRIPTION
Previously, if you had turned on 'Generate captions from image alt text', the image captions would appear in the `summary` generated for the entry:

```md
# Hello

![Image caption](file.jpg)

World
```

would produce:

```json
{
  "summary": "Image caption World",
  ...
}
```

instead of

```json
{
  "summary": "World",
  ...
}
```
