### PR TITLE
Adds link to status page

### DIFF
--- a/app/brochure/views/partials/footer.html
+++ b/app/brochure/views/partials/footer.html
@@ -30,6 +30,7 @@
     <li><a href="/news">News <span style="display:none;border-radius: 1em;background:gold;padding:1px 5px;font-size: 12px">3 hours ago</span></a></li>
     <li><a href="https://github.com/davidmerfield/blot">Source code</a></li>
     <li><a href="/notes">Notes</a></li>
+    <li><a href="https://status.blot.im/">Status</a></li>
     <li><a href="/contact">Contact</a></li>
   </ul>
   

--- a/todo.txt
+++ b/todo.txt
@@ -58,6 +58,11 @@ Add support for posts generated from Excel files, would generate a table. Use [t
 
 Use [blurhash](https://github.com/woltapp/blurhash) to generate placeholders when lazy loading images and tell [David](https://mail.google.com/mail/u/0/#inbox/FMfcgxwJXfqzZvHgrtSxzLBCwcvTsFFB)
 
+Improvements to status page:
+- customize the design of this page a little (could we self-host on a different service, e.g. linode, a page which makes an API call to updown?)
+- embed a brief status history in the brochure site somewhere
+- link to this status page in the 502 bad gateway error page
+
 Improvements to template editor
 - Add layout options to template editor for native templates
 - Work out how to make live but saveable modifications for preview purposes on the template editor

--- a/todo.txt
+++ b/todo.txt
@@ -374,8 +374,6 @@ Improve 404 log page on Dashboard
 - Add frequency indicator for each route 404 log and tell [Jamie](https://mail.google.com/mail/u/0/#inbox/FMfcgxwBVDLzTVpVZHfgwRgcmtGXFHXx)
 - Add filtering by date to 404 log and [tell this person](https://mail.google.com/mail/u/0/#inbox/1566e52d170f29ca)
 
-Create a status page and uptime monitor and tell [Amit](https://mail.google.com/mail/u/0/#inbox/FMfcgxwBTkBxqxfhmDdbXTTlfxvPVvSB). I like [this style](https://status.sunsed.com/) (just a JSON response)
-
 Add hasBreakpoint property to entry to allow greater control over display of {{{teaser}}} and tell [Pratik](https://mail.google.com/mail/u/0/#inbox/FMfcgxwBTsfMTHqWMQFmprMcjNpdBQzp)
 
 Add way to auto-refresh page during template development on preview subdomains. Tell [Ryan](https://mail.google.com/mail/u/1/#inbox/FMfcgxwBVDHXWxBGqwNlmsmgZjbnHXvg)


### PR DESCRIPTION
https://status.blot.im/

It would be nice to in future: 
- customize the design of this page a little (could we self-host on a different service, e.g. linode, a page which makes an API call to updown?)
- embed a brief status history in the brochure site somewhere
- link to this status page in the 502 bad gateway error page
