### PR TITLE
Decouple post-listen setup tasks

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -13,7 +13,21 @@ setup(async (err) => {
   // Open the server to handle requests
   server.listen(config.port, function () {
     console.log(clfdate(), `Server listening`);
-    
+
+    // Run non-blocking setup tasks after the port is bound so startup isn't delayed.
+    if (typeof setup.runPostListenTasks === "function") {
+      setup
+        .runPostListenTasks()
+        .catch((err) =>
+          console.error(
+            clfdate(),
+            "Setup:",
+            "Post-listen tasks encountered an error",
+            err
+          )
+        );
+    }
+
     // Send an email notification if the server starts or restarts
     email.SERVER_START(null, { container: config.container });
   });


### PR DESCRIPTION
## Summary
- move scheduler, client initialization, cache flush, local blog setup, and CDN purge into a new asynchronous helper in `app/setup.js`
- expose the helper via `setup.runPostListenTasks` and log its asynchronous execution and error handling
- trigger the helper from `app/index.js` after the server begins listening without blocking startup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f109ec81e88329a4e01c248dac09a7