### PR TITLE
TeX guide improvement

### DIFF
--- a/app/brochure/views/css/blot.css
+++ b/app/brochure/views/css/blot.css
@@ -29,7 +29,7 @@ body {
   color: #000;
   line-height: 1.45;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica,
-    "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
+  "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 16px;
   font-weight: 400;
   font-style: normal;
@@ -108,7 +108,7 @@ h1 {
   font-weight: 700;
   margin: 36px 0 16px;
   /*    border-bottom: 1px solid #eceff1;
-*/
+  */
   padding: 0 0 0.25em;
 }
 
@@ -342,7 +342,6 @@ a.video {
 }
 
 @media screen and (max-width: 800px) {
-
   a.video,
   background {
     margin-left: -2rem;
@@ -395,7 +394,7 @@ background .window {
   color: inherit;
   text-decoration: none;
   box-shadow: rgba(15, 15, 15, 0.1) 0px 0px 0px 1px,
-    rgba(15, 15, 15, 0.1) 0px 2px 4px;
+  rgba(15, 15, 15, 0.1) 0px 2px 4px;
   background: white;
 }
 
@@ -403,7 +402,7 @@ background .window {
   text-decoration: none;
   background: #f6f6f6;
   box-shadow: rgba(15, 15, 15, 0.1) 0px 0px 0px 1px,
-    rgba(15, 15, 15, 0.1) 0px 2px 4px;
+  rgba(15, 15, 15, 0.1) 0px 2px 4px;
 }
 
 .clients li a:hover strong {

--- a/app/brochure/views/css/blot.css
+++ b/app/brochure/views/css/blot.css
@@ -228,6 +228,24 @@ table {
   overflow-x: auto;
 }
 
+div.tex table {
+  table-layout: auto;
+  margin-bottom: 1.5em;
+}
+
+div.tex p {
+  margin-bottom: 3em;
+}
+
+div.tex table.reference td:nth-child(odd),
+div.tex table.symbol td {
+  font-family: KaTeX_Main, KaTeX_AMS;
+}
+
+div.tex table td.not-symbol {
+  font-family: inherit !important;
+}
+
 th,
 td {
   padding: 8px 0;

--- a/app/brochure/views/how/guides/tex.html
+++ b/app/brochure/views/how/guides/tex.html
@@ -3,360 +3,386 @@
 
 <p>Typesetting with \(\TeX\). This is a list of \(\TeX\) functions supported by Blot. It is sorted into logical groups.</p>
 
-<div class="tex">
 <background><pre class="text"><code>Blot will convert equations set in LaTeX. Wrap your LaTeX in two dollar signs ($) like this:
 
 $$ f(x) = 2x^2 + 2/3 $$
 </code></pre></background>
 
-<h2 id="accents">Accents</h2>
-
-<table class="symbol">
-  <tr>
-    <td style="width: 3em;">\(a'\)</td>
-    <td>a'</td>
-    <td style="width: 3em;">\(\overrightarrow{AB}\)</td>
-    <td>\overrightarrow{AB}</td>
-  </tr>
-  <tr>  
-    <td>\(\ddot{a}\)</td>
-    <td>\ddot{a}</td>
-    <td>\(\overleftarrow{AB}\)</td>
-    <td>\overleftarrow{AB}</td>
-  </tr>
-  <tr>
-    <td>\(a''\)</td>
-    <td>a''</td>
-    <td>\(\underrightarrow{AB}\)</td>
-    <td>\underrightarrow{AB}</td>
-  </tr>
-  <tr>  
-    <td>\(\grave{a}\)</td>
-    <td>\grave{a}</td>
-    <td>\(\underleftarrow{AB}\)</td>
-    <td>\underleftarrow{AB}</td>
-  </tr>
-  <tr>
-    <td>\(a^{\prime}\)</td>
-    <td style="white-space: nowrap">a^{\prime}</td>
-    <td>\(\overbrace{AB}\)</td>
-    <td>\overbrace{AB}</td>
-  </tr>
-  <tr>  
-    <td>\(\hat{\theta}\)</td>
-    <td>\hat{\theta}</td>
-    <td>\(\overleftrightarrow{AB}\)</td>
-    <td style="white-space: nowrap">\overleftrightarrow{AB}</td>
-  </tr>
-  <tr>
-    <td>\(\acute{a}\)</td>
-    <td>\acute{a}</td>
-    <td>\(\underbrace{AB}\)</td>
-    <td>\underbrace{AB}</td>
-  </tr>
-  <tr>  
-    <td>\(\widehat{ac}\)</td>
-    <td>\widehat{ac}</td>
-    <td>\(\underleftrightarrow{AB}\)</td>
-    <td style="white-space: nowrap">\underleftrightarrow{AB}</td>
-  </tr>
-  <tr>
-    <td>\(\bar{y}\)</td>
-    <td>\bar{y}</td>
-    <td>\(\overlinesegment{AB}\)</td>
-    <td>\overlinesegment{AB}</td>
-  </tr>
-  <tr>  
-    <td>\(\tilde{a}\)</td>
-    <td>\tilde{a}</td>
-    <td>\(\overgroup{AB}\)</td>
-    <td>\overgroup{AB}</td>
-  </tr>
-  <tr>
-    <td>\(\breve{a}\)</td>
-    <td>\breve{a}</td>
-    <td>\(\underlinesegment{AB}\)</td>
-    <td>\underlinesegment{AB}</td>
-  </tr>
-  <tr>  
-    <td>\(\widetilde{ac}\)</td>
-    <td style="white-space: nowrap">\widetilde{ac}</td>
-    <td>\(\undergroup{AB}\)</td>
-    <td>\undergroup{AB}</td>
-  </tr>
-  <tr>
-    <td>\(\check{a}\)</td>
-    <td>\check{a}</td>
-    <td>\(\overrightharpoon{ac}\)</td>
-    <td>\overrightharpoon{ac}</td>
-  </tr>
-  <tr>  
-    <td>\(\vec{F}\)</td>
-    <td>\vec{F}</td>
-    <td>\(\overleftharpoon{ac}\)</td>
-    <td>\overleftharpoon{ac}</td>
-  </tr>
-  <tr>
-    <td>\(\dot{a}\)</td>
-    <td>\dot{a}</td>
-    <td>\(\utilde{AB}\)</td>
-    <td>\utilde{AB}</td>
-  </tr>
-  <tr>  
-    <td>\(\overline{AB}\)</td>
-    <td>\overline{AB}</td>
-    <td>\(\Overrightarrow{AB}\)</td>
-    <td>\Overrightarrow{AB}</td>
-  </tr>
-  <tr>  
-    <td>\(\underline{AB}\)</td>
-    <td>\underline{AB}</td>
-    <td></td>
-    <td></td>
-  </tr>
-</table>
+<div class="tex">
+  <h2 id="accents">Accents</h2>
+  <table>
+    <tr>
+      <td>\(a'\)</td>
+      <td>a'</td>
+      <td>\(\overrightarrow{AB}\)</td>
+      <td>\overrightarrow{AB}</td>
+    </tr>
+    <tr>  
+      <td>\(\ddot{a}\)</td>
+      <td>\ddot{a}</td>
+      <td>\(\overleftarrow{AB}\)</td>
+      <td>\overleftarrow{AB}</td>
+    </tr>
+    <tr>
+      <td>\(a''\)</td>
+      <td>a''</td>
+      <td>\(\underrightarrow{AB}\)</td>
+      <td>\underrightarrow{AB}</td>
+    </tr>
+    <tr>  
+      <td>\(\grave{a}\)</td>
+      <td>\grave{a}</td>
+      <td>\(\underleftarrow{AB}\)</td>
+      <td>\underleftarrow{AB}</td>
+    </tr>
+    <tr>
+      <td>\(a^{\prime}\)</td>
+      <td style="white-space: nowrap">a^{\prime}</td>
+      <td>\(\overbrace{AB}\)</td>
+      <td>\overbrace{AB}</td>
+    </tr>
+    <tr>  
+      <td>\(\hat{\theta}\)</td>
+      <td>\hat{\theta}</td>
+      <td>\(\overleftrightarrow{AB}\)</td>
+      <td style="white-space: nowrap">\overleftrightarrow{AB}</td>
+    </tr>
+    <tr>
+      <td>\(\acute{a}\)</td>
+      <td>\acute{a}</td>
+      <td>\(\underbrace{AB}\)</td>
+      <td>\underbrace{AB}</td>
+    </tr>
+    <tr>  
+      <td>\(\widehat{ac}\)</td>
+      <td>\widehat{ac}</td>
+      <td>\(\underleftrightarrow{AB}\)</td>
+      <td style="white-space: nowrap">\underleftrightarrow{AB}</td>
+    </tr>
+    <tr>
+      <td>\(\bar{y}\)</td>
+      <td>\bar{y}</td>
+      <td>\(\overlinesegment{AB}\)</td>
+      <td>\overlinesegment{AB}</td>
+    </tr>
+    <tr>  
+      <td>\(\tilde{a}\)</td>
+      <td>\tilde{a}</td>
+      <td>\(\overgroup{AB}\)</td>
+      <td>\overgroup{AB}</td>
+    </tr>
+    <tr>
+      <td>\(\breve{a}\)</td>
+      <td>\breve{a}</td>
+      <td>\(\underlinesegment{AB}\)</td>
+      <td>\underlinesegment{AB}</td>
+    </tr>
+    <tr>  
+      <td>\(\widetilde{ac}\)</td>
+      <td style="white-space: nowrap">\widetilde{ac}</td>
+      <td>\(\undergroup{AB}\)</td>
+      <td>\undergroup{AB}</td>
+    </tr>
+    <tr>
+      <td>\(\check{a}\)</td>
+      <td>\check{a}</td>
+      <td>\(\overrightharpoon{ac}\)</td>
+      <td>\overrightharpoon{ac}</td>
+    </tr>
+    <tr>  
+      <td>\(\vec{F}\)</td>
+      <td>\vec{F}</td>
+      <td>\(\overleftharpoon{ac}\)</td>
+      <td>\overleftharpoon{ac}</td>
+    </tr>
+    <tr>
+      <td>\(\dot{a}\)</td>
+      <td>\dot{a}</td>
+      <td>\(\utilde{AB}\)</td>
+      <td>\utilde{AB}</td>
+    </tr>
+    <tr>  
+      <td>\(\overline{AB}\)</td>
+      <td>\overline{AB}</td>
+      <td>\(\Overrightarrow{AB}\)</td>
+      <td>\Overrightarrow{AB}</td>
+    </tr>
+    <tr>  
+      <td>\(\underline{AB}\)</td>
+      <td>\underline{AB}</td>
+      <td></td>
+      <td></td>
+    </tr>
+  </table>
   
+  <p>See also <a href="#other-letters">letters</a>.</p>
 
-<span class="fr">See also <a href="#other-letters">letters</a>.</span>
+  <h4>Accent functions inside <code>\text{…}</code></h4>
+  <table>
+    <tr>
+      <td>\(\text{\'{a}}\)</td>
+      <td>\'{a}</td>
 
-<h4>Accent functions inside <code>\text{…}</code>  </h4>
+      <td>\(\text{\~{a}}\)</td>
+      <td>\~{a}</td>
 
-<table class="symbol">
-  <tr>
-    <td style="width: 1.5em;">\(\text{\'{a}}\)</td>
-    <td>\'{a}</td>
-    <td style="width: 1.5em;">\(\text{\~{a}}\)</td>
-    <td>\~{a}</td>
-    <td style="width: 1.5em;">\(\text{\.{a}}\)</td>
-    <td>\.{a}</td>
-    <td style="width: 1.5em;">\(\text{\H{a}}\)</td>
-    <td>\H{a}</td>
-  </tr>
-  <tr>
-    <td>\(\text{\`{a}}\)</td>
-    <td>\`{a}</td>
-    <td>\(\text{\={a}}\)</td>
-    <td>\={a}</td>
-    <td>\(\text{\"{a}}\)</td>
-    <td>\"{a}</td>
-    <td>\(\text{\v{a}}\)</td>
-    <td>\v{a}</td>
-  </tr>
-  <tr>
-    <td>\(\text{\^{a}}\)</td>
-    <td>\^{a}</td>
-    <td>\(\text{\u{a}}\)</td>
-    <td>\u{a}</td>
-    <td>\(\text{\r{a}}\)</td>
-    <td>\r{a}</td>
-    <td></td>
-    <td></td>
-  </tr>
-</table>
+      <td>\(\text{\.{a}}\)</td>
+      <td>\.{a}</td>
+    </tr>
+    <tr>
+      <td>\(\text{\`{a}}\)</td>
+      <td>\`{a}</td>
 
+      <td>\(\text{\={a}}\)</td>
+      <td>\={a}</td>
 
-<h2 id="delimiters">Delimiters</h2>
+      <td>\(\text{\"{a}}\)</td>
+      <td>\"{a}</td>
+    </tr>
+    <tr>
+      <td>\(\text{\^{a}}\)</td>
+      <td>\^{a}</td>
 
-<table class="symbol" id="delim">
-  <tr>
-    <td style="width: 1.5em;">\((\,)\)</td>
-    <td>( )</td>
-    <td style="width: 1.5em;">\(\lgroup\:\rgroup\)</td>
-    <td>\lgroup<br>\rgroup</td>
-    <td style="width: 1.5em;">\(\lceil\:\rceil\)</td>
-    <td>\lceil<br>\rceil</td>
-    <td style="width: 1.5em;">\(\uparrow\)</td>
-    <td>\uparrow</td>
-  </tr>
-  <tr>
-    <td>\([\:]\)</td>
-    <td>[ ]</td>
-    <td>\(\lbrack\:\rbrack\)</td>
-    <td>\lbrack<br>\rbrack</td>
-    <td>\(\lfloor\:\rfloor\)</td>
-    <td>\lfloor<br>\rfloor</td>
-    <td>\(\downarrow\)</td>
-    <td>\downarrow</td>
-  </tr>
-  <tr>
-    <td>\(\{\,\}\)</td>
-    <td>\{&nbsp;\}</td>
-    <td>\(\lbrace\:\rbrace\)</td>
-    <td>\lbrace<br>\rbrace</td>
-    <td>\(\ulcorner \urcorner\)</td>
-    <td>\ulcorner<br>\urcorner</td>
-    <td>\(\updownarrow\)</td>
-    <td>\updownarrow</td>
-  </tr>
-  <tr>
-    <td>\(\langle\:\rangle\)</td>
-    <td>\langle<br>\rangle</td>
-    <td>\(\lt\:\gt\)</td>
-    <td>\lt<br>\gt</td>
-    <td>\(\llcorner \lrcorner\)</td>
-    <td>\llcorner<br>\lrcorner</td>
-    <td>\(\Uparrow\)</td>
-    <td>\Uparrow</td>
-  </tr>
-  <tr>
-    <td>\(|\)</td>
-    <td>|</td>
-    <td>\(\vert\)</td>
-    <td>\vert</td>
-    <td>\(\backslash\)</td>
-    <td>\backslash</td>
-    <td>\(\Downarrow\)</td>
-    <td>\Downarrow</td>
-  </tr>
-  <tr>
-    <td>\(\|\)</td>
-    <td>\|</td>
-    <td>\(\Vert\)</td>
-    <td>\Vert</td>
-    <td>\(\lmoustache\:\rmoustache\)</td>
-    <td>\lmoustache<br>\rmoustache</td>
-    <td>\(\Updownarrow\)</td>
-    <td>\Updownarrow</td>
-  </tr>
-  <tr>
-    <td>\(\lvert\;\rvert\)</td>
-    <td>\lvert<br>\rvert</td>
-    <td>\(\lVert\;\rVert\)</td>
-    <td>\lVert<br>\rVert</td>
-    <td></td>
-    <td>\left.</td>
-    <td></td>
-    <td>\right.</td>
-  </tr>
-</table>
+      <td>\(\text{\u{a}}\)</td>
+      <td>\u{a}</td>
 
-<h4 id="delimiter-sizing">Delimiter Sizing</h4>
+      <td>\(\text{\r{a}}\)</td>
+      <td>\r{a}</td>
 
-<table class="all-code">
-  <tr>
-    <td rowspan="2">\(\left(\LARGE{AB}\right)\)</td>
-    <td rowspan="2" >\left( \LARGE{AB} \right)</td>
-    <td>\left</td>
-    <td>\big</td>
-    <td>\bigl</td>
-    <td>\bigr</td>
-  </tr>
-  <tr>
-    <td>\middle</td>
-    <td>\Big</td>
-    <td>\Bigl</td>
-    <td>\Bigr</td>
-  </tr>
-  <tr>
-    <td rowspan="2">\(( \big( \Big( \bigg( \Bigg(\)</td>
-    <td rowspan="2">( \big( \Big( \bigg( \Bigg(</td>
-    <td>\right</td>
-    <td>\bigg</td>
-    <td>\biggl</td>
-    <td>\biggr</td>
-  </tr>
-  <tr>
-    <td></td>
-    <td>\Bigg</td>
-    <td>\Biggl</td>
-    <td>\Biggr</td>
-  </tr>
-</table>
+    </tr>
+    <tr>
+      <td>\(\text{\H{a}}\)</td>
+      <td>\H{a}</td>
 
-<h2 id="environments">Environments</h2>
+      <td>\(\text{\v{a}}\)</td>
+      <td>\v{a}</td>
 
-    <table class="symbol">
-        <tr>
-            <td>\(\begin{matrix} a & b \\ c & d \end{matrix}\)</td>
-            <td>
-                <pre><code>\begin{matrix}
-   a &amp; b \\
-   c &amp; d
-\end{matrix}</code></pre>
-            </td>
-            <td>\(\begin{array}{c|c} a & b \\ c & d \end{array}\)</td>
-            <td>
-                <pre><code>\begin{array}{c|c}
-   a &amp; b \\
-   c &amp; d
-\end{array}</code></pre>
-            </td>
-            <td>\(\begin{aligned} a&=b+c \\ d+e&=f \end{aligned}\)</td>
-            <td>
-                <pre><code>\begin{aligned}
-   a&amp;=b+c \\
-   d+e&=f
-\end{aligned}</code></pre>
-            </td>
-        </tr>
-        <tr>
-            <td>\(\begin{pmatrix} a & b \\ c & d \end{pmatrix}\)</td>
-            <td>
-                <pre><code>\begin{pmatrix}
-   a &amp; b \\
-   c &amp; d
-\end{pmatrix}</code></pre>
-            </td>
-            <td>\(\begin{bmatrix} a & b \\ c & d \end{bmatrix}\)</td>
-            <td>
-                <pre><code>\begin{bmatrix}
-   a &amp; b \\
-   c &amp; d
-\end{bmatrix}</code></pre>
-            </td>
+      <td></td>
+      <td></td>
+    </tr>
+  </table>
+
+  <h2 id="delimiters">Delimiters</h2>
+  <table class="reference" id="delim">
+    <tr>
+      <td>\((\,)\)</td>
+      <td>( )</td>
+
+      <td>\(\lgroup\:\rgroup\)</td>
+      <td>\lgroup<br>\rgroup</td>
+
+      <td>\(\lceil\:\rceil\)</td>
+      <td>\lceil<br>\rceil</td>
+
+      <td>\(\uparrow\)</td>
+      <td>\uparrow</td>
+    </tr>
+    <tr>
+      <td>\([\:]\)</td>
+      <td>[ ]</td>
+
+      <td>\(\lbrack\:\rbrack\)</td>
+      <td>\lbrack<br>\rbrack</td>
+
+      <td>⌊⌋</td>
+      <td>\lfloor<br>\rfloor</td>
+
+      <td>\(\downarrow\)</td>
+      <td>\downarrow</td>
+    </tr>
+    <tr>
+      <td>\(\{\,\}\)</td>
+      <td>\{&nbsp;\}</td>
+
+      <td>\(\lbrace\:\rbrace\)</td>
+      <td>\lbrace<br>\rbrace</td>
+
+      <td>\(\ulcorner \urcorner\)</td>
+      <td>\ulcorner<br>\urcorner</td>
+
+      <td>\(\updownarrow\)</td>
+      <td>\updownarrow</td>
+    </tr>
+    <tr>
+      <td>\(\langle\:\rangle\)</td>
+      <td>\langle<br>\rangle</td>
+
+      <td>\(\lt\:\gt\)</td>
+      <td>\lt<br>\gt</td>
+
+      <td>\(\llcorner \lrcorner\)</td>
+      <td>\llcorner<br>\lrcorner</td>
+
+      <td>\(\Uparrow\)</td>
+      <td>\Uparrow</td>
+    </tr>
+    <tr>
+      <td>\(|\)</td>
+      <td>|</td>
+
+      <td>\(\vert\)</td>
+      <td>\vert</td>
+
+      <td>\(\backslash\)</td>
+      <td>\backslash</td>
+
+      <td>\(\Downarrow\)</td>
+      <td>\Downarrow</td>
+    </tr>
+    <tr>
+      <td>\(\|\)</td>
+      <td>\|</td>
+
+      <td>\(\Vert\)</td>
+      <td>\Vert</td>
+
+      <td>\(\lmoustache\:\rmoustache\)</td>
+      <td>\lmoustache<br>\rmoustache</td>
+
+      <td>\(\Updownarrow\)</td>
+      <td>\Updownarrow</td>
+    </tr>
+    <tr>
+      <td>\(\lvert\;\rvert\)</td>
+      <td>\lvert<br>\rvert</td>
+
+      <td>\(\lVert\;\rVert\)</td>
+      <td>\lVert<br>\rVert</td>
+
+      <td></td>
+      <td>\left.</td>
+
+      <td></td>
+      <td>\right.</td>
+    </tr>
+  </table>
+
+  <h4 id="delimiter-sizing">Delimiter Sizing</h4>
+  <table>
+    <tr>
+      <td rowspan="2">\(\left(\LARGE{AB}\right)\)</td>
+      <td rowspan="2" >\left( \LARGE{AB} \right)</td>
+      <td>\left</td>
+      <td>\big</td>
+      <td>\bigl</td>
+      <td>\bigr</td>
+    </tr>
+    <tr>
+      <td style="padding-left: 1em;">\middle</td>
+      <td>\Big</td>
+      <td>\Bigl</td>
+      <td>\Bigr</td>
+    </tr>
+    <tr>
+      <td rowspan="2">\(( \big( \Big( \bigg( \Bigg(\)</td>
+      <td rowspan="2">( \big( \Big( \bigg( \Bigg(</td>
+      <td>\right</td>
+      <td>\bigg</td>
+      <td>\biggl</td>
+      <td>\biggr</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>\Bigg</td>
+      <td>\Biggl</td>
+      <td>\Biggr</td>
+    </tr>
+  </table>
+
+  <h2 id="environments">Environments</h2>
+
+  <table>
+    <tr>
+      <td>\(\begin{matrix} a&b\\c&d \end{matrix}\)</td>
+      <td><code style="font-size: smaller;">\begin{matrix}
+        a &amp; b \\
+        c &amp; d
+      \end{matrix}</code></td>
+
+      <td>\(\begin{array}{c|c} a&b\\c&d \end{array}\)</td>
+      <td><code style="font-size: smaller;">\begin{array}{c|c}
+        a &amp; b \\
+        c &amp; d
+      \end{array}</code></td>
+    </tr>
+
+    <tr>
+      <td>\(\begin{pmatrix} a & b\\c & d \end{pmatrix}\)</td>
+      <td><code style="font-size: smaller;">\begin{pmatrix}
+        a &amp; b \\
+        c &amp; d
+      \end{pmatrix}</code></td>
+
+      <td>\(\begin{bmatrix} a & b\\c & d \end{bmatrix}\)</td>
+      <td><code style="font-size: smaller;">\begin{bmatrix}
+        a &amp; b \\
+        c &amp; d
+      \end{bmatrix}</code></td>
+    </tr>
+
+    <tr>
+      <td>\(\begin{vmatrix} a & b\\c & d \end{vmatrix}\)</td>
+      <td><code style="font-size: smaller;">\begin{vmatrix}
+        a &amp; b \\
+        c &amp; d
+      \end{vmatrix}</code></td>
+
+      <td>\(\begin{Vmatrix} a & b\\c & d \end{Vmatrix}\)</td>
+      <td><code style="font-size: smaller;">\begin{Vmatrix}
+        a &amp; b \\
+        c &amp; d
+      \end{Vmatrix}</code> </td>
+    </tr>
+
+    <tr>
+      <td>\(\begin{Bmatrix} a & b\\c & d \end{Bmatrix}\)</td>
+      <td><code style="font-size: smaller;">\begin{Bmatrix}
+        a &amp; b \\
+        c &amp; d
+      \end{Bmatrix}</code></td>
+
+      <td>\(\def\arraystretch{1.5}\begin{array}{c:c:c} a & b & c\\\hline d & e & f\\\hdashline g & h & i \end{array}\)</td>
+      <td><code style="font-size: smaller;">\def\arraystretch{1.5}
+        \begin{array}{c:c:c}
+        a &amp; b &amp; c \\ \hline
+        d &amp; e &amp; f \\
+        \hdashline
+        g &amp; h &amp; i
+      \end{array}</code></td>
+
+    </tr>
+
+    <tr>
+      <td>\(\begin{aligned} a&=b+c\\d+e&=f \end{aligned}\)</td>
+      <td><code style="font-size: smaller;">\begin{aligned}
+        a&amp;=b+c \\
+        d+e&=f
+      \end{aligned}</code></td>
+
       <td>\(\begin{alignedat}{2}10&x+&3&y=2\\3&x+&13&y=4\end{alignedat}\)</td>
-      <td>
-        <pre><code>\begin{alignedat}{2}
-   10&x+ &3&y = 2 \\
-    3&x+&13&y = 4
-\end{alignedat}</code></pre>
-      </td>
-      </tr>
-        <tr>
-            <td>\(\begin{vmatrix} a & b \\ c & d \end{vmatrix}\)</td>
-            <td>
-                <pre><code>\begin{vmatrix}
-   a &amp; b \\
-   c &amp; d
-\end{vmatrix}</code></pre>
-            </td>
-            <td>\(\begin{Vmatrix} a & b \\ c & d \end{Vmatrix}\)</td>
-            <td>
-                <pre><code>\begin{Vmatrix}
-   a &amp; b \\
-   c &amp; d
-\end{Vmatrix}</code></pre>
-            </td>
-            <td>\(\begin{gathered} a=b \\ e=b+c \end{gathered}\)</td>
-      <td>
-                <pre><code>\begin{gathered}
-   a=b \\ 
-   e=b+c
-\end{gathered}</code></pre>
-      </td>
-        </tr>
-        <tr>
-            <td>\(\begin{Bmatrix} a & b \\ c & d \end{Bmatrix}\)</td>
-            <td>
-                <pre><code>\begin{Bmatrix}
-   a &amp; b \\
-   c &amp; d
-\end{Bmatrix}</code></pre>
-            </td>
-      <td></td>
-      <td></td>
-            <td>\(x = \begin{cases} a &\text{if } b \\ c &\text{if } d \end{cases}\)</td>
-            <td>
-                <pre><code>x = \begin{cases}
-   a &amp;\text{if } b  \\
-   c &amp;\text{if } d
-\end{cases}</code></pre>
-            </td>
-        </tr>
-    </table>
+      <td><code style="font-size: smaller;">\begin{alignedat}{2}
+        10&x+ &3&y = 2 \\
+        3&x+&13&y = 4
+      \end{alignedat}</code></td>
+    </tr>
 
-<p class="measure">There is also support for <code>{darray}</code> and <code>{dcases}</code>. Acceptable line separators include: <code>\\</code>, <code>\cr</code>, and <code>\\[<em>distance</em>]</code>. <em>Distance</em> can be written with any of the <a href="#units">units</a>. The <code>{array}</code> environment does not yet support <code>\hline</code>.</p>
+    <tr>
+      <td>\(\begin{gathered} a=b\\e=b+c \end{gathered}\)</td>
+      <td><code style="font-size: smaller;">\begin{gathered}
+        a=b \\ 
+        e=b+c
+      \end{gathered}</code></td>
 
+      <td>\(x = \begin{cases} a &\text{if } b\\c &\text{if } d \end{cases}\)</td>
+      <td><code style="font-size: smaller;">x = \begin{cases}
+        a &amp;\text{if } b  \\
+        c &amp;\text{if } d
+      \end{cases}</code></td>
+
+    </tr>
+  </table>
+
+  <p>There is also support for <code>{darray}</code> and <code>{dcases}</code>. Acceptable line separators include: <code>\\</code>, <code>\cr</code>, and <code>\\[<em>distance</em>]</code>. <em>Distance</em> can be written with any of the <a href="#units">units</a>. The <code>{array}</code> environment does not yet support <code>\hline</code>.</p>
 
 <!-- Filed a bug about this here:
 
@@ -374,18 +400,16 @@ https://github.com/Khan/KaTeX/issues/1245
   </table>
 -->
 
-
-<h2>Letters</h2>
-    
-<table class="symbol">
+  <h2 id="letters">Greek Letters</h2>
+  <table class="reference">
     <tr>
-      <td style="width: 1em;">Γ</td>
+      <td>Γ</td>
       <td>\Gamma</td>
-      <td style="width: 1em;">Δ</td>
+      <td>Δ</td>
       <td>\Delta</td>
-      <td style="width: 1em;">Θ</td>
+      <td>Θ</td>
       <td>\Theta</td>
-      <td style="width: 1em;">Λ</td>
+      <td>Λ</td>
       <td>\Lambda</td>
     </tr>
     <tr>
@@ -409,81 +433,81 @@ https://github.com/Khan/KaTeX/issues/1245
       <td></td>
     </tr>
     <tr>
-      <td><span class="katex"><span class="mathit">α</span></span></td>
+      <td>α</td>
       <td>\alpha</td>
-      <td><span class="katex"><span class="mathit">β</span></span></td>
+      <td>β</td>
       <td>\beta</td>
-      <td><span class="katex"><span class="mathit">γ</span></span></td>
+      <td>γ</td>
       <td>\gamma</td>
-      <td><span class="katex"><span class="mathit">δ</span></span></td>
+      <td>δ</td>
       <td>\delta</td>
     </tr>
     <tr>
-      <td><span class="katex"><span class="mathit">ϵ</span></span></td>
+      <td>ϵ</td>
       <td>\epsilon</td>
-      <td><span class="katex"><span class="mathit">ζ</span></span></td>
+      <td>ζ</td>
       <td>\zeta</td>
-      <td><span class="katex"><span class="mathit">η</span></span></td>
+      <td>η</td>
       <td>\eta</td>
-      <td><span class="katex"><span class="mathit">θ</span></span></td>
+      <td>θ</td>
       <td>\theta</td>
     </tr>
     <tr>
-      <td><span class="katex"><span class="mathit">ι</span></span></td>
+      <td>ι</td>
       <td>\iota</td>
-      <td><span class="katex"><span class="mathit">κ</span></span></td>
+      <td>κ</td>
       <td>\kappa</td>
-      <td><span class="katex"><span class="mathit">λ</span></span></td>
+      <td>λ</td>
       <td>\lambda</td>
-      <td><span class="katex"><span class="mathit">μ</span></span></td>
+      <td>μ</td>
       <td>\mu</td>
     </tr>
     <tr>
-      <td><span class="katex"><span class="mathit">ν</span></span></td>
+      <td>ν</td>
       <td>\nu</td>
-      <td><span class="katex"><span class="mathit">ξ</span></span></td>
+      <td>ξ</td>
       <td>\xi</td>
-      <td><span class="katex"><span class="mathit">o</span></span></td>
+      <td>o</td>
       <td>\omicron</td>
-      <td><span class="katex"><span class="mathit">π</span></span></td>
+      <td>π</td>
       <td>\pi</td>
     </tr>
     <tr>
-      <td><span class="katex"><span class="mathit">ρ</span></span></td>
+      <td>ρ</td>
       <td>\rho</td>
-      <td><span class="katex"><span class="mathit">σ</span></span></td>
+      <td>σ</td>
       <td>\sigma</td>
-      <td><span class="katex"><span class="mathit">τ</span></span></td>
+      <td>τ</td>
       <td>\tau</td>
-      <td><span class="katex"><span class="mathit">υ</span></span></td>
+      <td>υ</td>
       <td>\upsilon</td>
     </tr>
     <tr>
-      <td><span class="katex"><span class="mathit">ϕ</span></span></td>
+      <td>ϕ</td>
       <td>\phi</td>
-      <td><span class="katex"><span class="mathit">χ</span></span></td>
+      <td>χ</td>
       <td>\chi</td>
-      <td><span class="katex"><span class="mathit">ψ</span></span></td>
+      <td>ψ</td>
       <td>\psi</td>
-      <td><span class="katex"><span class="mathit">ω</span></span></td>
+      <td>ω</td>
       <td>\omega</td>
     </tr>
     <tr>
-      <td><span class="katex"><span class="mathit">ε</span></span></td>
+      <td>ε</td>
       <td>\varepsilon</td>
-      <td><span class="katex"><span class="mathit">ϰ</span></span></td>
+      <td>ϰ</td>
       <td>\varkappa</td>
-      <td><span class="katex"><span class="mathit">ϑ</span></span></td>
+      <td>ϑ</td>
       <td>\vartheta</td>
-      <td><span class="katex"><span class="mathit">ϖ</span></span></td>
+      <td>ϖ</td>
       <td>\varpi</td>
     </tr>
     <tr>
-      <td><span class="katex"><span class="mathit">ϱ</span></span></td>
+      <td>ϱ</td>
       <td>\varrho</td>
-      <td><span class="katex"><span class="mathit">ς</span></span></td>
+      <td>ς</td>
       <td>\varsigma</td>
-      <td><span class="katex"><span class="mathit">φ</span></span></td>
+      <td>φ</td>
       <td>\varphi</td>
       <td>ϝ</td>
       <td>\digamma</td>
@@ -491,82 +515,81 @@ https://github.com/Khan/KaTeX/issues/1245
     <tr><td colspan="8"></td></tr>
     <tr>
       <td class="not-symbol" colspan="2">Direct Input:</td>
-      <td class="symbol" colspan="6" style="font-family: KaTeX_Main, KaTeX_AMS;">Γ Δ Θ Λ Ξ Π Σ Υ Φ Ψ Ω<br><span class="katex"><span class="mathit">α β γ δ ϵ ζ η θ ι κ λ μ ν ξ o π ρ σ τ υ ϕ χ ψ ω ε ϑ ϖ ϱ ς φ</span></span></td>
-    </tr>
-</table>
-
-<h4 id="other-letters">Other Letters</h4>
-<table class="symbol">
-  <tr>
-    <td style="width: 1em;">\(\imath\)</td>
-    <td>\imath</td>
-    <td style="width: 1em;">\(\jmath\)</td>
-    <td>\jmath</td>
-    <td style="width: 1em;">ℵ</td>
-    <td>\aleph</td>
-    <td style="width: 1em;">ℶ</td>
-    <td>\beth</td>
-    <td style="width: 1em;">ℷ</td>
-    <td>\gimel</td>
-  </tr>
-  <tr>
-    <td>ℸ</td>
-    <td>\daleth</td>
-    <td>ð</td>
-    <td>\eth</td>
-    <td>Ⅎ</td>
-    <td>\Finv</td>
-    <td>⅁</td>
-    <td>\Game</td>
-    <td>ℓ</td>
-    <td>\ell</td>
-  </tr>
-  <tr>
-    <td>ℏ</td>
-    <td>\hbar</td>
-    <td>ℏ</td>
-    <td>\hslash</td>
-    <td>ℑ</td>
-    <td>\Im</td>
-    <td>ℜ</td>
-    <td>\Re</td>
-    <td>℘</td>
-    <td>\wp</td>
-  </tr>
-  <tr>
-    <td>∂</td>
-    <td>\partial</td>
-    <td>∇</td>
-    <td>\nabla</td>
-    <td>\(\Bbbk\)</td>
-    <td>\Bbbk</td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-  </tr>
-</table>
-
-  <table>
-    <tr>
-      <td rowspan="2">Direct Input:</td>
-      <td>ℂ ℍ ℕ ℙ ℚ ℝ ℤ</td>
-      <td style="font-family: KaTeX_Main, KaTeX_AMS;">∂ ð ∇ ℑ ℓ ℘ ℜ Ⅎ ℵ ℶ ℷ ℸ ⅁</td>
-    </tr>
-    <tr>
-      <td colspan="2"><span style="font-family: Times New Roman;">ÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖÙÚÛÜÝÞ<br>àáâãäåçèéêëìíîïðñòóôöùúûüýþÿ</span></td>
+      <td colspan="6" style="font-family: KaTeX_Main, KaTeX_AMS;">Γ Δ Θ Λ Ξ Π Σ Υ Φ Ψ Ω<br><span class="katex"><span class="mathit">α β γ δ ϵ ζ η θ ι κ λ μ ν ξ o π ρ σ τ υ ϕ χ ψ ω ε ϑ ϖ ϱ ς φ</span></span></td>
     </tr>
   </table>
-  
-<h4 id="letters-in-text">Letters inside <code>\text{}</code></h4>
 
-    <p><code>\text{…}</code> will accept the functions: <code>\ae</code>, <code>\AE</code>, <code>\oe</code>, <code>\OE</code>, <code>\o</code>, <code>\O</code>, <code>\ss</code>, <code>\i</code>, <code>\j</code>. <code>\text{…}</code> also accepts Unicode characters from:</p>
+
+  <h4 id="other-letters">Other Letters</h4>
+  <table class="reference">
+    <tr>
+      <td>\(\imath\)</td>
+      <td>\imath</td>
+      <td>\(\jmath\)</td>
+      <td>\jmath</td>
+      <td>ℵ</td>
+      <td>\aleph</td>
+      <td>ℶ</td>
+      <td>\beth</td>
+      <td>ℷ</td>
+      <td>\gimel</td>
+    </tr>
+    <tr>
+      <td>ℸ</td>
+      <td>\daleth</td>
+      <td>ð</td>
+      <td>\eth</td>
+      <td>Ⅎ</td>
+      <td>\Finv</td>
+      <td>⅁</td>
+      <td>\Game</td>
+      <td>ℓ</td>
+      <td>\ell</td>
+    </tr>
+    <tr>
+      <td>ℏ</td>
+      <td>\hbar</td>
+      <td>ℏ</td>
+      <td>\hslash</td>
+      <td>ℑ</td>
+      <td>\Im</td>
+      <td>ℜ</td>
+      <td>\Re</td>
+      <td>℘</td>
+      <td>\wp</td>
+    </tr>
+    <tr>
+      <td>∂</td>
+      <td>\partial</td>
+      <td>∇</td>
+      <td>\nabla</td>
+      <td>\(\Bbbk\)</td>
+      <td>\Bbbk</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+
+    <tr><td colspan="8"></td></tr>
+    <tr>
+      <td class="not-symbol" colspan="2">Direct Input:</td>
+      <td colspan="6" style="font-family: KaTeX_Main, KaTeX_AMS;">
+        <span>ℂ ℍ ℕ ℙ ℚ ℝ ℤ</span><br>
+        <span style="font-family: KaTeX_Main, KaTeX_AMS;">∂ ð ∇ ℑ ℓ ℘ ℜ Ⅎ ℵ ℶ ℷ ℸ ⅁</span><br>
+        <span style="font-family: Times New Roman;">ÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖÙÚÛÜÝÞ<br>àáâãäåçèéêëìíîïðñòóôöùúûüýþÿ</span>
+      </td>
+    </tr>
+  </table>
+
+  <h4 id="letters-in-text">Letters inside <code>\text{}</code></h4>
+  <p><code>\text{…}</code> will accept the functions: <code>\ae</code>, <code>\AE</code>, <code>\oe</code>, <code>\OE</code>, <code>\o</code>, <code>\O</code>, <code>\ss</code>, <code>\i</code>, <code>\j</code>. <code>\text{…}</code> also accepts Unicode characters from:</p>
 
   <table class="grid">
     <thead>
-    <tr>
-      <th>Script</th>   <th>Unicode Range</th>   <th>Script</th>   <th>Unicode Range</th>
-    </tr>
+      <tr>
+        <th>Script</th>   <th>Unicode Range</th>   <th>Script</th>   <th>Unicode Range</th>
+      </tr>
     </thead>
     <tbody>
       <tr>
@@ -601,16 +624,15 @@ https://github.com/Khan/KaTeX/issues/1245
         <td>Kannada</td><td>0C80 – 0CFF</td>   <td>Full width punctuation</td><td>FF00 – FF60</td>
       </tr>
       <tr>
-        <td>Malayalam</td><td style="white-space: nowrap">0D00 – 0D7F</td>
+        <td>Malayalam</td><td>0D00 – 0D7F</td>
+        <td></td><td></td>
       </tr>
     </tbody>
   </table>
 
-  <br>
 
-<h2 id="annotation">Annotation</h2>
-
-  <table class="symbol">
+  <h2 id="annotation">Annotation</h2>
+  <table>
     <tr>
       <td>\(\cancel{5}\)</td>
       <td>\cancel{5}</td>
@@ -634,231 +656,229 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\sout{abc}</td>
     </tr>
     <tr>
-            <td>\(\not =\)</td>
-            <td>\not =</td>
-            <td></td>
-            <td></td>
+      <td>\(\not =\)</td>
+      <td>\not =</td>
+      <td></td>
+      <td></td>
     </tr>
   </table>
-  
-<h2 id="overlap">Overlap</h2>
 
-    <table class="symbol">
-        <tr>
-            <td>\({=}\mathllap{/\,}\)</td>
+  <h2 id="overlap">Overlap</h2>
+  <table>
+    <tr>
+      <td>\({=}\mathllap{/\,}\)</td>
       <td>{=}<strong>\mathllap</strong>{/\,}</td>
       <td>\(\left(x^{\smash{2}}\right)\)</td>
       <td>\left(x^{<strong>\smash</strong>{2}}\right)</td>
-        </tr>
-        <tr>
-            <td>\(\mathrlap{\,/}{=}\)</td>
+    </tr>
+    <tr>
+      <td>\(\mathrlap{\,/}{=}\)</td>
       <td><strong>\mathrlap</strong>{\,/}{=}&nbsp;&nbsp;&nbsp;</td>
       <td>\(\sqrt{\smash[b]{y}}\)</td>
       <td>\sqrt{<strong>\smash[b]</strong>{y}}</td>
-        </tr>
+    </tr>
     <tr>
       <td>\( \displaystyle \sum_{\mathclap{1\le i\le j\le n}} x_{ij}\)</td>
       <td colspan="3">\sum_{<strong>\mathclap</strong>{1\le i\le j\le n}} x_{ij}</td>
     </tr>
-    </table>
-  
+  </table>
+
   <p>There is also support for <code>\llap</code>, <code>\rlap</code>, and <code>\clap</code>, but they will take only text, not math, as arguments.</p>
 
-<h2 id="spacing">Spacing</h2>
 
-    <table class="explain">
-        <thead>
-        <tr class="light">
-            <th>Function</th>
-            <th>Produces</th>
-            <th>Function</th>
-            <th>Produces</th>
-        </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>\!</td>
+  <h2 id="spacing">Spacing</h2>
+  <table class="explain">
+    <thead>
+      <tr class="light">
+        <th>Function</th>
+        <th>Produces</th>
+        <th>Function</th>
+        <th>Produces</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>\!</td>
         <td style="white-space: nowrap">– ³∕₁₈ em space</td>
-                <td>\kern{<em>distance</em>}</td>
-                <td>space, width = <em>distance</em></td>
-            </tr>
-            <tr>
-                <td>\,</td>
+        <td>\kern{<em>distance</em>}</td>
+        <td>space, width = <em>distance</em></td>
+      </tr>
+      <tr>
+        <td>\,</td>
         <td>³∕₁₈ em space</td>
-                <td>\mkern{<em>distance</em>}</td>
-                <td>space, width = <em>distance</em></td>
-            </tr>
+        <td>\mkern{<em>distance</em>}</td>
+        <td>space, width = <em>distance</em></td>
+      </tr>
       <tr>
         <td>\thinspace</td>
         <td>³∕₁₈ em space</td>
-                <td>\skip{<em>distance</em>}</td>
-                <td>space, width = <em>distance</em></td>
+        <td>\skip{<em>distance</em>}</td>
+        <td>space, width = <em>distance</em></td>
       </tr>
-            <tr>
-                <td>\:</td>
+      <tr>
+        <td>\:</td>
         <td>⁴∕₁₈ em space</td>
-                <td>\mskip{<em>distance</em>}</td>
-                <td>space, width = <em>distance</em></td>
-            </tr>
+        <td>\mskip{<em>distance</em>}</td>
+        <td>space, width = <em>distance</em></td>
+      </tr>
       <tr>
         <td>\medspace</td>
         <td>⁴∕₁₈ em space</td>
         <td>\hspace{<em>distance</em>}</td>
-                <td>space, width = <em>distance</em></td>
+        <td>space, width = <em>distance</em></td>
       </tr>
-            <tr>
-                <td>\;</td>
+      <tr>
+        <td>\;</td>
         <td>⁵∕₁₈ em space</td>
         <td>\hspace*{<em>distance</em>}</td>
-                <td>space, width = <em>distance</em></td>
-            </tr>
+        <td>space, width = <em>distance</em></td>
+      </tr>
       <tr>
         <td>\thickspace</td>
         <td>⁵∕₁₈ em space</td>
-                <td>\phantom{<em>content</em>}</td>
-                <td>space the width and height of <em>content</em></td>
+        <td>\phantom{<em>content</em>}</td>
+        <td>space the width and height of <em>content</em></td>
       </tr>
-            <tr>
-                <td>\enspace</td>
+      <tr>
+        <td>\enspace</td>
         <td>½ em space</td>
-                <td>\hphantom{<em>content</em>}</td>
-                <td>space the width of <em>content</em></td>
-            </tr>
-            <tr>
-                <td>\quad</td>
+        <td>\hphantom{<em>content</em>}</td>
+        <td>space the width of <em>content</em></td>
+      </tr>
+      <tr>
+        <td>\quad</td>
         <td>1 em space</td>
-                <td>\vphantom{<em>content</em>}</td>
-                <td>a strut the height of <em>content</em></td>
-            </tr>
-            <tr>
-                <td>\qquad</td>
+        <td>\vphantom{<em>content</em>}</td>
+        <td>a strut the height of <em>content</em></td>
+      </tr>
+      <tr>
+        <td>\qquad</td>
         <td>2 em space</td>
         <td></td>
         <td></td>
-            </tr>
-            <tr>
-                <td>~</td>
+      </tr>
+      <tr>
+        <td>~</td>
         <td style="white-space: nowrap">non-breaking space</td>
         <td></td>
         <td></td>
-            </tr>
-            <tr>
-                <td>\space</td>
+      </tr>
+      <tr>
+        <td>\space</td>
         <td>non-breaking space</td>
         <td></td>
         <td></td>
-            </tr>
-            <tr>
-                <td>\<em>space</em></td>
-                <td>non-breaking space</td>
+      </tr>
+      <tr>
+        <td>\<em>space</em></td>
+        <td>non-breaking space</td>
         <td></td>
         <td></td>
-            </tr>
-        </tbody>
-    </table>
+      </tr>
+
+    </tbody>
+  </table>
+
+  <p>
+    {<em>distance</em>} will accept any of the <a href="#units">units</a>.<br>
+    <code>\mkern</code> and <code>\mskip</code> will not work in text mode and both will write a console warning for any unit except <em>mu</em>.
+    <br><br>
+    See also <a href="#environments">environments</a>
+  </p>
+
+  <h4 id="vertical">Vertical Layout</h4>
   <table>
     <tr>
-      <td>Notes:</td><td>{<em>distance</em>} will accept any of the <a href="#units">units</a>.<br>
-      <code>\mkern</code> and <code>\mskip</code> will not work in text mode and both will write a console warning for any unit except <em>mu</em>.</td>
+      <td>\(x_n\)</td>
+      <td>x_n</td>
+      <td>\(\stackrel{!}{=}\)</td>
+      <td>\stackrel{!}{=}</td>
+      <td>\( a \atop b \)</td>
+      <td>a \atop b</td>
+    </tr>
+    <tr>
+      <td>\(e^x\)</td>
+      <td>e^x</td>
+      <td>\(\overset{!}{=}\)</td>
+      <td>\overset{!}{=}</td>
+      <td>\(a\raisebox{0.25em}{b}c\)&nbsp;</td>
+      <td>a\raisebox{0.25em}{b}c</td>
+    </tr>
+    <tr>
+      <td>\(_u^o\)</td>
+      <td>_u^o&nbsp;</td>
+      <td>\(\underset{!}{=}\)</td>
+      <td>\underset{!}{=}&nbsp;</td>
+      <td></td>
+      <td></td>
     </tr>
   </table>
-  <br>
 
-    <span class="fr">See also <a href="#environments">environments</a></span>
-      <h4 id="vertical">Vertical Layout</h4>
-
-    <table class="symbol">
-        <tr>
-            <td>\(x_n\)</td>
-            <td>x_n</td>
-            <td>\(\stackrel{!}{=}\)</td>
-            <td>\stackrel{!}{=}</td>
-            <td>\( a \atop b \)</td>
-            <td>a \atop b</td>
-        </tr>
-        <tr>
-            <td>\(e^x\)</td>
-            <td>e^x</td>
-            <td>\(\overset{!}{=}\)</td>
-            <td>\overset{!}{=}</td>
-            <td>\(a\raisebox{0.25em}{b}c\)&nbsp;</td>
-            <td>a\raisebox{0.25em}{b}c</td>
-        </tr>
-        <tr>
-            <td>\(_u^o\)</td>
-            <td>_u^o&nbsp;</td>
-            <td>\(\underset{!}{=}\)</td>
-            <td>\underset{!}{=}&nbsp;</td>
-            <td></td>
-            <td></td>
-        </tr>
-    </table>
+  <p>See also <a href="#relations">relations</a> and <a href="#binary">binary operators</a></p>
 
 
-        <span class="fr">See also <a href="#relations">relations</a> and <a href="#binary">binary operators</a></span>
-        <h2 id="logic">Logic and Set Theory</h2>
-
-    <table class="symbol">
-        <tr>
-            <td>∀</td>
-            <td>\forall</td>
-            <td>∁</td>
-            <td>\complement</td>
-            <td>∴</td>
-            <td>\therefore</td>
-            <td>¬</td>
-            <td>\neg or \lnot</td>
-        </tr>
-        <tr>
-            <td>∃</td>
-            <td>\exists</td>
-            <td>⊂</td>
-            <td>\subset</td>
-            <td>∵</td>
-            <td>\because</td>
-            <td>∅</td>
-            <td>\emptyset or \varnothing</td>
-        </tr>
-        <tr>
-            <td>∄</td>
-            <td>\nexists</td>
-            <td>⊃</td>
-            <td>\supset</td>
-            <td>↦</td>
-            <td>\mapsto</td>
-            <td></td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>∈</td>
-            <td>\in</td>
-            <td>∣</td>
-            <td>\mid</td>
-            <td>→</td>
-            <td>\to</td>
-            <td>⟹</td>
-            <td>\implies</td>
-        </tr>
-        <tr>
-            <td>∉</td>
-            <td>\notin</td>
-            <td>∧</td>
-            <td>\land</td>
-            <td>←</td>
-            <td>\gets</td>
-            <td>⟸</td>
-            <td>\impliedby</td>
-        </tr>
-        <tr>
-            <td>∋</td>
-            <td>\ni</td>
-            <td>∨</td>
-            <td>\lor</td>
-            <td>↔</td>
-            <td>\leftrightarrow</td>
-            <td>⟺</td>
-            <td>\iff</td>
-        </tr>
+  <h2 id="logic">Logic and Set Theory</h2>
+  <table>
+    <tr>
+      <td>∀</td>
+      <td>\forall</td>
+      <td>∁</td>
+      <td>\complement</td>
+      <td>∴</td>
+      <td>\therefore</td>
+      <td>¬</td>
+      <td>\neg or \lnot</td>
+    </tr>
+    <tr>
+      <td>∃</td>
+      <td>\exists</td>
+      <td>⊂</td>
+      <td>\subset</td>
+      <td>∵</td>
+      <td>\because</td>
+      <td>∅</td>
+      <td>\emptyset or \varnothing</td>
+    </tr>
+    <tr>
+      <td>∄</td>
+      <td>\nexists</td>
+      <td>⊃</td>
+      <td>\supset</td>
+      <td>↦</td>
+      <td>\mapsto</td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>∈</td>
+      <td>\in</td>
+      <td>∣</td>
+      <td>\mid</td>
+      <td>→</td>
+      <td>\to</td>
+      <td>⟹</td>
+      <td>\implies</td>
+    </tr>
+    <tr>
+      <td>∉</td>
+      <td>\notin</td>
+      <td>∧</td>
+      <td>\land</td>
+      <td>←</td>
+      <td>\gets</td>
+      <td>⟸</td>
+      <td>\impliedby</td>
+    </tr>
+    <tr>
+      <td>∋</td>
+      <td>\ni</td>
+      <td>∨</td>
+      <td>\lor</td>
+      <td>↔</td>
+      <td>\leftrightarrow</td>
+      <td>⟺</td>
+      <td>\iff</td>
+    </tr>
     <tr>
       <td>\(\notni\)</td>
       <td>\notni</td>
@@ -869,16 +889,20 @@ https://github.com/Khan/KaTeX/issues/1245
       <td></td>
       <td></td>
     </tr>
-    </table>
-  <table>
+
+    <tr><td colspan="8"></td></tr>
     <tr>
-      <td>Direct Input:</td>
-      <td><span style="font-family: KaTeX_Main, KaTeX_AMS;">∀ ∴ ∁ ∵ ∃ ∣ ∈ ∉ ∋ ⊂ ⊃ ∧ ∨ ↦ → ← ↔</span> ℂ ℍ ℕ ℙ ℚ ℝ ℤ</td>
+      <td class="not-symbol" colspan="2">Direct Input:</td>
+      <td colspan="6">
+        <span style="font-family: KaTeX_Main, KaTeX_AMS;">
+        ∀ ∴ ∁ ∵ ∃ ∣ ∈ ∉ ∋ ⊂ ⊃ ∧ ∨ ↦ → ← ↔</span> 
+        ℂ ℍ ℕ ℙ ℚ ℝ ℤ
+      </td>
     </tr>
   </table>
 
 
-<!-- <h2  id="macros">Macros</h2>
+  <!-- <h2  id="macros">Macros</h2>
   <div>
   <p>Before macros can be used, they must be defined in the KaTeX <a href="https://github.com/Khan/KaTeX#rendering-options">rendering options</a>. Available functions include:</p>
     <div>
@@ -887,438 +911,464 @@ https://github.com/Khan/KaTeX/issues/1245
     </div>
   </div> -->
 
-<h2 id="big">Big Operators</h2>
+  <h2 id="big">Big Operators</h2>
+  <table class="auto big-operator">
+    <tr>
+      <td>∑</td>
+      <td>\sum</td>
+      <td>∏</td>
+      <td>\prod</td>
+      <td>⋁</td>
+      <td>\bigvee</td>
+      <td>⨂</td>
+      <td>\bigotimes</td>
+    </tr>
+    <tr>
+      <td>∫</td>
+      <td>\int</td>
+      <td>∐</td>
+      <td>\coprod</td>
+      <td>⋀</td>
+      <td>\bigwedge</td>
+      <td>⨁</td>
+      <td>\bigoplus</td>
+    </tr>
+    <tr>
+      <td>∬</td>
+      <td>\iint</td>
+      <td>∫</td>
+      <td>\intop</td>
+      <td>⋂</td>
+      <td>\bigcap</td>
+      <td>⨀</td>
+      <td>\bigodot</td>
+    </tr>
+    <tr>
+      <td>∭</td>
+      <td>\iiint</td>
+      <td>∫</td>
+      <td>\smallint</td>
+      <td>⋃</td>
+      <td>\bigcup</td>
+      <td>⨄</td>
+      <td>\biguplus</td>
+    </tr>
+    <tr>
+      <td>∮</td>
+      <td>\oint</td>
+      <td></td>
+      <td></td>
+      <td>⨆</td>
+      <td>\bigsqcup</td>
+      <td></td>
+      <td></td>
+    </tr>
 
-    <table class="symbol big-operator">
-        <tr>
-            <td>∑</td>
-            <td>\sum</td>
-            <td>∏</td>
-            <td>\prod</td>
-            <td>⋁</td>
-            <td>\bigvee</td>
-            <td>⨂</td>
-            <td>\bigotimes</td>
-        </tr>
-        <tr>
-            <td>∫</td>
-            <td>\int</td>
-            <td>∐</td>
-            <td>\coprod</td>
-            <td>⋀</td>
-            <td>\bigwedge</td>
-            <td>⨁</td>
-            <td>\bigoplus</td>
-        </tr>
-        <tr>
-            <td>∬</td>
-            <td>\iint</td>
-            <td>∫</td>
-            <td>\intop</td>
-            <td>⋂</td>
-            <td>\bigcap</td>
-            <td>⨀</td>
-            <td>\bigodot</td>
-        </tr>
-        <tr>
-            <td>∭</td>
-            <td>\iiint</td>
-            <td>∫</td>
-            <td>\smallint</td>
-            <td>⋃</td>
-            <td>\bigcup</td>
-            <td>⨄</td>
-            <td>\biguplus</td>
-        </tr>
-        <tr>
-            <td>∮</td>
-            <td>\oint</td>
-            <td></td>
-            <td></td>
-            <td>⨆</td>
-            <td>\bigsqcup</td>
-            <td></td>
-            <td></td>
-        </tr>
-    </table>
+    <tr><td colspan="8"></td></tr>
+    <tr>
+      <td class="not-symbol" colspan="2">Direct Input:</td>
+      <td colspan="6" style="font-family: KaTeX_Size1;">
+        ∫ ∬ ∭ ∮ ∏ ∐ ∑ ⋀ ⋁ ⋂ ⋃ ⨀ ⨁ ⨂ ⨄ ⨆
+      </td>
+    </tr>
+  </table>
+
+
+  <h2 id="binary">Binary Operators</h2>
+  <!-- Scripts for: \centerdot, \pmod, \pod, and \smallsetminus -->
+  <table class="reference">
+    <tr>
+      <td>+</td>
+      <td>+</td>
+      <td>⋅</td>
+      <td>\cdot</td>
+      <td>⋗</td>
+      <td>\gtrdot</td>
+    </tr>
+    <tr>
+      <td>−</td>
+      <td>-</td>
+      <td>⋅</td>
+      <td>\cdotp</td>
+      <td>⊺</td>
+      <td>\intercal</td>
+    </tr>
+    <tr>
+      <td>/</td>
+      <td>/</td>
+      <td>\(\centerdot\)</td>
+      <td>\centerdot</td>
+      <td>∧</td>
+      <td>\land</td>
+    </tr>
+    <tr>
+      <td>∗</td>
+      <td>&ast;</td>
+      <td>∘</td>
+      <td>\circ</td>
+      <td>⋋</td>
+      <td>\leftthreetimes</td>
+    </tr>
+    <tr>
+      <td>⨿</td>
+      <td>\amalg</td>
+      <td>⊛</td>
+      <td>\circledast</td>
+      <td>.</td>
+      <td>\ldotp</td>
+    </tr>
+    <tr>
+      <td>&</td>
+      <td>\And</td>
+      <td>⊚</td>
+      <td>\circledcirc</td>
+      <td>∨</td>
+      <td>\lor</td>
+    </tr>
+    <tr>
+      <td>∗</td>
+      <td>\ast</td>
+      <td>⊝</td>
+      <td>\circleddash</td>
+      <td>⋖</td>
+      <td>\lessdot</td>
+    </tr>
+    <tr>
+      <td>⊼</td>
+      <td>\barwedge</td>
+      <td>⋓</td>
+      <td>\Cup</td>
+      <td>⊲</td>
+      <td>\lhd</td>
+    </tr>
+    <tr>
+      <td>◯</td>
+      <td>\bigcirc</td>
+      <td>∪</td>
+      <td>\cup</td>
+      <td>⋉</td>
+      <td>\ltimes</td>
+    </tr>
+    <tr>
+      <td>⊡</td>
+      <td>\boxdot</td>
+      <td>⋎</td>
+      <td>\curlyvee</td>
+      <td>⊳</td>
+      <td>\rhd</td>
+    </tr>
+    <tr>
+
+      <td>⋏</td>
+      <td>\curlywedge</td>
+      <td>∓</td>
+      <td>\mp</td>
+      <td>⊟</td>
+      <td>\boxminus</td>
+    </tr>
+    <tr>
+
+      <td>÷</td>
+      <td>\div</td>
+      <td>⊙</td>
+      <td>\odot</td>
+      <td>⊞</td>
+      <td>\boxplus</td>
+    </tr>
+    <tr>
+      <td>⋇</td>
+      <td>\divideontimes</td>
+      <td>⊖</td>
+      <td>\ominus</td>
+      <td>⊠</td>
+      <td>\boxtimes</td>
+    </tr>
+    <tr>
+      <td>∔</td>
+      <td>\dotplus</td>
+      <td>⊕</td>
+      <td>\oplus</td>
+      <td>∙</td>
+      <td>\bullet</td>
+    </tr>
+    <tr>
+      <td>⩞</td>
+      <td>\doublebarwedge</td>
+      <td>⊗</td>
+      <td>\otimes</td>
+      <td>⋒</td>
+      <td>\Cap</td>
+    </tr>
+    <tr>
+      <td>⋒</td>
+      <td>\doublecap</td>
+      <td>⊘</td>
+      <td>\oslash</td>
+      <td>∩</td>
+      <td>\cap</td>
+    </tr>
+    <tr>
+      <td>⋓</td>
+      <td>\doublecup</td>
+      <td>±</td>
+      <td>\pm</td>
+      <td>⋌</td>
+      <td>\rightthreetimes</td>
+    </tr>
+    <tr>
+      <td>⋊</td>
+      <td>\rtimes</td>
+      <td>∖</td>
+      <td>\setminus</td>
+      <td>\(\smallsetminus\)</td>
+      <td>\smallsetminus</td>
+    </tr>
+
+    <tr>
+      <td>⊓</td>
+      <td>\sqcap</td>
+      <td>⊔</td>
+      <td>\sqcup</td>
+      <td>×</td>
+      <td>\times</td>
+    </tr>
+
+    <tr>
+      <td>⊴</td>
+      <td>\unlhd</td>
+      <td>⊵</td>
+      <td>\unrhd</td>
+      <td>⊎</td>
+      <td>\uplus</td>
+    </tr>
+
+    <tr>
+      <td>∨</td>
+      <td>\vee</td>
+      <td>⊻</td>
+      <td>\veebar</td>
+      <td>∧</td>
+      <td>\wedge</td>
+    </tr>
+
+    <tr>
+      <td>≀</td>
+      <td>\wr</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+
+    <tr>
+      <td>\(x \pmod a\)</td>
+      <td>x \pmod a</td>
+      <td>\(x \pod a\)</td>
+      <td>x \pod a</td>
+      <td></td>
+      <td></td>
+    </tr> 
+    <tr>
+      <td>\(x\mod a\)</td>
+      <td>x\mod a</td>
+      <td>\(\bmod\)</td>
+      <td>\bmod</td>
+      <td></td>
+      <td></td>
+    </tr>
+
+    <tr><td colspan="8"></td></tr>
+    <tr>
+      <td class="not-symbol" colspan="1">Direct&nbsp;Input:</td>
+      <td colspan="7" style="font-family: KaTeX_Main, KaTeX_AMS;">
+        + - / * ⋅ ± × ÷ ∓ ∔ ∧ ∨ ∩ ∪ ≀ ⊎ ⊓ ⊔ ⊕ ⊖ ⊗ ⊘ ⊙ ⊚ ⊛ ⊝ ⊞ ⊟ ⊠ ⊡ ⊺ ⊻ ⊼ ⋇ ⋉ ⋊ ⋋ ⋌ ⋎ ⋏ ⋒ ⋓ ⩞
+      </td>
+    </tr>
+  </table>
+
+
+  <h2 id="binomial">Binomial Coefficients</h2>
+  <table class="reference">
+    <tr>
+      <td>\(\binom{n}{k}\)</td>
+      <td>\binom{n}{k}</td>
+      <td>\(\dbinom{n}{k}\)</td>
+      <td>\dbinom{n}{k}</td>
+      <td>\(\left\langle n \atop k \right\rangle\)</td>
+      <td>\left\langle<br>n \atop k<br>\right\rangle</td>
+    </tr>
+    <tr>
+      <td>\({n}\choose{k}\)</td>
+      <td>{n}\choose{k}</td>
+      <td>\(\tbinom{n}{k}\)</td>
+      <td>\tbinom{n}{k}</td>
+      <td></td>
+      <td></td>
+    </tr>
+  </table>
+
+
+  <h2 id="fractions">Fractions</h2>
   <table>
     <tr>
-      <td>Direct Input:</td>
-      <td style="font-family: KaTeX_Size1;">∫ ∬ ∭ ∮ ∏ ∐ ∑ ⋀ ⋁ ⋂ ⋃ ⨀ ⨁ ⨂ ⨄ ⨆</td>
+      <td>\(\frac{a}{b}\)</td>
+      <td>\frac{a}{b}</td>
+      <td>\(\dfrac{a}{b}\)</td>
+      <td>\dfrac{a}{b}</td>
+      <td>\({a}/{b}\)</td>
+      <td>{a}/{b}</td>
+    </tr>
+    <tr>
+      <td>\({a}\over{b}\)</td>
+      <td>{a}\over{b}</td>
+      <td>\(\tfrac{a}{b}\)</td>
+      <td>\tfrac{a}{b}</td>
+      <td></td>
+      <td></td>
     </tr>
   </table>
 
-<h2 id="binary">Binary Operators</h2>
 
-    <!-- Scripts for: \centerdot, \pmod, \pod, and \smallsetminus -->
-    <table class="symbol">
-        <tr>
-            <td>+</td>
-            <td>+</td>
-            <td>⋅</td>
-            <td>\cdot</td>
-            <td>⋗</td>
-            <td>\gtrdot</td>
-            <td>\(x \pmod a\)</td>
-            <td>x \pmod a</td>
+  <h2 id="math">Math Operators</h2>
+  <table class="reference">
+    <tr>
+      <td>arcsin</td>
+      <td>\arcsin</td>
+      <td>cotg</td>
+      <td>\cotg</td>
+      <td>ln</td>
+      <td>\ln</td>
+      <td>det</td>
+      <td>\det</td>
     </tr>
-        <tr>
-            <td>−</td>
-            <td>-</td>
-            <td>⋅</td>
-            <td>\cdotp</td>
-            <td>⊺</td>
-            <td>\intercal</td>
-            <td>\(x \pod a\)</td>
-            <td>x \pod a</td>
-        </tr>
-        <tr>
-            <td>/</td>
-            <td>/</td>
-            <td>\(\centerdot\)</td>
-            <td>\centerdot</td>
-            <td>∧</td>
-            <td>\land</td>
-            <td>⊳</td>
-            <td>\rhd</td>
-        </tr>
-        <tr>
-            <td>∗</td>
-            <td>&ast;</td>
-            <td>∘</td>
-            <td>\circ</td>
-            <td>⋋</td>
-            <td>\leftthreetimes</td>
-            <td>⋌</td>
-            <td>\rightthreetimes</td>
-        </tr>
-        <tr>
-            <td>⨿</td>
-            <td>\amalg</td>
-            <td>⊛</td>
-            <td>\circledast</td>
-            <td>.</td>
-            <td>\ldotp</td>
-            <td>⋊</td>
-            <td>\rtimes</td>
-        </tr>
-        <tr>
-            <td>&</td>
-            <td>\And</td>
-            <td>⊚</td>
-            <td>\circledcirc</td>
-            <td>∨</td>
-            <td>\lor</td>
-            <td>∖</td>
-            <td>\setminus</td>
-        </tr>
-        <tr>
-            <td>∗</td>
-            <td>\ast</td>
-            <td>⊝</td>
-            <td>\circleddash</td>
-            <td>⋖</td>
-            <td>\lessdot</td>
-            <td>\(\smallsetminus\)</td>
-            <td>\smallsetminus</td>
-        </tr>
-        <tr>
-            <td>⊼</td>
-            <td>\barwedge</td>
-            <td>⋓</td>
-            <td>\Cup</td>
-            <td>⊲</td>
-            <td>\lhd</td>
-            <td>⊓</td>
-            <td>\sqcap</td>
-        </tr>
-        <tr>
-            <td>◯</td>
-            <td>\bigcirc</td>
-            <td>∪</td>
-            <td>\cup</td>
-            <td>⋉</td>
-            <td>\ltimes</td>
-            <td>⊔</td>
-            <td>\sqcup</td>
-        </tr>
-        <tr>
-            <td>mod</td>
-            <td>\bmod</td>
-            <td>⋎</td>
-            <td>\curlyvee</td>
-            <td>mod</td>
-            <td>\mod</td>
-            <td>×</td>
-            <td>\times</td>
-        </tr>
-        <tr>
-            <td>⊡</td>
-            <td>\boxdot</td>
-            <td>⋏</td>
-            <td>\curlywedge</td>
-            <td>∓</td>
-            <td>\mp</td>
-            <td>⊴</td>
-            <td>\unlhd</td>
-        </tr>
-        <tr>
-            <td>⊟</td>
-            <td>\boxminus</td>
-            <td>÷</td>
-            <td>\div</td>
-            <td>⊙</td>
-            <td>\odot</td>
-            <td>⊵</td>
-            <td>\unrhd</td>
-        </tr>
-        <tr>
-            <td>⊞</td>
-            <td>\boxplus</td>
-            <td>⋇</td>
-            <td>\divideontimes</td>
-            <td>⊖</td>
-            <td>\ominus</td>
-            <td>⊎</td>
-            <td>\uplus</td>
-        </tr>
-        <tr>
-            <td>⊠</td>
-            <td>\boxtimes</td>
-            <td>∔</td>
-            <td>\dotplus</td>
-            <td>⊕</td>
-            <td>\oplus</td>
-            <td>∨</td>
-            <td>\vee</td>
-        </tr>
-        <tr>
-            <td>∙</td>
-            <td>\bullet</td>
-            <td>⩞</td>
-            <td>\doublebarwedge</td>
-            <td>⊗</td>
-            <td>\otimes</td>
-            <td>⊻</td>
-            <td>\veebar</td>
-        </tr>
-        <tr>
-            <td>⋒</td>
-            <td>\Cap</td>
-            <td>⋒</td>
-            <td>\doublecap</td>
-            <td>⊘</td>
-            <td>\oslash</td>
-            <td>∧</td>
-            <td>\wedge</td>
-        </tr>
-        <tr>
-            <td>∩</td>
-            <td>\cap</td>
-            <td>⋓</td>
-            <td>\doublecup</td>
-            <td>±</td>
-            <td>\pm</td>
-            <td>≀</td>
-            <td>\wr</td>
-        </tr>
-    </table>
+    <tr>
+      <td>arccos</td>
+      <td>\arccos</td>
+      <td>coth</td>
+      <td>\coth</td>
+      <td>log</td>
+      <td>\log</td>
+      <td>gcd</td>
+      <td>\gcd</td>
+    </tr>
+    <tr>
+      <td>arctan</td>
+      <td>\arctan</td>
+      <td>csc</td>
+      <td>\csc</td>
+      <td>sec</td>
+      <td>\sec</td>
+      <td>inf</td>
+      <td>\inf</td>
+    </tr>
+    <tr>
+      <td>arctg</td>
+      <td>\arctg</td>
+      <td>ctg</td>
+      <td>\ctg</td>
+      <td>sin</td>
+      <td>\sin</td>
+      <td>lim</td>
+      <td>\lim</td>
+    </tr>
+    <tr>
+      <td>arcctg</td>
+      <td>\arcctg</td>
+      <td>cth</td>
+      <td>\cth</td>
+      <td>sinh</td>
+      <td>\sinh</td>
+      <td>lim&#x2006;inf</td>
+      <td>\liminf</td>
+    </tr>
+    <tr>
+      <td>arg</td>
+      <td>\arg</td>
+      <td>deg</td>
+      <td>\deg</td>
+      <td>sh</td>
+      <td>\sh</td>
+      <td>lim&#x2006;sup</td>
+      <td>\limsup</td>
+    </tr>
+    <tr>
+      <td>ch</td>
+      <td>\ch</td>
+      <td>dim</td>
+      <td>\dim</td>
+      <td>tan</td>
+      <td>\tan</td>
+      <td>max</td>
+      <td>\max</td>
+    </tr>
+    <tr>
+      <td>cos</td>
+      <td>\cos</td>
+      <td>exp</td>
+      <td>\exp</td>
+      <td>tanh</td>
+      <td>\tanh</td>
+      <td>min</td>
+      <td>\min</td>
+    </tr>
+    <tr>
+      <td>cosec</td>
+      <td>\cosec</td>
+      <td>hom</td>
+      <td>\hom</td>
+      <td>tg</td>
+      <td>\tg</td>
+      <td>Pr</td>
+      <td>\Pr</td>
+    </tr>
+    <tr>
+      <td>cosh</td>
+      <td>\cosh</td>
+      <td>ker</td>
+      <td>\ker</td>
+      <td>th</td>
+      <td>\th</td>
+      <td>sup</td>
+      <td>\sup</td>
+    </tr>
+    <tr>
+      <td>cot</td>
+      <td>\cot</td>
+      <td>lg</td>
+      <td>\lg</td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>asin x</td>
+      <td colspan="7">\operatorname{asin} x</td>
+    </tr>
+  </table>
+
+  <p>Functions on the right side of this table can take <a href="#limits"><code>\limits</code></a>.<br>
+
+
+  <h2 id="sqrt">Sqrt</h2>
+  <table class="reference">
+    <tr>
+      <td>\(\sqrt{x}\)</td>
+      <td>&nbsp;\sqrt{x}</td>
+    </tr>
+    <tr>
+      <td>\(\sqrt[3]{x}\)</td>
+      <td>&nbsp;\sqrt[3]{x}</td>
+    </tr>
+  </table>
+
+
+  <h2  id="relations">Relations</h2>
+  <!-- This table has scripts in several cells. -->
   <table>
     <tr>
-      <td>Direct Input:</td>
-      <td style="font-family: KaTeX_Main, KaTeX_AMS;">+ - / * ⋅ ± × ÷ ∓ ∔ ∧ ∨ ∩ ∪ ≀ ⊎ ⊓ ⊔ ⊕ ⊖ ⊗ ⊘ ⊙ ⊚ ⊛ ⊝ ⊞ ⊟ ⊠ ⊡ ⊺ ⊻ ⊼ ⋇ ⋉ ⋊ ⋋ ⋌ ⋎ ⋏ ⋒ ⋓ ⩞</td>
-    </tr>
-  </table>
-  
-
-<h2 id="binomial">Binomial Coefficients</h2>
-
-    <table class="symbol">
-        <tr>
-            <td>\(\binom{n}{k}\)</td>
-            <td>\binom{n}{k}</td>
-            <td>\(\dbinom{n}{k}\)</td>
-            <td>\dbinom{n}{k}</td>
-            <td>\(\left\langle n \atop k \right\rangle\)</td>
-            <td>\left\langle<br>n \atop k<br>\right\rangle</td>
-        </tr>
-        <tr>
-            <td>\({n}\choose{k}\)</td>
-            <td>{n}\choose{k}</td>
-            <td>\(\tbinom{n}{k}\)</td>
-            <td>\tbinom{n}{k}</td>
-            <td></td>
-            <td></td>
-        </tr>
-    </table>
-
-<h2 id="fractions">Fractions</h2>
-
-    <table class="symbol">
-        <tr>
-            <td>\(\frac{a}{b}\)</td>
-            <td>\frac{a}{b}</td>
-            <td>\(\dfrac{a}{b}\)</td>
-            <td>\dfrac{a}{b}</td>
-            <td>\({a}/{b}\)</td>
-            <td>{a}/{b}</td>
-        </tr>
-        <tr>
-            <td>\({a}\over{b}\)</td>
-            <td>{a}\over{b}</td>
-            <td>\(\tfrac{a}{b}\)</td>
-            <td>\tfrac{a}{b}</td>
-            <td></td>
-            <td></td>
-        </tr>
-    </table>
-
-<h2 id="math">Math Operators</h2>
-
-    <table class="symbol">
-        <tr>
-            <td>\(\operatorname{asin} x\)</td>
-            <td>\operatorname{asin} x</td>
-        </tr>
-  </table>
-  <table id="math-tbl" class="symbol">
-    <tr>
-            <td>arcsin</td>
-            <td>\arcsin</td>
-            <td>cotg</td>
-            <td>\cotg</td>
-            <td>ln</td>
-            <td>\ln</td>
-            <td>det</td>
-            <td>\det</td>
-        </tr>
-        <tr>
-            <td>arccos</td>
-            <td>\arccos</td>
-            <td>coth</td>
-            <td>\coth</td>
-            <td>log</td>
-            <td>\log</td>
-            <td>gcd</td>
-            <td>\gcd</td>
-        </tr>
-        <tr>
-            <td>arctan</td>
-            <td>\arctan</td>
-            <td>csc</td>
-            <td>\csc</td>
-            <td>sec</td>
-            <td>\sec</td>
-            <td>inf</td>
-            <td>\inf</td>
-        </tr>
-        <tr>
-            <td>arctg</td>
-            <td>\arctg</td>
-            <td>ctg</td>
-            <td>\ctg</td>
-            <td>sin</td>
-            <td>\sin</td>
-            <td>lim</td>
-            <td>\lim</td>
-        </tr>
-        <tr>
-            <td>arcctg</td>
-            <td>\arcctg</td>
-            <td>cth</td>
-            <td>\cth</td>
-            <td>sinh</td>
-            <td>\sinh</td>
-            <td>lim&#x2006;inf</td>
-            <td>\liminf</td>
-        </tr>
-        <tr>
-            <td>arg</td>
-            <td>\arg</td>
-            <td>deg</td>
-            <td>\deg</td>
-            <td>sh</td>
-            <td>\sh</td>
-            <td>lim&#x2006;sup</td>
-            <td>\limsup</td>
-        </tr>
-        <tr>
-            <td>ch</td>
-            <td>\ch</td>
-            <td>dim</td>
-            <td>\dim</td>
-            <td>tan</td>
-            <td>\tan</td>
-            <td>max</td>
-            <td>\max</td>
-        </tr>
-        <tr>
-            <td>cos</td>
-            <td>\cos</td>
-            <td>exp</td>
-            <td>\exp</td>
-            <td>tanh</td>
-            <td>\tanh</td>
-            <td>min</td>
-            <td>\min</td>
-        </tr>
-        <tr>
-            <td>cosec</td>
-            <td>\cosec</td>
-            <td>hom</td>
-            <td>\hom</td>
-            <td>tg</td>
-            <td>\tg</td>
-            <td>Pr</td>
-            <td>\Pr</td>
-        </tr>
-        <tr>
-            <td>cosh</td>
-            <td>\cosh</td>
-            <td>ker</td>
-            <td>\ker</td>
-            <td>th</td>
-            <td>\th</td>
-            <td>sup</td>
-            <td>\sup</td>
-        </tr>
-        <tr>
-            <td>cot</td>
-            <td>\cot</td>
-            <td>lg</td>
-            <td>\lg</td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-        </tr>
-    </table>
-
-    <div>
-        <p>Functions on the right side of this table can take <a href="#limits"><code>\limits</code></a>.<br>
-    </div>
-
-<h2 id="sqrt">Sqrt</h2>
-
-    <table class="symbol">
-        <tr>
-            <td>\(\sqrt{x}\)</td>
-            <td>&nbsp;\sqrt{x}</td>
-        </tr>
-        <tr>
-            <td>\(\sqrt[3]{x}\)</td>
-            <td>&nbsp;\sqrt[3]{x}</td>
-        </tr>
-    </table>
-
-
-<h2  id="relations">Relations</h2>
-
-    <!-- This table has scripts in several cells. -->
-    <table class="symbol">
-    <tr>
-            <td>\(\stackrel{!}{=}\)</td>
-            <td colspan="9">\stackrel{!}{=}</td>
+      <td>\(\stackrel{!}{=}\)</td>
+      <td colspan="5">\stackrel{!}{=}</td>
     </tr>
     <tr>
       <td>=</td>
@@ -1327,10 +1377,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\curlyeqsucc</td>
       <td>⪆</td>
       <td>\gtrapprox</td>
-      <td>⊥</td>
-      <td>\perp</td>
-      <td>⪸</td>
-      <td>\succapprox</td>
     </tr>
     <tr>
       <td>&lt;</td>
@@ -1339,10 +1385,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\dashv</td>
       <td>⋛</td>
       <td>\gtreqless</td>
-      <td>⋔</td>
-      <td>\pitchfork</td>
-      <td>≽</td>
-      <td>\succcurlyeq</td>
     </tr>
     <tr>
       <td>&gt;</td>
@@ -1351,10 +1393,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\dblcolon</td>
       <td>⪌</td>
       <td>\gtreqqless</td>
-      <td>≺</td>
-      <td>\prec</td>
-      <td>⪰</td>
-      <td>\succeq</td>
     </tr>
     <tr>
       <td>:</td>
@@ -1363,10 +1401,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\doteq</td>
       <td>≷</td>
       <td>\gtrless</td>
-      <td>⪷</td>
-      <td>\precapprox</td>
-      <td>≿</td>
-      <td>\succsim</td>
     </tr>
     <tr>
       <td>≈</td>
@@ -1375,10 +1409,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\Doteq</td>
       <td>≳</td>
       <td>\gtrsim</td>
-      <td>≼</td>
-      <td>\preccurlyeq</td>
-      <td>⋑</td>
-      <td>\Supset</td>
     </tr>
     <tr>
       <td>≊</td>
@@ -1387,10 +1417,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\doteqdot</td>
       <td>∈</td>
       <td>\in</td>
-      <td>⪯</td>
-      <td>\preceq</td>
-      <td>⊃</td>
-      <td>\supset</td>
     </tr>
     <tr>
       <td>≍</td>
@@ -1399,10 +1425,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\eqcirc</td>
       <td>⋈</td>
       <td>\Join</td>
-      <td>≾</td>
-      <td>\precsim</td>
-      <td>⊇</td>
-      <td>\supseteq</td>
     </tr>
     <tr>
       <td>∍</td>
@@ -1411,10 +1433,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\eqcolon</td>
       <td>≤</td>
       <td>\le</td>
-      <td>∝</td>
-      <td>\propto</td>
-      <td>⫆</td>
-      <td>\supseteqq</td>
     </tr>
     <tr>
       <td>∽</td>
@@ -1423,10 +1441,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\Eqcolon</td>
       <td>≤</td>
       <td>\leq</td>
-      <td>≓</td>
-      <td>\risingdotseq</td>
-      <td>≈</td>
-      <td>\thickapprox</td>
     </tr>
     <tr>
       <td>⋍</td>
@@ -1435,10 +1449,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\eqqcolon</td>
       <td>≦</td>
       <td>\leqq</td>
-      <td>∣</td>
-      <td>\shortmid</td>
-      <td>∼</td>
-      <td>\thicksim</td>
     </tr>
     <tr>
       <td>≬</td>
@@ -1447,10 +1457,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\Eqqcolon</td>
       <td>⩽</td>
       <td>\leqslant</td>
-      <td>∥</td>
-      <td>\shortparallel</td>
-      <td>⊴</td>
-      <td>\trianglelefteq</td>
     </tr>
     <tr>
       <td>⋈</td>
@@ -1459,10 +1465,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\eqsim</td>
       <td>⪅</td>
       <td>\lessapprox</td>
-      <td>∼</td>
-      <td>\sim</td>
-      <td>≜</td>
-      <td>\triangleq</td>
     </tr>
     <tr>
       <td>≏</td>
@@ -1471,10 +1473,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\eqslantgtr</td>
       <td>⋚</td>
       <td>\lesseqgtr</td>
-      <td>≃</td>
-      <td>\simeq</td>
-      <td>⊵</td>
-      <td>\trianglerighteq</td>
     </tr>
     <tr>
       <td>≎</td>
@@ -1483,10 +1481,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\eqslantless</td>
       <td>⪋</td>
       <td>\lesseqqgtr</td>
-      <td>\(\smallfrown\)</td>
-      <td>\smallfrown</td>
-      <td>∝</td>
-      <td>\varpropto</td>
     </tr>
     <tr>
       <td>≗</td>
@@ -1495,10 +1489,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\equiv</td>
       <td>≶</td>
       <td>\lessgtr</td>
-      <td>\(\smallsmile\)</td>
-      <td>\smallsmile</td>
-      <td>△</td>
-      <td>\vartriangle</td>
     </tr>
     <tr>
       <td>\(\colonapprox\)</td>
@@ -1507,10 +1497,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\fallingdotseq</td>
       <td>≲</td>
       <td>\lesssim</td>
-      <td>⌣</td>
-      <td>\smile</td>
-      <td>⊲</td>
-      <td>\vartriangleleft</td>
     </tr>
     <tr>
       <td>\(\Colonapprox\)</td>
@@ -1519,10 +1505,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\frown</td>
       <td>≪</td>
       <td>\ll</td>
-      <td>⊏</td>
-      <td>\sqsubset</td>
-      <td>⊳</td>
-      <td>\vartriangleright</td>
     </tr>
     <tr>
       <td>\(\coloneq\)</td>
@@ -1531,10 +1513,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\ge</td>
       <td>⋘</td>
       <td>\lll</td>
-      <td>⊑</td>
-      <td>\sqsubseteq</td>
-      <td>\(\vcentcolon\)</td>
-      <td>\vcentcolon</td>
     </tr>
     <tr>
       <td>\(\Coloneq\)</td>
@@ -1543,10 +1521,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\geq</td>
       <td>⋘</td>
       <td>\llless</td>
-      <td>⊐</td>
-      <td>\sqsupset</td>
-      <td>⊢</td>
-      <td>\vdash</td>
     </tr>
     <tr>
       <td>\(\coloneqq\)</td>
@@ -1555,10 +1529,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\geqq</td>
       <td>&lt;</td>
       <td>\lt</td>
-      <td>⊒</td>
-      <td>\sqsupseteq</td>
-      <td>⊨</td>
-      <td>\vDash</td>
     </tr>
     <tr>
       <td>\(\Coloneqq\)</td>
@@ -1567,10 +1537,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\geqslant</td>
       <td>∣</td>
       <td>\mid</td>
-      <td>⋐</td>
-      <td>\Subset</td>
-      <td>⊩</td>
-      <td>\Vdash</td>
     </tr>
     <tr>
       <td>\(\colonsim\)</td>
@@ -1579,10 +1545,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\gg</td>
       <td>⊨</td>
       <td>\models</td>
-      <td>⊂</td>
-      <td>\subset</td>
-      <td>⊪</td>
-      <td>\Vvdash</td>
     </tr>
     <tr>
       <td>\(\Colonsim\)</td>
@@ -1591,10 +1553,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\ggg</td>
       <td>⊸</td>
       <td>\multimap</td>
-      <td>⊆</td>
-      <td>\subseteq</td>
-      <td>\(\)</td>
-      <td></td>
     </tr>
     <tr>
       <td>≅</td>
@@ -1603,10 +1561,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\gggtr</td>
       <td>∋</td>
       <td>\owns</td>
-      <td>⫅</td>
-      <td>\subseteqq</td>
-      <td>\(\)</td>
-      <td></td>
     </tr>
     <tr>
       <td>⋞</td>
@@ -1615,33 +1569,162 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\gt</td>
       <td>∥</td>
       <td>\parallel</td>
+    </tr>
+
+    <tr>
+      <td>⊥</td>
+      <td>\perp</td>
+      <td>⪸</td>
+      <td>\succapprox</td>
+      <td>⋔</td>
+      <td>\pitchfork</td>
+    </tr>
+
+    <tr>
+      <td>≽</td>
+      <td>\succcurlyeq</td>
+      <td>≺</td>
+      <td>\prec</td>
+      <td>⪰</td>
+      <td>\succeq</td>
+    </tr>
+
+    <tr>
+      <td>⪷</td>
+      <td>\precapprox</td>
+      <td>≿</td>
+      <td>\succsim</td>
+      <td>≼</td>
+      <td>\preccurlyeq</td>
+    </tr>
+
+    <tr>
+      <td>⋑</td>
+      <td>\Supset</td>
+      <td>⪯</td>
+      <td>\preceq</td>
+      <td>⊃</td>
+      <td>\supset</td>
+    </tr>
+
+    <tr>
+      <td>≾</td>
+      <td>\precsim</td>
+      <td>⊇</td>
+      <td>\supseteq</td>
+      <td>∝</td>
+      <td>\propto</td>
+    </tr>
+
+    <tr>
+      <td>⫆</td>
+      <td>\supseteqq</td>
+      <td>≓</td>
+      <td>\risingdotseq</td>
+      <td>≈</td>
+      <td>\thickapprox</td>
+    </tr>
+
+    <tr>
+      <td>∣</td>
+      <td>\shortmid</td>
+      <td>∼</td>
+      <td>\thicksim</td>
+      <td>∥</td>
+      <td>\shortparallel</td>
+    </tr>
+
+    <tr>
+      <td>⊴</td>
+      <td>\trianglelefteq</td>
+      <td>∼</td>
+      <td>\sim</td>
+      <td>≜</td>
+      <td>\triangleq</td>
+    </tr>
+
+    <tr>
+      <td>≃</td>
+      <td>\simeq</td>
+      <td>⊵</td>
+      <td>\trianglerighteq</td>
+      <td>\(\smallfrown\)</td>
+      <td>\smallfrown</td>
+    </tr>
+
+    <tr>
+      <td>∝</td>
+      <td>\varpropto</td>
+      <td>\(\smallsmile\)</td>
+      <td>\smallsmile</td>
+      <td>△</td>
+      <td>\vartriangle</td>
+    </tr>
+
+    <tr>
+      <td>⌣</td>
+      <td>\smile</td>
+      <td>⊲</td>
+      <td>\vartriangleleft</td>
+      <td>⊏</td>
+      <td>\sqsubset</td>
+    </tr>
+
+    <tr>
+      <td>⊳</td>
+      <td>\vartriangleright</td>
+      <td>⊑</td>
+      <td>\sqsubseteq</td>
+      <td>\(\vcentcolon\)</td>
+      <td>\vcentcolon</td>
+    </tr>
+
+    <tr>
+      <td>⊐</td>
+      <td>\sqsupset</td>
+      <td>⊢</td>
+      <td>\vdash</td>
+      <td>⊒</td>
+      <td>\sqsupseteq</td>
+    </tr>
+
+    <tr>
+      <td>⊨</td>
+      <td>\vDash</td>
+      <td>⋐</td>
+      <td>\Subset</td>
+      <td>⊩</td>
+      <td>\Vdash</td>
+    </tr>
+
+    <tr>
+      <td>⊂</td>
+      <td>\subset</td>
+      <td>⊪</td>
+      <td>\Vvdash</td>
+      <td>⊆</td>
+      <td>\subseteq</td>
+    </tr>
+
+    <tr>
+      <td>⫅</td>
+      <td>\subseteqq</td>
       <td>≻</td>
       <td>\succ</td>
-      <td>\(\)</td>
+      <td></td>
       <td></td>
     </tr>
-  </table>
-  <table>
+
+    <tr><td colspan="6"></td></tr>
     <tr>
-      <td>Direct Input:</td>
-      <td style="font-family: KaTeX_Main, KaTeX_AMS;">= &lt; &gt; : ∈ ∋ ∝ ∼ ∽ ≂ ≃ ≅ ≈ ≊ ≍ ≎ ≏ ≐ ≑ ≒ ≓ ≖ ≗ ≜ ≡ ≤ ≥ ≦ ≧ ≫ ≬ ≳ ≷ ≺ ≻ ≼ ≽ ≾ ≿ ⊂ ⊃ ⊆ ⊇ ⊏ ⊐ ⊑ ⊒ ⊢ ⊣ ⊩ ⊪ ⊸ ⋈ ⋍ ⋐ ⋑ ⋔ ⋙ ⋛ ⋞ ⋟ ⌢ ⌣ ⩾ ⪆ ⪌ ⪕ ⪖ ⪯ ⪰ ⪷ ⪸ ⫅ ⫆</td>
+      <td class="not-symbol" colspan="2">Direct Input:</td>
+      <td colspan="4" style="font-family: KaTeX_Main, KaTeX_AMS;">= &lt; &gt; : ∈ ∋ ∝ ∼ ∽ ≂ ≃ ≅ ≈ ≊ ≍ ≎ ≏ ≐ ≑ ≒ ≓ ≖ ≗ ≜ ≡ ≤ ≥ ≦ ≧ ≫ ≬ ≳ ≷ ≺ ≻ ≼ ≽ ≾ ≿ ⊂ ⊃ ⊆ ⊇ ⊏ ⊐ ⊑ ⊒ ⊢ ⊣ ⊩ ⊪ ⊸ ⋈ ⋍ ⋐ ⋑ ⋔ ⋙ ⋛ ⋞ ⋟ ⌢ ⌣ ⩾ ⪆ ⪌ ⪕ ⪖ ⪯ ⪰ ⪷ ⪸ ⫅ ⫆</td>
     </tr>
   </table>
 
-
-<h4 id="negated-relations">Negated Relations</h4>
+  <h4 id="negated-relations">Negated Relations</h4>
   <!-- This table contains one script, \notni-->
-    <table class="symbol">
-    <tr>
-            <td>\(\not =\)</td>
-            <td>\not =</td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td></td>
-        </tr>
+  <table class="reference">
     <tr>
       <td>⪊</td>
       <td>\gnapprox</td>
@@ -1649,8 +1732,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\ngeqslant</td>
       <td>⊈</td>
       <td>\nsubseteq</td>
-      <td>⪵</td>
-      <td>\precneqq</td>
     </tr>
     <tr>
       <td>⪈</td>
@@ -1659,8 +1740,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\ngtr</td>
       <td></td>
       <td>\nsubseteqq</td>
-      <td>⋨</td>
-      <td>\precnsim</td>
     </tr>
     <tr>
       <td>≩</td>
@@ -1669,8 +1748,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\nleq</td>
       <td>⊁</td>
       <td>\nsucc</td>
-      <td>⊊</td>
-      <td>\subsetneq</td>
     </tr>
     <tr>
       <td>⋧</td>
@@ -1679,8 +1756,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\nleqq</td>
       <td>⋡</td>
       <td>\nsucceq</td>
-      <td>⫋</td>
-      <td>\subsetneqq</td>
     </tr>
     <tr>
       <td></td>
@@ -1689,8 +1764,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\nleqslant</td>
       <td>⊉</td>
       <td>\nsupseteq</td>
-      <td>⪺</td>
-      <td>\succnapprox</td>
     </tr>
     <tr>
       <td>⪉</td>
@@ -1699,8 +1772,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\nless</td>
       <td></td>
       <td>\nsupseteqq</td>
-      <td>⪶</td>
-      <td>\succneqq</td>
     </tr>
     <tr>
       <td>⪇</td>
@@ -1709,8 +1780,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\nmid</td>
       <td>⋪</td>
       <td>\ntriangleleft</td>
-      <td>⋩</td>
-      <td>\succnsim</td>
     </tr>
     <tr>
       <td>≨</td>
@@ -1719,8 +1788,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\notin</td>
       <td>⋬</td>
       <td>\ntrianglelefteq</td>
-      <td>⊋</td>
-      <td>\supsetneq</td>
     </tr>
     <tr>
       <td>⋦</td>
@@ -1729,8 +1796,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\notni</td>
       <td>⋫</td>
       <td>\ntriangleright</td>
-      <td>⫌</td>
-      <td>\supsetneqq</td>
     </tr>
     <tr>
       <td></td>
@@ -1739,8 +1804,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\nparallel</td>
       <td>⋭</td>
       <td>\ntrianglerighteq</td>
-      <td></td>
-      <td>\varsubsetneq</td>
     </tr>
     <tr>
       <td>≆</td>
@@ -1749,8 +1812,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\nprec</td>
       <td>⊬</td>
       <td>\nvdash</td>
-      <td></td>
-      <td>\varsubsetneqq</td>
     </tr>
     <tr>
       <td>≠</td>
@@ -1759,8 +1820,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\npreceq</td>
       <td>⊭</td>
       <td>\nvDash</td>
-      <td></td>
-      <td>\varsupsetneq</td>
     </tr>
     <tr>
       <td>≠</td>
@@ -1769,8 +1828,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\nshortmid</td>
       <td>⊯</td>
       <td>\nVDash</td>
-      <td></td>
-      <td>\varsupsetneqq</td>
     </tr>
     <tr>
       <td>≱</td>
@@ -1779,8 +1836,6 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\nshortparallel</td>
       <td>⊮</td>
       <td>\nVdash</td>
-      <td></td>
-      <td></td>
     </tr>
     <tr>
       <td></td>
@@ -1789,315 +1844,393 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\nsim</td>
       <td>⪹</td>
       <td>\precnapprox</td>
+    </tr>
+    <tr>
+      <td>⪵</td>
+      <td>\precneqq</td>
+      <td>⋨</td>
+      <td>\precnsim</td>
+      <td>⊊</td>
+      <td>\subsetneq</td>
+    </tr>
+
+    <tr>
+      <td>⫋</td>
+      <td>\subsetneqq</td>
+      <td>⪺</td>
+      <td>\succnapprox</td>
+      <td>⪶</td>
+      <td>\succneqq</td>
+    </tr>
+
+    <tr>
+      <td>⋩</td>
+      <td>\succnsim</td>
+      <td>⊋</td>
+      <td>\supsetneq</td>
+      <td>⫌</td>
+      <td>\supsetneqq</td>
+    </tr>
+
+    <tr>
+      <td></td>
+      <td>\varsubsetneq</td>
+      <td></td>
+      <td>\varsubsetneqq</td>
+      <td></td>
+      <td>\varsupsetneq</td>
+    </tr>
+
+    <tr>
+      <td></td>
+      <td>\varsupsetneqq</td>
+      <td>\(\not =\)</td>
+      <td>\not =</td>
       <td></td>
       <td></td>
     </tr>
-  </table>
-  <table>
+
+    <tr><td colspan="6"></td></tr>
     <tr>
-      <td>Direct Input:</td>
-      <td style="font-family: KaTeX_Main, KaTeX_AMS;">∉ ∤ ∦ ≁ ≆ ≠ ≨ ≩ ≮ ≯ ≰ ≱ ⊀ ⊁ ⊈ ⊉ ⊊ ⊋ ⊬ ⊭ ⊮ ⊯ ⋠ ⋡ ⋦ ⋧ ⋨ ⋩ ⋬ ⋭ ⪇ ⪈ ⪉ ⪊ ⪵ ⪶ ⪹ ⪺ ⫋ ⫌</td>
+      <td class="not-symbol" colspan="2">Direct Input:</td>
+      <td colspan="4" style="font-family: KaTeX_Main, KaTeX_AMS;">∉ ∤ ∦ ≁ ≆ ≠ ≨ ≩ ≮ ≯ ≰ ≱ ⊀ ⊁ ⊈ ⊉ ⊊ ⊋ ⊬ ⊭ ⊮ ⊯ ⋠ ⋡ ⋦ ⋧ ⋨ ⋩ ⋬ ⋭ ⪇ ⪈ ⪉ ⪊ ⪵ ⪶ ⪹ ⪺ ⫋ ⫌</td>
     </tr>
   </table>
-  
-<h2 id="arrows">Arrows</h2>
 
-    <table class="symbol">
-        <tr>
-            <td>↺</td>
-            <td>\circlearrowleft</td>
-            <td>⇐</td>
-            <td>\Leftarrow</td>
-            <td>↬</td>
-            <td>\looparrowright</td>
-            <td>⇉</td>
-            <td>\rightrightarrows</td>
-        </tr>
-        <tr>
-            <td>↻</td>
-            <td>\circlearrowright</td>
-            <td>↢</td>
-            <td>\leftarrowtail</td>
-            <td>↰</td>
-            <td>\Lsh</td>
-            <td>⇝</td>
-            <td>\rightsquigarrow</td>
-        </tr>
-        <tr>
-            <td>↶</td>
-            <td>\curvearrowleft</td>
-            <td>↽</td>
-            <td>\leftharpoondown</td>
-            <td>↦</td>
-            <td>\mapsto</td>
-            <td>⇛</td>
-            <td>\Rrightarrow</td>
-        </tr>
-        <tr>
-            <td>↷</td>
-            <td>\curvearrowright</td>
-            <td>↼</td>
-            <td>\leftharpoonup</td>
-            <td>↗</td>
-            <td>\nearrow</td>
-            <td>↱</td>
-            <td>\Rsh</td>
-        </tr>
-        <tr>
-            <td>⇠</td>
-            <td>\dashleftarrow</td>
-            <td>⇇</td>
-            <td>\leftleftarrows</td>
-            <td>↚</td>
-            <td>\nleftarrow</td>
-            <td>↘</td>
-            <td>\searrow</td>
-        </tr>
-        <tr>
-            <td>⇢</td>
-            <td>\dashrightarrow</td>
-            <td>↔</td>
-            <td>\leftrightarrow</td>
-            <td>⇍</td>
-            <td>\nLeftarrow</td>
-            <td>↙</td>
-            <td>\swarrow</td>
-        </tr>
-        <tr>
-            <td>↓</td>
-            <td>\downarrow</td>
-            <td>⇔</td>
-            <td>\Leftrightarrow</td>
-            <td>↮</td>
-            <td>\nleftrightarrow</td>
-            <td>→</td>
-            <td>\to</td>
-        </tr>
-        <tr>
-            <td>⇓</td>
-            <td>\Downarrow</td>
-            <td>⇆</td>
-            <td>\leftrightarrows</td>
-            <td>⇎</td>
-            <td>\nLeftrightarrow</td>
-            <td>↞</td>
-            <td>\twoheadleftarrow</td>
-        </tr>
-        <tr>
-            <td>⇊</td>
-            <td>\downdownarrows</td>
-            <td>⇋</td>
-            <td>\leftrightharpoons</td>
-            <td>↛</td>
-            <td>\nrightarrow</td>
-            <td>↠</td>
-            <td>\twoheadrightarrow</td>
-        </tr>
-        <tr>
-            <td>⇃</td>
-            <td>\downharpoonleft</td>
-            <td>↭</td>
-            <td>\leftrightsquigarrow</td>
-            <td>⇏</td>
-            <td>\nRightarrow</td>
-            <td>↑</td>
-            <td>\uparrow</td>
-        </tr>
-        <tr>
-            <td>⇂</td>
-            <td>\downharpoonright</td>
-            <td>⇚</td>
-            <td>\Lleftarrow</td>
-            <td>↖</td>
-            <td>\nwarrow</td>
-            <td>⇑</td>
-            <td>\Uparrow</td>
-        </tr>
-        <tr>
-            <td>←</td>
-            <td>\gets</td>
-            <td>⟵</td>
-            <td>\longleftarrow</td>
-            <td>↾</td>
-            <td>\restriction</td>
-            <td>↕</td>
-            <td>\updownarrow</td>
-        </tr>
-        <tr>
-            <td>↩</td>
-            <td>\hookleftarrow</td>
-            <td>⟸</td>
-            <td>\Longleftarrow</td>
-            <td>→</td>
-            <td>\rightarrow</td>
-            <td>⇕</td>
-            <td>\Updownarrow</td>
-        </tr>
-        <tr>
-            <td>↪</td>
-            <td>\hookrightarrow</td>
-            <td>⟷</td>
-            <td>\longleftrightarrow</td>
-            <td>⇒</td>
-            <td>\Rightarrow</td>
-            <td>↿</td>
-            <td>\upharpoonleft</td>
-        </tr>
-        <tr>
-            <td>⟺</td>
-            <td>\iff</td>
-            <td>⟺</td>
-            <td>\Longleftrightarrow</td>
-            <td>↣</td>
-            <td>\rightarrowtail</td>
-            <td>↾</td>
-            <td>\upharpoonright</td>
-        </tr>
-        <tr>
-            <td>⟸</td>
-            <td>\impliedby</td>
-            <td>⟼</td>
-            <td>\longmapsto</td>
-            <td>⇁</td>
-            <td>\rightharpoondown</td>
-            <td>⇈</td>
-            <td>\upuparrows</td>
-        </tr>
-        <tr>
-            <td>⟹</td>
-            <td>\implies</td>
-            <td>⟶</td>
-            <td>\longrightarrow</td>
-            <td>⇀</td>
-            <td>\rightharpoonup</td>
-            <td></td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>⇝</td>
-            <td>\leadsto</td>
-            <td>⟹</td>
-            <td>\Longrightarrow</td>
-            <td>⇄</td>
-            <td>\rightleftarrows</td>
-            <td></td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>←</td>
-            <td>\leftarrow</td>
-            <td>↫</td>
-            <td>\looparrowleft</td>
-            <td>⇌</td>
-            <td>\rightleftharpoons</td>
-            <td></td>
-            <td></td>
-        </tr>
-    </table>
-  <table>
+
+  <h2 id="arrows">Arrows</h2>
+
+  <table class="reference">
     <tr>
-      <td>Direct Input:</td>
-      <td style="font-family: KaTeX_Main, KaTeX_AMS;">← ↑ → ↓ ↔ ↕ ↖ ↗ ↘ ↙ ↚ ↛ ↞ ↠ ↢ ↣ ↦ ↩ ↪ ↫ ↬ ↭ ↮ ↰ ↱ ↶ ↷ ↺ ↻ ↼ ↽ ↾ ↾ ↿ ⇀ ⇁ ⇂ ⇃ ⇄ ⇆ ⇇ ⇈ ⇉ ⇊ ⇋ ⇌ ⇍ ⇎ ⇏ ⇐ ⇑ ⇒ ⇓ ⇔ ⇕ ⇚ ⇛ ⇝ ⇠ ⇢ ⟵ ⟶ ⟷ ⟸ ⟹ ⟺ ⟼</td>
+      <td>↺</td>
+      <td>\circlearrowleft</td>
+      <td>⇐</td>
+      <td>\Leftarrow</td>
+    </tr>
+    <tr>
+      <td>↻</td>
+      <td>\circlearrowright</td>
+      <td>↢</td>
+      <td>\leftarrowtail</td>
+    </tr>
+    <tr>
+      <td>↶</td>
+      <td>\curvearrowleft</td>
+      <td>↽</td>
+      <td>\leftharpoondown</td>
+    </tr>
+    <tr>
+      <td>↷</td>
+      <td>\curvearrowright</td>
+      <td>↼</td>
+      <td>\leftharpoonup</td>
+    </tr>
+    <tr>
+      <td>⇠</td>
+      <td>\dashleftarrow</td>
+      <td>⇇</td>
+      <td>\leftleftarrows</td>
+    </tr>
+    <tr>
+      <td>⇢</td>
+      <td>\dashrightarrow</td>
+      <td>↔</td>
+      <td>\leftrightarrow</td>
+    </tr>
+    <tr>
+      <td>↓</td>
+      <td>\downarrow</td>
+      <td>⇔</td>
+      <td>\Leftrightarrow</td>
+    </tr>
+    <tr>
+      <td>⇓</td>
+      <td>\Downarrow</td>
+      <td>⇆</td>
+      <td>\leftrightarrows</td>
+    </tr>
+    <tr>
+      <td>⇊</td>
+      <td>\downdownarrows</td>
+      <td>⇋</td>
+      <td>\leftrightharpoons</td>
+    </tr>
+    <tr>
+      <td>⇃</td>
+      <td>\downharpoonleft</td>
+      <td>↭</td>
+      <td>\leftrightsquigarrow</td>
+    </tr>
+    <tr>
+      <td>⇂</td>
+      <td>\downharpoonright</td>
+      <td>⇚</td>
+      <td>\Lleftarrow</td>
+    </tr>
+    <tr>
+      <td>←</td>
+      <td>\gets</td>
+      <td>⟵</td>
+      <td>\longleftarrow</td>
+    </tr>
+    <tr>
+      <td>↩</td>
+      <td>\hookleftarrow</td>
+      <td>⟸</td>
+      <td>\Longleftarrow</td>
+    </tr>
+    <tr>
+      <td>↪</td>
+      <td>\hookrightarrow</td>
+      <td>⟷</td>
+      <td>\longleftrightarrow</td>
+    </tr>
+    <tr>
+      <td>⟺</td>
+      <td>\iff</td>
+      <td>⟺</td>
+      <td>\Longleftrightarrow</td>
+    </tr>
+    <tr>
+      <td>⟸</td>
+      <td>\impliedby</td>
+      <td>⟼</td>
+      <td>\longmapsto</td>
+    </tr>
+    <tr>
+      <td>⟹</td>
+      <td>\implies</td>
+      <td>⟶</td>
+      <td>\longrightarrow</td>
+    </tr>
+    <tr>
+      <td>⇝</td>
+      <td>\leadsto</td>
+      <td>⟹</td>
+      <td>\Longrightarrow</td>
+    </tr>
+    <tr>
+      <td>←</td>
+      <td>\leftarrow</td>
+      <td>↫</td>
+      <td>\looparrowleft</td>
+    </tr>
+    <tr>
+      <td>↬</td>
+      <td>\looparrowright</td>
+      <td>⇉</td>
+      <td>\rightrightarrows</td>
+    </tr>
+    <tr>
+      <td>↰</td>
+      <td>\Lsh</td>
+      <td>⇝</td>
+      <td>\rightsquigarrow</td>
+    </tr>
+    <tr>
+      <td>↦</td>
+      <td>\mapsto</td>
+      <td>⇛</td>
+      <td>\Rrightarrow</td>
+    </tr>
+    <tr>
+      <td>↗</td>
+      <td>\nearrow</td>
+      <td>↱</td>
+      <td>\Rsh</td>
+    </tr>
+    <tr>
+      <td>↚</td>
+      <td>\nleftarrow</td>
+      <td>↘</td>
+      <td>\searrow</td>
+    </tr>
+    <tr>
+      <td>⇍</td>
+      <td>\nLeftarrow</td>
+      <td>↙</td>
+      <td>\swarrow</td>
+    </tr>
+    <tr>
+      <td>↮</td>
+      <td>\nleftrightarrow</td>
+      <td>→</td>
+      <td>\to</td>
+    </tr>
+    <tr>
+      <td>⇎</td>
+      <td>\nLeftrightarrow</td>
+      <td>↞</td>
+      <td>\twoheadleftarrow</td>
+    </tr>
+    <tr>
+      <td>↛</td>
+      <td>\nrightarrow</td>
+      <td>↠</td>
+      <td>\twoheadrightarrow</td>
+    </tr>
+    <tr>
+      <td>⇏</td>
+      <td>\nRightarrow</td>
+      <td>↑</td>
+      <td>\uparrow</td>
+    </tr>
+    <tr>
+      <td>↖</td>
+      <td>\nwarrow</td>
+      <td>⇑</td>
+      <td>\Uparrow</td>
+    </tr>
+    <tr>
+      <td>↾</td>
+      <td>\restriction</td>
+      <td>↕</td>
+      <td>\updownarrow</td>
+    </tr>
+    <tr>
+      <td>→</td>
+      <td>\rightarrow</td>
+      <td>⇕</td>
+      <td>\Updownarrow</td>
+    </tr>
+    <tr>
+      <td>⇒</td>
+      <td>\Rightarrow</td>
+      <td>↿</td>
+      <td>\upharpoonleft</td>
+    </tr>
+    <tr>
+      <td>↣</td>
+      <td>\rightarrowtail</td>
+      <td>↾</td>
+      <td>\upharpoonright</td>
+    </tr>
+    <tr>
+      <td>⇁</td>
+      <td>\rightharpoondown</td>
+      <td>⇈</td>
+      <td>\upuparrows</td>
+    </tr>
+    <tr>
+      <td>⇀</td>
+      <td>\rightharpoonup</td>
+      <td>⇄</td>
+      <td>\rightleftarrows</td>
+    </tr>
+    <tr>
+      <td>⇌</td>
+      <td>\rightleftharpoons</td>
+      <td></td>
+      <td></td>
+    </tr>
+
+    <tr><td colspan="4"></td></tr>
+    <tr>
+      <td class="not-symbol" colspan="2">Direct Input:</td>
+      <td colspan="2" style="font-family: KaTeX_Main, KaTeX_AMS;">= &lt; &gt; : ∈ ∋ ∝ ∼ ∽ ≂ ≃ ≅ ≈ ≊ ≍ ≎ ≏ ≐ ≑ ≒ ≓ ≖ ≗ ≜ ≡ ≤ ≥ ≦ ≧ ≫ ≬ ≳ ≷ ≺ ≻ ≼ ≽ ≾ ≿ ⊂ ⊃ ⊆ ⊇ ⊏ ⊐ ⊑ ⊒ ⊢ ⊣ ⊩ ⊪ ⊸ ⋈ ⋍ ⋐ ⋑ ⋔ ⋙ ⋛ ⋞ ⋟ ⌢ ⌣ ⩾ ⪆ ⪌ ⪕ ⪖ ⪯ ⪰ ⪷ ⪸ ⫅ ⫆</td>
     </tr>
   </table>
-  
-<h4 id="extensible-arrows">Extensible Arrows</h4>
 
-  <table class="symbol">
+  <h4 id="extensible-arrows">Extensible Arrows</h4>
+  <table class="reference">
     <tr>
       <td>\(\xrightarrow{over}\)</td>
       <td>\xrightarrow{over}</td>
       <td>\(\xRightarrow{abc}\)</td>
       <td>\xRightarrow{abc}</td>
-      <td>\(\xrightharpoonup{abc}\)</td>
-      <td>\xrightharpoonup{abc}</td>
     </tr>
     <tr>
       <td>\(\xrightarrow[under]{over}\)</td>
       <td style="white-space: nowrap">\xrightarrow[under]{over}</td>
       <td>\(\xmapsto{abc}\)</td>
       <td>\xmapsto{abc}</td>
-      <td>\(\xrightharpoondown{abc}\)</td>
-      <td>\xrightharpoondown{abc}</td>
     </tr>
     <tr>
       <td>\(\xleftarrow{abc}\)</td>
       <td>\xleftarrow{abc}</td>
       <td>\(\xLeftarrow{abc}\)</td>
       <td>\xLeftarrow{abc}</td>
-      <td>\(\xleftharpoonup{abc}\)</td>
-      <td>\xleftharpoonup{abc}</td>
     </tr>
     <tr>
       <td>\(\xleftrightarrow{abc}\)</td>
       <td>\xleftrightarrow{abc}</td>
       <td>\(\xLeftrightarrow{abc}\)</td>
       <td>\xLeftrightarrow{abc}</td>
-      <td>\(\xleftharpoondown{abc}\)</td>
-      <td>\xleftharpoondown{abc}</td>
     </tr>
     <tr>
       <td>\(\xhookleftarrow{abc}\)</td>
       <td>\xhookleftarrow{abc}</td>
       <td>\(\xhookrightarrow{abc}\)</td>
       <td style="white-space: nowrap">\xhookrightarrow{abc}</td>
-      <td>\(\xrightleftharpoons{abc}\)</td>
-      <td style="white-space: nowrap">\xrightleftharpoons{abc}</td>
     </tr>
     <tr>
       <td>\(\xtwoheadrightarrow{abc}\)</td>
       <td>\xtwoheadrightarrow{abc}</td>
       <td>\(\xlongequal{abc}\)</td>
       <td>\xlongequal{abc}</td>
-      <td>\(\xleftrightharpoons{abc}\)</td>
-      <td>\xleftrightharpoons{abc}</td>
     </tr>
     <tr>
       <td>\(\xtwoheadleftarrow{abc}\)</td>
       <td>\xtwoheadleftarrow{abc}</td>
       <td>\(\xtofrom{abc}\)</td>
       <td>\xtofrom{abc}</td>
-      <td></td>
-      <td></td>
+    </tr>
+    <tr>
+      <td>\(\xrightharpoonup{abc}\)</td>
+      <td>\xrightharpoonup{abc}</td>
+      <td>\(\xrightharpoondown{abc}\)</td>
+      <td>\xrightharpoondown{abc}</td>
+    </tr>
+
+    <tr>
+      <td>\(\xleftharpoonup{abc}\)</td>
+      <td>\xleftharpoonup{abc}</td>
+      <td>\(\xleftharpoondown{abc}\)</td>
+      <td>\xleftharpoondown{abc}</td>
+    </tr>
+
+    <tr>
+      <td>\(\xrightleftharpoons{abc}\)</td>
+      <td style="white-space: nowrap">\xrightleftharpoons{abc}</td>
+      <td>\(\xleftrightharpoons{abc}\)</td>
+      <td>\xleftrightharpoons{abc}</td>
     </tr>
   </table>
 
   <p>Extensible arrows all can take an optional argument in the same manner as <code>\xrightarrow[under]{over}</code>.</p>
 
 
-<h2  id="class">Class Assignment</h2>
+  <h2  id="class">Class Assignment</h2>
+  <table class="symbol">
+    <tr>
+      <td>\mathbin</td>
+      <td>\mathclose</td>
+      <td>\mathinner</td>
+      <td>\mathop</td>
+    </tr>
+    <tr>
+      <td>\mathopen</td>
+      <td>\mathord</td>
+      <td>\mathpunct</td>
+      <td>\mathrel</td>
+    </tr>
+  </table>
 
-    <table class="all-code">
-        <tr>
-            <td>\mathbin</td>
-            <td>\mathclose</td>
-            <td>\mathinner</td>
-            <td>\mathop</td>
-        </tr>
-        <tr>
-            <td>\mathopen</td>
-            <td>\mathord</td>
-            <td>\mathpunct</td>
-            <td>\mathrel</td>
-        </tr>
-    </table>
 
-<h2 id="color">Color</h2>
-
-    <p>The color function behaves like a switch.</p>
-
-    <table class="symbol">
-      <tr>
+  <h2 id="color">Color</h2>
+  <p>The color function behaves like a switch.</p>
+  <table>
+    <tr>
       <td>\(\color{blue} F=ma\)</td>
       <td>\color{blue} F=ma</td>
-      </tr>
-      <tr>
+    </tr>
+    <tr>
       <td>\(\color{#fc625d} F=ma \)</td>
       <td>\color{#fc625d} F=ma</td>
     </tr>
-    </table>
+  </table>
 
-<!--   <p>As of KaTeX 0.8.1, the behavior of <code>\color</code> depends on the setting of <a href="https://github.com/Khan/KaTeX#rendering-options">rendering option</a> <code>colorIsTextColor</code>.</p>
+  <!--   <p>As of KaTeX 0.8.1, the behavior of <code>\color</code> depends on the setting of <a href="https://github.com/Khan/KaTeX#rendering-options">rendering option</a> <code>colorIsTextColor</code>.</p>
 
   <table class="grid">
     <tr>
@@ -2129,199 +2262,220 @@ https://github.com/Khan/KaTeX/issues/1245
       <td style="white-space: nowrap">\color{#228B22}{F=ma}</td>
     </tr>
   </table>
-  
-    <div> -->
-    <p>Other color functions always expect the content to be a function argument.</p>
 
-    <table class="symbol">
-      <tr>
-        <td>\(\textcolor{forestgreen}{F=ma}\)</td>
-        <td>\textcolor{forestgreen}{F=ma}</td>
-      </tr>
-      <tr>
-        <td>\(\textcolor{#fc625d}{F=ma}\)</td>
-        <td>\textcolor{#fc625d}{F=ma}</td>
-      </tr>
-      <tr>
-        <td>\(\colorbox{gold}{A}\)</td>
-        <td>\colorbox{gold}{A}</td>
-      </tr>
-      <tr>
-        <td>\(\fcolorbox{black}{gold}{A}\)</td>
-        <td>\fcolorbox{black}{gold}{A}</td>
-      </tr>
-    </table>
-  
-<p>For color definition, color functions will accept the standard HTML <a href="https://www.w3schools.com/colors/colors_names.asp">predefined color names</a>. They will also accept an RGB argument in CSS hexa­decimal style.</p>
+  <div> -->
 
-<h2 id="font">Font</h2>
+  <p>Other color functions always expect the content to be a function argument.</p>
 
-<table class="symbol tall">
-  <tr>
+  <table>
+    <tr>
+      <td>\(\textcolor{forestgreen}{F=ma}\)</td>
+      <td>\textcolor{forestgreen}{F=ma}</td>
+    </tr>
+    <tr>
+      <td>\(\textcolor{#fc625d}{F=ma}\)</td>
+      <td>\textcolor{#fc625d}{F=ma}</td>
+    </tr>
+    <tr>
+      <td>\(\colorbox{gold}{A}\)</td>
+      <td>\colorbox{gold}{A}</td>
+    </tr>
+    <tr>
+      <td>\(\fcolorbox{black}{gold}{A}\)</td>
+      <td>\fcolorbox{black}{gold}{A}</td>
+    </tr>
+  </table>
+
+  <p>For color definition, color functions will accept the standard HTML <a href="https://www.w3schools.com/colors/colors_names.asp">predefined color names</a>. They will also accept an RGB argument in CSS hexa­decimal style.</p>
+
+  <h2 id="font">Font</h2>
+
+  <table class="reference">
+    <tr>
       <td><span class="katex"><span class="mathrm">AB</span></span></td>
       <td>\mathrm{AB}</td>
-      <td><span class="katex"><span class="mathbf">AB</span></span></td>
-      <td>\mathbf{AB}</td>
       <td><span class="katex"><span class="mathit">AB</span></span></td>
       <td>\mathit{AB}</td>
-      <td><span class="katex"><span class="mathsf">AB</span></span></td>
-      <td>\mathsf{AB}</td>
-      <td><span class="katex"><span class="mathtt">AB</span></span></td>
-      <td>\mathtt{AB}</td>
-  </tr>
-  <tr>
+      <td><span class="katex"><span class="mathfrak">AB</span></span></td>
+      <td>\frak{AB}</td>
+    </tr>
+    <tr>
       <td><span class="katex"><span class="mathrm">AB</span></span></td>
       <td>\textrm{AB}</td>
-      <td><span class="katex"><span class="mathbf">AB</span></span></td>
-      <td>\textbf{AB}</td>
       <td><span class="katex"><span class="mathit">AB</span></span></td>
       <td>\textit{AB}</td>
-      <td><span class="katex"><span class="mathsf">AB</span></span></td>
-      <td>\textsf{AB}</td>
-      <td><span class="katex"><span class="mathtt">AB</span></span></td>
-      <td>\texttt{AB}</td>
-  </tr>
-  <tr>
+      <td><span class="katex"><span class="mathfrak">AB</span></span></td>
+      <td>\mathfrak{AB}</td>
+    </tr>
+    <tr>
       <td><span class="katex"><span class="mathrm">AB</span></span></td>
       <td>\rm{AB}</td>
-      <td><span class="katex"><span class="mathbf">AB</span></span></td>
-      <td>\bf{AB}</td>
       <td><span class="katex"><span class="mathit">AB</span></span></td>
       <td>\it{AB}</td>
-      <td><span class="katex"><span class="mathsf">AB</span></span></td>
-      <td>\sf{AB}</td>
-      <td><span class="katex"><span class="mathtt">AB</span></span></td>
-      <td>\tt{AB}</td>
-  </tr>
-  <tr>
+      <td><span class="katex"><span class="mathscr">AB</span></span></td>
+      <td>\mathscr{AB}</td>
+    </tr>
+    <tr>
       <td><span class="katex"><span class="mathrm">AB</span></span></td>
-      <td style="white-space: nowrap">\textnormal{AB}</td>
-      <td><span class="katex"><span class="mathbf">AB</span></span></td>
-      <td>\bold{AB}</td>
+      <td>\textnormal{AB}</td>
       <td><span class="katex"><span class="mathbb">AB</span></span></td>
       <td>\Bbb{AB}</td>
       <td><span class="katex"><span class="mathcal">AB</span></span></td>
-      <td style="white-space: nowrap">\mathcal{AB}</td>
-      <td><span class="katex"><span class="mathfrak">AB</span></span></td>
-      <td>\frak{AB}</td>
-  </tr>
-  <tr>
+      <td>\mathcal{AB}</td>
+    </tr>
+    <tr>
       <td><span class="katex"><span class="mathrm">AB</span></span></td>
       <td>\text{AB}</td>
-      <td><span class="katex"><span class="boldsymbol">AB</span></span></td>
-      <td style="white-space: nowrap">\boldsymbol{AB}</td>
       <td><span class="katex"><span class="mathbb">AB</span></span></td>
-      <td style="white-space: nowrap">\mathbb{AB}</td>
-<td><span class="katex"><span class="mathscr">AB</span></span></td>
-<td style="white-space: nowrap">\mathscr{AB}</td>
-      <td><span class="katex"><span class="mathfrak">AB</span></span></td>
-      <td style="white-space: nowrap">\mathfrak{AB}</td>
-  </tr>
-  <tr>
-    <td></td>
-    <td></td>
-    <td><span class="katex"><span class="boldsymbol">AB</span></span></td>
-    <td style="white-space: nowrap">\bm{AB}</td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
-  </tr>
-</table>
-  
+      <td>\mathbb{AB}</td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td><span class="katex"><span class="mathbf">AB</span></span></td>
+      <td>\mathbf{AB}</td>
+      <td><span class="katex"><span class="mathtt">AB</span></span></td>
+      <td>\mathtt{AB}</td>
+      <td></td>
+      <td></td>
+    </tr>
+
+    <tr>
+      <td><span class="katex"><span class="mathbf">AB</span></span></td>
+      <td>\textbf{AB}</td>
+      <td><span class="katex"><span class="mathtt">AB</span></span></td>
+      <td>\texttt{AB}</td>
+      <td></td>
+      <td></td>
+    </tr>
+
+    <tr>
+      <td><span class="katex"><span class="mathbf">AB</span></span></td>
+      <td>\bf{AB}</td>
+      <td><span class="katex"><span class="mathtt">AB</span></span></td>
+      <td>\tt{AB}</td>
+      <td></td>
+      <td></td>
+    </tr>
+
+    <tr>
+      <td><span class="katex"><span class="mathbf">AB</span></span></td>
+      <td>\bold{AB}</td>
+      <td><span class="katex"><span class="mathsf">AB</span></span></td>
+      <td>\textsf{AB}</td>  
+
+      <td></td>
+      <td></td>
+    </tr>
+
+    <tr>
+      <td><span class="katex"><span class="boldsymbol">AB</span></span></td>
+      <td>\boldsymbol{AB}</td>
+      <td><span class="katex"><span class="mathsf">AB</span></span></td>
+      <td>\sf{AB}</td>
+
+      <td></td>
+      <td></td>
+    </tr>
+
+    <tr>
+      <td><span class="katex"><span class="boldsymbol">AB</span></span></td>
+      <td>\bm{AB}</td>
+      <td><span class="katex"><span class="mathsf">AB</span></span></td>
+      <td>\mathsf{AB}</td>
+      <td></td>
+      <td></td>
+    </tr>
+  </table>
+
   <p>One can stack font family, font weight, and font shape by using the <code>\textXX</code> versions of the font functions. So <code>\textsf{\textbf{H}}</code> will produce \(\textsf{\textbf{H}}\).  The other versions so not stack, e.g., <code>\mathsf{\mathbf{H}}</code> will produce \(\mathsf{\mathbf{H}}\).</p>
 
-<h4 id="size">Size</h4>
+  <h4 id="size">Size</h4>
+  <table>
+    <tr>
+      <td>\(\Huge{AB}\)</td>
+      <td>\Huge{AB}</td>
+      <td>\(\normalsize{AB}\)</td>
+      <td>\normalsize{AB}</td>
+    </tr>
+    <tr>
+      <td>\(\huge{AB}\)</td>
+      <td>\huge{AB}</td>
+      <td>\(\small{AB}\)</td>
+      <td>\small{AB}</td>
+    </tr>
+    <tr>
+      <td>\(\LARGE{AB}\)</td>
+      <td>\LARGE{AB}</td>
+      <td>\(\footnotesize{AB}\)</td>
+      <td>\footnotesize{AB}</td>
+    </tr>
+    <tr>
+      <td>\(\Large{AB}\)</td>
+      <td>\Large{AB}</td>
+      <td>\(\scriptsize{AB}\)</td>
+      <td>\scriptsize{AB}</td>
+    </tr>
+    <tr>
+      <td>\(\large{AB}\)</td>
+      <td>\large{AB}</td>
+      <td>\(\tiny{AB}\)</td>
+      <td>\tiny{AB}</td>
+    </tr>
+  </table>
 
-    <table class="symbol">
-        <tr>
-            <td>\(\Huge AB\)</td>
-            <td>\Huge AB</td>
-            <td>\(\normalsize AB\)</td>
-            <td>\normalsize AB</td>
-        </tr>
-        <tr>
-            <td>\(\huge AB\)</td>
-            <td>\huge AB</td>
-            <td>\(\small AB\)</td>
-            <td>\small AB</td>
-        </tr>
-        <tr>
-            <td>\(\LARGE AB\)</td>
-            <td>\LARGE AB</td>
-            <td>\(\footnotesize AB\)</td>
-            <td>\footnotesize AB</td>
-        </tr>
-        <tr>
-            <td>\(\Large AB\)</td>
-            <td>\Large AB</td>
-            <td>\(\scriptsize AB\)</td>
-            <td>\scriptsize AB</td>
-        </tr>
-        <tr>
-            <td>\(\large AB\)</td>
-            <td>\large AB</td>
-            <td>\(\tiny AB\)</td>
-            <td>\tiny AB</td>
-        </tr>
-    </table>
+  <h4 id="style">Style</h4>
+  <table>
+    <tr>
+      <td>\(\displaystyle\sum_{i=1}^n\)</td>
+      <td><strong>\displaystyle</strong>\sum_{i=1}^n</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>\(\textstyle\sum_{i=1}^n\)</td>
+      <td><strong>\textstyle</strong>\sum_{i=1}^n</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>\(\scriptstyle x\)</td>
+      <td><strong>\scriptstyle</strong> x</td>
+      <td>The size of a first sub/superscript</td>
+    </tr>
+    <tr>
+      <td>\(\scriptscriptstyle x\)</td>
+      <td><strong>\scriptscriptstyle</strong> x</td>
+      <td>The size of subsequent sub/superscripts</td>
+    </tr>
+    <tr id="limits">
+      <td>\(\lim\limits_x\)</td>
+      <td>\lim<strong>\limits</strong>_x</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>\(\lim\nolimits_x\)</td>
+      <td>\lim<strong>\nolimits</strong>_x</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>\(\verb! x^2!\)</td>
+      <td><strong>\verb!</strong>x^2<strong>!</strong></td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>\(\text{x}\)</td>
+      <td><strong>\text</strong>{x}</td>
+      <td></td>
+    </tr>
+  </table>
 
-<h4 id="style">Style</h4>
 
-    <table id="style-tbl" class="symbol">
-        <tr>
-            <td>\(\displaystyle\sum_{i=1}^n\)</td>
-            <td style="white-space: nowrap"><strong>\displaystyle</strong>\sum_{i=1}^n</td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>\(\textstyle\sum_{i=1}^n\)</td>
-            <td><strong>\textstyle</strong>\sum_{i=1}^n</td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>\(\scriptstyle x\)</td>
-            <td><strong>\scriptstyle</strong> x</td>
-            <td>The size of a first sub/superscript</td>
-        </tr>
-        <tr>
-            <td>\(\scriptscriptstyle x\)</td>
-            <td><strong>\scriptscriptstyle</strong> x</td>
-            <td>The size of subsequent sub/superscripts</td>
-        </tr>
-        <tr id="limits">
-            <td>\(\lim\limits_x\)</td>
-            <td>\lim<strong>\limits</strong>_x</td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>\(\lim\nolimits_x\)</td>
-            <td>\lim<strong>\nolimits</strong>_x</td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>\(\verb! x^2 !\)</td>
-            <td><strong>\verb!</strong>x^2<strong>!</strong></td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>\(\text{x}\)</td>
-            <td><strong>\text</strong>{x}</td>
-            <td></td>
-        </tr>
-    </table>
-  
-  <div>    
-    <p><code>\text{…}</code> will accept nested <code>$…$</code> fragments and render them in math mode.</p>
-    
-    <p><code>\text{…}</code> will render an extended range of characters. See <a href="#letters-in-text">Letters inside \text</a>.</p>
-  </div>
+  <p><code>\text{…}</code> will accept nested <code>$…$</code> fragments and render them in math mode.
+    <br><br>
+    <code>\text{…}</code> will render an extended range of characters. See <a href="#letters-in-text">Letters inside \text</a>.</p>
 
-<h2  id="symbols">Symbols and Punctuation</h2>
 
-    <table class="symbol">
+  <h2 id="symbols">Symbols and Punctuation</h2>
+  <table class="reference">
     <tr>
       <td></td>
       <td>% comment</td>
@@ -2329,8 +2483,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\Box</td>
       <td>…</td>
       <td>\dots</td>
-      <td>✓</td>
-      <td>\checkmark</td>
+
     </tr>
     <tr>
       <td>%</td>
@@ -2339,8 +2492,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\square</td>
       <td>⋯</td>
       <td>\cdots</td>
-      <td>†</td>
-      <td>\dag</td>
+
     </tr>
     <tr>
       <td>#</td>
@@ -2349,8 +2501,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\blacksquare</td>
       <td>⋱</td>
       <td>\ddots</td>
-      <td>†</td>
-      <td>\dagger</td>
+
     </tr>
     <tr>
       <td>&amp;</td>
@@ -2359,8 +2510,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\triangle</td>
       <td>…</td>
       <td>\ldots</td>
-      <td>†</td>
-      <td>\textdagger</td>
+
     </tr>
     <tr>
       <td>_</td>
@@ -2369,8 +2519,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\triangledown</td>
       <td>⋮</td>
       <td>\vdots</td>
-      <td>‡</td>
-      <td>\ddag</td>
+
     </tr>
     <tr>
       <td>_</td>
@@ -2379,8 +2528,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\triangleleft</td>
       <td>…</td>
       <td>\mathellipsis</td>
-      <td>‡</td>
-      <td>\ddagger</td>
+
     </tr>
     <tr>
       <td>–</td>
@@ -2389,8 +2537,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\triangleright</td>
       <td>…</td>
       <td>\textellipsis</td>
-      <td>‡</td>
-      <td>\textdaggerdbl</td>
+
     </tr>
     <tr>
       <td>–</td>
@@ -2399,8 +2546,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\bigtriangledown</td>
       <td>♭</td>
       <td>\flat</td>
-      <td>$</td>
-      <td>\$</td>
+
     </tr>
     <tr>
       <td>—</td>
@@ -2409,8 +2555,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\bigtriangleup</td>
       <td>♮</td>
       <td>\natural</td>
-      <td>$</td>
-      <td>\textdollar</td>
+
     </tr>
     <tr>
       <td>—</td>
@@ -2419,8 +2564,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\blacktriangle</td>
       <td>♯</td>
       <td>\sharp</td>
-      <td>£</td>
-      <td>\pounds</td>
+
     </tr>
     <tr>
       <td>‘</td>
@@ -2429,8 +2573,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\blacktriangledown</td>
       <td>®</td>
       <td>\circledR</td>
-      <td>£</td>
-      <td>\textsterling</td>
+
     </tr>
     <tr>
       <td>‘</td>
@@ -2439,8 +2582,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\blacktriangleleft</td>
       <td>Ⓢ</td>
       <td>\circledS</td>
-      <td>¥</td>
-      <td>\yen</td>
+
     </tr>
     <tr>
       <td>’</td>
@@ -2449,8 +2591,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\blacktriangleright</td>
       <td>♣</td>
       <td>\clubsuit</td>
-      <td>√</td>
-      <td>\surd</td>
+
     </tr>
     <tr>
       <td>“</td>
@@ -2459,8 +2600,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\diamond</td>
       <td>♢</td>
       <td>\diamondsuit</td>
-      <td>°</td>
-      <td>\degree</td>
+
     </tr>
     <tr>
       <td>&quot;</td>
@@ -2469,8 +2609,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\Diamond</td>
       <td>♡</td>
       <td>\heartsuit</td>
-      <td>╲</td>
-      <td>\diagdown</td>
+
     </tr>
     <tr>
       <td>”</td>
@@ -2479,8 +2618,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\lozenge</td>
       <td>♠</td>
       <td>\spadesuit</td>
-      <td>╱</td>
-      <td>\diagup</td>
+
     </tr>
     <tr>
       <td>:</td>
@@ -2489,8 +2627,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\blacklozenge</td>
       <td>∠</td>
       <td>\angle</td>
-      <td>℧</td>
-      <td>\mho</td>
+
     </tr>
     <tr>
       <td>‵</td>
@@ -2499,8 +2636,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\star</td>
       <td>∡</td>
       <td>\measuredangle</td>
-      <td>✠</td>
-      <td>\maltese</td>
+
     </tr>
     <tr>
       <td>′</td>
@@ -2509,8 +2645,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\bigstar</td>
       <td>∢</td>
       <td>\sphericalangle</td>
-      <td>∇</td>
-      <td>\nabla</td>
+
     </tr>
     <tr>
       <td>&lt;</td>
@@ -2519,8 +2654,7 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\textbar</td>
       <td>⊤</td>
       <td>\top</td>
-      <td>∞</td>
-      <td>\infty</td>
+
     </tr>
     <tr>
       <td>&gt;</td>
@@ -2529,51 +2663,108 @@ https://github.com/Khan/KaTeX/issues/1245
       <td>\textbardbl</td>
       <td>⊥</td>
       <td>\bot</td>
-      <td></td>
-      <td></td>
+
     </tr>
     <tr>
       <td>{</td>
       <td>\textbraceleft</td>
       <td>}</td>
       <td>\textbraceright</td>
+      <td>✓</td>
+      <td>\checkmark</td>
+    </tr>
+
+    <tr>
+      <td>†</td>
+      <td>\dag</td>
+      <td>†</td>
+      <td>\dagger</td>
+      <td>†</td>
+      <td>\textdagger</td>
+    </tr>
+
+    <tr>
+      <td>‡</td>
+      <td>\ddag</td>
+      <td>‡</td>
+      <td>\ddagger</td>
+      <td>‡</td>
+      <td>\textdaggerdbl</td>
+    </tr>
+
+    <tr>
+      <td>$</td>
+      <td>\$</td>
+      <td>$</td>
+      <td>\textdollar</td>
+      <td>£</td>
+      <td>\pounds</td>
+    </tr>
+
+    <tr>
+      <td>£</td>
+      <td>\textsterling</td>
+      <td>¥</td>
+      <td>\yen</td>
+      <td>√</td>
+      <td>\surd</td>
+    </tr>
+
+    <tr>
+      <td>°</td>
+      <td>\degree</td>
+      <td>╲</td>
+      <td>\diagdown</td>
+      <td>╱</td>
+      <td>\diagup</td>
+    </tr>
+    <tr>
+      <td>℧</td>
+      <td>\mho</td>
+      <td>✠</td>
+      <td>\maltese</td>
+      <td>∇</td>
+      <td>\nabla</td>
+    </tr>
+    <tr>
+      <td>∞</td>
+      <td>\infty</td>
       <td></td>
       <td></td>
       <td></td>
       <td></td>
     </tr>
   </table>
-    <table class="symbol">
-        <tr>
-            <td>\(\KaTeX\)</td>
-            <td>\KaTeX</td>
-            <td>\(\LaTeX\)</td>
-            <td>\LaTeX</td>
-            <td>\(\TeX\)</td>
-            <td>\TeX</td>
-        </tr>
-    </table>
-
   <table>
     <tr>
+      <td>\(\KaTeX\)</td>
+      <td>\KaTeX</td>
+      <td>\(\LaTeX\)</td>
+      <td>\LaTeX</td> 
+      <td>\(\TeX\)</td>
+      <td>\TeX</td>
+    </tr>
+    <tr><td colspan="6"></td></tr>
+    <tr>
       <td>Direct Input:</td>
-      <td style="font-family: KaTeX_Main, KaTeX_AMS;">£ ¥ ∇ ∞ · ∠ ∡ ∢ ♠ ♡ ♢ ♣ ♭ ♮ ♯ ✓</td>
+      <td colspan="5" style="font-family: KaTeX_Main, KaTeX_AMS;">£ ¥ ∇ ∞ · ∠ ∡ ∢ ♠ ♡ ♢ ♣ ♭ ♮ ♯ ✓</td>
     </tr>
   </table>  
-    
-  
-  <h2  id="units">Units</h2>
 
-  <p>Units are proportioned as they are in TeX instead of CSS.</p>
 
+
+
+
+  <h2 id="units">Units</h2>
+  <p style="margin-bottom: 1.5em;">Units are proportioned as they are in TeX instead of CSS.</p>
   <table class="grid units">
     <thead>
-    <tr>
-      <th>Unit</th>
-      <th>Value</th>
-      <th>Unit</th>
-      <th>Value</th>
-    </tr>
+      <tr>
+        <th>Unit</th>
+        <th>Value</th>
+        <th>Unit</th>
+        <th>Value</th>
+      </tr>
     </thead>
     <tbody>
       <tr>
@@ -2631,55 +2822,64 @@ https://github.com/Khan/KaTeX/issues/1245
       <td><em>G</em> = 1.21 by default, because \(\TeX\) font-size is normally 1.21 × the surrounding font size. This value can be over-ridden by the CSS of an HTML page. For example, on this page, <em>G</em> = 1.0.</td>
     </tr>
   </table>
+
   
-  <br>
-  
-  <p>The effect of style and size:</p>
+
+  <h4>The effect of style and size</h4>
   <table>
     <thead>
-    <tr>
-      <th>Unit</th>
-      <th>textstyle</th>
-      <th>scriptscript</th>
-      <th>huge</th>
-    </tr>
+      <tr>
+        <th>Unit</th>
+        <th>textstyle</th>
+        <th>scriptscript</th>
+        <th>huge</th>
+      </tr>
     </thead>
     <tbody>
-    <tr>
-      <td>em or ex</td>
-      <td>\(\rule{1em}{1em}\)</td>
-      <td>\(\scriptscriptstyle\rule{1em}{1em}\)</td>
-      <td>\(\huge\rule{1em}{1em}\)</td>
-    </tr>
+      <tr>
+        <td>em or ex</td>
+        <td>\(\rule{1em}{1em}\)</td>
+        <td>\(\scriptscriptstyle\rule{1em}{1em}\)</td>
+        <td>\(\huge\rule{1em}{1em}\)</td>
+      </tr>
 
-    <tr>
-      <td>mu</td>
-      <td>\(\rule{18mu}{18mu}\)</td>
-      <td>\(\scriptscriptstyle\rule{18mu}{18mu}\)</td>
-      <td>\(\huge\rule{18mu}{18mu}\)</td>
-    </tr>
-    <tr>
-      <td>others</td>
-      <td>\(\rule{10pt}{10pt}\)</td>
-      <td>\(\scriptscriptstyle\rule{10pt}{10pt}\)</td>
-      <td>\(\huge\rule{10pt}{10pt}\)</td>
-    </tr>
+      <tr>
+        <td>mu</td>
+        <td>\(\rule{18mu}{18mu}\)</td>
+        <td>\(\scriptscriptstyle\rule{18mu}{18mu}\)</td>
+        <td>\(\huge\rule{18mu}{18mu}\)</td>
+      </tr>
+      <tr>
+        <td>others</td>
+        <td>\(\rule{10pt}{10pt}\)</td>
+        <td>\(\scriptscriptstyle\rule{10pt}{10pt}\)</td>
+        <td>\(\huge\rule{10pt}{10pt}\)</td>
+      </tr>
     </tbody>
   </table>
 
+  <p>See also the <a href="https://katex.org/docs/">official documentation of KaTeX</a>.</p>
 </div>
+
+
+
+<h2>Rendering process</h2>
+<p>
+  Blot uses KaTeX on the server side and does not require the visitor to enable JavaScript. 
+However, it means that you cannot modify the behavior of the renderer. Blot uses the default configuration which is good in most cases. If you need to customize KaTeX or, perhaps, use MathJax or another rendering library, then first disable the server-side rendering in the settings of your blog, then modify the template to add custom JavaScript. See <a href="/developers">developers section</a>.
+</p>
 
 <!-- 
 <script src="https://unpkg.com/katex@0.9.0-beta/dist/katex.min.js"></script>
 <script src="https://unpkg.com/katex@0.9.0-beta/dist/contrib/auto-render.min.js"></script>
- -->  
+-->  
 <!-- <script>
-    renderMathInElement(document.body);   
-    document.getElementById("mobile-nav").addEventListener('click', toggleMobileMenu, false);
+  renderMathInElement(document.body);   
+  document.getElementById("mobile-nav").addEventListener('click', toggleMobileMenu, false);
 
-    function toggleMobileMenu() {
-        var m = document.getElementById("mobile-menu");
-        m.className = (m.className == 'menu-on' ? 'menu-off' : 'menu-on' );
-        return true;
-    }
+  function toggleMobileMenu() {
+      var m = document.getElementById("mobile-menu");
+      m.className = (m.className == 'menu-on' ? 'menu-off' : 'menu-on' );
+      return true;
+  }
 </script>-->


### PR DESCRIPTION
This adds some info about KaTex rendering and fixes the layout and rendering issues of the TeX guide. 

Some examples before and after:

<img width="1523" alt="Screen Shot 2020-09-29 at 20 46 06" src="https://user-images.githubusercontent.com/2665931/94596797-4ff87e00-0295-11eb-979e-a5734bd44646.png">
<img width="1512" alt="Screen Shot 2020-09-29 at 20 46 31" src="https://user-images.githubusercontent.com/2665931/94596803-54249b80-0295-11eb-9f4c-b0446252f930.png">
<img width="1512" alt="Screen Shot 2020-09-29 at 20 46 46" src="https://user-images.githubusercontent.com/2665931/94596807-54bd3200-0295-11eb-99c1-4d7449262f08.png">
<img width="1522" alt="Screen Shot 2020-09-29 at 20 47 13" src="https://user-images.githubusercontent.com/2665931/94596810-54bd3200-0295-11eb-9b91-156ffd27cd76.png">
<img width="1518" alt="Screen Shot 2020-09-29 at 20 47 48" src="https://user-images.githubusercontent.com/2665931/94596812-5555c880-0295-11eb-8439-76c312c3596d.png">
<img width="1524" alt="Screen Shot 2020-09-29 at 20 48 06" src="https://user-images.githubusercontent.com/2665931/94596815-55ee5f00-0295-11eb-8da9-d4b491732212.png">

