### PR TITLE
Adds titlecase helper fn and blog plugin

### DIFF
--- a/app/build/plugins/titlecase/index.js
+++ b/app/build/plugins/titlecase/index.js
@@ -1,0 +1,22 @@
+const helper = require("helper");
+const titlecase = helper.titlecase;
+const cheerio = require("cheerio");
+
+function prerender(html, callback, options) {
+  const $ = cheerio.load(html);
+
+  try {
+    $('h1, h2, h3, h4, h5, h6').each(function(i, el) {
+      $(this).text(titlecase($(this).text()))
+    })
+  } catch (e) {}
+
+  return callback(null, $.html());
+}
+
+module.exports = {
+  prerender: prerender,
+  category: "Typography",
+  title: "Titlecase",
+  description: "Use Title Case for All Post Headings"
+};

--- a/app/build/plugins/titlecase/index.js
+++ b/app/build/plugins/titlecase/index.js
@@ -16,6 +16,7 @@ function prerender(html, callback, options) {
 
 module.exports = {
   prerender: prerender,
+  isDefault: false,
   category: "Typography",
   title: "Titlecase",
   description: "Use Title Case for All Post Headings"

--- a/app/build/plugins/titlecase/index.js
+++ b/app/build/plugins/titlecase/index.js
@@ -1,23 +1,20 @@
 const helper = require("helper");
 const titlecase = helper.titlecase;
-const cheerio = require("cheerio");
 
-function prerender(html, callback, options) {
-  const $ = cheerio.load(html);
-
+function render($, callback) {
   try {
-    $('h1, h2, h3, h4, h5, h6').each(function(i, el) {
-      $(this).text(titlecase($(this).text()))
-    })
+    $("h1, h2, h3, h4, h5, h6").each(function (i, el) {
+      $(this).text(titlecase($(this).text()));
+    });
   } catch (e) {}
 
-  return callback(null, $.html());
+  return callback();
 }
 
 module.exports = {
-  prerender: prerender,
+  render: render,
   isDefault: false,
   category: "Typography",
   title: "Titlecase",
-  description: "Use Title Case for All Post Headings"
+  description: "Use Title Case for All Post Headings",
 };

--- a/app/build/tests/plugins.js
+++ b/app/build/tests/plugins.js
@@ -1,0 +1,22 @@
+describe("build", function() {
+  var build = require("../index");
+  var fs = require("fs-extra");
+
+  global.test.blog();
+
+  it("will turn titles into title case if plugin is enabled", function(done) {
+    var contents = "# Title goes here";
+    var path = "/hello.txt";
+
+    fs.outputFileSync(this.blogDirectory + path, contents);
+
+    this.blog.plugins.titlecase = {enabled: true, options: {}};
+
+    build(this.blog, path, {}, function(err, entry) {
+      if (err) return done.fail(err);
+      expect(entry.html).toEqual('<h1 id="title-goes-here">Title Goes Here</h1>')
+      done();
+    });
+  });
+
+});

--- a/app/helper/titlecase.js
+++ b/app/helper/titlecase.js
@@ -1,0 +1,107 @@
+// Based on https://github.com/bdougherty/better-title-case
+
+const { URL } = require('url');
+
+const smallWords = [
+	'a', 'an', 'and', 'at', 'but', 'by',
+	'for', 'in', 'nor', 'of', 'on', 'or',
+	'so', 'the', 'to', 'up', 'yet',
+	'v', 'v.', 'via', 'vs', 'vs.'
+];
+
+const containers = ['(', '[', '{', '"', `'`, '_'];
+
+function isUrl(text) {
+	try {
+		const parsedUrl = new URL(text);
+		return Boolean(parsedUrl.hostname);
+	}
+	catch (error) {
+		return false;
+	}
+}
+
+function capitalize(string) {
+	if (string.length === 0) {
+		return string;
+	}
+
+	const letters = [...string];
+	const firstLetter = letters.shift();
+
+	if (containers.includes(firstLetter)) {
+		return `${firstLetter}${capitalize(letters)}`;
+	}
+
+	return `${firstLetter.toUpperCase()}${letters.join('')}`;
+}
+
+function titlecase(string = '', { excludedWords = [], useDefaultExcludedWords = true } = {}) {
+	if (string.toUpperCase() === string) {
+		string = string.toLowerCase();
+	}
+
+	if (useDefaultExcludedWords) {
+		excludedWords.push(...smallWords);
+	}
+
+	const words = string.trim().split(/(\s+)/);
+
+	let previousWord = '';
+	const lastWordIndex = words.length - 1;
+	const re = {
+		isEmail: /.+@.+\..+/,
+		isFilePath: /^(\/[\w.]+)+/,
+		isFileName: /^\w+\.\w{1,3}$/,
+		hasInternalCapital: /(?![-‑–—])[a-z]+[A-Z].*/,
+
+		hasHyphen: /[-‑–—]/g
+	};
+	const capitalizedWords = words.map((word, index) => {
+		if (word.match(/\s+/)) {
+			return word;
+		}
+
+		const isFirstWord = index === 0;
+		const isLastWord = index === lastWordIndex;
+
+		const startOfSubPhrase = previousWord.endsWith(':');
+		previousWord = word;
+
+		if (re.isEmail.test(word) || isUrl(word) || re.isFilePath.test(word) || re.isFileName.test(word) || re.hasInternalCapital.test(word)) {
+			return word;
+		}
+
+		const hasHyphen = word.match(re.hasHyphen);
+		if (hasHyphen) {
+			const isMultiPart = hasHyphen.length > 1;
+			const [hyphenCharacter] = hasHyphen;
+
+			return word.split(hyphenCharacter).map((subWord) => {
+				if (isMultiPart && excludedWords.indexOf(subWord.toLowerCase()) !== -1) {
+					return subWord;
+				}
+
+				return capitalize(subWord);
+			}).join(hyphenCharacter);
+		}
+
+		if (word.indexOf('/') !== -1) {
+			return word.split('/').map(capitalize).join('/');
+		}
+
+		if (isFirstWord || isLastWord) {
+			return capitalize(word);
+		}
+
+		if (!startOfSubPhrase && excludedWords.indexOf(word.toLowerCase()) !== -1) {
+			return word.toLowerCase();
+		}
+
+		return capitalize(word);
+	});
+
+	return capitalizedWords.join('');
+}
+
+module.exports = titlecase;

--- a/todo.txt
+++ b/todo.txt
@@ -151,7 +151,6 @@ com/mail/u/0/#inbox/1588e3df7489b554)
 - Add support for 'creating' a template inside '/Templates/'
   - Tell [Myron](https://twitter.com/rodriguesmyron) and [Ryan](https://mail.google.com/mail/u/0/#inbox/FMfcgxwDrvCRNqvVclgfcHmhpJKChMhV) and [Jussi](https://mail.google.com/mail/u/0/#inbox/FMfcgxwGCtQrKrPTxkKlfBMctjWQdbCM) on Twitter when it is possible to rename the folder created for a template in local editing.
 - Support template views inside a subfolder inside template folder, e.g. {{> partials/footer}} and then tell [Nash](https://mail.google.com/mail/u/0/#inbox/FMfcgxwChJfNfGHXPKxmntzZRfsDFHpq)
-- Add [titlecase](https://daringfireball.net/2008/05/title_case) helper function? 
 - Add support for the setting of custom headers (e.g. to enable CORS) and tell [Roy](https://mail.google.com/mail/u/0/#inbox/FMfcgxwDrRShkTjNqPxcnPjFcGthZgbh)
 - Add support for listing files in arbritary folders (e.g. use a custom folder as a 'public' folder) and tell [Nash](https://twitter.com/nashp/status/1111655667817947137)
 - Move to uuid based template IDs instead of slug


### PR DESCRIPTION
This adds a title case helper function (relevant [todo](https://github.com/davidmerfield/Blot/blob/master/todo.txt#L154)) and a blog plugin which automatically converts all blog headings (`h1` through `h6`) to Title Case. The plugin is disabled by default.

When reading the todo, I wasn't sure whether only the helper function is needed or a plugin is also needed. Feel free to remove `plugins/titlecase` accordingly.