### PR TITLE
Rename 'index' property to 'position' to prevent ambiguity

### DIFF
--- a/app/blog/render/load/list.js
+++ b/app/blog/render/load/list.js
@@ -12,7 +12,7 @@ module.exports = function(list) {
   // Decide before documenting this. Beware
   // if you use this in your theme before then.
   list = list.map(function(el, i) {
-    el.index = i + 1;
+    el.position = i + 1;
     return el;
   });
 

--- a/app/brochure/views/developers/reference/entry.html
+++ b/app/brochure/views/developers/reference/entry.html
@@ -94,6 +94,10 @@
       <td>List of tags for the entry</td>
     </tr>
     <tr>
+      <td><code>\{{index}}</code></td>
+      <td>The index of the entry in the list of all of your entries. For example, the first entry published has an \{{index}} of 1 and the 10th entry published has an \{{index}} of 10.</td>
+    </tr>    
+    <tr>
       <td><code>\{{menu}}</code></td>
       <td>&quot;true&quot; if the entry is a page on the menu, &quot;false&quot; if not</td>
     </tr>
@@ -121,7 +125,7 @@
       <td><code>\{{metadata}}</code></td>
       <td>object containing the metadata for the entry, if they exist.</td>
     </tr>
-    <tr>
+        <tr>
       <td><code>\{{id}}</code></td>
       <td>Alias for the <code>path</code> property, which uniquely identifies the post.</td>
     </tr>

--- a/app/brochure/views/developers/reference/lists.html
+++ b/app/brochure/views/developers/reference/lists.html
@@ -13,19 +13,19 @@
   <tbody>
     <tr>
       <td><code>\{{first}}</code></td>
-      <td>boolean, true if the item is first item in the list, false otherwise.</td>
+      <td>boolean, true if the item is first item in the list, false otherwise</td>
     </tr>
     <tr>
       <td><code>\{{last}}</code></td>
-      <td>boolean, true if the item is the last item in the list, false otherwise.</td>
+      <td>boolean, true if the item is the last item in the list, false otherwise</td>
     </tr>
     <tr>
       <td><code>\{{penultimate}}</code></td>
-      <td>boolean, true if the item is the penultimate item in the list, false otherwise.</td>
+      <td>boolean, true if the item is the penultimate item in the list, false otherwise</td>
     </tr>
     <tr>
-      <td><code>\{{index}}</code></td>
-      <td>integer, zero-based number indicating</td>
+      <td><code>\{{position}}</code></td>
+      <td>integer, indicating the position of the item in the list. For example, the first item in the list has a \{{position}} of 1 and the fourth has a \{{position}} of 4.</td>
     </tr>
       </tbody>
 </table>


### PR DESCRIPTION
Previously, the template renderer added an undocumented `index` property to each item in every list. The template renderer also adds an undocumented `index` property to each entry. The `index` property of each entry refers to the position of the entry in the list of all published entries. This created a conflict.

Now:
- The template renderer adds a documented `index` property to each entry, referring to the position of the entry in the list of all published entries
- The template renderer adds a documented `position` property to each list item, referring to the position of the item in the list

