### PR TITLE
Prevent screenshot from taking down server

### DIFF
--- a/app/helper/screenshot/index.js
+++ b/app/helper/screenshot/index.js
@@ -56,12 +56,14 @@ async function initialize() {
             devtools: false,
             args: BROWSER_ARGS,
             ignoreDefaultArgs: ["--disable-extensions"],
+            protocolTimeout: 30000  // Add just this line
           });
           const page = await browser.newPage();
           await page.goto("about:blank");
         }
       } catch (error) {
         browserInitializationPromise = null;
+        browser = null;  // Ensure browser is nulled on failure
         throw error;
       }
     })();


### PR DESCRIPTION
```
/usr/src/app/node_modules/puppeteer-core/lib/cjs/puppeteer/common/CallbackRegistry.js:101
    #error = new Errors_js_1.ProtocolError();
             ^

ProtocolError: Page.addScriptToEvaluateOnNewDocument timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.
    at <instance_members_initializer> (/usr/src/app/node_modules/puppeteer-core/lib/cjs/puppeteer/common/CallbackRegistry.js:101:14)
    at new Callback (/usr/src/app/node_modules/puppeteer-core/lib/cjs/puppeteer/common/CallbackRegistry.js:105:16)
    at CallbackRegistry.create (/usr/src/app/node_modules/puppeteer-core/lib/cjs/puppeteer/common/CallbackRegistry.js:23:26)
    at Connection._rawSend (/usr/src/app/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/Connection.js:93:26)
    at CdpCDPSession.send (/usr/src/app/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/CDPSession.js:69:33)
    at #createIsolatedWorld (/usr/src/app/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/FrameManager.js:367:23)
    at /usr/src/app/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/FrameManager.js:178:53
    at async Promise.all (index 4)
    at async FrameManager.initialize (/usr/src/app/node_modules/puppeteer-core/lib/cjs/puppeteer/cdp/FrameManager.js:169:13)
```
```
[26/Mar/2025:14:50:30 +0000] [green] Screenshot: Navigating browser to https://www.theverge.com/2023/3/22/23595159/pebble-small-android-phone-project-crowdfunding-migicovsky
[26/Mar/2025:14:50:50 +0000] [green] Screenshot: Error during screenshot: TimeoutError: Navigation timeout of 20000 ms exceeded
    at takeScreenshot (/usr/src/app/app/helper/screenshot/index.js:182:16)
[26/Mar/2025:14:50:50 +0000] [green] Screenshot: Attempting browser restart
[26/Mar/2025:14:50:50 +0000] [green] Screenshot: Closing browser
```