### PR TITLE
Queues

### DIFF
--- a/app/build/index.js
+++ b/app/build/index.js
@@ -1,74 +1,15 @@
-const prefix = () => clfdate() + " Build:";
-const debug = require("debug")("blot:build");
-const uuid = require("uuid/v4");
-const child_process = require("child_process");
-const clfdate = require("helper/clfdate");
-const jobs = {};
+// Launch queue to process the building of entries
+const bull = require("bull");
+const queue = new bull("build");
 
-let worker = new Worker();
+queue.process(__dirname + "/main.js");
 
-// Does this handle the cluster reload action too?
-// e.g. scripts/reload-server.sh?
-process.on("exit", function () {
-  worker.kill();
-});
-
-module.exports = function (blog, path, options, callback) {
-  const jobId = uuid();
-  jobs[jobId] = {
-    blog,
-    jobId,
-    path,
-    options,
-    callback,
-  };
-
-  worker.send({ blog, path, jobId, options }, function (err) {
-    if (err) {
-      console.log(prefix(), `failed to send job overseer=${process.pid}`, err);
-      return callback(new Error("Failed to build"));
-    }
-    console.log(
-      prefix(),
-      `sent job overseer=${process.pid} worker=${worker.pid}`
-    );
-  });
+module.exports = async function (blog, path, options, callback) {
+  try {
+    const job = await queue.add({ blog, path, options });
+    const result = await job.finished();
+    return callback(null, result);
+  } catch (e) {
+    return callback(e);
+  }
 };
-
-function Worker() {
-  console.log(prefix(), `Launching new build worker overseer=${process.pid}`);
-  const newWorker = child_process.fork(__dirname + "/main", {
-    detached: false,
-  });
-
-  newWorker.on("message", function ({ err, jobId, entry }) {
-    var job = jobs[jobId];
-
-    console.log(prefix(), `completed jobId=${jobId} error=${!!err}`);
-
-    if (job) {
-      delete jobs[jobId];
-    }
-
-    if (job.callback) {
-      job.callback(err, entry);
-    }
-  });
-
-  newWorker.on("exit", function (code) {
-    if (code !== 0) worker = new Worker();
-
-    console.log(
-      prefix(),
-      `Overseer pid=${process.pid} has a dead build process`
-    );
-
-    for (const jobId in jobs) {
-      const job = jobs[jobId];
-      job.callback(new Error("Failed to finish task"));
-      delete jobs[jobId];
-    }
-  });
-
-  return newWorker;
-}

--- a/app/build/single.js
+++ b/app/build/single.js
@@ -9,11 +9,10 @@ var converters = require("./converters");
 module.exports = function (blog, path, options, callback) {
   ensure(blog, "object").and(path, "string").and(callback, "function");
 
-  // Used for testing
   if (options.kill) {
     throw new Error("KILL THIS PROCESS PLEASE");
   }
-
+  
   async.each(
     converters,
     function (converter, next) {

--- a/app/build/tests/flaky-file.js
+++ b/app/build/tests/flaky-file.js
@@ -10,16 +10,23 @@ describe("flaky file", function () {
       var path = "/Hello.txt";
       var contents = "World";
 
+      console.log("Writing file...");
       await fs.outputFile(this.blogDirectory + path, contents);
 
+      console.log("Building file with error...");
       // will trigger uncaught exception
-      build(this.blog, path, { kill: true }, function (err) {
-        expect(err.message).toContain("Failed to finish task");
-        build(this.blog, path, { kill: false }, function (err, entry) {
+      build(this.blog, path, { kill: true }, (err) => {
+        expect(err.message).toContain("KILL THIS PROCESS PLEASE");
+
+        // setTimeout(function () {
+        console.log("Building file without error...");
+        build(this.blog, path, { kill: false }, (err, entry) => {
+          console.log("HERE WITH ERROR", err);
           if (err) return done.fail(err);
           expect(entry.html).toEqual("<p>World</p>");
           done();
         });
+        // }, 2000);
       });
     },
     10 * 1000 // set timeout to 10 seconds

--- a/app/build/tests/non-flaky-file.js
+++ b/app/build/tests/non-flaky-file.js
@@ -1,0 +1,23 @@
+describe("flaky file", function () {
+  var build = require("../index");
+  var fs = require("fs-extra");
+
+  global.test.blog();
+
+  it(
+    "will gracefully handle a file",
+    async function (done) {
+      var path = "/Hello.txt";
+      var contents = "World";
+      await fs.outputFile(this.blogDirectory + path, contents);
+
+      console.log("Building file without error...");
+      build(this.blog, path, { kill: false }, (err, entry) => {
+        if (err) return done.fail(err);
+        expect(entry.html).toEqual("<p>World</p>");
+        done();
+      });
+    },
+    10 * 1000 // set timeout to 10 seconds
+  );
+});

--- a/app/index.js
+++ b/app/index.js
@@ -19,18 +19,6 @@ if (cluster.isMaster) {
   // Write the master process PID so we can signal it
   fs.writeFileSync(config.pidfile, process.pid.toString(), "utf-8");
 
-  // Launch scheduler for background tasks, like backups, emails
-  scheduler();
-
-  // Run any initialization that clients need
-  // Google Drive will renew any webhooks, e.g.
-  for (const { init, display_name } of Object.values(require("clients"))) {
-    if (init) {
-      console.log(clfdate(), `Initializing ${display_name} client`);
-      init();
-    }
-  }
-
   // Fork workers.
   for (let i = 0; i < NUMBER_OF_WORKERS; i++) {
     cluster.fork();
@@ -48,6 +36,18 @@ if (cluster.isMaster) {
       publishScheduledEntries();
     }
   });
+
+  // Launch scheduler for background tasks, like backups, emails
+  scheduler();
+
+  // Run any initialization that clients need
+  // Google Drive will renew any webhooks, e.g.
+  for (const { init, display_name } of Object.values(require("clients"))) {
+    if (init) {
+      console.log(clfdate(), `Initializing ${display_name} client`);
+      init();
+    }
+  }
 
   // SIGUSR1 is used by node for debugging, so we use SIGUSR2 to
   // signal the master process that it's time to reboot the servers
@@ -110,8 +110,10 @@ if (cluster.isMaster) {
 } else {
   console.log(clfdate(), `Worker process running pid=${process.pid}`);
 
+  const server = require("./server");
+
   // Open the server to handle requests
-  require("./server").listen(config.port, function () {
+  server.listen(config.port, function () {
     console.log(
       clfdate(),
       `Worker process listening pid=${process.pid} port=${config.port}`

--- a/app/tests/bull/build.js
+++ b/app/tests/bull/build.js
@@ -1,0 +1,35 @@
+const bull = require("bull");
+var config = require("config");
+var redis = require("redis");
+var client = redis.createClient(config.redis.port);
+
+client.on("error", function (err) {
+  console.log("Redis Error:");
+  console.log(err);
+  if (err.trace) console.log(err.trace);
+  if (err.stack) console.log(err.stack);
+});
+const queue = new bull("example", {
+  createClient: function (type) {
+    switch (type) {
+      case "client":
+        return client;
+      case "subscriber":
+        return client;
+      default:
+        return client;
+    }
+  },
+});
+
+queue.process(__dirname + "/worker.js");
+
+module.exports = async function (data, callback) {
+  try {
+    const job = await queue.add(data);
+    const result = await job.finished();
+    return callback(null, result);
+  } catch (e) {
+    return callback(e);
+  }
+};

--- a/app/tests/bull/dependency.js
+++ b/app/tests/bull/dependency.js
@@ -1,0 +1,4 @@
+module.exports = function (data) {
+  if (data.throwInDependency)
+    throw new Error("Simulated exception in dependency");
+};

--- a/app/tests/bull/index.js
+++ b/app/tests/bull/index.js
@@ -1,0 +1,50 @@
+describe("bull", function () {
+  var build = require("./build");
+
+  global.test.blog();
+
+  it("recovers from an exception in processor", async function (done) {
+    build(
+      {
+        throw: true,
+      },
+      function (err) {
+        expect(err.message).toEqual("Simulated uncaught exception");
+        build({}, function (err, result) {
+          expect(result).toEqual("Success");
+          done();
+        });
+      }
+    );
+  });
+
+it("recovers from unexpected exit of worker", async function (done) {
+    build(
+      {
+        exitWithError: true,
+      },
+      function (err) {
+        expect(err.message).toEqual("Unexpected exit code: 1 signal: null");
+        build({}, function (err, result) {
+          expect(result).toEqual("Success");
+          done();
+        });
+      }
+    );
+  });
+
+  it("recovers from an exception in dependency of processor", async function (done) {
+    build(
+      {
+        throwInDependency: true,
+      },
+      function (err) {
+        expect(err.message).toEqual("Simulated exception in dependency");
+        build({}, function (err, result) {
+          expect(result).toEqual("Success");
+          done();
+        });
+      }
+    );
+  });
+});

--- a/app/tests/bull/worker.js
+++ b/app/tests/bull/worker.js
@@ -1,0 +1,26 @@
+console.log("Build process launched pid:", process.pid);
+
+const dependency = require("./dependency");
+const client = require("client");
+
+module.exports = function build({ data }, callback) {
+  console.log("Build process running, pid", process.pid, "data:", data);
+
+  if (data.throw) throw new Error("Simulated uncaught exception");
+
+  if (data.exitWithError) return process.exit(1);
+
+  dependency(data);
+
+  const delay = Math.random() * 1000;
+
+  client.ping(function (err, stat) {
+    if (err) return callback(err);
+    console.log("Pong from redis?", stat);
+    console.log("Waiting", delay, "ms to finish job...");
+    setTimeout(function () {
+      console.log("Waited", delay, "ms");
+      callback(null, "Success");
+    }, delay);
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13041,11 +13041,6 @@
       "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz",
       "integrity": "sha1-9C/YFV048hpbjqB8KOBj7RcAsTg="
     },
-    "async-exit-hook": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
-      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw=="
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -13735,6 +13730,58 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
     },
+    "bull": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bull/-/bull-4.6.2.tgz",
+      "integrity": "sha512-RA6wnL+rZ2GRHMhz+UxFEn7hlLBpxPEiW4A0UY3YwWnheRA55AT4MC0PknxqO1K55pGFKSh/GpHQaj8flJMm+w==",
+      "requires": {
+        "cron-parser": "^4.2.1",
+        "debuglog": "^1.0.0",
+        "get-port": "^5.1.1",
+        "ioredis": "^4.28.5",
+        "lodash": "^4.17.21",
+        "msgpackr": "^1.5.2",
+        "p-timeout": "^3.2.0",
+        "semver": "^7.3.2",
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "p-timeout": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+          "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -14215,6 +14262,14 @@
         "capture-stack-trace": "^1.0.0"
       }
     },
+    "cron-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.2.1.tgz",
+      "integrity": "sha512-5sJBwDYyCp+0vU5b7POl8zLWfgV5fOHxlc45FWoWdHecGC7MQHCjx0CHivCMRnGFovghKhhyYM+Zm9DcY5qcHg==",
+      "requires": {
+        "luxon": "^1.28.0"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -14399,6 +14454,11 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
+    },
+    "debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
     },
     "decamelize": {
       "version": "1.2.0",
@@ -16162,6 +16222,11 @@
           "dev": true
         }
       }
+    },
+    "get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
     },
     "get-proxy": {
       "version": "2.1.0",
@@ -18962,6 +19027,11 @@
         "yallist": "^2.1.2"
       }
     },
+    "luxon": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
+      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
+    },
     "magic-string": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
@@ -19265,6 +19335,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "msgpackr": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.5.4.tgz",
+      "integrity": "sha512-Z7w5Jg+2Q9z9gJxeM68d7tSuWZZGnFIRhZnyqcZCa/1dKkhOCNvR1TUV3zzJ3+vj78vlwKRzUgVDlW4jiSOeDA==",
+      "requires": {
+        "msgpackr-extract": "^1.0.14"
+      }
+    },
+    "msgpackr-extract": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-1.0.16.tgz",
+      "integrity": "sha512-fxdRfQUxPrL/TizyfYfMn09dK58e+d65bRD/fcaVH4052vj30QOzzqxcQIS7B0NsqlypEQ/6Du3QmP2DhWFfCA==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.2",
+        "node-gyp-build": "^4.2.3"
+      }
+    },
     "multiparty": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.2.3.tgz",
@@ -19347,6 +19435,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
       "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA="
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
     },
     "napi-build-utils": {
       "version": "1.0.2",
@@ -19483,6 +19577,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
       "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
+    },
+    "node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "optional": true
     },
     "node-schedule": {
       "version": "0.1.16",
@@ -20675,6 +20775,11 @@
           "dev": true
         }
       }
+    },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
     },
     "redis-commands": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
   "version": "0.0.0",
   "dependencies": {
     "async": "^2.6.1",
-    "async-exit-hook": "^2.0.1",
     "aws-sdk": "^2.814.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.4.3",
+    "bull": "^4.6.2",
     "cheerio": "^0.22.0",
     "chokidar": "^3.5.3",
     "clean-css": "^4.2.1",

--- a/scripts/blog/prune.js
+++ b/scripts/blog/prune.js
@@ -1,6 +1,6 @@
 var each = require("../each/blog");
 var Blog = require("models/blog");
-var client = require("redis").createClient();
+var client = require("models/client");
 var yesno = require("yesno");
 let multi = client.multi();
 let keysToDelete = {};

--- a/scripts/db/delete-cache-keys.js
+++ b/scripts/db/delete-cache-keys.js
@@ -1,4 +1,4 @@
-var client = require("redis").createClient();
+var client = require("models/client");
 var multi = client.multi();
 var keysToDelete = [];
 var yesno = require("yesno");

--- a/scripts/db/keys.js
+++ b/scripts/db/keys.js
@@ -1,4 +1,4 @@
-var client = require("redis").createClient();
+var client = require("models/client");
 var colors = require("colors/safe");
 
 if (require.main === module) {

--- a/scripts/delete/blog.js
+++ b/scripts/delete/blog.js
@@ -1,6 +1,6 @@
 var get = require("../blog/get");
 var async = require("async");
-var redis = require("redis").createClient();
+var redis = require("models/client");
 var User = require("models/user");
 var Blog = require("models/blog");
 

--- a/scripts/delete/cache.js
+++ b/scripts/delete/cache.js
@@ -1,4 +1,4 @@
-var redis = require("redis").createClient();
+var redis = require("models/client");
 
 var SCHEME = "cache:*";
 

--- a/scripts/delete/entries.js
+++ b/scripts/delete/entries.js
@@ -1,6 +1,6 @@
 require("../only_locally");
 
-var redis = require("redis").createClient();
+var redis = require("models/client");
 
 var SCHEME = "blog:*:entry:*";
 

--- a/scripts/delete/image_dimension_hashes.js
+++ b/scripts/delete/image_dimension_hashes.js
@@ -1,4 +1,4 @@
-var redis = require("redis").createClient();
+var redis = require("models/client");
 
 redis.keys("image:dimensions:*", function (error, sessionKeys) {
   sessionKeys.forEach(function (sessionKey) {

--- a/scripts/delete/old_blog_info.js
+++ b/scripts/delete/old_blog_info.js
@@ -1,4 +1,4 @@
-var redis = require("redis").createClient(),
+var redis = require("models/client"),
   _ = require("lodash"),
   Blog = require("models/blog");
 

--- a/scripts/delete/old_tag_keys.js
+++ b/scripts/delete/old_tag_keys.js
@@ -1,4 +1,4 @@
-var redis = require("redis").createClient();
+var redis = require("models/client");
 
 var TAGS = "blog:*:tags";
 var TAG = "blog:*:tag:*";

--- a/scripts/delete/search_indexes.js
+++ b/scripts/delete/search_indexes.js
@@ -1,6 +1,6 @@
 require("../only_locally");
 
-var redis = require("redis").createClient();
+var redis = require("models/client");
 
 var SCHEME = "blog:*:search*";
 

--- a/scripts/delete/sessions.js
+++ b/scripts/delete/sessions.js
@@ -1,4 +1,4 @@
-var redis = require("redis").createClient();
+var redis = require("models/client");
 
 countKeys("*");
 countKeys("sess:*");

--- a/scripts/delete/sync_keys.js
+++ b/scripts/delete/sync_keys.js
@@ -1,4 +1,4 @@
-var redis = require("redis").createClient();
+var redis = require("models/client");
 var forEach = require("helper/forEach");
 
 var SCHEMES = [

--- a/scripts/delete/upload_keys.js
+++ b/scripts/delete/upload_keys.js
@@ -1,4 +1,4 @@
-var redis = require("redis").createClient();
+var redis = require("models/client");
 var blogID = process.argv[2];
 
 if (!blogID) throw "Please specify a blog id";

--- a/scripts/delete/user.js
+++ b/scripts/delete/user.js
@@ -1,6 +1,6 @@
 var get = require("../blog/get");
 var async = require("async");
-var redis = require("redis").createClient();
+var redis = require("models/client");
 
 get(process.argv[2], function (user, blog) {
   console.log(user.name, blog.handle);

--- a/scripts/entry/wipe-image-and-thumbnail-cache.js
+++ b/scripts/entry/wipe-image-and-thumbnail-cache.js
@@ -1,5 +1,5 @@
 var get = require("../get/entry");
-var client = require("redis").createClient();
+var client = require("models/client");
 var async = require("async");
 
 if (require.main === module) {

--- a/scripts/git/wipe_old_token_key_format.js
+++ b/scripts/git/wipe_old_token_key_format.js
@@ -1,4 +1,4 @@
-var redis = require("redis").createClient();
+var redis = require("models/client");
 var each = require("../each/blog");
 
 each(function (user, blog, next) {

--- a/scripts/state/info.js
+++ b/scripts/state/info.js
@@ -1,6 +1,6 @@
 require("../only_locally");
 
-var client = require("redis").createClient();
+var client = require("models/client");
 var config = require("config");
 var Blog = require("blog");
 var async = require("async");

--- a/scripts/state/load.js
+++ b/scripts/state/load.js
@@ -2,7 +2,7 @@ require("../only_locally");
 
 var fs = require("fs-extra");
 var exec = require("child_process").exec;
-var redis = require("redis");
+var redis = require("ioredis");
 var cp = require("child_process");
 var ROOT = process.env.BLOT_DIRECTORY;
 
@@ -58,7 +58,7 @@ function main(label, callback) {
 
 function loadDB(directory, callback) {
   var dump = directory + "/dump.rdb";
-  var client = redis.createClient();
+  var client = new redis();
   var multi = client.multi();
 
   // If redis was already shut down, then


### PR DESCRIPTION
- [ ] Work out if switching to `ioredis` from `redis`, will solve zombie processes?
     - [ ] it seems to not have solved the issue, with rebase, running:
     - [ ] ` npm test app/build/tests/flaky-file.js` and then `ps aux | grep node | grep -v Keybase` shows a vestigial process
- [x] Consolidate versions of `redis` used in production and development and testing
- [x] Update node version running
- [x] Ensure the server is running `redis` of a sufficiently advanced version to support bull `>2.8.18`?
- [x] Remove `app/sketches`

---

`build/tests/flaky-file` seems to kind of work, only when the uncaught exception is thrown from the processor.js file. If the uncaught exception is thrown from a file required by the processor.js file, we get a weird error `unexpected exit code` both on my machine and on CI.

we need to be able to gracefully handle uncaught exceptions, both in required files and the main one

also, when the error is thrown in the main one, we get a zombie process `/bull/lib/process/master.js` after everything else closes, so weird behaviour is afoot

---

could we proxy some requests, e.g. /clients/sync ... to a different child process to keep the main server (for rendering blogs) snappy? this could be done at the nginx level, or the node js level

could we use queueing to avoid locking the blog folder?