### PR TITLE
Run folder build from post-listen tasks

### DIFF
--- a/app/setup.js
+++ b/app/setup.js
@@ -67,6 +67,19 @@ async function runPostListenTasks() {
     logError("Failed to configure local blogs", err);
   }
 
+  if (config.master && config.environment === "production") {
+    log("Building folders asynchronously");
+
+    setImmediate(async () => {
+      try {
+        await folders();
+        log("Built folders asynchronously");
+      } catch (err) {
+        logError("Error building folders", err);
+      }
+    });
+  }
+
   if (config.environment !== "production") {
     log("Skipping CDN purge (not in production)");
     return;
@@ -173,19 +186,6 @@ function main(callback) {
         // The docker build stage for production runs this script ahead of time
         if (config.environment !== "development") return;
         await documentation({ watch: true });
-      },
-
-      async function () {
-        if (config.environment !== "production") return;
-        if (!config.master) return;
-
-        log("Building folders");
-        try {
-          await folders();
-          log("Built folders");
-        } catch (e) {
-          log("Error building folders", e);
-        }
       },
 
     ],


### PR DESCRIPTION
## Summary
- run the production folder build from the post-listen task queue so startup is no longer blocked
- revert the folders template module to its original synchronous implementation without background guards

## Testing
- npm test *(fails: ./scripts/tests/test.env does not exist in the tests directory.)*

------
https://chatgpt.com/codex/tasks/task_e_68f34efda544832986ecefbaf27aca98