### PR TITLE
Fixes bug when migrating a blog with a slash in its title

### DIFF
--- a/app/clients/dropbox/routes/createFolder.js
+++ b/app/clients/dropbox/routes/createFolder.js
@@ -1,14 +1,12 @@
 var createClient = require("../util/createClient");
+var titleToFolder = require('./titleToFolder');
 
 module.exports = function(req, res, next) {
   if (req.unsavedAccount.full_access === false && !req.otherBlogsUseAppFolder)
     return next();
 
   var client = createClient(req.unsavedAccount.access_token);
-  var folder = req.blog.title;
-
-  folder = folder.split("/").join("");
-  folder = folder.trim();
+  var folder = titleToFolder(req.blog.title);
 
   client
     .filesCreateFolder({ path: "/" + folder, autorename: true })

--- a/app/clients/dropbox/routes/createFolder.js
+++ b/app/clients/dropbox/routes/createFolder.js
@@ -1,16 +1,16 @@
 var createClient = require("../util/createClient");
-var titleToFolder = require('./titleToFolder');
+var titleToFolder = require("./titleToFolder");
 
-module.exports = function(req, res, next) {
+module.exports = function (req, res, next) {
   if (req.unsavedAccount.full_access === false && !req.otherBlogsUseAppFolder)
     return next();
 
   var client = createClient(req.unsavedAccount.access_token);
-  var folder = titleToFolder(req.blog.title);
+  var folder = "/" + titleToFolder(req.blog.title);
 
   client
-    .filesCreateFolder({ path: "/" + folder, autorename: true })
-    .then(function(res) {
+    .filesCreateFolder({ path: folder, autorename: true })
+    .then(function (res) {
       req.unsavedAccount.folder = res.path_display;
       req.unsavedAccount.folder_id = res.id;
 

--- a/app/clients/dropbox/routes/moveExistingFiles.js
+++ b/app/clients/dropbox/routes/moveExistingFiles.js
@@ -2,8 +2,9 @@ var sync = require("sync");
 var database = require("../database");
 var createClient = require("../util/createClient");
 var async = require("async");
+var titleToFolder = require("./titleToFolder");
 
-module.exports = function(req, res, next) {
+module.exports = function (req, res, next) {
   var otherBlog = req.otherBlogUsingEntireAppFolder;
   var client, determineFolder, move;
 
@@ -14,15 +15,15 @@ module.exports = function(req, res, next) {
 
   // Get a lock on the blog to ensure no other changes happen during migration
   // might want to add retries here...
-  sync(otherBlog.id, function(err, folder, done) {
+  sync(otherBlog.id, function (err, folder, done) {
     if (err) return next(err);
 
-    async.retry(determineFolder, function(err, entries, folder, folderID) {
+    async.retry(determineFolder, function (err, entries, folder, folderID) {
       if (err) return done(err, next);
 
       move = async.apply(Move, client, entries);
 
-      async.retry(move, function(err) {
+      async.retry(move, function (err) {
         if (err) return done(err, next);
 
         database.set(
@@ -30,9 +31,9 @@ module.exports = function(req, res, next) {
           {
             folder: folder,
             folder_id: folderID,
-            cursor: ""
+            cursor: "",
           },
-          function(err) {
+          function (err) {
             done(err, next);
           }
         );
@@ -42,7 +43,7 @@ module.exports = function(req, res, next) {
 };
 
 function DetermineFolder(title, client, callback) {
-  var folder = "/" + (title || "Untitled");
+  var folder = "/" + titleToFolder(title);
   var folderID;
   var entries;
 
@@ -50,23 +51,23 @@ function DetermineFolder(title, client, callback) {
     .filesListFolder({
       path: "",
       include_deleted: false,
-      recursive: false
+      recursive: false,
     })
-    .then(function(res) {
-      res.entries.forEach(function(entry) {
+    .then(function (res) {
+      res.entries.forEach(function (entry) {
         if (entry.path_lower === folder.toLowerCase()) folder += " (1)";
       });
 
-      entries = res.entries.map(function(entry) {
+      entries = res.entries.map(function (entry) {
         return {
           from_path: entry.path_display,
-          to_path: folder + entry.path_display
+          to_path: folder + entry.path_display,
         };
       });
 
       return client.filesCreateFolder({ path: folder, autorename: false });
     })
-    .then(function(res) {
+    .then(function (res) {
       folder = res.path_display;
       folderID = res.id;
       callback(null, entries, folder, folderID);
@@ -80,12 +81,12 @@ function Move(client, entries, callback) {
   client
     .filesMoveBatch({
       entries: entries,
-      autorename: false
+      autorename: false,
     })
     .then(function checkBatchStatus(result) {
       if (result.empty) return Promise.resolve(result);
 
-      return client.filesMoveBatchCheck(result).then(function(res) {
+      return client.filesMoveBatchCheck(result).then(function (res) {
         switch (res[".tag"]) {
           case "in_progress":
             return checkBatchStatus(result);
@@ -100,7 +101,7 @@ function Move(client, entries, callback) {
         }
       });
     })
-    .then(function() {
+    .then(function () {
       callback(null);
     })
     .catch(callback);

--- a/app/clients/dropbox/routes/titleToFolder.js
+++ b/app/clients/dropbox/routes/titleToFolder.js
@@ -1,0 +1,8 @@
+module.exports = function titleToFolder (title) {
+	let folder = title || "Untitled";
+	
+	folder = folder.split("/").join("");
+	folder = folder.trim();
+
+	return folder;
+};


### PR DESCRIPTION
Let's say you:
- have a Blot account with one blog called `FOO/BAR` connected to Dropbox with 'App folder' permissions. Your blog's folder is located in `Dropbox/Apps/Blot`
- want to create a second blog titled `BAZ` that's connected to the same Dropbox account, with 'App folder' permissions

Previously, when you attempted to connect `BAZ` to Dropbox, Blot would attempt to:
- create a new folder with name `FOO/BAR` in `Dropbox/Apps/Blot`
- move the contents of `Dropbox/Apps/Blot` into `Dropbox/Apps/Blot/FOO/BAR`
- create a new folder `Dropbox/Apps/Blot/BAZ` for the new blog

The call to create a new folder with name `FOO/BAR` would trigger an error, since folders cannot contain slashes. 

This fix strips slashes from the name of this new folder before the migration, preventing this error
