### PR TITLE
Adds guides and tests for fancy lists

### DIFF
--- a/app/brochure/views/how/guides/markdown.html
+++ b/app/brochure/views/how/guides/markdown.html
@@ -76,11 +76,25 @@ Alternative subheading
 2. Deux
 3. Tres</pre>
 
+<p>Create a list which starts with a custom number by putting a single parenthesis like so:</p>
+<pre> 9) Ninth
+10) Tenth
+11) Eleventh</pre>
+
+<p>Create a list with non-nigit characters like so:</p>
+<pre>i. Unus
+ii. Duo
+iii. Tres</pre>
+
+<p>If it's a capital letter, put two characters after the period:</p>
+<pre>A.  Unus
+B.  Duo
+C.  Tres</pre>
+
 <p>Create a checklist like so:</p>
 <pre>- [x] First task
 - [ ] Second task
 - [ ] Third task</pre>
-
 
 <h2>Footnotes</h2>
 <p>Use square brackets and a caret (^) to mark the position of a footnote in your text:</p>

--- a/app/build/converters/markdown/tests/index.js
+++ b/app/build/converters/markdown/tests/index.js
@@ -44,6 +44,9 @@ describe("markdown converter", function() {
   it("handles return characters", from("/return-character.txt"));
   it("converts basic markdown", from("/basic-post.txt"));
   it("converts a list", from("/list.txt"));
+  it("converts a list with non-nigit characters", from("/list-with-non-digits.txt"));
+  it("converts a list with capital non-nigit characters", from("/list-with-capital-non-digits.txt"));
+  it("converts a list with custom numbers", from("/list-with-custom-numbers.txt"));
   it("converts a list with tasks", from("/list-with-tasks.txt"));
   it("handles pre-formatted indentation", from("/pre-formatted-indents.txt"));
 

--- a/app/build/converters/markdown/tests/list-with-capital-non-digits.txt
+++ b/app/build/converters/markdown/tests/list-with-capital-non-digits.txt
@@ -1,0 +1,11 @@
+Hey
+I.  Unus
+II.  Duo
+III.  Tres
+Now
+
+Hey
+A.  Unus
+B.  Duo
+C.  Tres
+Now

--- a/app/build/converters/markdown/tests/list-with-capital-non-digits.txt.html
+++ b/app/build/converters/markdown/tests/list-with-capital-non-digits.txt.html
@@ -1,0 +1,12 @@
+<p>Hey</p>
+<ol type="I">
+<li>Unus</li>
+<li>Duo</li>
+<li>Tres Now</li>
+</ol>
+<p>Hey</p>
+<ol type="A">
+<li>Unus</li>
+<li>Duo</li>
+<li>Tres Now</li>
+</ol>

--- a/app/build/converters/markdown/tests/list-with-custom-numbers.txt
+++ b/app/build/converters/markdown/tests/list-with-custom-numbers.txt
@@ -1,0 +1,5 @@
+Hey
+9)  Unus
+10)  Duo
+11)  Tres
+Now

--- a/app/build/converters/markdown/tests/list-with-custom-numbers.txt.html
+++ b/app/build/converters/markdown/tests/list-with-custom-numbers.txt.html
@@ -1,0 +1,6 @@
+<p>Hey</p>
+<ol start="9" type="1">
+<li>Unus</li>
+<li>Duo</li>
+<li>Tres Now</li>
+</ol>

--- a/app/build/converters/markdown/tests/list-with-non-digits.txt
+++ b/app/build/converters/markdown/tests/list-with-non-digits.txt
@@ -1,0 +1,5 @@
+Hey
+i. Unus
+ii. Duo
+iii. Tres
+Now

--- a/app/build/converters/markdown/tests/list-with-non-digits.txt.html
+++ b/app/build/converters/markdown/tests/list-with-non-digits.txt.html
@@ -1,0 +1,6 @@
+<p>Hey</p>
+<ol type="i">
+<li>Unus</li>
+<li>Duo</li>
+<li>Tres Now</li>
+</ol>


### PR DESCRIPTION
This adds tests and info about fancy lists to the Markdown guide. These features require at least `pandoc 1.13.2` (2014-12-20).

([Corresponding todo](https://github.com/davidmerfield/Blot/blob/master/todo.txt#L826))

