### PR TITLE
Adds option to preserve hard line breaks

### DIFF
--- a/app/build/converters/markdown/convert.js
+++ b/app/build/converters/markdown/convert.js
@@ -60,11 +60,8 @@ module.exports = function (blog, text, options, callback) {
     // we use our own highlighint library (hljs) later
     "--no-highlight",
 
-    // preserve line breaks
-    "--wrap=preserve",
-
     // such a dumb default feature... sorry john!
-    "--email-obfuscation=none"
+    "--email-obfuscation=none",
   ];
 
   if (options.bib) {
@@ -159,7 +156,7 @@ module.exports = function (blog, text, options, callback) {
   pandoc.stdin.end(text, "utf8");
 };
 
-function safely (method, input) {
+function safely(method, input) {
   try {
     input = method(input);
   } catch (e) {

--- a/app/build/converters/markdown/convert.js
+++ b/app/build/converters/markdown/convert.js
@@ -60,8 +60,11 @@ module.exports = function (blog, text, options, callback) {
     // we use our own highlighint library (hljs) later
     "--no-highlight",
 
+    // preserve line breaks
+    "--wrap=preserve",
+
     // such a dumb default feature... sorry john!
-    "--email-obfuscation=none",
+    "--email-obfuscation=none"
   ];
 
   if (options.bib) {
@@ -156,7 +159,7 @@ module.exports = function (blog, text, options, callback) {
   pandoc.stdin.end(text, "utf8");
 };
 
-function safely(method, input) {
+function safely (method, input) {
   try {
     input = method(input);
   } catch (e) {

--- a/app/build/converters/markdown/index.js
+++ b/app/build/converters/markdown/index.js
@@ -9,15 +9,16 @@ var katex = require("./katex");
 var convert = require("./convert");
 var metadata = require("./metadata");
 var extractBibAndCSL = require("./extractBibAndCSL");
+var linebreaks = require("./linebreaks");
 
-function is(path) {
+function is (path) {
   return (
     [".txt", ".text", ".md", ".markdown"].indexOf(extname(path).toLowerCase()) >
     -1
   );
 }
 
-function read(blog, path, options, callback) {
+function read (blog, path, options, callback) {
   ensure(blog, "object")
     .and(path, "string")
     .and(options, "object")
@@ -51,6 +52,12 @@ function read(blog, path, options, callback) {
       text = layout(text);
       time.end("layout");
 
+      if (blog.plugins.linebreaks.enabled) {
+        time("linebreaks");
+        text = linebreaks(text);
+        time.end("linebreaks");
+      }
+
       if (blog.plugins.katex.enabled) {
         time("katex");
         text = katex(text);
@@ -62,7 +69,7 @@ function read(blog, path, options, callback) {
 
         let options = {
           bib: bib,
-          csl: csl,
+          csl: csl
         };
 
         convert(blog, text, options, function (err, html) {

--- a/app/build/converters/markdown/katex.js
+++ b/app/build/converters/markdown/katex.js
@@ -30,14 +30,14 @@ module.exports = function (text) {
   return text;
 };
 
-function renderTex(str) {
+function renderTex (str) {
   // Cache the original string
   // in case of rendering error
   var _str = str;
 
   // Null or empty string, return delimiters
   // This is to guard against '$$$$' being in a post
-  if (!str) return '';
+  if (!str) return "";
 
   // If the Katex is on its own line, render it
   // in the larger 'display style'.

--- a/app/build/converters/markdown/linebreaks.js
+++ b/app/build/converters/markdown/linebreaks.js
@@ -1,0 +1,18 @@
+// Format linebreaks to be compatible with markdown
+module.exports = function (text) {
+  if (!text) return text;
+
+  const lines = text.split("\n");
+
+  text = lines
+    .map(line => {
+      if (!line || !line.trim()) return line;
+
+      if (line.endsWith("  ")) return line;
+
+      return line + "  ";
+    })
+    .join("\n");
+
+  return text;
+};

--- a/app/build/plugins/linebreaks/index.js
+++ b/app/build/plugins/linebreaks/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  category: "Typography",
+  title: "Hard linebreaks",
+  isDefault: false,
+  description: "Preserve linebreaks in markdown files"
+};

--- a/app/build/plugins/linebreaks/index.js
+++ b/app/build/plugins/linebreaks/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   category: "Typography",
-  title: "Hard linebreaks",
+  title: "Preserve line breaks",
   isDefault: false,
-  description: "Preserve linebreaks in markdown files"
+  description: "Keep original line breaks in Markdown files"
 };

--- a/app/build/tests/plugins/linebreaks.js
+++ b/app/build/tests/plugins/linebreaks.js
@@ -1,0 +1,12 @@
+describe("linebreaks plugin", function () {
+  require("./util/setup")();
+
+  it("will preserve linebreaks if enabled", function (done) {
+    const contents = "A line\nwith a break";
+    const path = "/hello.txt";
+    const html = "<p>A line<br>\nwith a break</p>";
+
+    this.blog.plugins.linebreaks = { enabled: true, options: {} };
+    this.buildAndCheck({ path, contents }, { html }, done);
+  });
+});

--- a/app/build/tests/plugins/util/setup.js
+++ b/app/build/tests/plugins/util/setup.js
@@ -1,0 +1,22 @@
+module.exports = () => {
+  const build = require("build");
+  const fs = require("fs-extra");
+
+  // Set up a test blog before each test
+  global.test.blog();
+
+  // Expose methods for creating fake files, paths, etc.
+  beforeEach(function () {
+    this.checkEntry = global.test.CheckEntry(this.blog.id);
+    this.syncAndCheck = global.test.SyncAndCheck(this.blog.id);
+    this.fake = global.test.fake;
+    this.buildAndCheck = ({ path, contents }, expectedEntry, cb) => {
+      fs.outputFileSync(this.blogDirectory + path, contents);
+      build(this.blog, path, {}, function (err, entry) {
+        for (let key in expectedEntry)
+          expect(expectedEntry[key]).toEqual(entry[key]);
+        cb();
+      });
+    };
+  });
+};

--- a/app/build/tests/plugins/wikilinks.js
+++ b/app/build/tests/plugins/wikilinks.js
@@ -1,9 +1,5 @@
 describe("wikilinks plugin", function () {
-  const build = require("build");
-  const fs = require("fs-extra");
-
-  // Set up a test blog before each test
-  global.test.blog();
+  require("./util/setup")();
 
   it("will convert wikilinks if plugin is enabled", function (done) {
     const contents = "A [[wikilink]]";
@@ -68,7 +64,7 @@ describe("wikilinks plugin", function () {
 
     const files = [
       { path: "/Target’s.md", content: "Link: target\n# Hey" },
-      { path, content: "[[Target’s]]" },
+      { path, content: "[[Target’s]]" }
     ];
 
     const entry = { path, html };
@@ -81,27 +77,26 @@ describe("wikilinks plugin", function () {
 
     const files = [
       { path: "/target.md", content: "Link: target\n# Title" },
-      { path, content: "[[title]]" },
+      { path, content: "[[title]]" }
     ];
 
     const entry = {
       path,
-      html: '<p><a href="/target" title="wikilink">Title</a></p>',
+      html: '<p><a href="/target" title="wikilink">Title</a></p>'
     };
 
     this.syncAndCheck(files, entry, done);
   });
 
   xit("will support media embedding", async function (done) {
-
     await this.blog.write({
       path: "/_Image.png",
-      content: await global.test.fake.pngBuffer(),
+      content: await global.test.fake.pngBuffer()
     });
 
     await this.blog.write({
       path: "/Post.txt",
-      content: "![[_Image.png]]",
+      content: "![[_Image.png]]"
     });
 
     await this.blog.rebuild();
@@ -115,12 +110,12 @@ describe("wikilinks plugin", function () {
 
     const files = [
       { path: "/target.md", content: "Link: target\n# Title" },
-      { path, content: "[[Target]]" },
+      { path, content: "[[Target]]" }
     ];
 
     const entry = {
       path,
-      html: '<p><a href="/target" title="wikilink">Title</a></p>',
+      html: '<p><a href="/target" title="wikilink">Title</a></p>'
     };
 
     this.syncAndCheck(files, entry, done);
@@ -136,7 +131,7 @@ describe("wikilinks plugin", function () {
       "[[/Subdirectory/tArget!file]]",
       "[[/Subdirectory/Target_file]]",
       "[[/Subdirectory/Target file]]",
-      "[[/Subdirectory/Target-file]]",
+      "[[/Subdirectory/Target-file]]"
     ];
     const content = tests.join("\n");
 
@@ -148,13 +143,13 @@ describe("wikilinks plugin", function () {
     const html =
       "<p>" +
       Array.from(Array(tests.length))
-        .map((i) => '<a href="/target" title="wikilink">Target</a>')
+        .map(i => '<a href="/target" title="wikilink">Target</a>')
         .join(" ") +
       "</p>";
 
     const files = [
       { path: linkPath, content: linkContent },
-      { path, content },
+      { path, content }
     ];
 
     const entry = { path, html };
@@ -170,7 +165,7 @@ describe("wikilinks plugin", function () {
 
     const files = [
       { path: "/Target's.md", content: "Link: target\n# Hey" },
-      { path, content: "[[Target's]]" },
+      { path, content: "[[Target's]]" }
     ];
 
     const entry = { path, html };
@@ -201,14 +196,13 @@ describe("wikilinks plugin", function () {
 
     const files = [
       { path: linkPath, content: linkContent },
-      { path, content },
+      { path, content }
     ];
 
     const entry = { path, html };
 
     this.syncAndCheck(files, entry, done);
   });
-
 
   // the linked file is added after the linking file
   it("turns wikilinks into links in reverse order", function (done) {
@@ -224,7 +218,7 @@ describe("wikilinks plugin", function () {
 
     const files = [
       { path, content },
-      { path: linkPath, content: linkContent },
+      { path: linkPath, content: linkContent }
     ];
 
     const entry = { path, html };
@@ -254,7 +248,7 @@ describe("wikilinks plugin", function () {
       // Absolute path with bad case and extension and without leading slash
       "[[sUb/child/taRget.txt]]",
       // Absolute path with extra slashes and without leading slash
-      "[[Sub//child//Target.txt/]]",
+      "[[Sub//child//Target.txt/]]"
     ];
 
     const content = tests.join("\n");
@@ -267,13 +261,13 @@ describe("wikilinks plugin", function () {
     const html =
       "<p>" +
       Array.from(Array(tests.length))
-        .map((i) => '<a href="/not-target" title="wikilink">Not Target</a>')
+        .map(i => '<a href="/not-target" title="wikilink">Not Target</a>')
         .join(" ") +
       "</p>";
 
     const files = [
       { path: linkPath, content: linkContent },
-      { path, content },
+      { path, content }
     ];
 
     const entry = { path, html };
@@ -299,7 +293,7 @@ describe("wikilinks plugin", function () {
       // Relative path without bad case and dot-slash
       "[[Child/target]]",
       // Relative path without bad case and dot-slash but extension
-      "[[Child/target.md]]",
+      "[[Child/target.md]]"
     ];
     const content = tests.join("\n");
 
@@ -311,13 +305,13 @@ describe("wikilinks plugin", function () {
     const html =
       "<p>" +
       Array.from(Array(tests.length))
-        .map((i) => '<a href="/target" title="wikilink">Target</a>')
+        .map(i => '<a href="/target" title="wikilink">Target</a>')
         .join(" ") +
       "</p>";
 
     const files = [
       { path: linkPath, content: linkContent },
-      { path, content },
+      { path, content }
     ];
 
     const entry = { path, html };
@@ -343,7 +337,7 @@ describe("wikilinks plugin", function () {
       // Relative path with bad case and without dot-slash
       "[[target]]",
       // Relative path without bad case and dot-slash but extension
-      "[[target.md]]",
+      "[[target.md]]"
     ];
     const content = tests.join("\n");
 
@@ -355,13 +349,13 @@ describe("wikilinks plugin", function () {
     const html =
       "<p>" +
       Array.from(Array(tests.length))
-        .map((i) => '<a href="/target" title="wikilink">Target</a>')
+        .map(i => '<a href="/target" title="wikilink">Target</a>')
         .join(" ") +
       "</p>";
 
     const files = [
       { path: linkPath, content: linkContent },
-      { path, content },
+      { path, content }
     ];
 
     const entry = { path, html };
@@ -387,7 +381,7 @@ describe("wikilinks plugin", function () {
       // Relative path with bad case and without dot-slash
       "[[../../Sub/target]]",
       // Relative path without bad case and dot-slash but extension
-      "[[../../Sub/target.md]]",
+      "[[../../Sub/target.md]]"
     ];
     const content = tests.join("\n");
 
@@ -399,13 +393,13 @@ describe("wikilinks plugin", function () {
     const html =
       "<p>" +
       Array.from(Array(tests.length))
-        .map((i) => '<a href="/target" title="wikilink">Target</a>')
+        .map(i => '<a href="/target" title="wikilink">Target</a>')
         .join(" ") +
       "</p>";
 
     const files = [
       { path: linkPath, content: linkContent },
-      { path, content },
+      { path, content }
     ];
 
     const entry = { path, html };
@@ -429,26 +423,11 @@ describe("wikilinks plugin", function () {
 
     const files = [
       { path, content },
-      { path: linkPath, content: linkContent },
+      { path: linkPath, content: linkContent }
     ];
 
     const entry = { path, html, dependencies: ["/target-of-link.md"] };
 
     this.syncAndCheck(files, entry, done);
-  });
-
-  // Expose methods for creating fake files, paths, etc.
-  beforeEach(function () {
-    this.checkEntry = global.test.CheckEntry(this.blog.id);
-    this.syncAndCheck = global.test.SyncAndCheck(this.blog.id);
-    this.fake = global.test.fake;
-    this.buildAndCheck = ({ path, contents }, expectedEntry, cb) => {
-      fs.outputFileSync(this.blogDirectory + path, contents);
-      build(this.blog, path, {}, function (err, entry) {
-        for (let key in expectedEntry)
-          expect(expectedEntry[key]).toEqual(entry[key]);
-        cb();
-      });
-    };
   });
 });

--- a/scripts/blog/migrate-to-latest-model.js
+++ b/scripts/blog/migrate-to-latest-model.js
@@ -1,15 +1,15 @@
 const each = require("../each/blog");
 const ensure = require("helper/ensure");
 const Blog = require("models/blog");
+const defaultPlugins = require("build/plugins").defaultList;
 
 each(
   (user, blog, next) => {
     if (!blog) return next();
-    if (blog.isDisabled) return next();
-    
+
     if (!blog.flags) {
       blog.flags = {
-        google_drive_beta: false,
+        google_drive_beta: false
       };
     }
 
@@ -22,10 +22,17 @@ each(
     if (blog.dateDisplay) delete blog.dateDisplay;
     if (blog.hideDates) delete blog.hideDates;
 
+    Object.keys(defaultPlugins).forEach(plugin => {
+      if (blog.plugins[plugin] === undefined) {
+        blog.plugins[plugin] = defaultPlugins[plugin];
+        console.log("Adding plugin", plugin, "to", blog.id);
+      }
+    });
+
     ensure(blog, Blog.scheme.TYPE, true);
     Blog.set(blog.id, blog, next);
   },
-  (err) => {
+  err => {
     if (err) throw err;
     console.log("All blogs processed!");
     process.exit();

--- a/todo.txt
+++ b/todo.txt
@@ -1,7 +1,3 @@
-Move blot data into /data directory
-- clean up tmpDir
-- move log directory into /data?
-
 Check that my [inter az bandwidth](https://us-east-1.console.aws.amazon.com/cost-management/home#/cost-explorer?chartStyle=STACK&costAggregate=unBlendedCost&endDate=2023-11-02&excludeForecasting=false&filter=%5B%7B%22dimension%22:%7B%22id%22:%22UsageTypeGroup%22,%22displayValue%22:%22Usage%20type%20group%22%7D,%22operator%22:%22INCLUDES%22,%22values%22:%5B%7B%22value%22:%22EC2:%20Data%20Transfer%20-%20Inter%20AZ%22,%22displayValue%22:%22EC2:%20Data%20Transfer%20-%20Inter%20AZ%22%7D%5D%7D%5D&futureRelativeRange=CUSTOM&granularity=Daily&groupBy=%5B%22Service%22%5D&historicalRelativeRange=CUSTOM&isDefault=true&reportName=New%20cost%20and%20usage%20report&showOnlyUncategorized=false&showOnlyUntagged=false&startDate=2023-10-01&usageAggregate=usageQuantity&useNormalizedUnits=false)
 - I goofed by using elastic ips for inter-region communication – I should have used private IPs – write about this
 
@@ -696,8 +692,6 @@ Improvements to simple local server (npm run local):
 -  Persist data somehow? import/export from local folder .blot?
 -  Fix 'Visit' link on dashboard
 -  Can we expand this to a simple self-hosting process ('npx blot-server')?
-
-Add options to [preserve linebreaks](https://stackoverflow.com/questions/26066621/preserve-line-breaks-in-pandoc-markdown-latex-conversion) in Markdown and tell [Matt](https://mail.google.com/mail/u/0/#inbox/FMfcgzGkXcwpJzKrBrGKDcZKBPSSdsfh)
 
 Template engine plan
 - create data/blogs/blogID/templates directory


### PR DESCRIPTION
By default, markdown collapses the following into a single continuous line for historical reasons (text editor column widths):

```
Hello
world
```

If enabled, this plugin will instead produce:

```
<p>Hello<br>
world</p>
```

- [ ] Tell Matt and Eduardo
- [ ] Run migrate model script on server