### PR TITLE
Fixes bug using Dropbox client with case of tags extracted from path

### DIFF
--- a/app/build/main.js
+++ b/app/build/main.js
@@ -109,7 +109,7 @@ function build(blog, path, options, callback) {
               " preparing additional properties for",
               entry.name
             );
-            entry = Prepare(entry);
+            entry = Prepare(entry, options);
             debug("Blog:", blog.id, path, " additional properties computed.");
           } catch (e) {
             return callback(e);

--- a/app/build/prepare/index.js
+++ b/app/build/prepare/index.js
@@ -40,7 +40,7 @@ function canOverwrite(key) {
 // url: 'string', // this is handled by set
 // scheduled: scheduled, // this is handled by set
 
-function Prepare(entry) {
+function Prepare(entry, options) {
   ensure(entry, "object")
     .and(entry.path, "string")
     .and(entry.size, "number")
@@ -109,7 +109,7 @@ function Prepare(entry) {
 
   if (entry.metadata.tags) tags = entry.metadata.tags.split(",");
 
-  tags = Tags(entry.path, tags);
+  tags = Tags(options.display_path || entry.path, tags);
   tags = _(tags)
     .map(function(tag) {
       return tag.trim();

--- a/app/build/prepare/index.js
+++ b/app/build/prepare/index.js
@@ -28,7 +28,7 @@ var overwrite = [
   "body",
   "summary",
   "teaser",
-  "teaserBody"
+  "teaserBody",
 ];
 
 function canOverwrite(key) {
@@ -40,7 +40,7 @@ function canOverwrite(key) {
 // url: 'string', // this is handled by set
 // scheduled: scheduled, // this is handled by set
 
-function Prepare(entry, options) {
+function Prepare(entry, options = {}) {
   ensure(entry, "object")
     .and(entry.path, "string")
     .and(entry.size, "number")
@@ -55,7 +55,7 @@ function Prepare(entry, options) {
   debug(entry.path, "Generating cheerio");
   var $ = cheerio.load(entry.html, {
     decodeEntities: false,
-    withDomLvl1: false // this may cause issues?
+    withDomLvl1: false, // this may cause issues?
   });
   debug(entry.path, "Generated  cheerio");
 
@@ -111,7 +111,7 @@ function Prepare(entry, options) {
 
   tags = Tags(options.display_path || entry.path, tags);
   tags = _(tags)
-    .map(function(tag) {
+    .map(function (tag) {
       return tag.trim();
     })
     .compact(tags)
@@ -156,8 +156,11 @@ function Prepare(entry, options) {
   // declared a page with no permalink set. We can't
   // do this earlier, since we don't know the slug then
   entry.permalink =
-    entry.metadata.permalink || entry.metadata.slug ||
-    entry.metadata.link || entry.metadata.url || "";
+    entry.metadata.permalink ||
+    entry.metadata.slug ||
+    entry.metadata.link ||
+    entry.metadata.url ||
+    "";
   entry.permalink = normalize(entry.permalink);
 
   debug(entry.path, "Generated  permalink");

--- a/app/build/prepare/index.js
+++ b/app/build/prepare/index.js
@@ -109,7 +109,7 @@ function Prepare(entry, options = {}) {
 
   if (entry.metadata.tags) tags = entry.metadata.tags.split(",");
 
-  tags = Tags(options.display_path || entry.path, tags);
+  tags = Tags(options.pathDisplay || entry.path, tags);
   tags = _(tags)
     .map(function (tag) {
       return tag.trim();

--- a/app/build/tests/index.js
+++ b/app/build/tests/index.js
@@ -55,14 +55,14 @@ describe("build", function () {
     });
   });
 
-  it("extracts tags with case from an optional display_path", function (done) {
+  it("extracts tags with case from an optional path with case", function (done) {
     const path = "/[foo]/bar.txt";
-    const display_path = "/[Foo]/bar.txt";
+    const pathDisplay = "/[Foo]/bar.txt";
     const contents = "Hello";
 
     fs.outputFileSync(this.blogDirectory + path, contents);
 
-    build(this.blog, path, { display_path }, (err, entry) => {
+    build(this.blog, path, { pathDisplay }, (err, entry) => {
       if (err) return done.fail(err);
       expect(entry.tags).toEqual(["Foo"]);
       done();

--- a/app/build/tests/index.js
+++ b/app/build/tests/index.js
@@ -1,23 +1,23 @@
-describe("build", function() {
+describe("build", function () {
   var build = require("../index");
   var fs = require("fs-extra");
 
   global.test.blog();
 
   // Only serve a test image when query contains valid user and password
-  global.test.server(function(server) {
-    server.get("/small.jpg", function(req, res) {
+  global.test.server(function (server) {
+    server.get("/small.jpg", function (req, res) {
       if (req.query && req.query.user === "x" && req.query.pass === "y")
         res.sendFile(__dirname + "/small.jpg");
       else res.sendStatus(400);
     });
 
-    server.get("/public.jpg", function(req, res) {
+    server.get("/public.jpg", function (req, res) {
       res.sendFile(__dirname + "/small.jpg");
     });
   });
 
-  it("handles image URLs with query strings", function(done) {
+  it("handles image URLs with query strings", function (done) {
     // The test server defined above will only respond with an image if
     // the query string is preserved. I was running into an ampersand
     // encoding issue where the & was replaced with &amp;
@@ -26,7 +26,7 @@ describe("build", function() {
 
     fs.outputFileSync(this.blogDirectory + path, contents);
 
-    build(this.blog, path, {}, function(err, entry) {
+    build(this.blog, path, {}, function (err, entry) {
       if (err) return done.fail(err);
 
       // verify the image was cached
@@ -35,21 +35,48 @@ describe("build", function() {
       // verify a thumbnail was generated from the image
       expect(entry.thumbnail.small).toEqual(
         jasmine.objectContaining({
-          name: "small.jpg"
+          name: "small.jpg",
         })
       );
       done();
     });
   });
 
-  it("resolves relative paths inside files", function(done) {
+  it("extracts tags from a file path", function (done) {
+    const path = "/[foo]/[bar]/[baz].txt";
+    const contents = "Hello";
+
+    fs.outputFileSync(this.blogDirectory + path, contents);
+
+    build(this.blog, path, {}, (err, entry) => {
+      if (err) return done.fail(err);
+      expect(entry.tags).toEqual(["foo", "bar", "baz"]);
+      done();
+    });
+  });
+
+  it("extracts tags with case from an optional display_path", function (done) {
+    const path = "/[foo]/bar.txt";
+    const display_path = "/[Foo]/bar.txt";
+    const contents = "Hello";
+
+    fs.outputFileSync(this.blogDirectory + path, contents);
+
+    build(this.blog, path, { display_path }, (err, entry) => {
+      if (err) return done.fail(err);
+      expect(entry.tags).toEqual(["Foo"]);
+      done();
+    });
+  });
+
+  it("resolves relative paths inside files", function (done) {
     var path = "/blog/foo.txt";
     var contents = "![Image](_foo.jpg)";
     var absolutePathToImage = "/blog/_foo.jpg";
 
     fs.outputFileSync(this.blogDirectory + path, contents);
 
-    build(this.blog, path, {}, function(err, entry) {
+    build(this.blog, path, {}, function (err, entry) {
       if (err) return done.fail(err);
 
       // It won't be cached since the image doesn't exist
@@ -58,12 +85,12 @@ describe("build", function() {
     });
   });
 
-  it("generates a blog post from an image with quotes in its filename", function(done) {
+  it("generates a blog post from an image with quotes in its filename", function (done) {
     var pathToImage = '/Hell"o\'W "orld.jpg';
 
     fs.copySync(__dirname + "/small.jpg", this.blogDirectory + pathToImage);
 
-    build(this.blog, pathToImage, {}, function(err, entry) {
+    build(this.blog, pathToImage, {}, function (err, entry) {
       if (err) return done.fail(err);
 
       // verify the image was cached
@@ -72,7 +99,7 @@ describe("build", function() {
       // verify a thumbnail was generated from the image
       expect(entry.thumbnail.small).toEqual(
         jasmine.objectContaining({
-          name: "small.jpg"
+          name: "small.jpg",
         })
       );
 
@@ -80,7 +107,7 @@ describe("build", function() {
     });
   });
 
-  it("handles images with accents and spaces in their filename", function(done) {
+  it("handles images with accents and spaces in their filename", function (done) {
     var path = "/blog/Hello world.txt";
     var contents = "![Best Image Ever](óå g.jpg)";
     var pathToImage = "/blog/óå g.jpg";
@@ -88,7 +115,7 @@ describe("build", function() {
     fs.outputFileSync(this.blogDirectory + path, contents);
     fs.copySync(__dirname + "/small.jpg", this.blogDirectory + pathToImage);
 
-    build(this.blog, path, {}, function(err, entry) {
+    build(this.blog, path, {}, function (err, entry) {
       if (err) return done.fail(err);
 
       // verify the image was cached
@@ -97,7 +124,7 @@ describe("build", function() {
       // verify a thumbnail was generated from the image
       expect(entry.thumbnail.small).toEqual(
         jasmine.objectContaining({
-          name: "small.jpg"
+          name: "small.jpg",
         })
       );
 
@@ -105,7 +132,7 @@ describe("build", function() {
     });
   });
 
-  it("will not use as image to become a thumbnail if it is too small", function(done) {
+  it("will not use as image to become a thumbnail if it is too small", function (done) {
     var path = "/Hello world.txt";
     var contents = "![Best Image Ever](test.jpg)";
     var pathToImage = "/test.jpg";
@@ -113,7 +140,7 @@ describe("build", function() {
     fs.outputFileSync(this.blogDirectory + path, contents);
     fs.copySync(__dirname + "/too-small.jpg", this.blogDirectory + pathToImage);
 
-    build(this.blog, path, {}, function(err, entry) {
+    build(this.blog, path, {}, function (err, entry) {
       if (err) return done.fail(err);
 
       // verify no thumbnail was generated from the image
@@ -122,7 +149,7 @@ describe("build", function() {
     });
   });
 
-  it("will not include caption text in summaries", function(done) {
+  it("will not include caption text in summaries", function (done) {
     var path = "/Hello world.txt";
     var contents = "# Hello\n\n![Image caption](file.jpg)\n\nWorld";
 
@@ -131,7 +158,7 @@ describe("build", function() {
     let blog = this.blog;
     blog.plugins.imageCaption.enabled = true;
 
-    build(blog, path, {}, function(err, entry) {
+    build(blog, path, {}, function (err, entry) {
       if (err) return done.fail(err);
 
       // verify a thumbnail was generated from the image
@@ -141,19 +168,19 @@ describe("build", function() {
     });
   });
 
-  it("will not generate a publish dateStamp for files without a date in their metadata or path", function(done) {
+  it("will not generate a publish dateStamp for files without a date in their metadata or path", function (done) {
     var path = "/No-date-in-this-path.txt";
     var contents = "No date in this file";
 
     fs.outputFileSync(this.blogDirectory + path, contents);
-    build(this.blog, path, {}, function(err, entry) {
+    build(this.blog, path, {}, function (err, entry) {
       if (err) return done.fail(err);
       expect(entry.dateStamp).toEqual(undefined);
       done();
     });
   });
 
-  it("will not cache image an image using the static query string", function(done) {
+  it("will not cache image an image using the static query string", function (done) {
     var path = "/Hello world.txt";
     var contents = "<img src='" + this.origin + "/public.jpg?static=1'>";
 
@@ -162,7 +189,7 @@ describe("build", function() {
     // creates <embed>'s instead of <img> for certain URLs
     fs.outputFileSync(this.blogDirectory + path, contents);
 
-    build(this.blog, path, {}, function(err, entry) {
+    build(this.blog, path, {}, function (err, entry) {
       if (err) return done.fail(err);
 
       // verify the image was not cached
@@ -171,7 +198,7 @@ describe("build", function() {
       // verify a thumbnail was still generated from the image
       expect(entry.thumbnail.small).toEqual(
         jasmine.objectContaining({
-          name: "small.jpg"
+          name: "small.jpg",
         })
       );
 

--- a/app/clients/dropbox/sync.js
+++ b/app/clients/dropbox/sync.js
@@ -110,7 +110,11 @@ module.exports = function main(blog, callback) {
                 // to update, so things like automatic title generation based on the
                 // file can be computed nicely.
                 folder.log(item.relative_path, "Updating path");
-                folder.update(item.relative_path, { name: item.name }, next);
+                folder.update(
+                  item.relative_path,
+                  { name: item.name, path_display: item.path_display },
+                  next
+                );
               },
               function () {
                 // If Dropbox says there are more changes

--- a/app/clients/dropbox/sync.js
+++ b/app/clients/dropbox/sync.js
@@ -108,11 +108,12 @@ module.exports = function main(blog, callback) {
                 // is case-insensitive but the file system for Blot's server is not.
                 // We therefore pass the name of the file, which has its case preserved
                 // to update, so things like automatic title generation based on the
-                // file can be computed nicely.
+                // file can be computed nicely, along with the display path, which also
+                // has case-preserved, for things like extracting tags from tag folders.
                 folder.log(item.relative_path, "Updating path");
                 folder.update(
                   item.relative_path,
-                  { name: item.name, path_display: item.path_display },
+                  { name: item.name, pathDisplay: item.path_display },
                   next
                 );
               },


### PR DESCRIPTION
In addition to the case-preserved `name`, we now support an optional `display_path` parameter, name copied from the Dropbox api, as an option for the entry building