### PR TITLE
Simplify random entry selection helper

### DIFF
--- a/app/blog/random.js
+++ b/app/blog/random.js
@@ -8,21 +8,9 @@ module.exports = function (req, res, next) {
   const queryIndex = url.indexOf("?");
   const queryString = queryIndex >= 0 ? url.slice(queryIndex) : "";
 
-  // todo: implement Entries.random using srandmember
-  Entries.getAll(req.blog.id, function (entries) {
-    if (!entries || !entries.length) return next();
-    let entry = randomFrom(entries);
-    let attempts = 0;
-    while (!entry.url && attempts < 100) {
-      entry = randomFrom(entries);
-      attempts++;
-    }
-    if (!entry.url) return next();
+  Entries.random(req.blog.id, function (entry) {
+    if (!entry || !entry.url) return next();
     res.set("Cache-Control", "no-cache");
     res.redirect(entry.url + queryString);
   });
 };
-
-function randomFrom(list) {
-  return list[Math.floor(Math.random() * list.length)];
-}


### PR DESCRIPTION
## Summary
- rely on Redis ZRANDMEMBER directly in `Entries.random` and remove legacy fallback logic
- drop the associated fallback unit test now that the helper assumes modern Redis support

## Testing
- npm test -- app/models/entries/tests.js *(fails: scripts/tests/test.env missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0000ad150832994ca1e2b32a8f8b7