### PR TITLE
Fix bug parsing RFC33319 date metadata

### DIFF
--- a/app/build/prepare/dateStamp/fromMetadata.js
+++ b/app/build/prepare/dateStamp/fromMetadata.js
@@ -39,6 +39,27 @@ function fromMetadata(dateString, userFormat) {
   } catch (e) {}
 
   try {
+    let rfcNormalized = moment.utc(
+      dateString,
+      [
+        "YYYY-MM-DD[T]HH:mm:ssZ",
+        "YYYY-MM-DD[T]HH:mm:ss.SSSZ",
+        "YYYY-MM-DD[T]HH:mm:ss.SSS",
+        "YYYY-MM-DD[T]HH:mm:ssZ[Z]"
+      ],
+      true
+    );
+
+    if (rfcNormalized.isValid()) {
+      return { created: rfcNormalized.valueOf(), adjusted: true };
+    }
+  } catch (e) {}
+
+  try {
+    strictNormalized = moment.utc(normalizedDateString, userFormats, true);
+  } catch (e) {}
+
+  try {
     strict = moment.utc(dateString, userFormats, true);
   } catch (e) {}
 
@@ -58,7 +79,7 @@ function fromMetadata(dateString, userFormat) {
     created = false;
   }
 
-  return created;
+  return { created, adjusted: false };
 }
 
 function formats(dateFormat) {
@@ -80,12 +101,6 @@ function formats(dateFormat) {
 
     list.push(arr.join("-"));
   }
-
-  // Add variants of the RFC339 Format
-  list.push("YYYY-MM-DD[T]HH:mm:ssZ");
-  list.push("YYYY-MM-DD[T]HH:mm:ss.SSSZ");
-  list.push("YYYY-MM-DD[T]HH:mm:ss.SSS");
-  list.push("YYYY-MM-DD[T]HH:mm:ssZ[Z]");
 
   return list;
 }

--- a/app/build/prepare/dateStamp/index.js
+++ b/app/build/prepare/dateStamp/index.js
@@ -1,78 +1,41 @@
-var helper = require("helper");
-var ensure = helper.ensure;
-var debug = require("debug")("blot:build:dateStamp");
+const helper = require("helper");
+const debug = require("debug")("blot:build:dateStamp");
 
-var fromPath = require("./fromPath");
-var fromMetadata = require("./fromMetadata");
-var type = helper.type;
+const fromPath = require("./fromPath");
+const fromMetadata = require("./fromMetadata");
+const type = helper.type;
 
-var moment = require("moment");
+const moment = require("moment");
 require("moment-timezone");
 
 module.exports = function(blog, path, metadata) {
-  ensure(blog, "object")
-    .and(path, "string")
-    .and(metadata, "object");
+  const { id, dateFormat, timeZone } = blog;
+  let dateStamp;
 
-  debug(
-    "Blog:",
-    blog.id,
-    "dateFormat:",
-    dateFormat,
-    "timeZone",
-    timeZone,
-    path
-  );
-
-  // Now we deal with a custom date!
-  var dateFormat = blog.dateFormat;
-  var timeZone = blog.timeZone;
-
-  var date = metadata.date || "";
-  var dateStamp = metadata.dateStamp || undefined;
-
-  debug("Blog:", blog.id, "dateStamp #1", dateStamp);
-
-  ensure(dateFormat, "string").and(timeZone, "string");
-
-  // The user specified a date stamp
-  // directly. Try to turn it into an integer.
-  // TODO: check if anyone uses this? probably remove
-  if (dateStamp !== undefined) dateStamp = validate(parseInt(dateStamp));
-
-  debug("Blog:", blog.id, "dateStamp #2", dateStamp);
-
-  // Return early since we have a date stamp
-  if (dateStamp) return dateStamp;
+  debug("Blog:", id, "dateFormat:", dateFormat, "timeZone", timeZone, path);
 
   // If the user specified a date
   // field in the entry's metadata,
   // try and parse a timestamp from it.
-  if (date && dateStamp === undefined)
-    dateStamp = validate(fromMetadata(date, dateFormat));
+  if (metadata.date) {
+    let parsedFromMetadata = fromMetadata(metadata.date, dateFormat, timeZone);
+    dateStamp = validate(parsedFromMetadata.created);
+    if (dateStamp && parsedFromMetadata.adjusted) {
+      return dateStamp;
+    } else if (dateStamp) {
+      return adjustByBlogTimezone(timeZone, dateStamp);
+    }
+  }
 
-  debug("Blog:", blog.id, "dateStamp #3", dateStamp);
+  if (dateStamp !== undefined) return dateStamp;
 
   // The user didn't specify a valid
   // date in the entry's metadata. Try
   // and extract one from the file's path
-  if (dateStamp === undefined) {
-    dateStamp = validate(fromPath(path).created);
-  }
+  dateStamp = validate(fromPath(path, timeZone).created);
+  dateStamp = adjustByBlogTimezone(timeZone, dateStamp);
 
-  debug("Blog:", blog.id, "dateStamp #4", dateStamp);
-
-  // If there is a date string specified as
-  // part of this post's metadata, try to parse
-  // a timestamp from this. We need to relativize
-  // this to the user's timezone because 'Jan 1st 2012'
-  // in the file of post means different timestamps
-  //  in different time zones.
-  if (dateStamp !== undefined)
-    dateStamp = validate(adjust(timeZone, dateStamp));
-
-  debug("Blog:", blog.id, "dateStamp #5", dateStamp);
-
+  // Either undefined or a valid dateStamp
   return dateStamp;
 };
 
@@ -83,9 +46,7 @@ function validate(stamp) {
   return undefined;
 }
 
-function adjust(timeZone, stamp) {
-  ensure(timeZone, "string").and(stamp, "number");
-
+function adjustByBlogTimezone(timeZone, stamp) {
   var zone = moment.tz.zone(timeZone);
   var offset = zone.offset(stamp);
 

--- a/app/build/prepare/dateStamp/tests/fromMetadata.js
+++ b/app/build/prepare/dateStamp/tests/fromMetadata.js
@@ -54,14 +54,14 @@ describe("date metadata", function() {
     supportedByAllFormats[result].forEach(function(metadata) {
       Object.keys(supportedBySpecficFormat).forEach(function(format) {
         it('parses "' + metadata + '" using date format ' + format, function() {
-          expect(moment.utc(fromMetadata(metadata, format)).format()).toEqual(
+          expect(moment.utc(fromMetadata(metadata, format).created).format()).toEqual(
             result
           );
         });
       });
 
       it('parses "' + metadata + '" without passing a format', function() {
-        expect(moment.utc(fromMetadata(metadata)).format()).toEqual(result);
+        expect(moment.utc(fromMetadata(metadata).created).format()).toEqual(result);
       });
     });
   });
@@ -72,7 +72,7 @@ describe("date metadata", function() {
     Object.keys(supportedBySpecficFormat[format]).forEach(function(result) {
       supportedBySpecficFormat[format][result].forEach(function(metadata) {
         it('parses "' + metadata + '" using date format ' + format, function() {
-          expect(moment.utc(fromMetadata(metadata, format)).format()).toEqual(
+          expect(moment.utc(fromMetadata(metadata, format).created).format()).toEqual(
             result
           );
         });

--- a/tests/dates/index.js
+++ b/tests/dates/index.js
@@ -21,6 +21,11 @@ describe("date integration tests", function() {
 		},
 		{
 			timeZone: "Asia/Calcutta",
+			dateMetadata: "2020-03-29T19:29:00+0530",
+			result: "Sun, 29 Mar 2020 19:29:00 +0530"
+		},
+		{
+			timeZone: "Asia/Calcutta",
 			dateMetadata: "2020/03/29 19:29",
 			result: "Sun, 29 Mar 2020 19:29:00 +0530"
 		}


### PR DESCRIPTION
- [x] Fix failing test
- [x] Refactor changes
- [x] Tell Amit

---

If your blog has a timezone "Asia/Calcutta", which is GMT + 05:30, and you create a blog post with the following date metadata:

```			
Date: 2020-03-29T19:29:00+0530
```

The date on your blog for that post should appear like this:

```
Sun, 29 Mar 2020 19:29:00 +0530
```

However, right now it looks like this:

```
Sun, 29 Mar 2020 13:59:00 +0530
```

This happens because we adjust parsed dates from the blog's timezone to UTC before saving them:

https://github.com/davidmerfield/Blot/blob/master/app/build/prepare/dateStamp/index.js#L86

We need to skip this adjustment when the date already comes with a timezone.