### PR TITLE
Fixes bug with images whose name contains quotes

### DIFF
--- a/app/build/converters/img/index.js
+++ b/app/build/converters/img/index.js
@@ -28,7 +28,7 @@ function read(blog, path, options, callback) {
 
     var contents =
       '<img src="' +
-      path +
+      encodeURI(path) +
       '" title="' +
       title +
       '" alt="' +

--- a/app/build/tests/index.js
+++ b/app/build/tests/index.js
@@ -58,10 +58,32 @@ describe("build", function() {
     });
   });
 
+  it("generates a blog post from an image with quotes in its filename", function(done) {
+    var pathToImage = '/Hello "john" World.jpg';
+
+    fs.copySync(__dirname + "/small.jpg", this.blogDirectory + pathToImage);
+
+    build(this.blog, pathToImage, {}, function(err, entry) {
+      if (err) return done.fail(err);
+
+      // verify the image was cached
+      expect(entry.html).toContain("/_image_cache/");
+
+      // verify a thumbnail was generated from the image
+      expect(entry.thumbnail.small).toEqual(
+        jasmine.objectContaining({
+          name: "small.jpg"
+        })
+      );
+
+      done();
+    });
+  });
+
   it("handles images with accents and spaces in their filename", function(done) {
     var path = "/blog/Hello world.txt";
-    var contents = "![Best Image Ever](óå g's\"s.jpg)";
-    var pathToImage = "/blog/óå g's\"s.jpg";
+    var contents = "![Best Image Ever](óå g.jpg)";
+    var pathToImage = "/blog/óå g.jpg";
 
     fs.outputFileSync(this.blogDirectory + path, contents);
     fs.copySync(__dirname + "/small.jpg", this.blogDirectory + pathToImage);

--- a/app/build/tests/index.js
+++ b/app/build/tests/index.js
@@ -59,7 +59,7 @@ describe("build", function() {
   });
 
   it("generates a blog post from an image with quotes in its filename", function(done) {
-    var pathToImage = '/Hello "john" World.jpg';
+    var pathToImage = '/Hell"o\'W "orld.jpg';
 
     fs.copySync(__dirname + "/small.jpg", this.blogDirectory + pathToImage);
 

--- a/app/build/tests/index.js
+++ b/app/build/tests/index.js
@@ -60,8 +60,8 @@ describe("build", function() {
 
   it("handles images with accents and spaces in their filename", function(done) {
     var path = "/blog/Hello world.txt";
-    var contents = "![Best Image Ever](óå g.jpg)";
-    var pathToImage = "/blog/óå g.jpg";
+    var contents = "![Best Image Ever](óå g's\"s.jpg)";
+    var pathToImage = "/blog/óå g's\"s.jpg";
 
     fs.outputFileSync(this.blogDirectory + path, contents);
     fs.copySync(__dirname + "/small.jpg", this.blogDirectory + pathToImage);

--- a/todo.txt
+++ b/todo.txt
@@ -47,8 +47,6 @@ Disable access to s3 blogs bucket
 
 Fix bug with particular emoji and tell [John](https://mail.google.com/mail/u/0/#inbox/FMfcgxwHNqBKcPSQQHZtCFpKHrPDFkDq)
 
-Fix bug with encoded apostrophe's in file names for thumbnail generator: /image_library/_didn&#39;tmakethecut.jpg doesn't work.
-
 Add custom metadata to turn off/on comments on specific post or page and tell [Hani](https://mail.google.com/mail/u/0/#inbox/FMfcgxwHNqCSdngxBKHqctWBTgmFBbkB)
 
 Fix case-sensitivity issue for relative (and absolute?) paths to files in folder in production and tell [Marco](https://mail.google.com/mail/u/0/#inbox/FMfcgxwHNWHHtTmhpstcFdMfRRpzbnNw)


### PR DESCRIPTION
Handles images with quotes in their name. Previously, an entry derived from an image called _john's_son.jpg_ would fail. This also means thumbnails are now generated properly for such images.