### PR TITLE
Sets default charset for NGINX responses

### DIFF
--- a/config/nginx/http.conf
+++ b/config/nginx/http.conf
@@ -6,6 +6,10 @@ access_log /var/www/blot/logs/nginx.log access_log_format;
 # Hide the nginx version in the server header
 server_tokens off;
 
+# Added to set the content-type charset header 
+# for text files served by NGINX
+charset utf-8;
+
 include /var/www/blot/config/nginx/static-file.conf;
 
 upstream blot_node {


### PR DESCRIPTION
Requested so that emojis show up in text files. I hope this doesn't have side-effects