### PR TITLE
Trim template subdomain length

### DIFF
--- a/app/dashboard/views/template/index.html
+++ b/app/dashboard/views/template/index.html
@@ -140,9 +140,9 @@ flex-basis: 50%;">{{name}}</span>
     <button {{#checked}} disabled{{/checked}} type="submit"><span class="square">Install{{#checked}}ed{{/checked}}</span></button>
   </form>
 
-  <form method='post'  style="display:inline" action="/settings/template/new">
+  <form method='post' style="display:inline" action="/settings/template/new">
     <input type="hidden" name="redirect" value="/settings/template">
-    <input type="hidden" name="name" value="Copy of {{name}}" />
+    <input type="hidden" name="name" value="{{^isMine}}Copy of {{/isMine}}{{name}}" />
     <input type="hidden" name="cloneFrom" value="{{id}}" />
     <button type="submit"><span class="square">Fork</span></button>
   </form>

--- a/app/models/template/create.js
+++ b/app/models/template/create.js
@@ -15,7 +15,6 @@ module.exports = function create(owner, name, metadata, callback) {
   // or the string 'SITE' which represents
   // a BLOT template not editable by any blog
   // ensure a blogID is always a number, never 'SITE'
-
   ensure(owner, "string")
     .and(metadata, "object")
     .and(name, "string")
@@ -26,16 +25,15 @@ module.exports = function create(owner, name, metadata, callback) {
 
   // The slug cannot contain a slash, or it messes
   // up the routing middleware.
-  var slug = helper.makeSlug(name.split("/").join("-"));
+  metadata.slug = metadata.slug || helper.makeSlug(name).slice(0, 30);
+  metadata.slug = metadata.slug.split("/").join("-");
 
   // Each template has an ID which is namespaced under its owner
-  var id = makeID(owner, slug);
+  metadata.id = makeID(owner, metadata.slug);
 
   // Defaults
-  metadata.id = id;
   metadata.name = name;
   metadata.owner = owner;
-  metadata.slug = slug;
   metadata.locals = metadata.locals || {};
   metadata.description = metadata.description || "";
   metadata.thumb = metadata.thumb || "";
@@ -43,7 +41,9 @@ module.exports = function create(owner, name, metadata, callback) {
 
   ensure(metadata, metadataModel);
 
-  client.exists(key.metadata(id), function(err, stat) {
+  let id = metadata.id;
+
+  client.exists(key.metadata(id), function (err, stat) {
     if (err) throw err;
 
     // Don't overwrite an existing template
@@ -53,7 +53,7 @@ module.exports = function create(owner, name, metadata, callback) {
       return callback(err);
     }
 
-    client.sadd(key.blogTemplates(owner), id, function(err) {
+    client.sadd(key.blogTemplates(owner), id, function (err) {
       if (err) throw err;
 
       if (metadata.isPublic) {
@@ -65,7 +65,7 @@ module.exports = function create(owner, name, metadata, callback) {
       function then(err) {
         if (err) throw err;
 
-        setMetadata(id, metadata, function(err) {
+        setMetadata(id, metadata, function (err) {
           if (err) throw err;
 
           if (metadata.cloneFrom) {


### PR DESCRIPTION
Previously long template names would cause a bug, browsers refused to render sufficiently long preview subdomains. This change will clip the length of preview subdomains.