### PR TITLE
Adds Flickr oembed support

### DIFF
--- a/app/build/plugins/bluesky/index.js
+++ b/app/build/plugins/bluesky/index.js
@@ -26,7 +26,7 @@ const Url = require("url");
 const fetch = require("node-fetch");
 
 function render($, callback) {
-  console.log("bluesky plugin", "render", $.html());
+  // console.log("bluesky plugin", "render", $.html());
 
   each(
     $,
@@ -61,7 +61,7 @@ function render($, callback) {
         "https://embed.bsky.app/oembed?" +
         new URLSearchParams(params).toString();
 
-      console.log(oembedUrl);
+      // console.log(oembedUrl);
 
       fetch(oembedUrl)
         .then((res) => res.json())

--- a/app/build/plugins/flickr/README
+++ b/app/build/plugins/flickr/README
@@ -1,0 +1,20 @@
+Flickr oEmbed Plugin
+
+This module converts plain Flickr URLs in HTML into embedded Flickr widgets using the Flickr oEmbed API.
+
+Features
+	•	Supports both short (flic.kr) and full (flickr.com) Flickr URLs.
+	•	Automatically replaces bare links with Flickr embeds.
+	•	Graceful handling of invalid URLs or API failures.
+
+e.g. in your markdown file:
+
+```
+# Title of post
+
+https://www.flickr.com/photos/jemostrom/54145631949/
+
+Some text here
+```
+
+When rendered will include a flickr embed for the linked photo, rather than a plain link.

--- a/app/build/plugins/flickr/index.js
+++ b/app/build/plugins/flickr/index.js
@@ -1,0 +1,77 @@
+/* from flickr 
+
+oEmbed Endpoint
+
+The official oEmbed endpoint for Bluesky posts is 
+
+https://www.flickr.com/services/oembed/
+
+    url (required): flickr.com or flic.kr url to a post or gallery
+    format (optional): json
+*/
+
+const each = require("../eachEl");
+const Url = require("url");
+const fetch = require("node-fetch");
+
+function render($, callback) {
+  console.log("flickr plugin", "render", $.html());
+
+  each(
+    $,
+    "a",
+    function (el, next) {
+      var href, host, text, id;
+
+      try {
+        href = $(el).attr("href");
+        text = $(el).text();
+        host = Url.parse(href).host;
+      } catch (e) {
+        return next();
+      }
+
+      // Ensure we managed to extract everything from the url
+      if (!href || !text || !host) return next();
+
+      // Look for bare links
+      if (href !== text) return next();
+
+      // which point to a post on flickr
+      if (host !== "flickr.com" && host !== "flic.kr") return next();
+
+      var params = {
+        url: href,
+        format: "json"
+      };
+
+      var oembedUrl = "https://www.flickr.com/services/oembed/?" +
+        new URLSearchParams(params).toString();
+
+
+      fetch(oembedUrl)
+        .then((res) => res.json())
+        .then((data) => {
+          if (!data || !data.html) return next();
+
+          var html = data.html;
+
+          $(el).replaceWith(html);
+          next();
+        })
+        .catch(() => {
+          return next();
+        });
+    },
+    function () {
+      callback();
+    }
+  );
+}
+
+module.exports = {
+  render: render,
+  category: "external",
+  title: "Flickr",
+  description: "Embed Flickr posts and galleries",
+};

--- a/app/build/plugins/flickr/index.js
+++ b/app/build/plugins/flickr/index.js
@@ -15,8 +15,6 @@ const Url = require("url");
 const fetch = require("node-fetch");
 
 function render($, callback) {
-  console.log("flickr plugin", "render", $.html());
-
   each(
     $,
     "a",
@@ -37,17 +35,23 @@ function render($, callback) {
       // Look for bare links
       if (href !== text) return next();
 
-      // which point to a post on flickr
-      if (host !== "flickr.com" && host !== "flic.kr") return next();
+      // which point to a post on flickr, include all flickr hosts including www. subdomain
+      if (
+        host !== "flickr.com" &&
+        host !== "flic.kr" &&
+        host !== "www.flickr.com" &&
+        host !== "www.flic.kr"
+      )
+        return next();
 
       var params = {
         url: href,
-        format: "json"
+        format: "json",
       };
 
-      var oembedUrl = "https://www.flickr.com/services/oembed/?" +
+      var oembedUrl =
+        "https://www.flickr.com/services/oembed/?" +
         new URLSearchParams(params).toString();
-
 
       fetch(oembedUrl)
         .then((res) => res.json())

--- a/app/build/plugins/flickr/index.js
+++ b/app/build/plugins/flickr/index.js
@@ -36,13 +36,7 @@ function render($, callback) {
       if (href !== text) return next();
 
       // which point to a post on flickr, include all flickr hosts including www. subdomain
-      if (
-        host !== "flickr.com" &&
-        host !== "flic.kr" &&
-        host !== "www.flickr.com" &&
-        host !== "www.flic.kr"
-      )
-        return next();
+      if (!/^(www\.)?(flickr\.com|flic\.kr)$/.test(host)) return next();
 
       var params = {
         url: href,
@@ -56,8 +50,8 @@ function render($, callback) {
       fetch(oembedUrl)
         .then((res) => res.json())
         .then((data) => {
-          if (!data || !data.html) return next();
-
+          if (!data || typeof data.html !== "string") return next();
+          
           var html = data.html;
 
           $(el).replaceWith(html);

--- a/app/build/plugins/flickr/tests.js
+++ b/app/build/plugins/flickr/tests.js
@@ -1,46 +1,67 @@
-describe("bluesky plugin", function () {
-    const replaceURLsWithEmbeds = require("./index.js").render;
-    const cheerio = require("cheerio");
-  
-    it("works", function (done) {
-      // html bare link to a post on bluesky
-      const html =
-        '<a href="https://bsky.app/profile/logicallyjc.bsky.social/post/3lbretguxqk2b">https://bsky.app/profile/logicallyjc.bsky.social/post/3lbretguxqk2b</a>';
-  
-      const $ = cheerio.load(html);
-  
-      replaceURLsWithEmbeds($, function () {
-  
-          console.log('html:', $.html());
-        expect($("a[href='https://bsky.app/profile/logicallyjc.bsky.social/post/3lbretguxqk2b']").length).toBe(0);
-        expect($("blockquote").length).toBe(1);
-        done();
-      });
-    });
-  
-    it("does not error when there are no links", function (done) {
-      const html = "<p>hello</p>";
-  
-      const $ = cheerio.load(html);
-  
-      replaceURLsWithEmbeds($, function () {
-        expect($("a").length).toBe(0);
-        expect($("blockquote").length).toBe(0);
-        done();
-      });
-    });
-  
-    // if the bluesky link is invalid or poorly formatted, it should not be replaced
-    it("does not error when the link is invalid", function (done) {
-      const html = '<a href="https://bsky.app">https://bsky.app</a>';
-  
-      const $ = cheerio.load(html);
-  
-      replaceURLsWithEmbeds($, function () {
-        expect($("a").length).toBe(1);
-        expect($("blockquote").length).toBe(0);
-        done();
-      });
+describe("flickr plugin", function () {
+  const replaceURLsWithEmbeds = require("./index.js").render;
+  const cheerio = require("cheerio");
+
+  it("works for short flickr URLs", function (done) {
+    // html bare link to a post on bluesky
+    const html =
+      '<a href="https://flic.kr/p/2quEvYr">https://flic.kr/p/2quEvYr</a>';
+
+    const $ = cheerio.load(html);
+
+    replaceURLsWithEmbeds($, function () {
+      expect($("a[href='https://flic.kr/p/2quEvYr']").length).toBe(0);
+      expect($("a[data-flickr-embed='true']").length).toBe(1);
+      expect($("img").length).toBe(1);
+      expect($("script").length).toBe(1);
+      done();
     });
   });
-  
+
+  it("works for full flickr URLs", function (done) {
+    const html =
+      '<a href="https://www.flickr.com/photos/jemostrom/54145631949/">https://www.flickr.com/photos/jemostrom/54145631949/<a>';
+
+    const $ = cheerio.load(html);
+
+    replaceURLsWithEmbeds($, function () {
+      console.log("html:", $.html());
+
+      expect(
+        $("a[href='https://www.flickr.com/photos/jemostrom/54145631949/']")
+          .length
+      ).toBe(1);
+      expect($("a[data-flickr-embed='true']").length).toBe(1);
+      expect($("img").length).toBe(1);
+      expect($("script").length).toBe(1);
+      done();
+    });
+  });
+
+  it("does not error when there are no links", function (done) {
+    const html = "<p>hello</p>";
+
+    const $ = cheerio.load(html);
+
+    replaceURLsWithEmbeds($, function () {
+      expect($("a").length).toBe(0);
+      expect($("blockquote").length).toBe(0);
+      done();
+    });
+  });
+
+  // if the flickr link is invalid or poorly formatted, it should not be replaced
+  it("does not error when the flickr link is invalid", function (done) {
+    const html = '<a href="https://bsky.app">https://bsky.app</a>';
+
+    const $ = cheerio.load(html);
+
+    replaceURLsWithEmbeds($, function () {
+      expect($("a").length).toBe(1);
+      expect($(".flickr-embed").length).toBe(0);
+      expect($("img").length).toBe(0);
+      expect($("script").length).toBe(0);
+      done();
+    });
+  });
+});

--- a/app/build/plugins/flickr/tests.js
+++ b/app/build/plugins/flickr/tests.js
@@ -1,0 +1,46 @@
+describe("bluesky plugin", function () {
+    const replaceURLsWithEmbeds = require("./index.js").render;
+    const cheerio = require("cheerio");
+  
+    it("works", function (done) {
+      // html bare link to a post on bluesky
+      const html =
+        '<a href="https://bsky.app/profile/logicallyjc.bsky.social/post/3lbretguxqk2b">https://bsky.app/profile/logicallyjc.bsky.social/post/3lbretguxqk2b</a>';
+  
+      const $ = cheerio.load(html);
+  
+      replaceURLsWithEmbeds($, function () {
+  
+          console.log('html:', $.html());
+        expect($("a[href='https://bsky.app/profile/logicallyjc.bsky.social/post/3lbretguxqk2b']").length).toBe(0);
+        expect($("blockquote").length).toBe(1);
+        done();
+      });
+    });
+  
+    it("does not error when there are no links", function (done) {
+      const html = "<p>hello</p>";
+  
+      const $ = cheerio.load(html);
+  
+      replaceURLsWithEmbeds($, function () {
+        expect($("a").length).toBe(0);
+        expect($("blockquote").length).toBe(0);
+        done();
+      });
+    });
+  
+    // if the bluesky link is invalid or poorly formatted, it should not be replaced
+    it("does not error when the link is invalid", function (done) {
+      const html = '<a href="https://bsky.app">https://bsky.app</a>';
+  
+      const $ = cheerio.load(html);
+  
+      replaceURLsWithEmbeds($, function () {
+        expect($("a").length).toBe(1);
+        expect($("blockquote").length).toBe(0);
+        done();
+      });
+    });
+  });
+  

--- a/app/build/plugins/flickr/tests.js
+++ b/app/build/plugins/flickr/tests.js
@@ -18,6 +18,39 @@ describe("flickr plugin", function () {
     });
   });
 
+  it("works with multiple Flickr links in the input", function (done) {
+    const html = `
+      <a href="https://flic.kr/p/2quEvYr">https://flic.kr/p/2quEvYr</a>
+      <a href="https://www.flickr.com/photos/jemostrom/54145631949/">https://www.flickr.com/photos/jemostrom/54145631949/</a>
+    `;
+  
+    const $ = cheerio.load(html);
+  
+    replaceURLsWithEmbeds($, function () {
+      expect($("a[data-flickr-embed='true']").length).toBe(2);
+      expect($("img").length).toBe(2);
+      expect($("script").length).toBe(2);
+      done();
+    });
+  });
+
+  it("handles a mix of valid and invalid links", function (done) {
+    const html = `
+      <a href="https://flic.kr/p/2quEvYr">https://flic.kr/p/2quEvYr</a>
+      <a href="https://example.com">https://example.com</a>
+    `;
+  
+    const $ = cheerio.load(html);
+  
+    replaceURLsWithEmbeds($, function () {
+      expect($("a[href='https://example.com']").length).toBe(1);
+      expect($("a[data-flickr-embed='true']").length).toBe(1);
+      expect($("img").length).toBe(1);
+      expect($("script").length).toBe(1);
+      done();
+    });
+  });
+
   it("works for full flickr URLs", function (done) {
     const html =
       '<a href="https://www.flickr.com/photos/jemostrom/54145631949/">https://www.flickr.com/photos/jemostrom/54145631949/<a>';
@@ -25,7 +58,6 @@ describe("flickr plugin", function () {
     const $ = cheerio.load(html);
 
     replaceURLsWithEmbeds($, function () {
-      console.log("html:", $.html());
 
       expect(
         $("a[href='https://www.flickr.com/photos/jemostrom/54145631949/']")
@@ -50,6 +82,20 @@ describe("flickr plugin", function () {
     });
   });
 
+  it("skips links where href does not match text", function (done) {
+    const html = '<a href="https://flic.kr/p/2quEvYr">Some other text</a>';
+  
+    const $ = cheerio.load(html);
+  
+    replaceURLsWithEmbeds($, function () {
+      expect($("a[href='https://flic.kr/p/2quEvYr']").length).toBe(1);
+      expect($("a[data-flickr-embed='true']").length).toBe(0);
+      expect($("img").length).toBe(0);
+      expect($("script").length).toBe(0);
+      done();
+    });
+  });
+
   // if the flickr link is invalid or poorly formatted, it should not be replaced
   it("does not error when the flickr link is invalid", function (done) {
     const html = '<a href="https://bsky.app">https://bsky.app</a>';
@@ -58,6 +104,7 @@ describe("flickr plugin", function () {
 
     replaceURLsWithEmbeds($, function () {
       expect($("a").length).toBe(1);
+      expect($("a[href='https://bsky.app']").text()).toBe("https://bsky.app");
       expect($(".flickr-embed").length).toBe(0);
       expect($("img").length).toBe(0);
       expect($("script").length).toBe(0);

--- a/app/build/plugins/index.js
+++ b/app/build/plugins/index.js
@@ -27,6 +27,7 @@ var loaded = loadPlugins({
   disqus: require("./disqus"),
   emoticons: require("./emoticons"),
   externalLinks: require("./externalLinks"),
+  flickr: require("./flickr"),
   image: require("./image"),
   imageCaption: require("./imageCaption"),
   katex: require("./katex"),


### PR DESCRIPTION

This module converts plain Flickr URLs in HTML into embedded Flickr widgets using the Flickr oEmbed API.

Features
	•	Supports both short (flic.kr) and full (flickr.com) Flickr URLs.
	•	Automatically replaces bare links with Flickr embeds.
	•	Graceful handling of invalid URLs or API failures.

e.g. in your markdown file:

```
# Title of post

https://www.flickr.com/photos/jemostrom/54145631949/

Some text here
```

When rendered will include a flickr embed for the linked photo, rather than a plain link.