### PR TITLE
Handle missing entries in iterator

### DIFF
--- a/app/models/entries/index.js
+++ b/app/models/entries/index.js
@@ -178,6 +178,7 @@ module.exports = (function () {
         ids,
         function (id, next) {
           Entry.get(blogID, id, function (entry) {
+            if (!entry) return next();
             dothis(entry, next);
           });
         },


### PR DESCRIPTION
## Summary
- skip processing when an entry lookup returns no record in Entries.each

## Testing
- node app/sync/fix/entry-ghosts.js

------
https://chatgpt.com/codex/tasks/task_e_68f5580feb7c832999715d288c04da62