### PR TITLE
Sanitize entries when dropping

### DIFF
--- a/app/models/entry/drop.js
+++ b/app/models/entry/drop.js
@@ -3,6 +3,47 @@ var ensure = require("helper/ensure");
 var set = require("./set");
 var get = require("./get");
 
+function sanitize(entry) {
+  var now = Date.now();
+  var created = typeof entry.created === "number" ? entry.created : now;
+  var dateStamp = typeof entry.dateStamp === "number" ? entry.dateStamp : created;
+  var updated = typeof entry.updated === "number" ? entry.updated : created;
+
+  return {
+    id: entry.id || "",
+    guid: entry.guid || (entry.id ? "entry_" + entry.id : ""),
+    url: entry.url || "",
+    permalink: entry.permalink || "",
+    title: entry.title || "",
+    titleTag: "",
+    body: "",
+    summary: "",
+    teaser: "",
+    teaserBody: "",
+    more: false,
+    html: "",
+    slug: entry.slug || "",
+    name: entry.name || "",
+    path: entry.path || "",
+    size: typeof entry.size === "number" ? entry.size : 0,
+    tags: [],
+    dependencies: [],
+    backlinks: [],
+    internalLinks: [],
+    menu: false,
+    page: false,
+    deleted: true,
+    draft: false,
+    scheduled: false,
+    thumbnail: {},
+    dateStamp: dateStamp,
+    created: created,
+    updated: updated,
+    metadata: {},
+    exif: {},
+  };
+}
+
 module.exports = function drop(blogID, path, callback) {
   ensure(blogID, "string").and(path, "string").and(callback, "function");
 
@@ -11,6 +52,6 @@ module.exports = function drop(blogID, path, callback) {
       return callback();
     }
 
-    set(blogID, path, { deleted: true }, callback);
+    set(blogID, path, sanitize(entry), callback);
   });
 };


### PR DESCRIPTION
## Summary
- sanitize entries before persisting a deletion so only required fields remain
- retain identifiers, timeline metadata, and permalink data used by rename/backlink systems
- clear large content fields, tags, and relationship arrays to reduce storage footprint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f35a0e08008329a8db2b41dbdde2c9