### PR TITLE
Document heading anchor wikilink resolution

### DIFF
--- a/app/views/how/formatting/wikilinks.html
+++ b/app/views/how/formatting/wikilinks.html
@@ -42,7 +42,21 @@ The wikilink above is equivalent to this Markdown:
   <li>
     <strong>By title</strong> Works for posts and pages, is case-insensitive.
   </li>
+  <li>
+    <strong>By heading anchor</strong> Blot supports linking to headings within
+    the same post or page. The following wikilink forms are accepted and treated
+    interchangeably: <code>[[Heading Title]]</code>,
+    <code>[[#Heading Title]]</code>, <code>[[heading-id]]</code>, and
+    <code>[[#heading-id]]</code>.
+  </li>
 </ol>
+
+<pre><code>[[#My section heading]]</code></pre>
+
+<p>
+  The snippet above links directly to the <code>My section heading</code> heading
+  in the current document.
+</p>
 
 <h2>Examples</h2>
 


### PR DESCRIPTION
## Summary
- document heading anchor resolution as an additional wikilink lookup option
- clarify supported wikilink forms for heading anchors
- add a copyable example showing a same-page heading link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed5274b6c08329999fed31131d6c2c