### PR TITLE
Add script to purge entry-related Redis keys

### DIFF
--- a/scripts/blog/purge-entry-database.js
+++ b/scripts/blog/purge-entry-database.js
@@ -1,0 +1,100 @@
+const colors = require("colors/safe");
+const getBlog = require("../get/blog");
+const redisKeys = require("../util/redisKeys");
+const client = require("client");
+const getConfirmation = require("../util/getConfirmation");
+
+const ENTRY_LISTS = [
+  "all",
+  "created",
+  "entries",
+  "drafts",
+  "scheduled",
+  "pages",
+  "deleted",
+];
+
+async function collectKeys(blog) {
+  const blogPrefix = `blog:${blog.id}:`;
+  const patterns = [
+    ...ENTRY_LISTS.map((list) => `${blogPrefix}${list}`),
+    `${blogPrefix}entry:*`,
+    `${blogPrefix}url:*`,
+    `${blogPrefix}dependents:*`,
+    `${blogPrefix}tags:all`,
+    `${blogPrefix}tags:entries:*`,
+    `${blogPrefix}tags:entry:*`,
+    `${blogPrefix}tags:name:*`,
+    `${blogPrefix}ignored_files`,
+  ];
+
+  const keys = new Set();
+
+  for (const pattern of patterns) {
+    await redisKeys(pattern, async (key) => {
+      if (key.startsWith(blogPrefix)) {
+        keys.add(key);
+      }
+    });
+  }
+
+  return Array.from(keys);
+}
+
+async function main(blog) {
+  try {
+    const keys = await collectKeys(blog);
+
+    if (!keys.length) {
+      console.log(colors.yellow("No keys to delete."));
+      return;
+    }
+
+    console.log(colors.cyan("Found the following keys:"));
+    console.log(JSON.stringify(keys, null, 2));
+
+    const confirmed = await getConfirmation(
+      `Delete ${keys.length} keys`
+    );
+
+    if (!confirmed) {
+      console.log(colors.yellow("Aborted without deleting any keys."));
+      return;
+    }
+
+    await new Promise((resolve, reject) => {
+      const multi = client.multi();
+      multi.del(keys);
+      multi.exec((err, results) => {
+        if (err) return reject(err);
+
+        const deleted = Array.isArray(results)
+          ? results.reduce((sum, value) => sum + (Array.isArray(value) ? value[1] : 0), 0)
+          : 0;
+        console.log(
+          colors.green(
+            `Deleted ${keys.length} keys for blog ${blog.id}. Redis removed ${deleted} keys.`
+          )
+        );
+        resolve();
+      });
+    });
+  } catch (err) {
+    throw err;
+  }
+}
+
+if (require.main === module) {
+  getBlog(process.argv[2], function (err, user, blog) {
+    if (err) throw err;
+
+    main(blog)
+      .then(() => process.exit())
+      .catch((error) => {
+        console.error(colors.red("Error:", error.message));
+        process.exit(1);
+      });
+  });
+}
+
+module.exports = main;


### PR DESCRIPTION
## Summary
- add a purge-entry-database maintenance script that resolves a blog via the existing CLI bootstrap
- aggregate Redis key patterns for entry, tag, and ignored-file data and display them for review
- prompt for confirmation before deleting the collected keys with a Redis MULTI/DEL pipeline

## Testing
- node -e "require('./scripts/blog/purge-entry-database')"

------
https://chatgpt.com/codex/tasks/task_e_68f34ed36b388329bebfd57c15a204c3