### PR TITLE
Use px instead of % for padding on bandcamp embeds

### DIFF
--- a/app/build/plugins/videoEmbeds/bandcamp.js
+++ b/app/build/plugins/videoEmbeds/bandcamp.js
@@ -11,7 +11,7 @@ function template(url, width, height) {
   return (
     '<div style="width:0;height:0"> </div><div class="videoContainer bandcamp" style="padding-bottom: ' +
     height +
-    '%"><iframe width="' +
+    'px"><iframe width="' +
     width +
     '" height="' +
     height +


### PR DESCRIPTION
This fixes a typo introduced in #379.

Whoops, I missed this originally. This should now produce the
desired result :)