### PR TITLE
Zero-downtime server reloads

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -2,36 +2,92 @@ const config = require("config");
 const cluster = require("cluster");
 const numCPUs = require("os").cpus().length;
 const clfdate = require("helper").clfdate;
-
+const async = require("async");
 if (cluster.isMaster) {
-  const scheduler = require("./scheduler");
+  // Launch scheduled tasks
+  require("./scheduler")();
 
-  console.log(clfdate(), `Master process running pid=${process.pid} environment=${config.environment} cache=${config.cache}`);
+  console.log(
+    clfdate(),
+    `Master process running pid=${process.pid} environment=${config.environment} cache=${config.cache}`
+  );
+
+  // Write the master process PID so we can signal it
+  require("fs").writeFileSync(config.pidfile, process.pid, "utf-8");
 
   // Fork workers.
   for (let i = 0; i < numCPUs; i++) {
     cluster.fork();
   }
 
-  // The moment the first worker comes online we schedule background tasks
-  let first_listener = true;
-
-  cluster.on("listening", (worker, address) => {
-    if (first_listener) scheduler();
-    first_listener = false;
+  cluster.on("exit", (worker, code, signal) => {
+    console.log(clfdate(), "worker is dead");
+    if (worker.exitedAfterDisconnect === true) {
+      // we only want to reboot if the worker died by error
+    } else {
+      cluster.fork();
+    }
   });
 
-  cluster.on("exit", (worker, code, signal) => {
-    console.log("worker is dead:", worker.isDead());
-    cluster.fork();
+  // SIGUSR1 is used by node for debugging, so we use SIGUSR2 to
+  // signal the master process that it's time to reboot the servers
+  process.on("SIGUSR2", function () {
+    let workerIDs = Object.keys(cluster.workers);
+
+    console.log(
+      clfdate(),
+      `Master process recieved signal to replace ${workerIDs.length} workers`
+    );
+
+    async.eachSeries(
+      workerIDs,
+      function (workerID, next) {
+        let worker;
+        let replacementWorker;
+        let timeout;
+
+        console.log(
+          clfdate(),
+          `Replacing worker ${workerIDs.indexOf(workerID) + 1}/${
+            workerIDs.length
+          }`
+        );
+
+        worker = cluster.workers[workerID];
+
+        worker.on("disconnect", function () {
+          clearTimeout(timeout);
+        });
+
+        worker.disconnect();
+
+        timeout = setTimeout(() => {
+          worker.kill();
+        }, 2000);
+
+        replacementWorker = cluster.fork();
+
+        replacementWorker.on("listening", function () {
+          console.log(
+            clfdate(),
+            `Replaced worker ${workerIDs.indexOf(workerID) + 1}/${
+              workerIDs.length
+            }`
+          );
+          workerID++;
+          next();
+        });
+      },
+      function (err) {
+        console.log(clfdate(), `Master process replaced all workers`);
+      }
+    );
   });
 } else {
-  const Blot = require("./server");
-
   console.log(clfdate(), `Worker process running pid=${process.pid}`);
 
   // Open the server to handle requests
-  Blot.listen(config.port, function () {
+  require("./server").listen(config.port, function () {
     console.log(
       clfdate(),
       `Worker process listening pid=${process.pid} port=${config.port}`

--- a/config/blot/setup.js
+++ b/config/blot/setup.js
@@ -27,6 +27,7 @@ redis.mset(
 // Create empty directories if they don't exist
 fs.ensureDirSync(root + "/blogs");
 fs.ensureDirSync(root + "/tmp");
+fs.ensureDirSync(root + "/data");
 fs.ensureDirSync(root + "/logs");
 fs.ensureDirSync(root + "/db");
 fs.ensureDirSync(root + "/static");

--- a/config/index.js
+++ b/config/index.js
@@ -12,7 +12,7 @@ module.exports = {
   blog_static_files_dir: process.env.BLOT_DIRECTORY + "/static",
   blog_folder_dir: process.env.BLOT_DIRECTORY + "/blogs",
   cache_directory: process.env.BLOT_CACHE_DIRECTORY,
-  
+
   ip: process.env.BLOT_IP || "127.0.0.1",
 
   port: 8080,

--- a/config/index.js
+++ b/config/index.js
@@ -3,6 +3,7 @@ module.exports = {
   environment: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   host: process.env.BLOT_HOST,
   protocol: process.env.BLOT_PROTOCOL + "://",
+  pidfile: process.env.BLOT_DIRECTORY + '/data/process.pid',
 
   maintenance: process.env.BLOT_MAINTENANCE === "true",
   cache: process.env.BLOT_CACHE === "true",
@@ -11,7 +12,7 @@ module.exports = {
   blog_static_files_dir: process.env.BLOT_DIRECTORY + "/static",
   blog_folder_dir: process.env.BLOT_DIRECTORY + "/blogs",
   cache_directory: process.env.BLOT_CACHE_DIRECTORY,
-
+  
   ip: process.env.BLOT_IP || "127.0.0.1",
 
   port: 8080,

--- a/scripts/reboot.js
+++ b/scripts/reboot.js
@@ -1,0 +1,6 @@
+const child_process = require("child_process");
+const config = require("config");
+const fs = require("fs");
+
+const pid = fs.readFileSync(config.pidfile, "utf-8");
+child_process.execSync(`kill -s USR2 ${pid}`);

--- a/scripts/reboot.js
+++ b/scripts/reboot.js
@@ -1,6 +1,6 @@
 const child_process = require("child_process");
 const config = require("config");
 const fs = require("fs");
-
 const pid = fs.readFileSync(config.pidfile, "utf-8");
+
 child_process.execSync(`kill -s USR2 ${pid}`);


### PR DESCRIPTION
- Uses [cluster](https://nodejs.org/api/cluster.html) module to allow us to reload the server without downtime
- Changes to code in `app/scheduler` (now run by the master process) require a hard-reload of the master process, which is accomplished on the server with `sudo stop blot && sudo start blot`
- All other changes can be applied to production server with `node scripts/reboot`
- What happens if the new code doesn't run? Could we abort the replacement of worker nodes?