### PR TITLE
Fixes slug metadata

### DIFF
--- a/app/build/prepare/index.js
+++ b/app/build/prepare/index.js
@@ -25,12 +25,13 @@ var overwrite = [
   "title",
   "titleTag",
   "body",
+  "slug",
   "summary",
   "teaser",
-  "teaserBody",
+  "teaserBody"
 ];
 
-function canOverwrite(key) {
+function canOverwrite (key) {
   return overwrite.indexOf(key) > -1;
 }
 
@@ -39,7 +40,7 @@ function canOverwrite(key) {
 // url: 'string', // this is handled by set
 // scheduled: scheduled, // this is handled by set
 
-function Prepare(entry) {
+function Prepare (entry) {
   ensure(entry, "object")
     .and(entry.path, "string")
     .and(entry.size, "number")
@@ -54,7 +55,7 @@ function Prepare(entry) {
   debug(entry.path, "Generating cheerio");
   var $ = cheerio.load(entry.html, {
     decodeEntities: false,
-    withDomLvl1: false, // this may cause issues?
+    withDomLvl1: false // this may cause issues?
   });
   debug(entry.path, "Generated  cheerio");
 
@@ -160,20 +161,19 @@ function Prepare(entry) {
   // do this earlier, since we don't know the slug then
   let permalinkCandidates = [
     entry.metadata.permalink,
-    entry.metadata.slug,
     entry.metadata.link,
-    entry.metadata.url,
+    entry.metadata.url
   ];
 
   permalinkCandidates = permalinkCandidates
     .filter(
-      (candidate) =>
+      candidate =>
         candidate &&
         type(candidate, "string") &&
         candidate.indexOf("://") === -1
     )
     .map(normalize)
-    .filter((candidate) => candidate !== "");
+    .filter(candidate => candidate !== "");
 
   entry.permalink = permalinkCandidates.shift() || "";
   debug(entry.path, "Generated  permalink");
@@ -195,11 +195,11 @@ function Prepare(entry) {
   return entry;
 }
 
-function truthy(str) {
+function truthy (str) {
   return !falsy(str);
 }
 
-function isPage(path) {
+function isPage (path) {
   return (
     pathNormalizer(path).toLowerCase().startsWith("/page/") ||
     pathNormalizer(path).toLowerCase().startsWith("/pages/")

--- a/app/models/entry/_setUrl.js
+++ b/app/models/entry/_setUrl.js
@@ -56,7 +56,6 @@ function Candidates (blog, entry) {
   // or posts with user specified permalinks.
   if (
     !entry.metadata.permalink &&
-    !entry.metadata.slug &&
     !entry.metadata.link &&
     !entry.metadata.url &&
     !entry.page

--- a/app/sync/tests/build.js
+++ b/app/sync/tests/build.js
@@ -88,6 +88,33 @@ describe("build", function () {
     this.syncAndCheck(file, entry, done);
   });
 
+  it("incorporates slug metadata into a permalink format", function (done) {
+    const ctx = this;
+    require("models/blog").set(
+      ctx.blog.id,
+      { permalink: { format: "/post/{{slug}}" } },
+      () => {
+        const path = "/hey.txt";
+        const content = "Slug: foo\n\nHey!";
+
+        const file = { path, content };
+        const entry = { path, url: "/post/foo" };
+
+        ctx.syncAndCheck(file, entry, done);
+      }
+    );
+  });
+
+  it("uses slug metadata", function (done) {
+    const path = "/hey.txt";
+    const content = "Slug: foo\n\nHey!";
+
+    const file = { path, content };
+    const entry = { path, url: "/foo" };
+
+    this.syncAndCheck(file, entry, done);
+  });
+
   it("uses link metadata", function (done) {
     const path = "/hey.txt";
     const content = "Link: example.com/\n\nHey!";


### PR DESCRIPTION
You can now do this:
```
Slug: foo
```
And properly incorporate it into a permalink format, e.g. `/posts/{{slug}}`