### PR TITLE
Update node to LTS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # If you ever add more node versions you need to replace current caching node_modules with caching of ~/.npm
-        node-version: [16.14.0]
+        node-version: [20.11.0]
         pandoc-version: [3.1.1]
         redis-version: [6.2.6]
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A blogging platform",
   "main": "app/index.js",
   "engines": {
-    "node": "16.14.0",
+    "node": "20.11.0",
     "npm": "8.3.1"
   },
   "jshintConfig": {


### PR DESCRIPTION
[Guide to updating node](https://github.com/davidmerfield/Blot/blob/d5d47f1c39d49b13ebf20fa1f30600ce46e94451/notes/_guides/_update-node-to-lts.txt)

---
- [ ] Update AWS ec2 AMI to AL2023 so we can install node 18
---
- [ ] Edit BLOT_NODE_VERSION to 20.11.0 in `/etc/blot/environment.sh`
- [ ] nvm install 20.11.0
- [ ] npm ci
- [ ] restart