### PR TITLE
Resolve query name conundrum

### DIFF
--- a/app/blog/tests/routing.js
+++ b/app/blog/tests/routing.js
@@ -6,7 +6,7 @@ describe("routing", function () {
 
     await this.template(
       {
-        "example.html": "Success {{params.page}}",
+        "example.html": "Success {{request.params.page}}",
       },
       {
         views: {

--- a/app/blog/tests/template.js
+++ b/app/blog/tests/template.js
@@ -76,7 +76,7 @@ describe("template engine", function () {
 
   it("exposes the url query to the template view", async function () {
     await this.template({
-      "foo.html": `{{query.bar}}`,
+      "foo.html": `{{request.query.bar}}`,
     });
 
     const res = await this.get(`/foo.html?bar=baz`);
@@ -92,6 +92,6 @@ describe("template engine", function () {
 
     const res1 = await this.get(`/foo.html`);
 
-    expect((await res1.text()).trim()).toEqual("[object Object]");
+    expect((await res1.text()).trim()).toEqual("");
   });
 });

--- a/app/blog/view.js
+++ b/app/blog/view.js
@@ -15,13 +15,13 @@ module.exports = function (req, res, next) {
 
     if (!viewName) return next();
 
+    // Overwrite the request params with the params parsed from the URL
     if (params) {
       req.params = params;
-      res.locals.params = params;
     }
 
-    // we expose the query string object parsed by express
-    res.locals.query = req.query;
+    // expose the query and params to the view
+    res.locals.request = { query: req.query, params: req.params };
 
     return res.renderView(viewName, next);
   });

--- a/app/blog/view.js
+++ b/app/blog/view.js
@@ -21,6 +21,8 @@ module.exports = function (req, res, next) {
     }
 
     // expose the query and params to the view
+    // DON'T set query directly because a lot of templates rely
+    // on the previous mapping of req.query.q to res.locals.query
     res.locals.request = { query: req.query, params: req.params };
 
     return res.renderView(viewName, next);


### PR DESCRIPTION
we overwrite {{query}} but it's used on a lot of the templates so their search boxes will be filled with OBJECT OBJECT