### PR TITLE
Fix bug with nested nodes and titlecase plugin

### DIFF
--- a/app/build/plugins/titlecase/index.js
+++ b/app/build/plugins/titlecase/index.js
@@ -2,8 +2,16 @@ const titlecase = require("helper/titlecase");
 
 function render($, callback) {
   try {
-    $("h1, h2, h3, h4, h5, h6").each(function (i, el) {
-      $(this).text(titlecase($(this).text()));
+    $("h1, h2, h3, h4, h5, h6").each(function findTextNodes(i, node) {
+      $(node)
+        .contents()
+        .each((i, childNode) => {
+          if (childNode.nodeType === 3) {
+            $(childNode).replaceWith(titlecase(childNode.data));
+          } else {
+            findTextNodes(i, childNode);
+          }
+        });
     });
   } catch (e) {}
 

--- a/app/build/tests/plugins.js
+++ b/app/build/tests/plugins.js
@@ -72,4 +72,13 @@ describe("build", function () {
     this.blog.plugins.titlecase = { enabled: true, options: {} };
     this.buildAndCheck({ path, contents }, { html }, done);
   });
+
+  it("will turn titles with nested children into title case if plugin is enabled", function (done) {
+    const contents = "# Title *goes [with](/here)* children";
+    const path = "/hello.txt";
+    const html = '<h1 id="title-goes-with-children">Title <em>Goes <a href="/here">With</a></em> Children</h1>';
+
+    this.blog.plugins.titlecase = { enabled: true, options: {} };
+    this.buildAndCheck({ path, contents }, { html }, done);
+  });
 });

--- a/app/helper/titlecase.js
+++ b/app/helper/titlecase.js
@@ -65,7 +65,7 @@ function titlecase(
     excludedWords.push(...smallWords);
   }
 
-  const words = string.trim().split(/(\s+)/);
+  const words = string.split(/(\s+)/);
 
   let previousWord = "";
   const lastWordIndex = words.length - 1;


### PR DESCRIPTION
Before, titlecase plugin would transform this:

```md
# Hello *world*
```

Into this incorrect result:

```html
<h1 id="hello-world">Hello World</h1>
```

Rather than the expected result:

```html
<h1 id="hello-world">Hello <em>World</em></h1>
```
