### PR TITLE
Clarify Word document import guidance

### DIFF
--- a/app/views/how/files/word-documents.html
+++ b/app/views/how/files/word-documents.html
@@ -10,3 +10,37 @@
   <a href="https://en.wikipedia.org/wiki/OpenOffice.org">OpenOffice</a>. Much
   formatting is stripped so posts match the style of your site.
 </p>
+
+<h2>Metadata</h2>
+
+<p>
+  Add <a href="/how/metadata">metadata</a> to your document by starting with a
+  block of <code>key: value</code> pairs in the first paragraph or by inserting
+  a <a href="/how/metadata#yaml">YAML front matter</a> block. Blot reads this
+  information the same way it does for plain text posts, so fields like
+  <code>Title</code>, <code>Date</code> and <code>Tags</code> are picked up
+  automatically.
+</p>
+
+<h2>Headings</h2>
+
+<p>
+  Blot looks for bold text to determine the structure of the post. A bold line
+  at the top becomes the post title, and additional bold paragraphs are turned
+  into headings so the published page has a sensible outline.
+</p>
+
+<h2>Images and assets</h2>
+
+<p>
+  Blot extracts images embedded in the document and adds them directly to the
+  post created from the Word file, so they appear in the same place as they did
+  in your document.
+</p>
+
+<h2>Formatting cleanup</h2>
+
+<p>
+  Inline styles and unused tags are removed during conversion. This keeps the
+  post lightweight and lets your site's theme control the final appearance.
+</p>


### PR DESCRIPTION
## Summary
- link the Word document metadata instructions to the metadata guide and YAML section
- correct the documentation of how embedded images are handled during Word imports
- remove the RTF conversion note from the Markdown guide for now

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68ee20876cf88329a0e961b4bf14e2d3