### PR TITLE
Skip template rebuild when snapshots are unchanged

### DIFF
--- a/app/templates/index.js
+++ b/app/templates/index.js
@@ -353,6 +353,7 @@ function createViewSnapshot(view) {
   return {
     content: view.content,
     url: urlInfo.url,
+    urlPatterns: urlInfo.urlPatterns,
     partials: partials,
     locals: view.locals || {},
   };
@@ -394,6 +395,7 @@ function createStoredViewSnapshot(views) {
     map[view.name] = {
       content: view.content,
       url: view.url,
+      urlPatterns: view.urlPatterns || (view.url ? [view.url] : []),
       partials: view.partials || {},
       locals: view.locals || {},
     };


### PR DESCRIPTION
## Summary
- assemble template metadata and view definitions once per directory
- compare the assembled snapshot with stored metadata and views to skip redundant rebuilds
- reuse the precomputed view definitions when rebuilding templates is necessary

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0ae17ab0c83299487c027761ef43b