### PR TITLE
Move template rebuild to post-listen tasks

### DIFF
--- a/app/setup.js
+++ b/app/setup.js
@@ -20,6 +20,26 @@ async function runPostListenTasks() {
     console.error(clfdate(), "Setup:", message, error || "");
   };
 
+  let templatesBuilt = false;
+
+  if (config.master) {
+    log("Building templates after listen");
+    try {
+      await new Promise((resolve, reject) => {
+        templates(
+          { watch: config.environment === "development" },
+          (err) => (err ? reject(err) : resolve())
+        );
+      });
+      templatesBuilt = true;
+      log("Built templates after listen");
+    } catch (err) {
+      logError("Failed to build templates after listen", err);
+    }
+  } else {
+    log("Skipping template build after listen (not master)");
+  }
+
   try {
     if (config.master) {
       log("Starting scheduler asynchronously");
@@ -52,7 +72,11 @@ async function runPostListenTasks() {
   }
 
   try {
-    log("Flushing caches asynchronously");
+    if (templatesBuilt) {
+      log("Flushing caches after template rebuild");
+    } else {
+      log("Flushing caches asynchronously");
+    }
     flush();
   } catch (err) {
     logError("Failed to flush caches", err);
@@ -151,22 +175,12 @@ function main(callback) {
       },
 
       function (callback) {
-        // we only want to build the templates once per deployment
         if (config.master) {
-          log("Building templates");
-          templates(
-            // we only want to watch for changes in the templates in development
-            { watch: config.environment === "development" },
-            function (err) {
-              if (err) throw err;
-              log("Built templates");
-              callback();
-            }
-          );
+          log("Deferring template build until after listen");
         } else {
-          log("Skipping template build");
-          callback();
+          log("Skipping template build (not master)");
         }
+        callback();
       },
 
       async function () {


### PR DESCRIPTION
## Summary
- move the template rebuild from the pre-listen setup steps into the post-listen task runner while keeping the master guard
- log that the build is deferred during setup and flush caches after the post-listen rebuild completes
- drop the readiness helper and restore the templates module to its prior behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f34f30f1d08329a1e1457bd71b6dd7