### PR TITLE
Support promise-based hashing in transformer helper

### DIFF
--- a/app/helper/transformer/hash.js
+++ b/app/helper/transformer/hash.js
@@ -3,6 +3,19 @@ var crypto = require("crypto");
 var debug = require("debug")("blot:helper:transformer:hash");
 
 module.exports = function (path, callback) {
+  if (typeof callback === "function") {
+    return hashFile(path, callback);
+  }
+
+  return new Promise(function (resolve, reject) {
+    hashFile(path, function (err, hash) {
+      if (err) return reject(err);
+      resolve(hash);
+    });
+  });
+};
+
+function hashFile(path, callback) {
   var hash;
 
   fs.createReadStream(path)
@@ -13,4 +26,4 @@ module.exports = function (path, callback) {
       debug(path, "hashed to", hash);
       callback(null, hash);
     });
-};
+}

--- a/app/helper/transformer/tests/hash.js
+++ b/app/helper/transformer/tests/hash.js
@@ -1,0 +1,31 @@
+describe("transformer hash helper", function () {
+  var fs = require("fs-extra");
+  var crypto = require("crypto");
+  var HashFile = require("../hash");
+
+  require("./setup")({});
+
+  function expectedHash(path) {
+    var contents = fs.readFileSync(path);
+    return crypto.createHash("sha1").update(contents).digest("hex");
+  }
+
+  it("computes a SHA-1 digest with a callback", function (done) {
+    var expected = expectedHash(this.localPath);
+
+    HashFile(this.localPath, function (err, hash) {
+      if (err) return done.fail(err);
+
+      expect(hash).toEqual(expected);
+      done();
+    });
+  });
+
+  it("computes a SHA-1 digest when used as a promise", function () {
+    var expected = expectedHash(this.localPath);
+
+    return HashFile(this.localPath).then(function (hash) {
+      expect(hash).toEqual(expected);
+    });
+  });
+});

--- a/app/helper/transformer/tests/lookup.js
+++ b/app/helper/transformer/tests/lookup.js
@@ -107,19 +107,23 @@ describe("transformer", function () {
 
     test.transformer.lookup(test.path, firstTransform, function (
       err,
-      firstResult
+      firstResult,
+      firstHash
     ) {
       if (err) return done.fail(err);
 
       test.transformer.lookup(test.path, secondTransform, function (
         err,
-        secondResult
+        secondResult,
+        secondHash
       ) {
         if (err) return done.fail(err);
 
         expect(firstTransform).toHaveBeenCalled();
         expect(secondTransform).not.toHaveBeenCalled();
         expect(firstResult).toEqual(secondResult);
+        expect(firstHash).toEqual(jasmine.any(String));
+        expect(secondHash).toEqual(firstHash);
 
         done();
       });


### PR DESCRIPTION
## Summary
- add a promise-returning code path to the transformer hash helper while retaining callbacks
- update transformer path handling to await the hash helper and streamline the caching flow
- add hash helper tests and extend transformer caching coverage for consistent hashes

## Testing
- npm test app/helper/transformer/tests/hash.js *(fails: scripts/tests/test.env is missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eba94614e083298ebc718ea209bc93