### PR TITLE
Add pagination to tagged entries template

### DIFF
--- a/app/templates/latest/blog/tagged.html
+++ b/app/templates/latest/blog/tagged.html
@@ -12,6 +12,17 @@
         <a class="full-line" href="{{{url}}}"><em>{{title}}</em> &nbsp;<span class="small">{{date}}</span></a>
         {{/entries}}
       </div>
+      {{#pagination}}
+      <div class="pagination">
+        {{#previous}}
+        <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+        {{/previous}}
+        Page {{current}} of {{total}}
+        {{#next}}
+        <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+        {{/next}}
+      </div>
+      {{/pagination}}
       <p><a class="small date" href="/archives">View the archives &rarr;</a></p>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add pagination block to the tagged blog template by reusing the standard pagination markup
- ensure the newer/older links point to the tagged routes that include the tag slug

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3d0bbc2e08329945ae5f997b0e5c5