### PR TITLE
Improves template faq layout

### DIFF
--- a/app/brochure/views/css/blot.css
+++ b/app/brochure/views/css/blot.css
@@ -144,6 +144,21 @@ ul.templates li {
   width: 33%;
   padding: 1rem;
   box-sizing: border-box;
+  flex-basis: calc(33.33% - 20px);
+}
+
+@media screen and (max-width: 1000px) {
+  ul.templates li {
+    flex-basis: calc(50% - 20px);
+    margin-right: 20px;
+  }
+}
+  
+@media screen and (max-width: 700px) {
+  ul.templates li {
+    flex-basis: 100%;
+    margin-right: 20px;
+  }
 }
 
 ul.templates li a {

--- a/app/brochure/views/templates/index.html
+++ b/app/brochure/views/templates/index.html
@@ -5,7 +5,7 @@
 
 <style type="text/css">
   
-  .templates a .browser {margin-top:6px;border: 1px solid var(--light-border-color);border-radius: 6px;display: block;padding: 0.25rem 0.25rem 0;box-shadow: 0 0 10px rgba(0,0,0,0.03);transition: transform .1s ease;transform: scale(1);max-height: 200px;overflow: hidden;}
+  .templates a .browser {margin-top:6px;border: 1px solid var(--light-border-color);border-radius: 6px;display: block;padding: 0.25rem 0.25rem 0;box-shadow: 0 0 10px rgba(0,0,0,0.03);transition: transform .1s ease;transform: scale(1);max-height: 200px;overflow: hidden; width: fit-content;}
 
   .templates a .browser:before {content: "ooo";display: block;border-bottom: 1px solid var(--light-border-color);color: var(--dark-border-color);font-size: 10px;line-height: 5px;margin:0 -0.25rem;padding:0 0.25rem 0.25rem;}
   ul.templates li a {text-decoration: none;min-height: auto}


### PR DESCRIPTION
This small change will show three columns on large viewport widths, two columns on medium viewport widths and one column on small viewport widths for the https://blot.im/templates page.

Something to consider is to make higher resolution images so these are not blurry when stretched.

![Frame 16](https://user-images.githubusercontent.com/52251483/219237524-15a8967f-92da-44a3-a366-d0749102ba1c.png)
