### PR TITLE
Adds function to format images in template

### DIFF
--- a/app/blog/render/retrieve/imageFormat.js
+++ b/app/blog/render/retrieve/imageFormat.js
@@ -1,0 +1,58 @@
+/* 
+
+This function will adjust the rendered HTML for each image 
+tag inside a blog post's HTML and BODY and TEASER
+
+Use it like this:
+
+{{#entry}}
+	
+	{{! The template used to render any images in the post}}
+	{{#imageFormat}}
+	<img src="{{{url}}}" width="{{width}}">
+	{{/imageFormat}}
+	
+	{{! Where the result appears}}
+	{{{html}}}
+
+{{/entry}}
+
+*/
+
+var cheerio = require("cheerio");
+var debug = require("debug")("blot:render:imageFormat");
+
+function absoluteURLs(base, $) {
+  try {
+    $("img").each(function() {
+      var src = $(this).attr("src");
+      var result = 
+     $(this).replaceWith(result)
+    });
+  } catch (e) {
+    debug(e);
+  }
+
+  return $;
+}
+
+module.exports = function(req, callback) {
+  return callback(null, function() {
+    return function(text, render) {
+      var base = req.protocol + "://" + req.get("host");
+
+      text = render(text);
+
+      var $ = cheerio.load(text);
+
+      text = absoluteURLs(base, $);
+      text = $.html();
+
+      return text;
+    };
+  });
+};
+
+// We also want to use this function in encodeXML
+// so we export it without the callback wrapper.
+module.exports.absoluteURLs = absoluteURLs;


### PR DESCRIPTION
- [ ] Allow opt-in EXIF access
- [ ] Tell [Stuart](https://twitter.com/stuartfrisby/status/1134447737750114304) 
- [ ] Tell [Nash](https://mail.google.com/mail/u/0/#inbox/FMfcgxwCgxwbBltTWcCwfGklFZsKXLbc)


Would transform the output of the build process, something like this:
```
<img src="..."
  data-caption="..."
  data-width="..."
  data-height="..."
  data-exif-location="..."
/>
```

into an object:
```json
{
  "caption": "...",
  "width": "...",
  "height": "..."
}
```

that would then be used to render a mustache-template retrieved from inside the `{{#formatImages}}` block:

```
<figure>
	  <img src="{{{url}}}" width="{{width}}">
          <figcaption>{{caption}}</figcaption>
</figure>
```

Here's how usage would look in a template file:
```

{{#entry}}
	
	{{#formatImages}}
        <figure>
	  <img src="{{{url}}}" width="{{width}}">
          <figcaption>{{caption}}</figcaption>
        </figure>
	{{/formatImages}}
	
	{{{html}}}

{{/entry}}
```