### PR TITLE
Improve in-page wikilink heading resolution

### DIFF
--- a/app/build/tests/plugins/wikilinks.js
+++ b/app/build/tests/plugins/wikilinks.js
@@ -48,6 +48,38 @@ describe("wikilinks plugin", function () {
     this.buildAndCheck({ path, contents }, { html }, done);
   });
 
+  it("will normalize same-page heading anchors", function (done) {
+    const contents = "# Heading Here\n\nSee [[#Heading Here]].";
+    const path = "/hello.txt";
+    const html =
+      '<h1 id="heading-here">Heading Here</h1>\n<p>See <a href="#heading-here" title="wikilink">#Heading Here</a>.</p>';
+
+    this.blog.plugins.wikilinks = { enabled: true, options: {} };
+    this.buildAndCheck({ path, contents }, { html }, done);
+  });
+
+  it("will match heading links to custom ids", function (done) {
+    const contents =
+      '<h2 id="headinghere">Heading Here</h2>\n\nSee [[#Heading Here]].';
+    const path = "/hello.txt";
+    const html =
+      '<h2 id="headinghere">Heading Here</h2>\n<p>See <a href="#headinghere" title="wikilink">#Heading Here</a>.</p>';
+
+    this.blog.plugins.wikilinks = { enabled: true, options: {} };
+    this.buildAndCheck({ path, contents }, { html }, done);
+  });
+
+  it("will match heading links to nested anchors", function (done) {
+    const contents =
+      '<h3><a id="h.abc123"></a>Heading From Docs</h3>\n\nSee [[#Heading From Docs]].';
+    const path = "/hello.txt";
+    const html =
+      '<h3><a id="h.abc123"></a>Heading From Docs</h3>\n<p>See <a href="#h.abc123" title="wikilink">#Heading From Docs</a>.</p>';
+
+    this.blog.plugins.wikilinks = { enabled: true, options: {} };
+    this.buildAndCheck({ path, contents }, { html }, done);
+  });
+
   it("will convert wikilinks next to ignored nodes", function (done) {
     const contents =
       "<script>console.log('hey');</script>\n\nA **[[wikilink elsewhere]]** ";


### PR DESCRIPTION
## Summary
- search for headings whose text matches same-page wikilinks and reuse their anchor ids
- fall back to fuzzy id and name matches so custom or generated anchors stay reachable
- add regression coverage for custom heading ids and nested anchor elements

## Testing
- npm test -- wikilinks *(fails: ./scripts/tests/test.env does not exist in the tests directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ecd2acb3348329ac915602274996c2