### PR TITLE
Use CDN to serve files in site folder referenced by template

### DIFF
--- a/app/models/template/setView.js
+++ b/app/models/template/setView.js
@@ -96,6 +96,10 @@ module.exports = function setView(templateID, updates, callback) {
         view.retrieve = view.retrieve || {};
         view.partials = view.partials || {};
 
+        // Todo, identify links or hrefs to static files 
+        // and add them to the retrieve list so at runtime
+        // they can be replaced with CDN links? We want to
+        // avoid serving static files from the server if possible
         var parseResult = parseTemplate(view.content);
 
         // TO DO REMOVE THIS


### PR DESCRIPTION
The problem is file serving from the EBS disk via node is really slow.

The goal is to avoid people putting fonts in their site folder then embedding them in a template. We want these requests to go through the CDN where possible

- [ ] We could do something at the render middleware which retrieved a full list of folder urls and if there's a match, add the cdn origin and a hash parameters
  - [ ] maybe use a fast html parser (parse5?) rather than a regex
  - [ ] to make this work we maybe need to use the metadata model to store a modified time, content hash, etc
- [ ] Ensure the correct access control origin headers are set by the CDN for these files so fonts still work