### PR TITLE
Fix metadata parsing for empty YAML front matter

### DIFF
--- a/app/build/metadata.js
+++ b/app/build/metadata.js
@@ -31,6 +31,14 @@ function Metadata (html) {
       // and understand them
       let mixedCaseMetadata = YAML.parse(frontmatter);
 
+      if (
+        !mixedCaseMetadata ||
+        typeof mixedCaseMetadata !== "object" ||
+        Array.isArray(mixedCaseMetadata)
+      ) {
+        mixedCaseMetadata = {};
+      }
+
       // Map { Permalink } to { permalink }
       // Blot uses lowercase metadata keys
       Object.keys(mixedCaseMetadata).forEach(mixedCaseKey => {

--- a/app/build/tests/index.js
+++ b/app/build/tests/index.js
@@ -301,7 +301,18 @@ describe("build", function () {
       array: ["one", "two"],
       object: { key: "value" },
     });
-    
+
+    done();
+  });
+
+  it("will tolerate empty YAML front matter", async function (done) {
+    const path = "/post.txt";
+    const contents = `---\n---\n\n# Hello`;
+    const entry = await this.build(path, contents);
+
+    expect(entry.metadata).toEqual({});
+    expect(entry.html.trim()).toEqual("<h1 id=\"hello\">Hello</h1>");
+
     done();
   });
 


### PR DESCRIPTION
## Summary
- treat parsed YAML front matter that resolves to null or non-object as empty metadata
- add a regression test to ensure empty front matter no longer throws during build

## Testing
- not run (requires docker-based test environment)


------
https://chatgpt.com/codex/tasks/task_e_68ec0b72c364832980278cb30922929d