### PR TITLE
Adds pagination to template engine

### DIFF
--- a/app/blog/render/retrieve/index.js
+++ b/app/blog/render/retrieve/index.js
@@ -22,6 +22,7 @@ var dictionary = {
   isActive: require("./isActive"),
   latestEntry: require("./latestEntry"),
   page: require("./page"),
+  paginate: require("./paginate"),
   plugin_css: require("./plugin_css"),
   plugin_js: require("./plugin_js"),
   popular_tags: require("./popular_tags"),

--- a/app/blog/render/retrieve/paginate.js
+++ b/app/blog/render/retrieve/paginate.js
@@ -1,0 +1,44 @@
+var Entries = require("entries");
+
+module.exports = function(req, callback) {
+
+	console.log('HERE!');
+
+	var blog = req.blog;
+
+	var pageNo, pageSize;
+
+	try {
+		pageNo = parseInt(req.params.page) || parseInt(req.query.page) || 1;
+	} catch (e) {
+		pageNo = 1;
+	}
+
+	try {
+		// when I remove the blog.pageSize option,
+		// consider users whove customized the page size
+		// but use a default template...
+		pageSize = req.template.locals.page_size || req.blog.pageSize;
+		pageSize = parseInt(pageSize) || 5;
+	} catch (e) {
+		pageSize = 5;
+	}
+
+	Entries.getPage(blog.id, pageNo, pageSize, function(posts, pagination) {
+		var pageTitle = blog.title;
+
+		if (pageNo > 1) {
+			pageTitle = "Page " + pageNo + " of " + pageTitle;
+		}
+
+		pagination.current = pageNo;
+
+		return callback(null, {
+			posts: posts,
+			next: pagination.next,
+			total: pagination.total,
+			previous: pagination.previous,
+			current: pageNo
+		});
+	});
+};


### PR DESCRIPTION
Could we use this in combination with custom routes to allow the inclusion of paginated entries on other pages?

```
{{#paginate}}
  
  {{#posts}}
   <a href="{{{url}}}">{{{title}}}</a><br>
  {{/posts}}

  {{#next_page}}

  {{/next_page}}

  <p>Page: {{current_page}}</p>

  {{#previous_page}}

  {{/previous_page}}


{{/paginate}}

{{#posts_page}}

{{/posts_page}}

{{#posts_page.next}}
<a href="/page/{{next}}">Next posts</a>
{{/posts_page.next}}

```

This would generate a paginated list of posts:

```
{{#paginate}}

  {{#posts}}
  ...
  {{/posts}}

  {{#next}}
  <a href="{{.}"></a>
  {{/next}}

{{/paginate}}
```

This would list all the posts on the blog:

```
  {{#posts}}
  ...
  {{/posts}}
```

This would be ideal, but it's confusing with pages since they are a kind of entry:

```
{{#page}}
  {{#posts}}
  ...
  {{/posts}}
  {{#next}}
  ...
  {{/next}}
{{/page}}
```

Is there a bisyllabic word we could use instead of the trisyllabic word? There doesn't seem to be another way to say paginate. Foliate seems to be the other option, but that word is even more obscure.

```posts_per_page: 10```

What about making next, previous just properties of the posts array, and automatically paginate it?

```
  {{#posts}}
    ...
  {{/posts}}
  {{#posts.next_page}}
  <a href="page/{{posts.next}}">Next</a>
  {{/posts.next_page}}
```

