### PR TITLE
Replace helmet frame protections with custom middleware

### DIFF
--- a/app/blog/draft.js
+++ b/app/blog/draft.js
@@ -59,10 +59,11 @@ module.exports = function route(server) {
     response.set("Cache-Control", "no-cache");
 
     renderDraft(request, response, next, filePath, function (html) {
-      // this is to override the header set by the middleware
-      // helmet.frameguard in server.js. It prevents Firefox
-      // from rendering the iframe in the preview file.
+      // Remove the frame protection headers added by the server
+      // middleware. They prevent Firefox from rendering the iframe
+      // used in the preview file.
       response.removeHeader("X-Frame-Options");
+      response.removeHeader("Content-Security-Policy");
 
       // bodyHTML is passed after HTML
       response.send(html);

--- a/app/blog/vhosts.js
+++ b/app/blog/vhosts.js
@@ -98,6 +98,7 @@ module.exports = function (req, res, next) {
     if (previewTemplate) {
       // Necessary to allow the template editor to embed the page
       res.removeHeader("X-Frame-Options");
+      res.removeHeader("Content-Security-Policy");
 
       req.preview = true;
       res.set("Cache-Control", "no-cache");

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "fs-extra": "11.1.0",
     "googleapis": "144.0.0",
     "he": "1.1.0",
-    "helmet": "3.21.2",
     "highlight.js": "10.4.1",
     "html-minifier": "4.0.0",
     "http-auth": "3.2.3",


### PR DESCRIPTION
## Summary
- remove the helmet dependency and replace its frameguard usage with inlined middleware that sets both X-Frame-Options and CSP frame-ancestors
- update draft preview and template preview flows to clear the new headers when embedding is required

## Testing
- npm test app/build/tests/drafts.js *(fails: requires scripts/tests/test.env which is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ee4ab8082483299a98e6b7b665b265