### PR TITLE
Add script to sanitize deleted entries

### DIFF
--- a/scripts/blog/sanitize-deleted-entries.js
+++ b/scripts/blog/sanitize-deleted-entries.js
@@ -1,0 +1,56 @@
+/**
+ * Removes database residue for entries marked as deleted.
+ *
+ * Usage:
+ *   node scripts/blog/sanitize-deleted-entries.js --o <blogId>
+ */
+
+const colors = require("colors/safe");
+const minimist = require("minimist");
+const eachEntry = require("../each/entry");
+const Entry = require("models/entry");
+
+const options = minimist(process.argv.slice(2));
+
+let total = 0;
+let sanitized = 0;
+let errors = 0;
+
+eachEntry(
+  function (user, blog, entry, next) {
+    if (!entry.deleted) return next();
+
+    total += 1;
+
+    Entry.drop(blog.id, entry.path, function (err) {
+      if (err) {
+        errors += 1;
+        console.error(
+          colors.red(
+            `Failed to drop deleted entry ${blog.id} ${entry.path}: ${err.message || err}`
+          )
+        );
+      } else {
+        sanitized += 1;
+        console.log(
+          colors.green(`Dropped deleted entry ${blog.id} ${entry.path}`)
+        );
+      }
+
+      next();
+    });
+  },
+  function () {
+    console.log(colors.cyan(`Processed ${total} deleted entries.`));
+    console.log(colors.green(`Sanitized ${sanitized} entries.`));
+
+    if (errors) {
+      console.error(colors.red(`Encountered ${errors} errors.`));
+      process.exit(1);
+    } else {
+      console.log(colors.green("Encountered 0 errors."));
+      process.exit();
+    }
+  },
+  options
+);


### PR DESCRIPTION
## Summary
- add a maintenance script to sanitize deleted entries via Entry.drop
- log results with success/error counts and exit non-zero when drop calls fail while supporting entry filters via CLI options

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f38235ea14832990b8bbf372655de3