### PR TITLE
Document EXIF options in developer reference

### DIFF
--- a/app/views/developers/reference.yml
+++ b/app/views/developers/reference.yml
@@ -81,7 +81,11 @@
 
     - name: imageExif
       type: string
-      description: "Controls how much image metadata Blot preserves. One of 'off', 'basic', or 'full'."
+      description: |
+        Controls how much image metadata Blot preserves. One of `off`, `basic`, or `full`—the default is `basic`.
+        - Off: strips all EXIF data before publishing.
+        - Basic: keeps core camera and exposure details such as `Make`, `Model`, `LensMake`, `LensModel`, `ExposureTime`, `FNumber`, `ISO`, `FocalLength`, `ExposureCompensation`, and `DateTimeOriginal`.
+        - Full: keeps everything from Basic plus GPS coordinates including `GPSLatitude`, `GPSLatitudeRef`, `GPSLongitude`, `GPSLongitudeRef`, `GPSAltitude`, and `GPSAltitudeRef`.
       example: "{{blog.imageExif}}"
 
 - name: entry
@@ -214,7 +218,32 @@
 
     - name: exif
       type: object
-      description: "Sanitized EXIF metadata for image-based entries. Empty when EXIF is disabled or unavailable."
+      description: |
+        Sanitized EXIF metadata populated for image-based entries when EXIF preservation is enabled on the blog. Templates can iterate over the object as a context block, for example: `{{#entry.exif}}{{Make}}{{/entry.exif}}`.
+      example: |
+        {{#entry.exif}}
+        {{Make}} {{Model}} — {{ExposureTime}}s at f/{{FNumber}}, ISO {{ISO}}
+        {{/entry.exif}}
+
+        Basic mode keys:
+          - Make
+          - Model
+          - LensMake
+          - LensModel
+          - ExposureTime
+          - FNumber
+          - ISO
+          - FocalLength
+          - ExposureCompensation
+          - DateTimeOriginal
+
+        Full mode also includes:
+          - GPSLatitude
+          - GPSLatitudeRef
+          - GPSLongitude
+          - GPSLongitudeRef
+          - GPSAltitude
+          - GPSAltitudeRef
 
     - name: name
       type: string


### PR DESCRIPTION
## Summary
- clarify the meaning and defaults of the blog.imageExif configuration option
- document how entry.exif is populated and provide representative EXIF keys for each mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0e270b43483299d35308c2c2e532d