### PR TITLE
Extracts a thumbnail from video embeds

### DIFF
--- a/app/build/plugins/videoEmbeds/vimeo.js
+++ b/app/build/plugins/videoEmbeds/vimeo.js
@@ -6,11 +6,13 @@ var basename = require("path").basename;
 // the video player will not show. This causes issues with
 // inline elements displaying (adds extra space) solution needed
 // that doesn't disrupt page layout...
-function template(id, ratio) {
+function template(id, ratio, thumbnail) {
   return (
     '<div style="width:0;height:0"> </div><div class="videoContainer vimeo" style="padding-bottom: ' +
     ratio +
-    '%"><iframe src="//player.vimeo.com/video/' +
+    '%" ><iframe data-thumbnail="' +
+    thumbnail +
+    '" src="//player.vimeo.com/video/' +
     id +
     '?badge=0&color=ffffff&byline=0&portrait=0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>'
   );
@@ -23,7 +25,7 @@ function apiURL(id) {
 var FAIL = "Could not retrieve video properties";
 
 module.exports = function (href, callback) {
-  var id, height, width, ratio, el;
+  var id, height, width, ratio, el, thumbnail;
 
   try {
     // we trim because without it,
@@ -51,11 +53,11 @@ module.exports = function (href, callback) {
     el = body[0];
 
     if (!el || !el.width || !el.height) return callback(new Error(FAIL));
-
+    thumbnail = el.thumbnail_large + ".jpg";
     height = el.height;
     width = el.width;
     ratio = (height / width) * 100;
 
-    return callback(null, template(id, ratio));
+    return callback(null, template(id, ratio, thumbnail));
   });
 };

--- a/app/build/thumbnail/candidates.js
+++ b/app/build/thumbnail/candidates.js
@@ -1,9 +1,10 @@
-var cheerio = require("cheerio");
+const cheerio = require("cheerio");
+const URL = require("url");
 
 module.exports = function (metadata, html) {
-  var candidates = [];
+  const candidates = [];
 
-  var $ = cheerio.load(html, { decodeEntities: false });
+  const $ = cheerio.load(html, { decodeEntities: false });
 
   // Would be nice to resolve this relative to
   // the location of the entry so we could
@@ -12,8 +13,28 @@ module.exports = function (metadata, html) {
     candidates.push(metadata.thumbnail);
   }
 
+  $(".videoContainer iframe").each(function () {
+    try {
+      const { hostname, pathname } = URL.parse($(this).attr("src"));
+
+      if (hostname !== "www.youtube-nocookie.com") return;
+
+      const id = pathname.slice("/embed/".length);
+
+      if (!id) return;
+
+      candidates.push(`https://i.ytimg.com/vi/${id}/maxresdefault.jpg`);
+      candidates.push(`http://img.youtube.com/vi/${id}/mqdefault.jpg`);
+
+      // see here for a discussion of youtube thumbnail URLs:
+      // https://stackoverflow.com/questions/2068344/how-do-i-get-a-youtube-video-thumbnail-from-the-youtube-api
+    } catch (e) {
+      return;
+    }
+  });
+
   $("img").each(function () {
-    var src = $(this).attr("src");
+    const src = $(this).attr("src");
 
     // The img lacks an src attribute – it happens!
     if (!src) return;

--- a/app/build/thumbnail/candidates.js
+++ b/app/build/thumbnail/candidates.js
@@ -15,6 +15,15 @@ module.exports = function (metadata, html) {
 
   $(".videoContainer iframe").each(function () {
     try {
+      // handle vimeo
+      const thumbnail = $(this).attr("data-thumbnail");
+
+      if (thumbnail) {
+        candidates.push(thumbnail);
+        return;
+      }
+
+      // handle youtube
       const { hostname, pathname } = URL.parse($(this).attr("src"));
 
       if (hostname !== "www.youtube-nocookie.com") return;


### PR DESCRIPTION
If you embed a youtube video in a post, its thumbnail can now be used as the post's thumbnail on Blot
- [x] Add support for vimeo
- [ ] Tell [questioner and rebuild site](https://blot.im/questions/1215)