### PR TITLE
Adds bluesky embed plugin

### DIFF
--- a/app/build/plugins/bluesky/index.js
+++ b/app/build/plugins/bluesky/index.js
@@ -1,0 +1,91 @@
+/* from bluesky docs:
+
+oEmbed Endpoint
+
+The official oEmbed endpoint for Bluesky posts is https://embed.bsky.app/oembed, which accepts the following HTTP GET query parameters:
+
+    url (required): bsky.app or AT-URI pointing to a post
+    format (optional): json is the default and only supported format
+    maxwidth (optional, integer): range is 220 to 600; default is 600
+    maxheight (optional, integer): part of oEmbed specification, but not used for Bluesky post embeds
+
+The rendered height of posts is not known until rendered, so the maxheight is ignored and the height field in the response JSON is always null. This follows the precedent of Twitter tweet embeds.
+
+The oEmebd response contains roughly the same HTML snippet as found at embed.bsky.app, with the same public content policy mentioned above.
+
+The HTTP URL patterns which the oEmbed endpoint supports are:
+
+    https://bsky.app/profile/:user/post/:id: post embeds
+
+You can learn more about oEmbed at https://oembed.com. Bluesky is a registered provider, included in the JSON directory at https://oembed.com/providers.json.
+
+*/
+
+const each = require("../eachEl");
+const Url = require("url");
+const fetch = require("node-fetch");
+
+function render($, callback) {
+  console.log("bluesky plugin", "render", $.html());
+
+  each(
+    $,
+    "a",
+    function (el, next) {
+      var href, host, text, id;
+
+      try {
+        href = $(el).attr("href");
+        text = $(el).text();
+        host = Url.parse(href).host;
+      } catch (e) {
+        return next();
+      }
+
+      // Ensure we managed to extract everything from the url
+      if (!href || !text || !host) return next();
+
+      // Look for bare links
+      if (href !== text) return next();
+
+      // which point to a post on bluesky
+      if (host !== "bsky.app") return next();
+
+      var params = {
+        url: href,
+        format: "json",
+        maxwidth: 600,
+      };
+
+      var oembedUrl =
+        "https://embed.bsky.app/oembed?" +
+        new URLSearchParams(params).toString();
+
+      console.log(oembedUrl);
+
+      fetch(oembedUrl)
+        .then((res) => res.json())
+        .then((data) => {
+          if (!data || !data.html) return next();
+
+          var html = data.html;
+
+          $(el).replaceWith(html);
+          next();
+        })
+        .catch(() => {
+          return next();
+        });
+    },
+    function () {
+      callback();
+    }
+  );
+}
+
+module.exports = {
+  render: render,
+  category: "external",
+  title: "Bluesky",
+  description: "Embed posts from Bluesky URLs",
+};

--- a/app/build/plugins/bluesky/tests.js
+++ b/app/build/plugins/bluesky/tests.js
@@ -2,7 +2,7 @@ describe("bluesky plugin", function () {
   const replaceURLsWithEmbeds = require("./index.js").render;
   const cheerio = require("cheerio");
 
-  it("works", function () {
+  it("works", function (done) {
     // html bare link to a post on bluesky
     const html =
       '<a href="https://bsky.app/profile/logicallyjc.bsky.social/post/3lbretguxqk2b">https://bsky.app/profile/logicallyjc.bsky.social/post/3lbretguxqk2b</a>';
@@ -10,12 +10,15 @@ describe("bluesky plugin", function () {
     const $ = cheerio.load(html);
 
     replaceURLsWithEmbeds($, function () {
-      expect($("a").length).toBe(0);
+
+        console.log('html:', $.html());
+      expect($("a[href='https://bsky.app/profile/logicallyjc.bsky.social/post/3lbretguxqk2b']").length).toBe(0);
       expect($("blockquote").length).toBe(1);
+      done();
     });
   });
 
-  it("does not error when there are no links", function () {
+  it("does not error when there are no links", function (done) {
     const html = "<p>hello</p>";
 
     const $ = cheerio.load(html);
@@ -23,11 +26,12 @@ describe("bluesky plugin", function () {
     replaceURLsWithEmbeds($, function () {
       expect($("a").length).toBe(0);
       expect($("blockquote").length).toBe(0);
+      done();
     });
   });
 
   // if the bluesky link is invalid or poorly formatted, it should not be replaced
-  it("does not error when the link is invalid", function () {
+  it("does not error when the link is invalid", function (done) {
     const html = '<a href="https://bsky.app">https://bsky.app</a>';
 
     const $ = cheerio.load(html);
@@ -35,6 +39,7 @@ describe("bluesky plugin", function () {
     replaceURLsWithEmbeds($, function () {
       expect($("a").length).toBe(1);
       expect($("blockquote").length).toBe(0);
+      done();
     });
   });
 });

--- a/app/build/plugins/bluesky/tests.js
+++ b/app/build/plugins/bluesky/tests.js
@@ -1,0 +1,40 @@
+describe("bluesky plugin", function () {
+  const replaceURLsWithEmbeds = require("./index.js").render;
+  const cheerio = require("cheerio");
+
+  it("works", function () {
+    // html bare link to a post on bluesky
+    const html =
+      '<a href="https://bsky.app/profile/logicallyjc.bsky.social/post/3lbretguxqk2b">https://bsky.app/profile/logicallyjc.bsky.social/post/3lbretguxqk2b</a>';
+
+    const $ = cheerio.load(html);
+
+    replaceURLsWithEmbeds($, function () {
+      expect($("a").length).toBe(0);
+      expect($("blockquote").length).toBe(1);
+    });
+  });
+
+  it("does not error when there are no links", function () {
+    const html = "<p>hello</p>";
+
+    const $ = cheerio.load(html);
+
+    replaceURLsWithEmbeds($, function () {
+      expect($("a").length).toBe(0);
+      expect($("blockquote").length).toBe(0);
+    });
+  });
+
+  // if the bluesky link is invalid or poorly formatted, it should not be replaced
+  it("does not error when the link is invalid", function () {
+    const html = '<a href="https://bsky.app">https://bsky.app</a>';
+
+    const $ = cheerio.load(html);
+
+    replaceURLsWithEmbeds($, function () {
+      expect($("a").length).toBe(1);
+      expect($("blockquote").length).toBe(0);
+    });
+  });
+});

--- a/app/build/plugins/index.js
+++ b/app/build/plugins/index.js
@@ -8,6 +8,7 @@ var extend = require("helper/extend");
 var deCamelize = require("helper/deCamelize");
 var time = require("helper/time");
 var async = require("async");
+const bluesky = require("./bluesky");
 
 // Wait 10 minutes to go to next plugin
 var TIMEOUT = 10 * 60 * 1000;
@@ -20,6 +21,7 @@ var defaultPlugins = {};
 var loaded = loadPlugins({
   analytics: require("./analytics"),
   autoImage: require("./autoImage"),
+  bluesky: require("./bluesky"),
   codeHighlighting: require("./codeHighlighting"),
   commento: require("./commento"),
   disqus: require("./disqus"),


### PR DESCRIPTION
Adds a plugin to replace bare URLs to Bluesky posts, e.g.

```
https://bsky.app/profile/ibra1.bsky.social/post/3lbq2xwks7s2y
```

with the embed:

<img width="653" alt="Screenshot 2024-11-25 at 1 50 31 PM" src="https://github.com/user-attachments/assets/579aa27f-e1cc-4df5-879a-ef0d8405ae27">

This feature can be enabled on the Services page of your site's dashboard.
