### PR TITLE
Add wikilink tests for explicit heading ids

### DIFF
--- a/app/build/tests/plugins/wikilinks.js
+++ b/app/build/tests/plugins/wikilinks.js
@@ -81,6 +81,32 @@ Heading Here
     this.buildAndCheck({ path, contents }, { html }, done);
   });
 
+  it("will match heading links to explicit ids", function (done) {
+    const contents =
+      '<h2 id="heading-here">Heading Here</h2>\n\nSee [[heading-here]].';
+    const path = "/hello.txt";
+    const html = `<h2 id="heading-here">
+Heading Here
+</h2>
+<p>See <a href="#heading-here" title="wikilink">Heading Here</a>.</p>`;
+
+    this.blog.plugins.wikilinks = { enabled: true, options: {} };
+    this.buildAndCheck({ path, contents }, { html }, done);
+  });
+
+  it("will match heading links to explicit ids with hash", function (done) {
+    const contents =
+      '<h2 id="heading-here">Heading Here</h2>\n\nSee [[#heading-here]].';
+    const path = "/hello.txt";
+    const html = `<h2 id="heading-here">
+Heading Here
+</h2>
+<p>See <a href="#heading-here" title="wikilink">Heading Here</a>.</p>`;
+
+    this.blog.plugins.wikilinks = { enabled: true, options: {} };
+    this.buildAndCheck({ path, contents }, { html }, done);
+  });
+
   it("will match heading links to nested anchors", function (done) {
     const contents =
       '<h3><a id="h.abc123"></a>Heading From Docs</h3>\n\nSee [[#Heading From Docs]].';


### PR DESCRIPTION
## Summary
- add test coverage ensuring wikilinks resolve explicit heading ids
- cover both direct id references and references that include the hash prefix

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed527704188329aafbeb9079932f0a