### PR TITLE
Fixes default date format bug

### DIFF
--- a/app/dashboard/routes/settings/load/dates.js
+++ b/app/dashboard/routes/settings/load/dates.js
@@ -16,7 +16,7 @@ var displays = [
   "MMMM D, Y [at] h:mma",
   "D MMMM Y",
   "Y-MM-DD",
-  "Y-MM-DD hh:mm"
+  "Y-MM-DD HH:mm"
 ];
 
 module.exports = function(req, res, next) {

--- a/scripts/fix-date-display.js
+++ b/scripts/fix-date-display.js
@@ -1,0 +1,23 @@
+var eachBlog = require("./each/blog");
+var Blog = require("blog");
+var yesno = require("yesno");
+
+const OLD_FORMAT = "Y-MM-DD hh:mm";
+const NEW_FORMAT = "Y-MM-DD HH:mm";
+
+eachBlog(function(user, blog, next) {
+  if (blog.dateDisplay !== OLD_FORMAT) return next();
+
+  yesno.ask(
+    `Change date format for ${blog.handle} from ${OLD_FORMAT} to ${NEW_FORMAT}? (y/n)`,
+    true,
+    function(ok) {
+      if (ok) {
+        Blog.set(blog.id, { dateDisplay: NEW_FORMAT }, next);
+      } else {
+        console.log("Did not update date display");
+        next();
+      }
+    }
+  );
+}, process.exit);


### PR DESCRIPTION
Previously, a post at 4pm would appear as `04:00` instead of `16:00` due to my misreading of the Moment.js date token `hh` vs. `HH`.

Many thanks to Robert for spotting this.