### PR TITLE
Add method to format an entry's updated and created dates

### DIFF
--- a/app/blog/render/load/augment.js
+++ b/app/blog/render/load/augment.js
@@ -14,6 +14,8 @@ module.exports = function(req, res) {
 
   return function(entry) {
     entry.formatDate = FormatDate(entry.dateStamp, req.blog.timeZone);
+    entry.formatUpdated = FormatDate(entry.updated, req.blog.timeZone);
+    entry.formatCreated = FormatDate(entry.created, req.blog.timeZone);
     entry.absoluteURL =
       req.blog.locals.blogURL +
       entry.url

--- a/app/blog/render/load/augment.js
+++ b/app/blog/render/load/augment.js
@@ -16,6 +16,7 @@ module.exports = function(req, res) {
     entry.formatDate = FormatDate(entry.dateStamp, req.blog.timeZone);
     entry.formatUpdated = FormatDate(entry.updated, req.blog.timeZone);
     entry.formatCreated = FormatDate(entry.created, req.blog.timeZone);
+    
     entry.absoluteURL =
       req.blog.locals.blogURL +
       entry.url


### PR DESCRIPTION
You can now format the date an entry was last updated, as well as the date the entry was created (i.e. first existed on Blot).

```
{{#entry}}
Published: {{#formatDate}} ... {{/formatDate}}
Updated: {{#formatUpdated}} ... {{/formatUpdated}}
Created: {{#formatCreated}} ... {{/formatCreated}}
{{/entry}}
```