### PR TITLE
Updates brochure/views/index.html

### DIFF
--- a/app/brochure/views/index.html
+++ b/app/brochure/views/index.html
@@ -187,7 +187,7 @@ break-inside: avoid;
     padding-left: 12px
    }
    .tmplw a {flex-basis: 100%;box-sizing: border-box;padding: 0 0 0 0;color: inherit;margin-top: 1.45em;display: flex;}
-   .tmplw a img {width: 47%;height: auto;border:1px solid var(--light-border-color);border-radius: 3px}
+   .tmplw a img {max-width: 47%;aspect-ratio: 1.6 / 1;height: auto;border:1px solid var(--light-border-color);border-radius: 3px}
    .tmplw .arrow-link :nth-child(2) {opacity: 1}
    .tmplw small {font-weight:600;display: none;}
    .tmplw strong {display: block;}


### PR DESCRIPTION
At the moment, the homepage template images when viewed on Gecko-based browsers have a weird layout. This doesn't seem to be an issue on Blink-based browsers. This small patch addresses this issue on Gecko-based renders and is compatible with all others.

Replacing `width` with `max-width` seems to fix this. Also adding `aspect-ratio` makes for more consistent resizing of images.

![219190250-ff9d8d84-481c-4213-8709-f6e9929bacf1](https://user-images.githubusercontent.com/52251483/219482991-e79f2439-958b-4008-bf79-f9c72d95abfb.png)
