### PR TITLE
Add TTL management for deleted entries and prune stale list IDs

### DIFF
--- a/app/models/entries/tests.js
+++ b/app/models/entries/tests.js
@@ -2,11 +2,119 @@ const redis = require("models/client");
 const Entries = require("./index"); // Replace with the correct path to the Entries module
 const Entry = require("../entry");
 const Blog = require("../blog");
+const entryKey = require("../entry/key").entry;
+
+function buildEntry(path, overrides) {
+  const now = Date.now();
+  const normalizedPath = path.startsWith("/") ? path : "/" + path;
+  const id = overrides && overrides.id ? overrides.id : normalizedPath;
+
+  const base = {
+    id,
+    guid: id + ":guid",
+    url: "",
+    permalink: "",
+    title: "Test entry",
+    titleTag: "<h1>Test entry</h1>",
+    body: "<p>Body</p>",
+    summary: "Body",
+    teaser: "Body",
+    teaserBody: "<p>Body</p>",
+    more: false,
+    html: "<h1>Test entry</h1><p>Body</p>",
+    slug: id.replace(/\//g, "-").replace(/\./g, "-"),
+    name: normalizedPath.replace(/^\//, ""),
+    path: normalizedPath,
+    size: 0,
+    tags: [],
+    dependencies: [],
+    backlinks: [],
+    internalLinks: [],
+    menu: false,
+    page: false,
+    deleted: false,
+    draft: false,
+    scheduled: false,
+    thumbnail: {},
+    dateStamp: now,
+    created: now,
+    updated: now,
+    metadata: {},
+    exif: {},
+  };
+
+  return Object.assign(base, overrides || {});
+}
 
 describe("entries", function () {
   // Cleans up the Redis database after each test
   // and exposes a test blog to each test
   global.test.blog();
+
+  describe("entry TTL management", function () {
+    it("sets a TTL when deleted and clears it when restored", function (done) {
+      const blogID = this.blog.id;
+      const path = "/ttl-entry.txt";
+      const key = entryKey(blogID, path);
+
+      Entry.set(blogID, path, buildEntry(path), function (err) {
+        if (err) return done.fail(err);
+
+        redis.ttl(key, function (err, ttl) {
+          if (err) return done.fail(err);
+          expect(ttl).toBe(-1);
+
+          Entry.set(blogID, path, { deleted: true }, function (err) {
+            if (err) return done.fail(err);
+
+            redis.ttl(key, function (err, ttlAfterDelete) {
+              if (err) return done.fail(err);
+              expect(ttlAfterDelete).toBeGreaterThan(0);
+              expect(ttlAfterDelete).toBeLessThanOrEqual(24 * 60 * 60);
+
+              Entry.set(blogID, path, { deleted: false }, function (err) {
+                if (err) return done.fail(err);
+
+                redis.ttl(key, function (err, ttlAfterRestore) {
+                  if (err) return done.fail(err);
+                  expect(ttlAfterRestore).toBe(-1);
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe("pruneMissing", function () {
+    it("removes orphaned IDs from entry lists", function (done) {
+      const blogID = this.blog.id;
+      const path = "/prune-entry.txt";
+      const ghostID = "/ghost-entry";
+      const listKey = `blog:${blogID}:entries`;
+
+      Entry.set(blogID, path, buildEntry(path), function (err) {
+        if (err) return done.fail(err);
+
+        redis.zadd(listKey, Date.now(), ghostID, function (err) {
+          if (err) return done.fail(err);
+
+          Entries.pruneMissing(blogID, function (err) {
+            if (err) return done.fail(err);
+
+            redis.zrange(listKey, 0, -1, function (err, members) {
+              if (err) return done.fail(err);
+              expect(members).toContain(path);
+              expect(members).not.toContain(ghostID);
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
 
   it("getTotal should return the total number of entries for a blog", async function (done) {
     const key = `blog:${this.blog.id}:entries`;

--- a/app/sync/fix/list-ghosts.js
+++ b/app/sync/fix/list-ghosts.js
@@ -1,4 +1,5 @@
 const Entry = require("models/entry");
+const Entries = require("models/entries");
 const client = require("models/client");
 const async = require("async");
 
@@ -7,37 +8,41 @@ var lists = ["all", "created", "entries", "drafts", "scheduled", "pages"];
 function main(blog, callback) {
   const report = [];
 
-  async.each(
-    lists,
-    function (list, next) {
-      client.zrevrange("blog:" + blog.id + ":" + list, 0, -1, function (
-        err,
-        res
-      ) {
-        if (err) return next(err);
-        async.each(
-          res,
-          function (id, next) {
-            Entry.get(blog.id, id, function (entry) {
-              if (entry && entry.id === id) return next();
+  Entries.pruneMissing(blog.id, function (err) {
+    if (err) return callback(err);
 
-              report.push([list, "MISMATCH", id]);
-              client.zrem("blog:" + blog.id + ":" + list, id, function (err) {
-                if (err) return next(err);
-                if (!entry) return next();
-                Entry.set(blog.id, entry.id, entry, next);
+    async.each(
+      lists,
+      function (list, next) {
+        client.zrevrange("blog:" + blog.id + ":" + list, 0, -1, function (
+          err,
+          res
+        ) {
+          if (err) return next(err);
+          async.each(
+            res,
+            function (id, next) {
+              Entry.get(blog.id, id, function (entry) {
+                if (entry && entry.id === id) return next();
+
+                report.push([list, "MISMATCH", id]);
+                client.zrem("blog:" + blog.id + ":" + list, id, function (err) {
+                  if (err) return next(err);
+                  if (!entry) return next();
+                  Entry.set(blog.id, entry.id, entry, next);
+                });
               });
-            });
-          },
-          next
-        );
-      });
-    },
-    function (err) {
-      if (err) return callback(err);
-      callback(null, report);
-    }
-  );
+            },
+            next
+          );
+        });
+      },
+      function (err) {
+        if (err) return callback(err);
+        callback(null, report);
+      }
+    );
+  });
 }
 
 module.exports = main;


### PR DESCRIPTION
## Summary
- ensure Entry.set applies a 24-hour TTL for deleted entries and clears it when restoring
- add an Entries.pruneMissing helper and reuse it in the list-ghosts fix script
- expand the entries test suite to cover TTL handling and pruning orphaned IDs

## Testing
- `npm test app/models/entries/tests.js` *(fails: ./scripts/tests/test.env does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68f3d92462008329b632fe14f9941129