### PR TITLE
Fixes literal 'null' string for empty YAML metadata

### DIFF
--- a/app/build/metadata.js
+++ b/app/build/metadata.js
@@ -4,7 +4,7 @@ const YAML = require("yaml");
 
 const alphaNumericRegEx = /^([a-zA-Z0-9\-_ ]+)$/;
 
-function Metadata(html) {
+function Metadata (html) {
   ensure(html, "string");
 
   // We try and normalize all the different ways to end a line
@@ -33,9 +33,15 @@ function Metadata(html) {
 
       // Map { Permalink } to { permalink }
       // Blot uses lowercase metadata keys
-      Object.keys(mixedCaseMetadata).forEach((mixedCaseKey) => {
+      Object.keys(mixedCaseMetadata).forEach(mixedCaseKey => {
         let key = mixedCaseKey.toLowerCase();
         let value = mixedCaseMetadata[mixedCaseKey];
+
+        // map 'null' values to empty strings
+        // otherwise we end up with metadata properties
+        // that are the string 'null' instead of simply empty
+        if (value === null) value = "";
+
         metadata[key] = value;
       });
 
@@ -159,7 +165,7 @@ function Metadata(html) {
 
   return {
     html: html,
-    metadata: metadata,
+    metadata: metadata
   };
 }
 

--- a/app/build/tests/metadata.js
+++ b/app/build/tests/metadata.js
@@ -9,7 +9,7 @@ describe("metadata parser", function () {
     ).toEqual({
       permalink: "",
       page: "yes",
-      date: "12/10/12",
+      date: "12/10/12"
     });
   });
 
@@ -21,7 +21,7 @@ describe("metadata parser", function () {
     ).toEqual({
       permalink: "",
       page: "yes",
-      date: "12/10/12",
+      date: "12/10/12"
     });
   });
 
@@ -33,7 +33,7 @@ describe("metadata parser", function () {
     ).toEqual({
       permalink: "",
       page: "yes",
-      date: "12/10/12",
+      date: "12/10/12"
     });
   });
 
@@ -44,11 +44,23 @@ describe("metadata parser", function () {
       ).metadata
     ).toEqual({
       permalink: "hey",
-      page: "yes",
+      page: "yes"
     });
   });
 
+  it("parses empty YAML metadata", function () {
+    expect(
+      Metadata(["---", "Summary: ", "---", "", "# Hi"].join("\n")).metadata
+    ).toEqual({
+      summary: ""
+    });
+  });
 
+  it("parses empty metadata", function () {
+    expect(Metadata(["Summary: ", "", "# Hi"].join("\n")).metadata).toEqual({
+      summary: ""
+    });
+  });
 
   it("handles colons", function () {
     expect(
@@ -58,7 +70,7 @@ describe("metadata parser", function () {
         )
       ).metadata
     ).toEqual({
-      author: "me",
+      author: "me"
     });
   });
 
@@ -66,13 +78,13 @@ describe("metadata parser", function () {
     expect(
       Metadata(["Author:me", "Hey", "Date: 1"].join("\n")).metadata
     ).toEqual({
-      author: "me",
+      author: "me"
     });
   });
 
   it("handles spaces in the metadata key", function () {
     expect(Metadata(["Author name: Jason"].join("\n")).metadata).toEqual({
-      "author name": "Jason",
+      "author name": "Jason"
     });
   });
 
@@ -82,13 +94,13 @@ describe("metadata parser", function () {
 
   it("allows dashes in the metadata key", function () {
     expect(Metadata(["Is-Social: Yes"].join("\n")).metadata).toEqual({
-      "is-social": "Yes",
+      "is-social": "Yes"
     });
   });
 
   it("allows underscores in the metadata key", function () {
     expect(Metadata(["Is_Social: Yes"].join("\n")).metadata).toEqual({
-      is_social: "Yes",
+      is_social: "Yes"
     });
   });
 
@@ -99,7 +111,7 @@ describe("metadata parser", function () {
   it("handles pure metadata", function () {
     expect(Metadata(["only:metadata", "in:this"].join("\n")).metadata).toEqual({
       only: "metadata",
-      in: "this",
+      in: "this"
     });
   });
 
@@ -108,7 +120,7 @@ describe("metadata parser", function () {
       Metadata(
         [
           "# Since the title: is on the first line, no metada should be extracted",
-          "Date: 1",
+          "Date: 1"
         ].join("\n")
       ).metadata
     ).toEqual({});


### PR DESCRIPTION
Previously, the following metadata:

```
---
Summary:
---
```
Would produce a summary with the text `'null'` rather than an empty string

