### PR TITLE
Fix bug when Link metadata contains URL

### DIFF
--- a/app/build/prepare/index.js
+++ b/app/build/prepare/index.js
@@ -154,14 +154,24 @@ function Prepare(entry) {
   // Add the permalink automatically if the metadata
   // declared a page with no permalink set. We can't
   // do this earlier, since we don't know the slug then
-  entry.permalink =
-    entry.metadata.permalink ||
-    entry.metadata.slug ||
-    entry.metadata.link ||
-    entry.metadata.url ||
-    "";
-  entry.permalink = normalize(entry.permalink);
+  let permalinkCandidates = [
+    entry.metadata.permalink,
+    entry.metadata.slug,
+    entry.metadata.link,
+    entry.metadata.url,
+  ];
 
+  permalinkCandidates = permalinkCandidates
+    .filter(
+      (candidate) =>
+        candidate &&
+        type(candidate, "string") &&
+        candidate.indexOf("://") === -1
+    )
+    .map(normalize)
+    .filter((candidate) => candidate !== "");
+
+  entry.permalink = permalinkCandidates.shift() || "";
   debug(entry.path, "Generated  permalink");
 
   debug(entry.path, "Generating meta-overwrite");

--- a/tests/index.js
+++ b/tests/index.js
@@ -66,6 +66,7 @@ jasmine.addReporter({
 
 global.test = {
   CheckEntry: require("./util/checkEntry"),
+  SyncAndCheck: require("./util/syncAndCheck"),
 
   compareDir: require("./util/compareDir"),
 

--- a/tests/util/checkEntry.js
+++ b/tests/util/checkEntry.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 var colors = require("colors");
+var type = require("helper/type");
 
 function pad(len) {
   var str = "";
@@ -19,15 +20,26 @@ module.exports = function CheckEntry(blogID) {
 
       for (var i in entry) {
         try {
-          assert.deepEqual(
-            entry[i],
-            result[i],
-            i +
-              colors.dim(" [expected] ") +
-              entry[i] +
-              colors.dim("\n" + pad(i.length + 1) + "[returned] ") +
-              result[i]
-          );
+          if (type(entry[i], "function")) {
+            assert.deepEqual(
+              entry[i](result[i]),
+              true,
+              i +
+                colors.dim(" [failed check] ") +
+                colors.dim("\n" + pad(i.length + 1) + "[returned] ") +
+                result[i]
+            );
+          } else {
+            assert.deepEqual(
+              entry[i],
+              result[i],
+              i +
+                colors.dim(" [expected] ") +
+                entry[i] +
+                colors.dim("\n" + pad(i.length + 1) + "[returned] ") +
+                result[i]
+            );
+          }
         } catch (e) {
           message.push(e.message);
         }

--- a/tests/util/syncAndCheck.js
+++ b/tests/util/syncAndCheck.js
@@ -1,0 +1,30 @@
+const async = require("async");
+const type = require("helper/type");
+const CheckEntry = require("./CheckEntry");
+const sync = require("sync");
+const fs = require("fs-extra");
+
+module.exports = function SyncAndCheck(blogID) {
+  return (files, entries, callback) => {
+    if (type(files) === "object") files = [files];
+    if (type(entries) === "object") entries = [entries];
+
+    sync(blogID, (err, folder, syncDone) => {
+      if (err) return callback(err);
+
+      async.eachSeries(
+        files,
+        ({ path, content, options = {} }, next) => {
+          fs.outputFileSync(folder.path + path, content, "utf-8");
+          folder.update(path, options, next);
+        },
+        (err) => {
+          if (err) return syncDone(err, callback);
+          async.eachSeries(entries, CheckEntry(blogID), (err) => {
+            syncDone(err, callback);
+          });
+        }
+      );
+    });
+  };
+};

--- a/tests/util/syncAndCheck.js
+++ b/tests/util/syncAndCheck.js
@@ -1,6 +1,6 @@
 const async = require("async");
 const type = require("helper/type");
-const CheckEntry = require("./CheckEntry");
+const CheckEntry = require("./checkEntry");
 const sync = require("sync");
 const fs = require("fs-extra");
 


### PR DESCRIPTION
This post:

```
Link: http://example.com

....
```
Would have the permalink `/` (i.e. become the homepage of the site) because of the vagaries of `helper/urlNormalizer`. This PR fixes that bug, without touching `helper/urlNormalizer` that seems to be overly depended-on.