### PR TITLE
Add wikilink filename resolver

### DIFF
--- a/app/build/plugins/wikilinks/byFilename.js
+++ b/app/build/plugins/wikilinks/byFilename.js
@@ -3,14 +3,16 @@ const { dirname, join, basename, normalize } = require("path");
 const localPath = require("helper/localPath");
 const caseSensitivePath = require("helper/caseSensitivePath");
 
-module.exports = function byFilename(blogID, pathOfPost, href, callback) {
+module.exports = function byFilename(
+  blogID,
+  pathOfPost,
+  href,
+  isLink,
+  callback
+) {
   if (!href) return callback(new Error("No filename provided"));
 
   const stripped = href.split("|")[0].trim();
-
-  if (!stripped || stripped.includes("/") || stripped.includes("#"))
-    return callback(new Error("No filename"));
-
   const targetName = basename(stripped);
 
   if (!targetName) return callback(new Error("No filename"));
@@ -60,19 +62,29 @@ module.exports = function byFilename(blogID, pathOfPost, href, callback) {
           });
         }
 
-        caseSensitivePath(root, join(current, targetName), function (matchErr, matchPath) {
-          if (!matchErr && matchPath && matchPath.startsWith(root)) {
-            const resolvedPath = "/" + matchPath.slice(root.length);
+        caseSensitivePath(
+          root,
+          join(current, targetName),
+          function (matchErr, matchPath) {
+            if (!matchErr && matchPath && matchPath.startsWith(root)) {
+              const resolvedPath = "/" + matchPath.slice(root.length);
 
-            return getEntry(blogID, resolvedPath, function (entry) {
-              if (entry) return callback(null, entry);
+              return getEntry(blogID, resolvedPath, function (entry) {
+                if (entry) {
+                  return callback(null, entry);
+                } else {
+                  return callback(null, {
+                    url: resolvedPath,
+                    title: targetName,
+                    path: resolvedPath,
+                  });
+                }
+              });
+            }
 
-              searchNext();
-            });
+            searchNext();
           }
-
-          searchNext();
-        });
+        );
       }
     );
   }

--- a/app/build/plugins/wikilinks/byHeadingAnchor.js
+++ b/app/build/plugins/wikilinks/byHeadingAnchor.js
@@ -15,9 +15,8 @@ module.exports = function byHeadingAnchor($, href, done) {
   if (!resolution) return done(new Error("Not a heading anchor"));
 
   done(null, {
-    type: "heading-anchor",
-    href: ensureHash(resolution.anchor),
-    anchor: stripHash(resolution.anchor),
+    url: ensureHash(resolution.anchor),
+    path: null,
     title: resolution.title || target,
   });
 };

--- a/app/build/plugins/wikilinks/byPath.js
+++ b/app/build/plugins/wikilinks/byPath.js
@@ -28,7 +28,7 @@ const fs = require("fs-extra");
 // wikilink: [[/Posts/target]]
 // target: /Posts/target.txt
 
-module.exports = function byPath(blogID, pathOfPost, href, callback) {
+module.exports = function byPath(blogID, pathOfPost, href, isLink, callback) {
   const root = localPath(blogID, "/");
   const getEntry = require("models/entry").get;
 

--- a/app/build/plugins/wikilinks/byTitle.js
+++ b/app/build/plugins/wikilinks/byTitle.js
@@ -8,14 +8,26 @@ module.exports = function byTitle(blogID, href, done) {
   getAll(blogID, function (allEntries) {
     const perfectMatch = allEntries.find((entry) => entry.title === href);
 
-    if (perfectMatch) return done(null, perfectMatch);
+    if (perfectMatch) {
+      return done(null, {
+        url: perfectMatch.url,
+        title: perfectMatch.title,
+        path: perfectMatch.path
+      });
+    }
 
     // Will trim, lowercase, remove punctuation, etc.
     const roughMatch = allEntries.find(
       (entry) => makeSlug(entry.title) === makeSlug(href)
     );
 
-    if (roughMatch) return done(null, roughMatch);
+    if (roughMatch) {
+      return done(null, {
+        url: roughMatch.url,
+        title: roughMatch.title,
+        path: roughMatch.path
+      });
+    }
 
     done(new Error("No entry found by title with href: " + href));
   });

--- a/app/build/plugins/wikilinks/index.js
+++ b/app/build/plugins/wikilinks/index.js
@@ -42,34 +42,16 @@ function render($, callback, { blogID, path }) {
       const piped = isLink && makeSlug($node.html()) !== makeSlug(href);
 
       const lookups = [
-        byPath.bind(null, blogID, path, href),
-        byFilename.bind(null, blogID, path, href),
+        byPath.bind(null, blogID, path, href, isLink),
+        byFilename.bind(null, blogID, path, href, isLink),
         byURL.bind(null, blogID, href),
         byTitle.bind(null, blogID, href),
         byHeadingAnchor.bind(null, $, href),
       ];
 
-      tryEach(lookups, function (err, entry) {
-        if (entry && entry.type === "heading-anchor") {
-          $(node).attr("href", entry.href);
-
-          if (!piped && entry.title) $(node).html(entry.title);
-
-          return next();
-        }
-
-        if (entry) {
-          const link = entry.url;
-
-          $node.attr(attribute, link);
-
-          if (isLink && !piped) $node.html(entry.title);
-
-          dependencies.push(entry.path);
-          return next();
-        }
-
-        if (!href.startsWith("#")) {
+      tryEach(lookups, function (err, result) {
+        
+        if (err || !result || !result.url) {
           // we failed to find a path, we should register paths to watch
           // if pathOfPost is '/Posts/foo.txt' then dirOfPost is '/Posts'
           const dirOfPost = dirname(path);
@@ -82,15 +64,25 @@ function render($, callback, { blogID, path }) {
             resolvedHref,
             resolvedHref + ".md",
             resolvedHref + ".txt",
-            resolvedHref + ".png",
-            resolvedHref + ".jpg",
-            resolvedHref + ".gif",
-            resolvedHref + ".PNG",
-            resolvedHref + ".JPG",
-            resolvedHref + ".GIF",
           ];
 
           pathsToWatch.forEach((path) => dependencies.push(path));
+          return next();
+        }
+
+        const { url, title, path: linkedPath } = result;
+
+        if (isLink) {
+          $node.attr("href", url);
+          if (!piped) {
+            $node.text(title || url);
+          }
+        } else {
+          $node.attr("src", url);
+        }
+
+        if (linkedPath) {
+          dependencies.push(linkedPath);
         }
 
         next();

--- a/app/build/tests/plugins/wikilinks.js
+++ b/app/build/tests/plugins/wikilinks.js
@@ -625,4 +625,24 @@ Heading Here
 
     this.syncAndCheck(files, entry, done);
   });
+
+  // You can embed images by wikilink using only the filename
+  it("turns wikilinks into links using dependencies", function (done) {
+    const path = "/contains-wikilink.md";
+    const content = "![[Image.jpg]]";
+
+    const imagePath = "/_Images/Image.jpg";
+    const imageContent = "BinaryImageContent";
+
+    const html = '<p><img src="/_Images/Image.jpg" title="wikilink" alt="Image.jpg"><span class="caption">wikilink</span></p>';
+
+    const files = [
+      { path: imagePath, content: imageContent },
+      { path, content },
+    ];
+
+    const entry = { path, html, dependencies: ["/Image.jpg", "/_Images/Image.jpg"] };
+
+    this.syncAndCheck(files, entry, done);
+  });
 });


### PR DESCRIPTION
## Summary
- add a filename-based wikilink lookup that searches nearby folders breadth-first
- resolve matches using canonical entry data before falling back to URL and title handlers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f214232d9083299a9907bc8a6b2065