### PR TITLE
Hides hidden pages from search engines

### DIFF
--- a/app/blog/entry.js
+++ b/app/blog/entry.js
@@ -87,6 +87,11 @@ module.exports = function(server) {
             entry: entry
           });
 
+          // Asks search engines not to index hidden pages
+          if (entry.page && entry.menu === false) {
+            response.set("X-Robots-Tag", "noindex");
+          }
+
           response.renderView("entry.html", next);
         });
       });


### PR DESCRIPTION
Adds an `X-Robots-Tag: noindex` header to hidden pages, i.e. pages with `Menu: no` metadata. We already do this for drafts, should this happen for hidden pages too?

I suppose there are some pages which a customer might not want on their blog's menu, but might still want indexed. Perhaps we should add a `no-index` header instead? Perhaps we should add a way to set arbitrary headers?

@freetonik do you have any thoughts on this?