### PR TITLE
Refactor deployment prompt order

### DIFF
--- a/scripts/deploy/index.js
+++ b/scripts/deploy/index.js
@@ -11,8 +11,6 @@ const constants = require("./constants");
 const { CONTAINERS } = constants;
 const { REGISTRY_URL, PLATFORM_OS } = constants;
 
-let confirmed = false;
-
 async function detectPlatform() {
   console.log("Detecting server platform...");
   const platformOs = PLATFORM_OS;
@@ -71,17 +69,6 @@ async function deployContainer(container, platform, imageHash) {
   console.log(dockerRunCommand);
   console.log();
 
-  if (!confirmed) {
-    confirmed = await askForConfirmation(
-      "Are you sure you want to run this command? (y/n): "
-    );
-  }
-
-  if (!confirmed) {
-    console.log("Deployment canceled.");
-    process.exit(0);
-  }
-
   console.log("Pulling new image...");
   await sshCommand(`docker pull ${REGISTRY_URL}:${imageHash}`);
 
@@ -120,6 +107,15 @@ async function main() {
       throw new Error(
         `Image for platform ${platform.platformOs}/${platform.platformArch} does not exist.`
       );
+    }
+
+    const confirmed = await askForConfirmation(
+      "Are you sure you want to deploy this image? (y/n): "
+    );
+
+    if (!confirmed) {
+      console.log("Deployment canceled.");
+      process.exit(0);
     }
 
     // validate that each container has a unique name and port


### PR DESCRIPTION
## Summary
- prompt for deployment immediately after confirming the target image exists
- remove the deployContainer confirmation to avoid prompting after additional validation work
- keep container validation but run it only after the user confirms

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f202750ca48329b258ccebcf78f203