### PR TITLE
Add dockerignore to trim build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Files and directories excluded from the Docker build context
+# These paths are regenerated during image builds or are not required at runtime.
+.git
+.github
+.gitignore
+.env
+*.env
+*.log
+*.rdb
+npm-debug.log*
+yarn-error.log*
+node_modules/
+package-lock.json
+app/views-built/
+blogs/
+cache/
+data/
+scripts/deploy/out/
+static/
+tmp/

--- a/README
+++ b/README
@@ -27,3 +27,13 @@ https://example.localhost/ - Your site
 You can edit the folder for the example blog inside the `data` directory:
 
 ./data/blogs/blog_$ID
+
+## Docker build context
+
+The `.dockerignore` file keeps the Docker build context lean by excluding
+directories that are regenerated during image builds or contain local caches,
+such as `node_modules/`, `data/`, and other temporary output. The Dockerfile
+continues to copy the source code, configuration, and scripts that are required
+at runtime (`app/`, `config/`, `scripts/`, and `TODO`). If you add new
+directories that only contain build artifacts, remember to add them to
+`.dockerignore` so they do not slow down image builds.


### PR DESCRIPTION
## Summary
- add a .dockerignore file so generated directories and caches are not sent to Docker builds
- document the ignore list in the README so contributors understand which assets stay out of the image context

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f203664470832985c1c530aea65406