### PR TITLE
Sticky sidebar

### DIFF
--- a/app/brochure/views/css/sidebar.css
+++ b/app/brochure/views/css/sidebar.css
@@ -68,6 +68,9 @@ input[name="toggle"] {
 
 .sidebar a:active {opacity: 0.5}
 
+nav {
+  display: initial;
+}
 
 nav a {
   display: block;
@@ -172,13 +175,12 @@ nav a.selected:hover {
 
 .logbut {display: flex;justify-content: flex-start;}
 .logbut a {color: grey}
-    /*.logbut a {color:grey;text-align:center;border-radius:6px;border: 1px solid var(--light-border-color);position: relative;padding:6px 12px;margin: 0 0.5rem;}*/
-    .logbut a:first-child {padding-right:1rem;border-right: 1px solid var(--light-border-color)}
-    .logbut a:last-child {padding-left: 1rem}
-    
-    .logbut a:after {
+  /*.logbut a {color:grey;text-align:center;border-radius:6px;border: 1px solid var(--light-border-color);position: relative;padding:6px 12px;margin: 0 0.5rem;}*/
+  .logbut a:first-child {padding-right:1rem;border-right: 1px solid var(--light-border-color)}
+  .logbut a:last-child {padding-left: 1rem}
+  .logbut a:after {
   content: "";
-      display: none;
+  display: none;
   position: absolute;
   top: 0;
   bottom: 2px;
@@ -235,6 +237,7 @@ nav a.selected:hover {
 }
 .on-this-page {
   position: sticky;
-  top: 2rem
+  top: 2rem;
+  margin-top: 2em;
 }
 

--- a/app/brochure/views/partials/breadcrumbs.html
+++ b/app/brochure/views/partials/breadcrumbs.html
@@ -1,5 +1,5 @@
 <!-- <div style="width:100%;clear: both;overflow-x: scroll;"> -->
-<div class="breadcrumbs breadcrumbs__list" style="overflow-x: scroll;
+<div class="breadcrumbs breadcrumbs__list" style="overflow-x: auto;
   overflow-y: hidden;
   white-space: nowrap;
 font-size:14px;flex-grow: 1;border: 1px solid var(--light-border-color);border-left: none;border-right: none;border-top:none;border-bottom:none;padding: 0 0 0 0">


### PR DESCRIPTION
Hey @davidmerfield,

The first change fixes the sticky "on this page" block in the sidebar (e.g. https://blot.im/how/guides/tex)

---

The second change fixes the breadcrumbs container scrollbar that was always visible on macs that have a mouse connected. It looked like this:

<img width="825" alt="Screen Shot 2021-02-23 at 11 00 32" src="https://user-images.githubusercontent.com/2665931/108821897-f6d41280-75c6-11eb-8a30-df5b2271d4c3.png">

To fix it, I changed `overflow-x: scroll` to `overflow-x: auto`, so that the scrollbar appears only when content is truly scrollable:

<img width="650" alt="Screen Shot 2021-02-23 at 11 01 56" src="https://user-images.githubusercontent.com/2665931/108821977-15d2a480-75c7-11eb-9c07-c7035bf7a726.png">

This doesn't look too nice, though. Perhaps, we should simply wrap long breadcrumbs around like so?

<img width="669" alt="Screen Shot 2021-02-23 at 11 02 26" src="https://user-images.githubusercontent.com/2665931/108822066-3864bd80-75c7-11eb-9faa-bb35596e4c15.png">
