### PR TITLE
Adds support for Link metadata as an alias for Permalink

### DIFF
--- a/app/brochure/views/how/guides/urls.html
+++ b/app/brochure/views/how/guides/urls.html
@@ -1,12 +1,12 @@
-<h1>URL format</h1>
+<h1>Link format</h1>
 
-<p>Each post is assigned a permalink (permanent URL) automatically. You can edit the format of these permalinks on <a href="/log-in?then=/">the dashboard</a>. If you change a permalink, its former URL redirects automatically.</p>
+<p>Each post or page is assigned a permanent link automatically. You can edit the format of these links on <a href="/log-in?then=/">the dashboard</a>. If you change the link of a blog post, its old link will redirect to its new link automatically.</p>
 
 <small><table>
   <thead>
     <tr>
-      <th class="light">Example URL</th>
-      <th class="light">Custom permalink format</th>
+      <th class="light">Example</th>
+      <th class="light">Custom link format</th>
     </tr>
   </thead>
   <tbody>
@@ -27,7 +27,7 @@
 
 <h2>Reference</h2>
 
-<p>All the properties of a blog post that you can combine in your permalink format.</p>
+<p>All the properties of a blog post that you can combine in your link format.</p>
 
 <small><table>
   <thead>
@@ -50,7 +50,7 @@
 
     <tr>
       <td><code>\{{path}}</code></td>
-      <td>The file’s path in lowercase. A blog post's permalink cannot be identical to the path to its source file so combine this with other properties.</td>
+      <td>The file’s path in lowercase. A blog post's link cannot be identical to the path to its source file so combine this with other properties.</td>
     </tr>
     <tr>
 

--- a/app/brochure/views/how/metadata.html
+++ b/app/brochure/views/how/metadata.html
@@ -1,9 +1,9 @@
 <h1>Metadata</h1>
 
-<p>Each blog post’s permalink, title and publish date is generated automatically. You can override some or all of this metadata on the file’s first line.</p>
+<p>The link, title and publish date of each blog post are generated automatically. You can override some or all of this metadata on the file’s first line.</p>
 
   <pre class="text with-chrome" title="Post.txt"><code>Date: {{{date 'MMMM Do, YYYY'}}}
-Permalink: /metadata
+Link: metadata
 
 You must leave a space after the colon between the metadata property (e.g. Date) and its value. Metadata must be separated from the rest of the post by at least one blank line. 
 
@@ -115,10 +115,9 @@ Tags are case-insensitive and may contain whitespace. Blot picks the case you us
       </td>
     </tr>
     <tr>
-      <td>Permalink</td>
-      <td>Defaults to a URL-friendly version of the post’s title. Specify a different permalink in the file’s metadata, or adjust the <a href="/how/guides/urls">default permalink format</a>.
-        <!-- <br><a class="next small db bt b--black-10" style="margin-bottom:0" href="/how/dates">Read more about permalinks</a>
- -->
+      <td>Link</td>
+      <td>Defaults to a URL-friendly version of the post’s title. Specify a different link in the file’s metadata, or adjust the <a href="/how/guides/urls">default link format</a>.
+       
       </td>
     </tr>
     <tr>
@@ -163,7 +162,7 @@ Tags are case-insensitive and may contain whitespace. Blot picks the case you us
 <div style="max-width:39em;margin:3em 0 4em">
   <pre class="code html" title="Post.html"><code><!--
 Date: {{{date 'MMMM Do, YYYY'}}}
-Permalink: /metadata
+Link: /metadata
 -->
 
 The comment containing metadata in an HTML file

--- a/app/brochure/views/how/pages.html
+++ b/app/brochure/views/how/pages.html
@@ -23,9 +23,9 @@ This page will not appear on your blog‘s menu.
 </code></pre>
 
 <h2>Create a landing page</h2>
-<p>You can create a landing page with the <em>Permalink</em> <a href="./metadata">metadata</a>.</p>
+<p>You can create a landing page with the <em>Link</em> <a href="./metadata">metadata</a>.</p>
 
-  <pre class="text with-chrome" title="Home.txt"><code>Permalink: /
+  <pre class="text with-chrome" title="Home.txt"><code>Link: /
 
 This page will replace your blog‘s homepage. If you still want your readers to access the list of your blog posts, consider adding a link to ‘/page/1’ to your blog’s menu.
 </code></pre>

--- a/app/build/prepare/index.js
+++ b/app/build/prepare/index.js
@@ -156,7 +156,8 @@ function Prepare(entry) {
   // declared a page with no permalink set. We can't
   // do this earlier, since we don't know the slug then
   entry.permalink =
-    entry.metadata.permalink || entry.metadata.slug || entry.metadata.url || "";
+    entry.metadata.permalink || entry.metadata.slug. ||
+    entry.metadata.link || entry.metadata.url || "";
   entry.permalink = normalize(entry.permalink);
 
   debug(entry.path, "Generated  permalink");

--- a/app/build/prepare/index.js
+++ b/app/build/prepare/index.js
@@ -156,7 +156,7 @@ function Prepare(entry) {
   // declared a page with no permalink set. We can't
   // do this earlier, since we don't know the slug then
   entry.permalink =
-    entry.metadata.permalink || entry.metadata.slug. ||
+    entry.metadata.permalink || entry.metadata.slug ||
     entry.metadata.link || entry.metadata.url || "";
   entry.permalink = normalize(entry.permalink);
 


### PR DESCRIPTION
Before, you'd set the URL of an entry using the `Permalink` metadata. If applied this PR would support `Link` metadata to achieve the same result:

```
Link: apple

# Aeneid

Arma virumque cano troiae qui primus ab oris
```

Why? I like that it has four characters, lining up in fixed-width text-editors with the other two most popular metadata keys, `Date` and `Tags`. It also seems less jargon-y to me.

```
Date: 12-20-2020
Link: apple
Tags: fruit

# Aeneid

Arma virumque cano troiae qui primus ab oris
```

Note, this change wouldn't break the old methods of setting the permalink of an entry.
