### PR TITLE
Improves the way locals are extracted from templates

### DIFF
--- a/app/models/template/parseTemplate.js
+++ b/app/models/template/parseTemplate.js
@@ -61,9 +61,17 @@ function parseTemplate(template) {
         token[0] === "^" ||
         token[0] === "&"
       ) {
+        // e.g. all_entries.length
         var variable = token[1];
+        // e.g. all_entries
+        var variableRoot =
+          variable.indexOf(".") > -1 &&
+          variable.slice(0, variable.indexOf("."));
 
         if (retrieveThese.indexOf(variable) > -1) retrieve[variable] = true;
+
+        if (retrieveThese.indexOf(variableRoot) > -1)
+          retrieve[variableRoot] = true;
 
         // console.log(context + variable);
 

--- a/app/models/template/tests/parseTemplate.js
+++ b/app/models/template/tests/parseTemplate.js
@@ -1,0 +1,35 @@
+describe("parseTemplate", function () {
+  require("./setup")({ createTemplate: true });
+
+  var parseTemplate = require("../parseTemplate");
+
+  it("parses an empty template", function () {
+    var template = "";
+    var result = parseTemplate(template);
+    expect(result).toEqual({ partials: {}, retrieve: {} });
+  });
+
+  it("parses partials from a template", function () {
+    var template = `{{> foo}}`;
+    var result = parseTemplate(template);
+    expect(result).toEqual({ partials: { foo: null }, retrieve: {} });
+  });
+
+  it("parses locals to retrieve from a template", function () {
+    var template = `{{folder}}`; // folder is on the whitelist of variables
+    var result = parseTemplate(template);
+    expect(result).toEqual({ partials: {}, retrieve: { folder: true } });
+  });
+
+  it("ignores locals that cannot be retrieved from a template", function () {
+    var template = `{{xyz}}`; // not on the whitelist of variables
+    var result = parseTemplate(template);
+    expect(result).toEqual({ partials: {}, retrieve: {} });
+  });
+
+  it("captures the root local used", function () {
+    var template = `{{folder.length}}`; // not on the whitelist of variables
+    var result = parseTemplate(template);
+    expect(result).toEqual({ partials: {}, retrieve: { folder: true } });
+  });
+});


### PR DESCRIPTION
Previously, this would not have worked as a standalone template view:

```
{{all_entries.length}} entries posted.
```

Now it does! Also adds some tests