### PR TITLE
Updates notes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         # If you ever add more node versions you need to replace current caching node_modules with caching of ~/.npm
         node-version: [16.14.0]
-        pandoc-version: [2.11.3.2]
+        pandoc-version: [3.1.1]
         redis-version: [6.2.6]
 
     environment: Tests

--- a/app/build/converters/markdown/tests/examples/citations-absolute-path-to-bib.txt.html
+++ b/app/build/converters/markdown/tests/examples/citations-absolute-path-to-bib.txt.html
@@ -2,8 +2,8 @@
 bibliography: /bibliography.bib
 -->
 <p><span class="citation" data-cites="item1">Doe (2005)</span></p>
-<div id="refs" class="references csl-bib-body hanging-indent" role="doc-bibliography">
-<div id="ref-item1" class="csl-entry" role="doc-biblioentry">
+<div id="refs" class="references csl-bib-body hanging-indent" role="list">
+<div id="ref-item1" class="csl-entry" role="listitem">
 Doe, John. 2005. <em>First Book</em>. Cambridge: Cambridge University Press.
 </div>
 </div>

--- a/app/build/converters/markdown/tests/examples/citations-broken-csl.txt.html
+++ b/app/build/converters/markdown/tests/examples/citations-broken-csl.txt.html
@@ -3,8 +3,8 @@ bibliography: bibliography.bib
 csl: does-not-exist.csl
 -->
 <p><span class="citation" data-cites="item1">Doe (2005)</span></p>
-<div id="refs" class="references csl-bib-body hanging-indent" role="doc-bibliography">
-<div id="ref-item1" class="csl-entry" role="doc-biblioentry">
+<div id="refs" class="references csl-bib-body hanging-indent" role="list">
+<div id="ref-item1" class="csl-entry" role="listitem">
 Doe, John. 2005. <em>First Book</em>. Cambridge: Cambridge University Press.
 </div>
 </div>

--- a/app/build/converters/markdown/tests/examples/citations-citation.txt.html
+++ b/app/build/converters/markdown/tests/examples/citations-citation.txt.html
@@ -2,8 +2,8 @@
 bibliography: bibliography.bib
 -->
 <p><span class="citation" data-cites="item1">Doe (2005)</span></p>
-<div id="refs" class="references csl-bib-body hanging-indent" role="doc-bibliography">
-<div id="ref-item1" class="csl-entry" role="doc-biblioentry">
+<div id="refs" class="references csl-bib-body hanging-indent" role="list">
+<div id="ref-item1" class="csl-entry" role="listitem">
 Doe, John. 2005. <em>First Book</em>. Cambridge: Cambridge University Press.
 </div>
 </div>

--- a/app/build/converters/markdown/tests/examples/citations-citations.txt.html
+++ b/app/build/converters/markdown/tests/examples/citations-citations.txt.html
@@ -19,22 +19,22 @@ bibliography: bibliography.bib
 <li><p>With some markup <span class="citation" data-cites="item1">(<em>see</em> Doe 2005, 32)</span>.</p></li>
 </ul>
 <h1 class="unnumbered" id="references">References</h1>
-<div id="refs" class="references csl-bib-body hanging-indent" role="doc-bibliography">
-<div id="ref-item1" class="csl-entry" role="doc-biblioentry">
+<div id="refs" class="references csl-bib-body hanging-indent" role="list">
+<div id="ref-item1" class="csl-entry" role="listitem">
 Doe, John. 2005. <em>First Book</em>. Cambridge: Cambridge University Press.
 </div>
-<div id="ref-item2" class="csl-entry" role="doc-biblioentry">
+<div id="ref-item2" class="csl-entry" role="listitem">
 ———. 2006. <span>“Article.”</span> <em>Journal of Generic Studies</em> 6: 33–34.
 </div>
-<div id="ref-item3" class="csl-entry" role="doc-biblioentry">
+<div id="ref-item3" class="csl-entry" role="listitem">
 Doe, John, and Jenny Roe. 2007. <span>“Why Water Is Wet.”</span> In <em>Third Book</em>, edited by Sam Smith. Oxford: Oxford University Press.
 </div>
 </div>
-<section class="footnotes" role="doc-endnotes">
+<section id="footnotes" class="footnotes footnotes-end-of-document" role="doc-endnotes">
 <hr>
 <ol>
-<li id="#footnote-ID_REMOVED" role="doc-endnote"><p>A citation without locators <span class="citation" data-cites="item3">(Doe and Roe 2007)</span>.<a href="#ref-ID_REMOVED" class="footnote-back" role="doc-backlink">↩︎</a></p></li>
-<li id="#footnote-ID_REMOVED" role="doc-endnote"><p>Some citations <span class="citation" data-cites="item2 item3 item1">(see Doe 2006, chap. 3; 2005; Doe and Roe 2007)</span>.<a href="#ref-ID_REMOVED" class="footnote-back" role="doc-backlink">↩︎</a></p></li>
-<li id="#footnote-ID_REMOVED" role="doc-endnote"><p>Like a citation without author: <span class="citation" data-cites="item1">(2005)</span>, and now Doe with a locator <span class="citation" data-cites="item2">(2006, 44)</span>.<a href="#ref-ID_REMOVED" class="footnote-back" role="doc-backlink">↩︎</a></p></li>
+<li id="#footnote-ID_REMOVED"><p>A citation without locators <span class="citation" data-cites="item3">(Doe and Roe 2007)</span>.<a href="#ref-ID_REMOVED" class="footnote-back" role="doc-backlink">↩︎</a></p></li>
+<li id="#footnote-ID_REMOVED"><p>Some citations <span class="citation" data-cites="item2 item3 item1">(see Doe 2006, chap. 3; 2005; Doe and Roe 2007)</span>.<a href="#ref-ID_REMOVED" class="footnote-back" role="doc-backlink">↩︎</a></p></li>
+<li id="#footnote-ID_REMOVED"><p>Like a citation without author: <span class="citation" data-cites="item1">(2005)</span>, and now Doe with a locator <span class="citation" data-cites="item2">(2006, 44)</span>.<a href="#ref-ID_REMOVED" class="footnote-back" role="doc-backlink">↩︎</a></p></li>
 </ol>
 </section>

--- a/app/build/converters/markdown/tests/examples/citations-custom-csl.txt.html
+++ b/app/build/converters/markdown/tests/examples/citations-custom-csl.txt.html
@@ -3,8 +3,8 @@ bibliography: bibliography.bib
 csl: style.csl
 -->
 <p><span class="citation" data-cites="item1">[1]</span></p>
-<div id="refs" class="references csl-bib-body" role="doc-bibliography">
-<div id="ref-item1" class="csl-entry" role="doc-biblioentry">
+<div id="refs" class="references csl-bib-body" role="list">
+<div id="ref-item1" class="csl-entry" role="listitem">
 <div class="csl-left-margin">[1] </div><div class="csl-right-inline">J. Doe, <em>First book</em>. Cambridge: Cambridge University Press, 2005.</div>
 </div>
 </div>

--- a/app/build/converters/markdown/tests/examples/citations-group.txt.html
+++ b/app/build/converters/markdown/tests/examples/citations-group.txt.html
@@ -2,11 +2,11 @@
 bibliography: bibliography.bib
 -->
 <p>A citation group <span class="citation" data-cites="item1 item3">(see Doe 2005, 34–35; also Doe and Roe 2007, chap. 3)</span>.</p>
-<div id="refs" class="references csl-bib-body hanging-indent" role="doc-bibliography">
-<div id="ref-item1" class="csl-entry" role="doc-biblioentry">
+<div id="refs" class="references csl-bib-body hanging-indent" role="list">
+<div id="ref-item1" class="csl-entry" role="listitem">
 Doe, John. 2005. <em>First Book</em>. Cambridge: Cambridge University Press.
 </div>
-<div id="ref-item3" class="csl-entry" role="doc-biblioentry">
+<div id="ref-item3" class="csl-entry" role="listitem">
 Doe, John, and Jenny Roe. 2007. <span>“Why Water Is Wet.”</span> In <em>Third Book</em>, edited by Sam Smith. Oxford: Oxford University Press.
 </div>
 </div>

--- a/app/build/converters/markdown/tests/examples/citations-markup.txt.html
+++ b/app/build/converters/markdown/tests/examples/citations-markup.txt.html
@@ -2,8 +2,8 @@
 bibliography: bibliography.bib
 -->
 <p>With some markup <span class="citation" data-cites="item1">(<em>see</em> Doe 2005, 32)</span>.</p>
-<div id="refs" class="references csl-bib-body hanging-indent" role="doc-bibliography">
-<div id="ref-item1" class="csl-entry" role="doc-biblioentry">
+<div id="refs" class="references csl-bib-body hanging-indent" role="list">
+<div id="ref-item1" class="csl-entry" role="listitem">
 Doe, John. 2005. <em>First Book</em>. Cambridge: Cambridge University Press.
 </div>
 </div>

--- a/app/build/converters/markdown/tests/examples/citations-relative-path-to-bib.txt.html
+++ b/app/build/converters/markdown/tests/examples/citations-relative-path-to-bib.txt.html
@@ -2,8 +2,8 @@
 bibliography: ./bibliography.bib
 -->
 <p><span class="citation" data-cites="item1">Doe (2005)</span></p>
-<div id="refs" class="references csl-bib-body hanging-indent" role="doc-bibliography">
-<div id="ref-item1" class="csl-entry" role="doc-biblioentry">
+<div id="refs" class="references csl-bib-body hanging-indent" role="list">
+<div id="ref-item1" class="csl-entry" role="listitem">
 Doe, John. 2005. <em>First Book</em>. Cambridge: Cambridge University Press.
 </div>
 </div>

--- a/app/build/converters/markdown/tests/examples/citations-with-page.txt.html
+++ b/app/build/converters/markdown/tests/examples/citations-with-page.txt.html
@@ -2,8 +2,8 @@
 bibliography: bibliography.bib
 -->
 <p><span class="citation" data-cites="item1">Doe (2005, 30)</span> says blah.</p>
-<div id="refs" class="references csl-bib-body hanging-indent" role="doc-bibliography">
-<div id="ref-item1" class="csl-entry" role="doc-biblioentry">
+<div id="refs" class="references csl-bib-body hanging-indent" role="list">
+<div id="ref-item1" class="csl-entry" role="listitem">
 Doe, John. 2005. <em>First Book</em>. Cambridge: Cambridge University Press.
 </div>
 </div>

--- a/app/build/converters/markdown/tests/examples/footnotes.txt.html
+++ b/app/build/converters/markdown/tests/examples/footnotes.txt.html
@@ -1,9 +1,9 @@
 <p>How about footnotes, are they parsed? Use this syntax.<a href="#footnote-ID_REMOVED" class="footnote-ref" id="#ref-ID_REMOVED" role="doc-noteref"><sup>1</sup></a> Another line with a different footnote.<a href="#footnote-ID_REMOVED" class="footnote-ref" id="#ref-ID_REMOVED" role="doc-noteref"><sup>2</sup></a> And now for an inline footnote.<a href="#footnote-ID_REMOVED" class="footnote-ref" id="#ref-ID_REMOVED" role="doc-noteref"><sup>3</sup></a></p>
-<section class="footnotes" role="doc-endnotes">
+<section id="footnotes" class="footnotes footnotes-end-of-document" role="doc-endnotes">
 <hr>
 <ol>
-<li id="#footnote-ID_REMOVED" role="doc-endnote"><p>And the note goes here.<a href="#ref-ID_REMOVED" class="footnote-back" role="doc-backlink">↩︎</a></p></li>
-<li id="#footnote-ID_REMOVED" role="doc-endnote"><p>And the second goes here too.<a href="#ref-ID_REMOVED" class="footnote-back" role="doc-backlink">↩︎</a></p></li>
-<li id="#footnote-ID_REMOVED" role="doc-endnote"><p>inline footnote here<a href="#ref-ID_REMOVED" class="footnote-back" role="doc-backlink">↩︎</a></p></li>
+<li id="#footnote-ID_REMOVED"><p>And the note goes here.<a href="#ref-ID_REMOVED" class="footnote-back" role="doc-backlink">↩︎</a></p></li>
+<li id="#footnote-ID_REMOVED"><p>And the second goes here too.<a href="#ref-ID_REMOVED" class="footnote-back" role="doc-backlink">↩︎</a></p></li>
+<li id="#footnote-ID_REMOVED"><p>inline footnote here<a href="#ref-ID_REMOVED" class="footnote-back" role="doc-backlink">↩︎</a></p></li>
 </ol>
 </section>

--- a/app/build/converters/markdown/tests/examples/list-with-tasks.txt.html
+++ b/app/build/converters/markdown/tests/examples/list-with-tasks.txt.html
@@ -1,8 +1,5 @@
 <ul class="task-list">
-<li><input type="checkbox" disabled="" />
-Task</li>
-<li><input type="checkbox" disabled="" checked="" />
-Completed task</li>
-<li><input type="checkbox" disabled="" />
-Other task</li>
+<li><input type="checkbox" />Task</li>
+<li><input type="checkbox" checked="" />Completed task</li>
+<li><input type="checkbox" />Other task</li>
 </ul>

--- a/notes/_guides/_updating-pandoc.txt
+++ b/notes/_guides/_updating-pandoc.txt
@@ -1,21 +1,39 @@
 # Update the version of pandoc used by Blot
 
-1. Download [the latest mac build](https://github.com/jgm/pandoc/releases) of pandoc move the executable to the location of $BLOT_PANDOC_PATH. Something approximating:
+## In development environment
+
+1. Download [the latest mac build](https://github.com/jgm/pandoc/releases) of pandoc move the executable to the location of:
+
+$ echo $BLOT_PANDOC_PATH
+
+Something approximating:
 
 $ cp ~/Dowloads/pandoc/bin/pandoc /usr/local/bin/pandoc
 
-2. Run the build tests locally:
+2. Run the build tests locally and work through any changes:
 
 $ npm test app/build
 
-3. Update the version of pandoc used by travis by editing PANDOC_VERSION in env > global of .travis.yml. Make sure the CI tests pass in a new PR for this change.
+## In test environment
 
-4. On the server, curl the linux executable and unzip it:
+Update the version of pandoc used by GitHub actions by editing:
 
-$ wget https://github.com/jgm/pandoc/releases/download/2.11.3.2/pandoc-2.11.3.2-linux-amd64.tar.gz
-$ tar xvzf $TGZ --strip-components 1 -C $DEST
+.github/workflows/tests.yml
 
+Changing PANDOC_VERSION:
 
+pandoc-version: [3.1.1]
 
+Commit to a new branch, push and then make sure the CI tests pass in a new PR for this change.
 
+## In production
 
+On the server, curl the linux executable and unzip it then move it into place:
+
+$ cd ~
+$ TGZ=https://github.com/jgm/pandoc/releases/download/3.1.1/pandoc-3.1.1-linux-amd64.tar.gz
+$ wget $TGZ
+$ tar xvzf $TGZ
+$ cp pandoc/bin/pandoc $BLOT_PANDOC_PATH
+
+Then restart Blot!

--- a/notes/_guides/_updating-pandoc.txt
+++ b/notes/_guides/_updating-pandoc.txt
@@ -30,10 +30,17 @@ Commit to a new branch, push and then make sure the CI tests pass in a new PR fo
 
 On the server, curl the linux executable and unzip it then move it into place:
 
+First check the variables are set:
+
+$ echo $BLOT_PANDOC_PATH
+
+Then move to home directory, download and unzip pandoc, then install it
+
 $ cd ~
-$ TGZ=https://github.com/jgm/pandoc/releases/download/3.1.1/pandoc-3.1.1-linux-amd64.tar.gz
-$ wget $TGZ
-$ tar xvzf $TGZ
-$ cp pandoc/bin/pandoc $BLOT_PANDOC_PATH
+$ wget https://github.com/jgm/pandoc/releases/download/3.1.1/pandoc-3.1.1-linux-amd64.tar.gz
+
+$ tar xvzf pandoc-3.1.1-linux-amd64.tar.gz
+
+$ cp pandoc-3.1.1-linux-amd64.tar.gz/bin/pandoc $BLOT_PANDOC_PATH
 
 Then restart Blot!


### PR DESCRIPTION
- the `role` attributes of footnotes wrapper has changed
- markdown task lists (e.g. `- [ ] ...`) no longer have attributed `disabled=""` on checkboxes