### PR TITLE
Fixes titles of developers pages

### DIFF
--- a/app/brochure/routes/developers.js
+++ b/app/brochure/routes/developers.js
@@ -1,10 +1,23 @@
 var Express = require("express");
 var developers = new Express.Router();
+var titleFromSlug = require('../../../app/helper/titleFromSlug');
+
+var TITLES = {
+  "json-feed": "JSON feed",
+  "posts-tagged": "Posts by tag",
+};
+
 
 developers.use(function(req, res, next) {
   res.locals.base = "/developers";
   res.locals.layout = "developers/layout";
   res.locals.selected = {};
+  
+  var url = req.originalUrl;
+  let slug = url.split("/").pop();
+  let title = TITLES[slug] || titleFromSlug(slug);
+  res.locals.title = title;
+
   next();
 });
 

--- a/app/brochure/routes/index.js
+++ b/app/brochure/routes/index.js
@@ -3,6 +3,7 @@ var brochure = new Express.Router();
 var finder = require("finder");
 var tex = require("./tools/tex");
 var config = require("config");
+var capitalize = require('../../../app/helper/capitalize');
 
 var TITLES = {
   how: "How to use Blot",
@@ -113,10 +114,6 @@ brochure.use(function(err, req, res, next) {
 
   next(err);
 });
-
-function capitalize(str) {
-  return str[0].toUpperCase() + str.slice(1);
-}
 
 function trimLeadingAndTrailingSlash(str) {
   if (!str) return str;

--- a/app/dashboard/routes/importer/helper/insert_metadata.js
+++ b/app/dashboard/routes/importer/helper/insert_metadata.js
@@ -1,4 +1,5 @@
 var moment = require("moment");
+var helper = require("helper");
 
 module.exports = function insert_metadata(post, callback) {
   var lines = [];
@@ -17,7 +18,7 @@ module.exports = function insert_metadata(post, callback) {
 
   if (post.metadata)
     for (var key in post.metadata)
-      lines.push(capitalize(key) + ": " + post.metadata[key]);
+      lines.push(helper.capitalize(key) + ": " + post.metadata[key]);
 
   if (post.title) {
     lines.push(""); // leave a blank line between metadata and title
@@ -28,7 +29,3 @@ module.exports = function insert_metadata(post, callback) {
 
   callback(null, post);
 };
-
-function capitalize(str) {
-  return str[0].toUpperCase() + str.slice(1);
-}

--- a/app/dashboard/routes/settings/load/plugins.js
+++ b/app/dashboard/routes/settings/load/plugins.js
@@ -2,7 +2,7 @@ var Mustache = require("mustache");
 var _ = require("lodash");
 var pluginList = require("../../../../build/plugins").list;
 var helper = require("helper");
-var capitalise = helper.capitalise;
+var capitalize = helper.capitalize;
 var deCamelize = helper.deCamelize;
 
 module.exports = function(req, res, next) {
@@ -40,7 +40,7 @@ module.exports = function(req, res, next) {
   };
 
   plugins = helper.arrayify(plugins, function(plugin) {
-    var name = capitalise(deCamelize(plugin.category || "general"));
+    var name = capitalize(deCamelize(plugin.category || "general"));
     var slug = name
       .split(" ")
       .join("-")

--- a/app/helper/capitalise.js
+++ b/app/helper/capitalise.js
@@ -1,4 +1,0 @@
-module.exports = function capitalise(string) {
-  string = string || "";
-  return string.charAt(0).toUpperCase() + string.slice(1);
-};

--- a/app/helper/capitalize.js
+++ b/app/helper/capitalize.js
@@ -1,0 +1,3 @@
+module.exports = function(str) {
+  return str[0].toUpperCase() + str.slice(1);
+}

--- a/app/helper/titleFromSlug.js
+++ b/app/helper/titleFromSlug.js
@@ -1,0 +1,5 @@
+var capitalize = require("./capitalize")
+
+module.exports = function(str) {
+  return capitalize(str.split('-').join(" "))
+}

--- a/app/templates/index.js
+++ b/app/templates/index.js
@@ -73,7 +73,7 @@ function build(directory, callback) {
   }
 
   id = TEMPLATES_OWNER + ":" + basename(directory);
-  name = templatePackage.name || helper.capitalise(basename(directory));
+  name = templatePackage.name || helper.capitalize(basename(directory));
   description = templatePackage.description || "";
   isPublic = templatePackage.isPublic !== false;
 


### PR DESCRIPTION
This PR changes the generation of `<TITLE>` values of developers pages. Before the change, titles were simply capitalized slugs (e.g. here https://blot.im/developers/how-blot-works). After the change, titles are either set via `TITLES` constant map (similar to other brochure pages), or, if no value is present in the map, generated from the slug by removing the dashes and capitalizing the result. 