### PR TITLE
Migrate entries to hashs rather than JSON blobs

### DIFF
--- a/app/models/entry/format.js
+++ b/app/models/entry/format.js
@@ -1,0 +1,69 @@
+var model = require("./model");
+
+function shouldSerialize(type) {
+  return type && type !== "string";
+}
+
+function parseField(field, value) {
+  if (value === null || value === undefined) return undefined;
+
+  var type = model[field];
+
+  if (!shouldSerialize(type)) return value;
+
+  try {
+    return JSON.parse(value);
+  } catch (err) {
+    return value;
+  }
+}
+
+function serializeField(field, value) {
+  if (value === undefined || value === null) return undefined;
+
+  var type = model[field];
+
+  if (!shouldSerialize(type)) return value;
+
+  return JSON.stringify(value);
+}
+
+function serialize(entry, fields) {
+  var output = {};
+
+  var keys = fields || Object.keys(model);
+
+  keys.forEach(function (field) {
+    if (!Object.prototype.hasOwnProperty.call(entry, field)) return;
+
+    var serialized = serializeField(field, entry[field]);
+
+    if (serialized === undefined) return;
+
+    output[field] = serialized;
+  });
+
+  return output;
+}
+
+function deserialize(hash) {
+  var output = {};
+
+  if (!hash) return output;
+
+  Object.keys(hash).forEach(function (field) {
+    var parsed = parseField(field, hash[field]);
+
+    if (parsed === undefined) return;
+
+    output[field] = parsed;
+  });
+
+  return output;
+}
+
+module.exports = {
+  parse: parseField,
+  serialize: serialize,
+  deserialize: deserialize,
+};

--- a/app/models/entry/get.js
+++ b/app/models/entry/get.js
@@ -2,51 +2,199 @@ var ensure = require("helper/ensure");
 var type = require("helper/type");
 
 var redis = require("models/client");
-var entryKey = require("./key").entry;
+var keys = require("./key");
+var format = require("./format");
 
 var Entry = require("./instance");
 
-module.exports = function (blogID, entryIDs, callback) {
-  ensure(blogID, "string").and(callback, "function");
+module.exports = function (blogID, entryIDs, fields, callback) {
+  ensure(blogID, "string");
 
-  var single = false;
+  if (type(entryIDs, "function")) {
+    callback = entryIDs;
+    entryIDs = undefined;
+    fields = undefined;
+  }
 
-  // Empty list of entry IDs, leave now!
+  if (type(fields, "function")) {
+    callback = fields;
+    fields = undefined;
+  }
+
+  ensure(callback, "function");
+
+  var singleEntry = false;
+  var singleField = false;
+  var requestedFields;
+
+  if (entryIDs === undefined) entryIDs = [];
+
   if (type(entryIDs, "array") && !entryIDs.length) {
     return callback([]);
   }
 
-  // We're only getting one entry now...
   if (type(entryIDs, "string")) {
-    single = true;
+    singleEntry = true;
     entryIDs = [entryIDs];
   }
 
-  entryIDs = entryIDs.map(function (entryID) {
-    return entryKey(blogID, entryID);
-  });
-
   ensure(entryIDs, "array");
 
-  redis.mget(entryIDs, function (err, entries) {
+  if (fields !== undefined) {
+    if (type(fields, "string")) {
+      requestedFields = [fields];
+      singleField = true;
+    } else if (type(fields, "array")) {
+      requestedFields = fields;
+    } else {
+      throw new Error("Fields must be a string or an array");
+    }
+  }
+
+  var hashKeys = entryIDs.map(function (entryID) {
+    return keys.entryHash(blogID, entryID);
+  });
+
+  var jsonKeys = entryIDs.map(function (entryID) {
+    return keys.entry(blogID, entryID);
+  });
+
+  var batch = redis.batch();
+
+  hashKeys.forEach(function (hashKey) {
+    if (requestedFields) batch.hmget(hashKey, requestedFields);
+    else batch.hgetall(hashKey);
+  });
+
+  batch.exec(function (err, replies) {
     if (err) throw err;
 
-    entries = entries || [];
+    replies = replies || [];
 
-    entries = entries.filter(function (entry) {
-      return entry;
+    var entries = new Array(entryIDs.length);
+    var missing = [];
+
+    replies.forEach(function (reply, index) {
+      if (requestedFields) {
+        var values = Array.isArray(reply) ? reply : [];
+        var hasValue = values.some(function (value) {
+          return value !== null && value !== undefined;
+        });
+
+        if (!hasValue) {
+          missing.push(index);
+          return;
+        }
+
+        var partial = {};
+
+        requestedFields.forEach(function (field, fieldIndex) {
+          var raw = values[fieldIndex];
+          if (raw === null || raw === undefined) return;
+          partial[field] = format.parse(field, raw);
+        });
+
+        entries[index] = partial;
+      } else {
+        if (!reply || !Object.keys(reply).length) {
+          missing.push(index);
+          return;
+        }
+
+        var deserialized = format.deserialize(reply);
+        entries[index] = new Entry(deserialized);
+      }
     });
 
-    entries = entries.map(function (entry) {
-      return new Entry(JSON.parse(entry)); // return value
-    });
-
-    if (single) {
-      entries = entries[0];
+    if (!missing.length) {
+      return finalize(entries);
     }
 
-    if (single && !entries) return callback();
+    var fallbackKeys = missing.map(function (index) {
+      return jsonKeys[index];
+    });
 
-    return callback(entries);
+    redis.mget(fallbackKeys, function (err, jsonEntries) {
+      if (err) throw err;
+
+      jsonEntries = jsonEntries || [];
+
+      jsonEntries.forEach(function (json, offset) {
+        if (!json) return;
+
+        var parsed;
+
+        try {
+          parsed = JSON.parse(json);
+        } catch (e) {
+          return;
+        }
+
+        var targetIndex = missing[offset];
+
+        if (requestedFields) {
+          var partial = {};
+
+          requestedFields.forEach(function (field) {
+            if (!Object.prototype.hasOwnProperty.call(parsed, field)) return;
+            partial[field] = parsed[field];
+          });
+
+          entries[targetIndex] = partial;
+        } else {
+          entries[targetIndex] = new Entry(parsed);
+        }
+      });
+
+      finalize(entries);
+    });
   });
+
+  function finalize(entries) {
+    var existing = entries.filter(function (entry) {
+      return entry !== undefined;
+    });
+
+    if (!requestedFields) {
+      if (singleEntry) {
+        var entry = existing[0];
+        if (!entry) return callback();
+        return callback(entry);
+      }
+
+      return callback(existing);
+    }
+
+    var results = existing.map(function (entry) {
+      return entry || {};
+    });
+
+    if (singleField) {
+      var fieldName = requestedFields[0];
+
+      results = results.map(function (entry) {
+        if (
+          entry &&
+          Object.prototype.hasOwnProperty.call(entry, fieldName)
+        ) {
+          return entry[fieldName];
+        }
+        return undefined;
+      });
+
+      if (singleEntry) {
+        if (!results.length) return callback();
+        return callback(results[0]);
+      }
+
+      return callback(results);
+    }
+
+    if (singleEntry) {
+      if (!results.length) return callback();
+      return callback(results[0]);
+    }
+
+    return callback(results);
+  }
 };

--- a/app/models/entry/key.js
+++ b/app/models/entry/key.js
@@ -9,6 +9,10 @@ module.exports = {
     return "blog:" + blogID + ":entry:" + pathNormalize(path);
   },
 
+  entryHash: function (blogID, path) {
+    return "blog:" + blogID + ":entry-hash:" + pathNormalize(path);
+  },
+
   // Set representing the paths of files which depend on this particular
   // path. The path itself may or may not be its own entry.
   // A path cannot have dependencies however without it also being an entry

--- a/app/models/entry/tests/get.js
+++ b/app/models/entry/tests/get.js
@@ -1,0 +1,114 @@
+describe("entry.get", function () {
+  require("./setup")();
+
+  const redis = require("models/client");
+  const get = require("../get");
+  const key = require("../key");
+  const format = require("../format");
+
+  const del = (...keys) => {
+    const filtered = keys.filter(Boolean);
+
+    if (!filtered.length) return Promise.resolve();
+
+    return new Promise((resolve, reject) => {
+      redis.del(filtered, err => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+  };
+
+  const hmset = (hashKey, values) =>
+    new Promise((resolve, reject) => {
+      redis.hmset(hashKey, values, err => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+
+  const fetch = (blogID, path, fields) =>
+    new Promise(resolve => {
+      if (fields === undefined) {
+        get(blogID, path, entry => resolve(entry));
+      } else {
+        get(blogID, path, fields, value => resolve(value));
+      }
+    });
+
+  it("returns the full entry from the hash store", async function (done) {
+    const path = "/hash-entry.txt";
+    const hashKey = key.entryHash(this.blog.id, path);
+    const legacyKey = key.entry(this.blog.id, path);
+    const stored = {
+      id: path,
+      title: "Hash entry",
+      tags: ["hash", "entry"],
+      size: 321,
+      menu: true,
+    };
+
+    await del(hashKey, legacyKey);
+    await hmset(hashKey, format.serialize(stored));
+
+    const entry = await fetch(this.blog.id, path);
+
+    expect(entry).toEqual(jasmine.objectContaining(stored));
+
+    await del(hashKey, legacyKey);
+
+    done();
+  });
+
+  it("falls back to the legacy JSON key when the hash is missing", async function (done) {
+    const path = "/legacy-entry.txt";
+    const hashKey = key.entryHash(this.blog.id, path);
+
+    const entry = await this.set(path, "Title: Legacy entry\n\nHello");
+
+    await del(hashKey);
+
+    const fetched = await fetch(this.blog.id, path);
+
+    expect(fetched).toEqual(jasmine.objectContaining({ title: entry.title }));
+
+    done();
+  });
+
+  it("returns a scalar when requesting a single field", async function (done) {
+    const path = "/hash-title.txt";
+    const hashKey = key.entryHash(this.blog.id, path);
+    const legacyKey = key.entry(this.blog.id, path);
+    const stored = {
+      id: path,
+      title: "Hash title",
+      size: 10,
+    };
+
+    await del(hashKey, legacyKey);
+    await hmset(hashKey, format.serialize(stored));
+
+    const title = await fetch(this.blog.id, path, "title");
+
+    expect(title).toEqual(stored.title);
+
+    await del(hashKey, legacyKey);
+
+    done();
+  });
+
+  it("returns a field value when falling back to the JSON entry", async function (done) {
+    const path = "/legacy-title.txt";
+    const hashKey = key.entryHash(this.blog.id, path);
+
+    const entry = await this.set(path, "Title: Legacy title\n\nHello");
+
+    await del(hashKey);
+
+    const title = await fetch(this.blog.id, path, "title");
+
+    expect(title).toEqual(entry.title);
+
+    done();
+  });
+});


### PR DESCRIPTION
## Summary
- add an entry hash key helper and shared serializer/deserializer utilities
- refactor entry.get to read from hash-backed data with optional field selection, using Redis batch() for hash reads
- add tests covering hash reads, JSON fallback, and single-field lookups

## Testing
- not run (requires Docker-based test environment unavailable in this workspace)

------
https://chatgpt.com/codex/tasks/task_e_68f0a985f1f88329a4a1156865a0031b