### PR TITLE
Make date settings available to templates

### DIFF
--- a/app/blog/draft.js
+++ b/app/blog/draft.js
@@ -98,9 +98,6 @@ module.exports = function route(server) {
         entry.previous = previousEntry;
         entry.adjacent = !!(nextEntry || previousEntry);
 
-        // Dont show dates on a page
-        if (blog.hideDates || entry.menu) delete entry.date;
-
         response.addLocals({
           pageTitle: entry.title + " - " + blog.title,
           pageDescription: entry.summary,

--- a/app/blog/render/load/augment.js
+++ b/app/blog/render/load/augment.js
@@ -76,6 +76,8 @@ module.exports = function (req, res) {
         .utc(entry.dateStamp)
         .tz(blog.timeZone)
         .format(dateDisplay);
+    } else {
+      delete entry.date;
     }
 
     return entry;

--- a/app/blog/render/load/augment.js
+++ b/app/blog/render/load/augment.js
@@ -7,9 +7,10 @@ require("moment-timezone");
 module.exports = function (req, res) {
   var blog = req.blog;
 
-  // res.locals.hide_date
-  var hideDate = blog.hideDates || false;
-  var dateDisplay = blog.dateDisplay;
+  // Can be either inherited from the properties of the blog
+  // or from the template, or from the view
+  var hideDate = res.locals.hideDates || res.locals.hide_dates || false;
+  var dateDisplay = res.locals.dateDisplay || res.locals.date_display;
 
   return function (entry) {
     entry.formatDate = FormatDate(entry.dateStamp, req.blog.timeZone);

--- a/app/blog/render/retrieve/page.js
+++ b/app/blog/render/retrieve/page.js
@@ -6,8 +6,6 @@ module.exports = function (req, callback) {
     pageSize = req.blog.pageSize || 5;
 
   Entries.getPage(blog.id, pageNo, pageSize, function (entries, pagination) {
-    for (var i in entries)
-      if (blog.hideDates || entries[i].menu) delete entries[i].date;
 
     var pageTitle = blog.title;
 


### PR DESCRIPTION
At the moment, the setting to hide or show dates on a blog (`hideDates`) and the setting for the format of the date (`dateDisplay`) is stored under the `blog` rather than the `template`.  If applied, this will allow setting these properties through the template.

This is the first step to fix #327. Eventually we will:
- migrate all blog-level settings to individual templates
- removing references to hideDates and dateDisplay on the blog model (leaving it to templates)