### PR TITLE
Document Obsidian embed syntax for wikilinks

### DIFF
--- a/app/views/how/formatting/wikilinks.html
+++ b/app/views/how/formatting/wikilinks.html
@@ -106,3 +106,72 @@ your own text using the following syntax:
   <em>New link format</em> set to <em>absolute path in vault</em> as long as
   your Obsidian Vault is not inside a subdirectory of your site folder on Blot.
 </p>
+
+<h2>Embedding files with Obsidian</h2>
+
+<p>
+  Obsidian lets you embed files such as images, audio, video, PDFs, and
+  Markdown notes using the same wikilink syntax prefixed with an exclamation
+  mark: <code>![[...]]</code>. Blot mirrors this behaviour and converts embeds
+  into the correct HTML output when your site is built.
+</p>
+
+<p>
+  You can embed any file that Blot already knows how to publish. This includes
+  common image formats (<code>.png</code>, <code>.jpg</code>, <code>.jpeg</code>,
+  <code>.gif</code>, <code>.svg</code>), audio (<code>.mp3</code>,
+  <code>.wav</code>), video (<code>.mp4</code>, <code>.mov</code>), PDFs, and
+  Markdown notes. Attachments from your Obsidian vault sync to Blot in the same
+  folder structure, so embeds continue to work when your site is published.
+</p>
+
+<p>Here are some common examples of Obsidian-style embeds:</p>
+
+<table>
+  <tr>
+    <th>Intent</th>
+    <th>Markdown</th>
+    <th>Notes</th>
+  </tr>
+  <tr>
+    <td>Image with custom alt text</td>
+    <td><code>![[Garden/Flowers.png|Summer wildflowers]]</code></td>
+    <td>
+      The text after the pipe becomes the image's alt text on your published
+      site.
+    </td>
+  </tr>
+  <tr>
+    <td>Relative path from the current note</td>
+    <td><code>![[../Audio/Birds.mp3]]</code></td>
+    <td>
+      Uses a relative path to embed a file in a nearby folder. This mirrors
+      Obsidian's <em>New link format → relative path to file</em> preference.
+    </td>
+  </tr>
+  <tr>
+    <td>Absolute path within the vault</td>
+    <td><code>![[/Reference/Slides/Overview.pdf]]</code></td>
+    <td>
+      Works when Obsidian is configured to use <em>absolute path in vault</em>
+      links. The leading slash points to the root of your site folder on Blot.
+    </td>
+  </tr>
+  <tr>
+    <td>Embed another note</td>
+    <td><code>![[Project plan]]</code></td>
+    <td>
+      Inserts the rendered Markdown from another note inline. This is useful
+      for reusing checklists, snippets, or reference material across pages.
+    </td>
+  </tr>
+</table>
+
+<p>
+  When embedding Markdown notes, Blot renders the note's content inline on the
+  page. Media files are rendered with the appropriate HTML element and include
+  any alt text, captions, or titles that you add within Obsidian. If you prefer
+  to keep embeds in a dedicated <code>attachments</code> folder, Obsidian's
+  default attachment settings work without extra configuration—just make sure
+  the folder is inside your blog directory so the files can sync to Blot.
+</p>

--- a/app/views/tools/text-editors/obsidian.html
+++ b/app/views/tools/text-editors/obsidian.html
@@ -8,3 +8,52 @@ Popular: true
 <h1>Obsidian</h1>
 
 <h2>Create a website with Obsidian</h2>
+
+<p>
+  Obsidian is a Markdown note-taking app that uses plain files stored on your
+  computer. Because Blot turns folders of files into websites, the two work
+  well together—just point Blot at the same folder you use as your Obsidian
+  vault.
+</p>
+
+<h3>Recommended settings</h3>
+
+<ul>
+  <li>
+    Set <strong>New link format</strong> to <em>relative path to file</em>. Blot
+    also understands <em>absolute path in vault</em> if your vault is the root of
+    your blog folder.
+  </li>
+  <li>
+    Keep your attachments in a folder inside the vault (Obsidian's default
+    <code>attachments</code> location works). Blot mirrors this folder structure
+    when publishing your site.
+  </li>
+</ul>
+
+<h3>Blot features for Obsidian users</h3>
+
+<ul>
+  <li>
+    <strong>Wikilinks</strong>: Blot resolves <code>[[Links]]</code> using the
+    same filename logic as Obsidian. You can customise the link text with the
+    <code>[[Page name|Custom text]]</code> syntax.
+  </li>
+  <li>
+    <strong>Embeds</strong>: Obsidian's <code>![[...]]</code> syntax works for
+    images, audio, video, PDFs, and notes. Alt text after the pipe (for example
+    <code>![[File.png|Caption]]</code>) becomes the published <code>alt</code>
+    attribute.
+  </li>
+  <li>
+    <strong>Markdown notes as components</strong>: Embedding another note (for
+    example <code>![[Project overview]]</code>) renders the Markdown inline on
+    your site, so you can reuse content in multiple posts.
+  </li>
+</ul>
+
+<p>
+  See the <a href="/how/formatting/wikilinks">wikilinks guide</a> for detailed
+  examples of how embeds and link resolution behave when your notes are
+  published with Blot.
+</p>


### PR DESCRIPTION
## Summary
- expand the wikilinks guide with richer guidance on Obsidian-style embeds, supported file types, and attachments
- add note-embedding example and clarify relative versus absolute vault paths
- update the Obsidian tool page with recommended settings and links to the detailed embed documentation

## Testing
- `node app/documentation/build/index.js` *(fails: cannot find module 'config' in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed52801a4c8329979261c0221f2d97