### PR TITLE
Adds new {{stem}} token to link formats

### DIFF
--- a/app/brochure/views/how/guides/urls.html
+++ b/app/brochure/views/how/guides/urls.html
@@ -50,10 +50,18 @@
 
     <tr>
       <td><code>\{{path}}</code></td>
-      <td>The file’s path in lowercase. A blog post's link cannot be identical to the path to its source file so combine this with other properties.</td>
+      <td>The file’s path in lowercase. Note that a post's link cannot be identical to the path to its source file so combine this with other properties.</td>
     </tr>
-    <tr>
 
+    <tr>
+      <td><code>\{{path-without-extension}}</code></td>
+      <td>The file’s path in lowercase without the file extension.</td>
+    </tr>
+
+    <tr>
+      <td><code>\{{stem}}</code></td>
+      <td>A URL-friendly version of the file’s path without the file extension.</td>
+    </tr>
 
     <tr>
       <td><code>\{{size}}</code></td>

--- a/app/build/prepare/permalink.js
+++ b/app/build/prepare/permalink.js
@@ -1,7 +1,10 @@
+var makeSlug = require("helper/makeSlug");
 var mustache = require("mustache");
-var DEFAULT = "{{slug}}";
 var moment = require("moment");
+
 require("moment-timezone");
+
+var DEFAULT = "{{slug}}";
 
 // this needs to be pulled directly from the moment library
 // i copied them from the docs.
@@ -119,8 +122,15 @@ module.exports = function (timeZone, format, entry) {
 
     for (var i in entry) if (allow.indexOf(i) > -1) view[i] = entry[i];
 
+    // this needs a better name but make sure to update any
+    // existing custom formats for folks...
+    view["path-without-extension"] = entry.path.slice(
+      0,
+      entry.path.lastIndexOf(".")
+    );
+
     // stem should be path without extension
-    view.stem = entry.path.slice(0, entry.path.lastIndexOf("."));
+    view.stem = makeSlug(view["path-without-extension"]);
 
     // this needs a better name but make sure to update any
     // existing custom formats for folks...

--- a/app/build/prepare/tests/permalink.js
+++ b/app/build/prepare/tests/permalink.js
@@ -6,7 +6,23 @@ describe("title parser", function () {
   it("generates a permalink from the entry's path", function () {
     let entry = {
       path: "/[design]/bar.txt",
-      name: 'bar.txt',
+      name: "bar.txt",
+      size: 123,
+      html: "",
+      updated: 123,
+      draft: false,
+      metadata: {},
+    };
+
+    let permalink = Permalink(this.blog.timeZone, "{{stem}}", entry);
+
+    expect(permalink).toEqual("/design/bar");
+  });
+
+  it("generates a permalink from the entry's path", function () {
+    let entry = {
+      path: "/[design]/bar.txt",
+      name: "bar.txt",
       size: 123,
       html: "",
       updated: 123,
@@ -16,7 +32,7 @@ describe("title parser", function () {
 
     let permalink = Permalink(
       this.blog.timeZone,
-      '{{stem}}',
+      "{{path-without-extension}}",
       entry
     );
 

--- a/app/helper/makeSlug.js
+++ b/app/helper/makeSlug.js
@@ -3,9 +3,8 @@ var MAX_LENGTH = 100;
 
 // This must always return a string but it can be empty
 function makeSlug(string) {
-  var words,
-    components,
-    trimmed = "";
+  var words;
+  var trimmed = "";
 
   ensure(string, "string");
 
@@ -54,14 +53,12 @@ function makeSlug(string) {
 
   slug = trimmed;
 
-  // Remove leading and trailing
-  // slashes and dashes.
+  slug = slug
+    .split("/")
+    .map((str) => trimLeadingAndTrailing(str, ["-"]))
+    .join("/");
 
-  while (slug.length > 1 && (slug[0] === "/" || slug[0] === "-"))
-    slug = slug.slice(1);
-
-  while (slug.length > 1 && (slug.slice(-1) === "/" || slug.slice(-1) === "-"))
-    slug = slug.slice(0, -1);
+  slug = trimLeadingAndTrailing(slug, ["-", "/"]);
 
   if (slug === "-") slug = "";
 
@@ -70,6 +67,15 @@ function makeSlug(string) {
   slug = slug || "";
 
   return slug;
+}
+
+function trimLeadingAndTrailing(str, characters) {
+  while (str.length > 1 && characters.indexOf(str[0]) > -1) str = str.slice(1);
+
+  while (str.length > 1 && characters.indexOf(str.slice(-1)) > -1)
+    str = str.slice(0, -1);
+
+  return str;
 }
 
 var Is = require("./_is");
@@ -100,6 +106,10 @@ is("1-2-3-4", "1-2-3-4");
 is("12 34", "12-34");
 is("f/ü/k", "f/%C3%BC/k");
 is("微博", "%E5%BE%AE%E5%8D%9A");
+
+is("/[design]/abc", "design/abc");
+
+is("/[design](foo)/apple bc", "design-foo/apple-bc");
 
 is(
   "remove object replacement character: ￼",

--- a/app/helper/makeSlug.js
+++ b/app/helper/makeSlug.js
@@ -53,6 +53,8 @@ function makeSlug(string) {
 
   slug = trimmed;
 
+  // remove internal leading and trailing hyphens, e.g. 
+  // /-foo-/bar -> /foo/bar
   slug = slug
     .split("/")
     .map((str) => trimLeadingAndTrailing(str, ["-"]))


### PR DESCRIPTION
In your custom permalink format you can now use:

- `{{path-without-extension}}`, The file’s path in lowercase without the file extension.
- `{{stem}}`, A URL-friendly version of the file’s path without the file extension.
