### PR TITLE
Adds Cloudflare web analytics option

### DIFF
--- a/app/build/plugins/analytics/form.html
+++ b/app/build/plugins/analytics/form.html
@@ -12,6 +12,6 @@
   </select>
 </label>
 <label id="trackingIdInput" style="{{^trackingID}}display:none{{/trackingID}}">
-  Tracking ID:
+  <span>Tracking ID:</span>
   <input name="plugins.analytics.options.trackingID" value="{{trackingID}}" type="text" placeholder=""/>
 </label>

--- a/app/build/plugins/analytics/form.html
+++ b/app/build/plugins/analytics/form.html
@@ -8,6 +8,7 @@
     <option {{provider.SimpleAnalytics}} value="SimpleAnalytics">Simple Analytics</option>
     <option {{provider.Fathom}} value="Fathom">Fathom</option>
     <option {{provider.Plausible}} value="Plausible">Plausible</option>
+    <option {{provider.Cloudflare}} value="Cloudflare">Cloudflare</option>
   </select>
 </label>
 <label id="trackingIdInput" style="{{^trackingID}}display:none{{/trackingID}}">

--- a/app/build/plugins/analytics/public.js
+++ b/app/build/plugins/analytics/public.js
@@ -76,5 +76,15 @@ fathom('trackPageview');
     s.parentNode.insertBefore(pa, s);
 })(); 
 {{/plugins.analytics.options.provider.Plausible}}
-
+{{#plugins.analytics.options.provider.Cloudflare}}
+(function () {
+    var pa = document.createElement('script');
+    pa.type = 'text/javascript';
+    pa.defer = true;
+    pa.setAttribute("data-cf-beacon", "{'token': '{{plugins.analytics.options.trackingID}}'}");
+    pa.src = 'https://static.cloudflareinsights.com/beacon.min.js';
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(pa, s);
+})(); 
+{{/plugins.analytics.options.provider.Cloudflare}}
 }

--- a/app/dashboard/views/settings/services.html
+++ b/app/dashboard/views/settings/services.html
@@ -139,18 +139,18 @@
     $('.plugin > label input[type=checkbox]').click(function() {
       $(this).parent().parent().parent().toggleClass('checked')
     });
-  // Simple Analytics doesn't require a tracking ID
-  if ($('#selectAnalytics').val() !== 'None' && ['SimpleAnalytics', 'Plausible'].indexOf($('#selectAnalytics').val()) === -1) {
-    $('#trackingIdInput').show();
-  } else {
-    $('#trackingIdInput').hide();
-  }
+  // Simple Analytics and Plausible don't require a tracking ID
   $('#selectAnalytics').change(function() {
     if ($(this).val() !== 'None' && ['SimpleAnalytics', 'Plausible'].indexOf($(this).val()) === -1) {
+      // Cloudflare requires Token rather than Tracking ID
+      if ($(this).val() == 'Cloudflare') { $('#trackingIdInput span').text("Token:"); }
+      else { $('#trackingIdInput span').text("Tracking ID:"); }
       $('#trackingIdInput').show();
     } else {
       $('#trackingIdInput').hide();
     }
   });
+  // Trigger change event for correct state on page load
+  $('#selectAnalytics').trigger("change");
   </script>
 </div>


### PR DESCRIPTION
This PR adds the option to embed Cloudflare analytics. It also removes duplicate jQuery code to manage the state of the HTML form in settings and changes the `Tracking ID` label to `Token` when Cloudflare is selected to make it easier for users to understand.