### PR TITLE
Updates stripe customer email when it changes mid-sign up

### DIFF
--- a/app/brochure/routes/sign-up/index.js
+++ b/app/brochure/routes/sign-up/index.js
@@ -162,12 +162,14 @@ passwordForm.post(parse, function(req, res, next) {
       if (err) return next(err);
 
       // The user has changed their email since signing up
+      // TODO: add logging
       if (req.session.email !== user.email) {
         stripe.customers.update(
           subscription.customer,
           { email: user.email },
           function() {
-            // noop
+            // TODO: handle this error but it's not
+            // all that important
           }
         );
       }


### PR DESCRIPTION
Previously, if you changed your email address on the interstitial form (see below) after signing up, the Stripe customer would not update.

![image](https://user-images.githubusercontent.com/747928/87208666-581bcf80-c2dd-11ea-8d15-56d729b868ea.png)

Now it does! In future, it would be wonderful to work out how to use the Stripe API to resend the receipt to the new email
