### PR TITLE
Fixes template editor indentation bug

### DIFF
--- a/app/dashboard/views/template-editor/source-code/edit.html
+++ b/app/dashboard/views/template-editor/source-code/edit.html
@@ -46,6 +46,7 @@
     var editor = CodeMirror.fromTextArea(document.getElementById("source"), {
       mode: { name: "handlebars", base: $("#source").attr("data-mode") },
       lineNumbers: true,
+      smartIndent: false,
       styleActiveLine: true,
       theme: "default",
     });


### PR DESCRIPTION
Toggles the `smartIndent` setting for [CodeMirror](https://codemirror.net/doc/manual.html) which was causing annoyingly incorrect indentation on the web template editor. The 'dumb' indentation just copies the indent from the line before, and works much better in my experience.