### PR TITLE
Ensure entries initialize exif metadata

### DIFF
--- a/app/models/entry/set.js
+++ b/app/models/entry/set.js
@@ -65,6 +65,7 @@ module.exports = function set (blogID, path, updates, callback) {
     if (entry.dependencies === undefined) entry.dependencies = [];
     if (entry.backlinks === undefined) entry.backlinks = [];
     if (entry.internalLinks === undefined) entry.internalLinks = [];
+    if (!entry.exif || typeof entry.exif !== "object") entry.exif = {};
 
     entry.scheduled = entry.dateStamp > Date.now();
 


### PR DESCRIPTION
## Summary
- default entry.exif to an empty object when missing or invalid
- keep existing validation flow intact so legacy entries pass ensure()

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0e98485cc8329822cab2d2c2c21de