### PR TITLE
Upgrade scheduling for node-schedule 2.x

### DIFF
--- a/app/scheduler/index.js
+++ b/app/scheduler/index.js
@@ -3,7 +3,7 @@ var async = require("async");
 var dailyUpdate = require("./daily");
 var email = require("helper/email");
 var clfdate = require("helper/clfdate");
-var schedule = require("node-schedule").scheduleJob;
+const scheduler = require("node-schedule");
 var checkFeaturedSites = require("../documentation/featured/check");
 var config = require("config");
 var publishScheduledEntries = require("./publish-scheduled-entries");
@@ -24,7 +24,7 @@ let NOTIFIED_LOW_DISK_SPACE = false;
 
 module.exports = function () {
   // Log useful system information, once per minute
-  schedule("* * * * *", function () {
+  scheduler.scheduleJob("* * * * *", function () {
     // Detect any zombie processes
     zombies(function (err) {
       if (err) throw err;
@@ -131,7 +131,7 @@ module.exports = function () {
   });
 
   console.log(clfdate(), "Scheduled daily check of storage disk usage");
-  schedule({ hour: 10, minute: 0 }, function () {
+  scheduler.scheduleJob({ hour: 10, minute: 0 }, function () {
     console.log(clfdate(), "Scheduler: Checking available disk space");
 
     exec("df -h", function (err, stdout) {
@@ -166,7 +166,7 @@ module.exports = function () {
   //   clfdate(),
   //   "Scheduled daily check of folders for sync abnormalities"
   // );
-  // schedule({ hour: 8, minute: 0 }, function () {
+  // scheduler.scheduleJob({ hour: 8, minute: 0 }, function () {
   //   console.log(clfdate(), "Fix sync: checking folders");
   //   fix(function (err, report) {
   //     if (err) {
@@ -180,7 +180,7 @@ module.exports = function () {
 
 
   console.log(clfdate(), "Scheduled daily check of suspected fraudulent users");
-  schedule({ hour: 11, minute: 0 }, async function () {
+  scheduler.scheduleJob({ hour: 11, minute: 0 }, async function () {
     console.log(clfdate(), "Checking for potential fraudulent users");
 
     let customers;
@@ -199,7 +199,7 @@ module.exports = function () {
   });
 
   console.log(clfdate(), "Scheduled daily check of featured sites");
-  schedule({ hour: 8, minute: 0 }, function () {
+  scheduler.scheduleJob({ hour: 8, minute: 0 }, function () {
     console.log(clfdate(), "Checking featured sites");
     checkFeaturedSites(function (err) {
       if (err) {
@@ -212,7 +212,7 @@ module.exports = function () {
 
   // At some point I should check this doesnt consume too much memory
   console.log(clfdate(), "Scheduled daily update email");
-  schedule({ hour: 12, minute: 0 }, function () {
+  scheduler.scheduleJob({ hour: 12, minute: 0 }, function () {
     console.log(clfdate(), "Generating daily update email...");
     dailyUpdate(function () {
       console.log(clfdate(), "Daily update email update was sent.");

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "multiparty": "4.2.3",
     "mustache": "4.2.0",
     "node-fetch": "2.6.7",
-    "node-schedule": "0.1.16",
+    "node-schedule": "^2.1.1",
     "parse5": "7.2.1",
     "path-to-regexp": "8.2.0",
     "pretty": "2.0.0",


### PR DESCRIPTION
## Summary
- upgrade node-schedule to the current 2.x line
- update scheduler modules to hold job handles so rescheduling and cancellation behave correctly
- ensure entry publication and subscription reminder jobs clean up and reschedule safely under the new API

## Testing
- npm test *(fails: scripts/tests/test.env missing)*
- node - <<'NODE' … *(manual scheduled entry smoke test)*
- node - <<'NODE' … *(manual subscription reminder smoke test)*
- node - <<'NODE' … *(manual maintenance scheduler smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_68ee492bf8b48329a8a7d6b9957b4664