### PR TITLE
Updates redis to LTS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         # If you ever add more node versions you need to replace current caching node_modules with caching of ~/.npm
         node-version: [12.16.3]
         pandoc-version: [2.11.3.2]
-        redis-version: [4]
+        redis-version: [6.2]
 
     environment: Tests
     

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         # If you ever add more node versions you need to replace current caching node_modules with caching of ~/.npm
         node-version: [12.16.3]
         pandoc-version: [2.11.3.2]
-        redis-version: [6.2]
+        redis-version: [6.2.6]
 
     environment: Tests
     

--- a/notes/_guides/_update-redis-to-lts.txt
+++ b/notes/_guides/_update-redis-to-lts.txt
@@ -1,0 +1,62 @@
+# Update the version of Redis
+
+The most important step is to make sure you run Blot's test suite against the new version of redis to catch any obvious breaking changes.
+
+First, work out the version of redis you'd like to use. I do this by visiting [the official website](https://redis.io/download) and selecting the stable version recommended for most users.
+
+The rest of the guide assumes this version happens to be ```6.2.6```.
+
+## In development
+
+First we need to update the redis version in .github/workflows/tests.yml which is used to run the test suite:
+
+```
+        redis-version: [6.2.6]
+```
+
+Then we do the following on MacOS:
+
+$ wget https://download.redis.io/releases/redis-6.2.6.tar.gz
+$ tar xzf redis-6.2.6.tar.gz
+$ cd redis-6.2.6
+$ make
+$ make test
+$ make install
+
+Then we do the following on our production server:
+
+$ wget https://download.redis.io/releases/redis-6.2.6.tar.gz
+$ tar xzf redis-6.2.6.tar.gz
+$ cd redis-6.2.6
+$ make
+$ make install
+
+Restart the production server:
+
+```
+sudo stop redis && sudo start redis
+```
+
+and NGINX and Blot:
+
+```
+sudo stop blot && sudo start blot
+```
+
+```
+sudo stop nginx && sudo start nginx
+```
+
+Here's the production checklist for the PR:
+
+```
+/usr/local/bin/redis-server -version
+wget https://download.redis.io/releases/redis-6.2.6.tar.gz
+tar xzf redis-6.2.6.tar.gz
+cd redis-6.2.6
+make
+make test
+make install
+/usr/local/bin/redis-server -version
+sudo restart redis
+```

--- a/notes/_guides/_update-redis-to-lts.txt
+++ b/notes/_guides/_update-redis-to-lts.txt
@@ -16,47 +16,63 @@ First we need to update the redis version in .github/workflows/tests.yml which i
 
 Then we do the following on MacOS:
 
-$ wget https://download.redis.io/releases/redis-6.2.6.tar.gz
-$ tar xzf redis-6.2.6.tar.gz
-$ cd redis-6.2.6
-$ make
-$ make test
-$ make install
-
-Then we do the following on our production server:
-
-$ wget https://download.redis.io/releases/redis-6.2.6.tar.gz
-$ tar xzf redis-6.2.6.tar.gz
-$ cd redis-6.2.6
-$ make
-$ make install
-
-Restart the production server:
-
 ```
-sudo stop redis && sudo start redis
-```
-
-and NGINX and Blot:
-
-```
-sudo stop blot && sudo start blot
-```
-
-```
-sudo stop nginx && sudo start nginx
-```
-
-Here's the production checklist for the PR:
-
-```
-/usr/local/bin/redis-server -version
 wget https://download.redis.io/releases/redis-6.2.6.tar.gz
 tar xzf redis-6.2.6.tar.gz
 cd redis-6.2.6
 make
 make test
 make install
-/usr/local/bin/redis-server -version
-sudo restart redis
+```
+
+Then we do the following on our production server:
+
+```
+wget https://download.redis.io/releases/redis-6.2.6.tar.gz
+tar xzf redis-6.2.6.tar.gz
+cd redis-6.2.6
+make
+make install
+```
+
+Restart the production server:
+
+```
+ps aux | grep redis
+sudo stop redis && sudo start redis
+ps aux | grep redis
+```
+
+and NGINX and Blot, which obviously depend on redis:
+
+```
+ps aux | grep node
+sudo stop blot && sudo start blot
+ps aux | grep node
+```
+
+```
+ps aux | grep nginx
+sudo stop nginx && sudo start nginx
+ps aux | grep nginx
+```
+
+Here's the production checklist for the PR:
+
+```
+# Note the version for a later sanity check
+/usr/local/bin/redis-server -v
+wget https://download.redis.io/releases/redis-6.2.6.tar.gz
+tar xzf redis-6.2.6.tar.gz
+cd redis-6.2.6
+make
+# I don't run `make test` since I'm not sure if its a good idea in prod
+make install
+# Note the version has changed
+/usr/local/bin/redis-server -v
+# To check we run the new bin
+ps aux | grep redis
+sudo stop redis && sudo start redis
+# Ensure we run the new bin
+ps aux | grep redis
 ```


### PR DESCRIPTION
```
/usr/local/bin/redis-server -v
wget https://download.redis.io/releases/redis-6.2.6.tar.gz
tar xzf redis-6.2.6.tar.gz
cd redis-6.2.6
make
make test
make install
/usr/local/bin/redis-server -v
sudo restart redis
```