### PR TITLE
Updates layout css

### DIFF
--- a/app/brochure/views/partials/layout.html
+++ b/app/brochure/views/partials/layout.html
@@ -24,7 +24,7 @@
 }
 
   @media screen and (max-width: 1000px) {
-	    .yiel {padding-left: 1.5rem}
+	    .yiel {padding-left: 1.5rem; padding-right: 1.5rem}
 }
 	@media screen and (max-width: 800px) {
 /*		.doc-left {padding: 0;grid-column-start: 1;grid-column-end: 12;grid-row: 1}


### PR DESCRIPTION
At the moment, when reading a post on a mobile device, padding does not seem to exist on the right side of the viewport for the blog post, resulting in an asymmetrical viewing experience. This simple solution fixes that.

![Frame 6](https://user-images.githubusercontent.com/52251483/214545877-09299239-1404-478f-86d9-e95d510925d2.png)
