### PR TITLE
Handle oversized Dropbox downloads gracefully

### DIFF
--- a/app/views/how/sync/dropbox.html
+++ b/app/views/how/sync/dropbox.html
@@ -27,6 +27,14 @@
   do not apply because Blot hosts the contents of your folder on its own server.
 </p>
 
+<h3>File size limits</h3>
+
+<p>
+  Dropbox sync skips files larger than 50 MB. Blot creates an empty placeholder
+  for the skipped file in your blog folder and sets its modification time so
+  you can see that the file was skipped.
+</p>
+
 <h2>Using your phone or tablet</h2>
 
 <p>


### PR DESCRIPTION
## Summary
- add a 50 MB limit when downloading files from Dropbox and skip oversized files
- ensure skipped files write an empty placeholder and preserve modification time
- document the Dropbox file size limit in the sync instructions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3d5cc96948329847c130753ebf0ff