### PR TITLE
Update styles

### DIFF
--- a/app/views/css/blot.css
+++ b/app/views/css/blot.css
@@ -58,7 +58,7 @@ html {
 
   --border-color: #403E3C;
   --dark-border-color: #575653;
-  --light-border-color: #343331;
+  --light-border-color: #B6B4AF;
 
   --inset-image-border-color: rgba(0,0,0,0.05);
   

--- a/app/views/how/posts/tex.html
+++ b/app/views/how/posts/tex.html
@@ -5,15 +5,15 @@
   Blot. It is sorted into logical groups.
 </p>
 
-<background>
-  <pre
-    class="text"><code>Blot can typeset $$\TeX$$. Use two dollar signs ($) to delimit the $$\TeX$$. You can use $$\TeX$$ in the middle of a sentence, or on its own line:
+<pre class="text">
+  <code>
+    Blot can typeset $$\TeX$$. Use two dollar signs ($) to delimit the $$\TeX$$. You can use $$\TeX$$ in the middle of a sentence, or on its own line:
 
-$$
-f(x) = 2x^2 + 2/3
-$$
-</code></pre>
-</background>
+    $$
+    f(x) = 2x^2 + 2/3
+    $$
+  </code>
+</pre>
 
 <div class="tex">
   <h2 id="accents">Accents</h2>

--- a/app/views/partials/breadcrumbs.html
+++ b/app/views/partials/breadcrumbs.html
@@ -21,7 +21,7 @@ justify-content: space-between;">
 <style>
 
   #breadcrumbs a {
-  color: var(--light-text-color);
+  color: var(--medium-text-color);
   font-size: 16px;
 
   text-decoration: none;


### PR DESCRIPTION
- Changes the code block in the Tex page to follow the same formatting as the code blocks on other pages like the Layout page. This gives it normal width.
- Switches breadcrumb text to use the medium color instead of light.
- Lightens the color used in `--light-border-color` for light mode. I can leave this out if it changes too much, but it seems to provide more contrast with the `--dark-border-color`, which actually seemed to be lighter. See the lines and dots in the changelog on the News page, and the separators in the lists of the How To page.