### PR TITLE
Adds ability to disable comments via post metadata

### DIFF
--- a/app/blog/entry.js
+++ b/app/blog/entry.js
@@ -27,10 +27,10 @@ module.exports = function(server) {
     Entry.getByUrl(blog.id, url, function(entry) {
       if (!entry || entry.deleted || entry.draft) return next();
 
-      // If comments are enabled in settings, they are shown on all entries and pages
+      // If comments are enabled in settings, they are shown on all blog posts and pages
       // Disable comments in cases:
-      // 1. Entry metadata DOES have  'Comments: No'
-      // 2. Page metadata DOES'T have 'Comments: Yes'
+      // 1. Blog post metadata DOES have  'Comments: No'
+      // 2. Page metadata DOES NOT have   'Comments: Yes'
       if ((entry.metadata.comments === 'No') || 
           (entry.metadata.comments !== 'Yes' && entry.page)) {
         delete blog.plugins.commento;

--- a/app/blog/entry.js
+++ b/app/blog/entry.js
@@ -27,6 +27,16 @@ module.exports = function(server) {
     Entry.getByUrl(blog.id, url, function(entry) {
       if (!entry || entry.deleted || entry.draft) return next();
 
+      // If comments are enabled in settings, they are shown on all entries and pages
+      // Disable comments in cases:
+      // 1. Entry metadata DOES have  'Comments: No'
+      // 2. Page metadata DOES'T have 'Comments: Yes'
+      if ((entry.metadata.comments === 'No') || 
+          (entry.metadata.comments !== 'Yes' && entry.page)) {
+        delete blog.plugins.commento;
+        delete blog.plugins.disqus;
+      }
+
       // Redirect this entry to the file from which it was generated
       // I use this when debugging user blogs.
       if (entry.path && request.query && request.query.source)
@@ -62,10 +72,10 @@ module.exports = function(server) {
         }
 
         plugins.load("entryHTML", blog.plugins, function(err, pluginHTML) {
-          // Dont show plugin HTML on a page or a draft.
+          // Dont show plugin HTML on a draft.
           // Don't show plugin HTML on a preview subdomain.
           // This is to prevent Disqus getting stuck on one URL.
-          if (entry.page || entry.draft || request.preview) {
+          if (entry.draft || request.preview) {
             pluginHTML = "";
           }
 

--- a/app/brochure/views/how/guides/comments.html
+++ b/app/brochure/views/how/guides/comments.html
@@ -24,5 +24,8 @@
 <span class="a">Disqus</span></a></li>
 </ul>
 
+<h2>Controlling comments on individual entries</h2>
+<p>When enabled, comments are shown on blog posts and are not shown on pages. You can change this for individual posts and pages by setting the <code>Comments</code> to <code>Yes</code> or <code>No</code> in the <a href="/how/metadata">metadata</a>. </p>
+
 <h2>Switching commenting systems</h2>
 <p>You can replace the commenting system on your site with a few clicks on the <a href="/settings/services">Services page</a> of your site's dashboard.</p>

--- a/app/brochure/views/how/metadata.html
+++ b/app/brochure/views/how/metadata.html
@@ -122,6 +122,11 @@ Tags are case-insensitive and may contain whitespace. Blot picks the case you us
       </td>
     </tr>
     <tr>
+      <td>Comments</td>
+      <td>Determines whether comments are enabled on the blog post or the page. Can be ’Yes’ or ’No’. Defaults to ’Yes’ for blog posts and ’No’ for pages. Has no effect if comments are disabled in the blog settings.
+      </td>
+    </tr>
+    <tr>
       <td>Summary</td>
       <td>Defaults to the text of the first sentence of the first paragraph in the file.</td>
     </tr>


### PR DESCRIPTION
This adds the ability to control comments on a per entry basis. 

Now, if comments are enabled in settings, they are shown on all blog posts **and pages**. We disable comments in cases:
1. It's a BLOG POST, and metadata DOES have  `'Comments: No'`
2. It's a PAGE, and metadata DOES NOT have ` 'Comments: Yes'`

---

The corresponding entry in the `todo.txt`:
> Add custom metadata to turn off/on comments on specific post or page and tell [Hani](https://mail.google.com/mail/u/0/#inbox/FMfcgxwHNqCSdngxBKHqctWBTgmFBbkB)

(I did not remove that entry from the `todo.txt` since it involves sending an email to a customer).