### PR TITLE
Ensure imageExif mode persists when missing

### DIFF
--- a/app/models/blog/set.js
+++ b/app/models/blog/set.js
@@ -36,10 +36,15 @@ module.exports = function (blogID, blog, callback) {
 
       if (err) return callback(err);
 
+      var previousMode = (former && former.imageExif) || "off";
+
       if (Object.prototype.hasOwnProperty.call(latest, "imageExif")) {
-        var previous = (former && former.imageExif) || "off";
         latest.imageExif = normalizeImageExif(latest.imageExif, {
-          fallback: previous,
+          fallback: previousMode,
+        });
+      } else if (!former.imageExif) {
+        latest.imageExif = normalizeImageExif(previousMode, {
+          fallback: "off",
         });
       }
 


### PR DESCRIPTION
## Summary
- derive the previous imageExif mode when loading existing blog settings
- normalize explicit imageExif updates and apply the fallback normalization when the field is missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0e98ec0b48329b430e8ec378731ea