### PR TITLE
Handle missing pathname in urlNormalizer

### DIFF
--- a/app/helper/tests/urlNormalizer.js
+++ b/app/helper/tests/urlNormalizer.js
@@ -10,5 +10,6 @@ describe("urlNormalizer", function () {
     is("http://blot.im/foo/bar", "/foo/bar");
     is("/foo/bar/", "/foo/bar");
     is("foo/bar/", "/foo/bar");
+    is("mailto:test@example.com", "");
   });
 });

--- a/app/helper/urlNormalizer.js
+++ b/app/helper/urlNormalizer.js
@@ -9,10 +9,13 @@ function urlNormalizer(url) {
   if (!url) return "";
 
   try {
-    url = parse(url).pathname;
+    const parsed = parse(url);
+    url = (parsed && parsed.pathname) || "";
   } catch (e) {
     return "";
   }
+
+  if (!url) return "";
 
   if (url.slice(0, 1) !== "/") url = "/" + url;
 


### PR DESCRIPTION
## Summary
- avoid crashing in `urlNormalizer` when `url.parse` returns a falsy pathname
- add a regression test covering `mailto:` links which previously triggered the failure

## Testing
- npm test -- --filter=urlNormalizer *(fails: ./scripts/tests/test.env does not exist in the tests directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ebb866362083299956244ad0c32185