### PR TITLE
Add defensive entry guards and regression test for missing entry data

### DIFF
--- a/app/blog/tests/sync.js
+++ b/app/blog/tests/sync.js
@@ -1,0 +1,35 @@
+describe("sync", function () {
+  const Entry = require("models/entry");
+  const client = require("models/client");
+  const rebuild = require("sync/rebuild");
+
+  require("./util/setup")();
+
+  it("rebuilds missing entry data without crashing", async function () {
+    const path = "/Ghost.txt";
+
+    await this.write({ path, content: "Hello" });
+    await this.blog.rebuild();
+    await this.blog.check({ path });
+
+    const entryKey = Entry.key.entry(this.blog.id, path);
+
+    await new Promise((resolve, reject) => {
+      client.del(entryKey, (err) => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+
+    await new Promise((resolve, reject) => {
+      rebuild(this.blog.id, (err) => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+
+    const rebuiltEntry = await this.blog.check({ path });
+    expect(rebuiltEntry).toBeDefined();
+    expect(rebuiltEntry.path).toEqual(path);
+  });
+});

--- a/app/models/entries/index.js
+++ b/app/models/entries/index.js
@@ -179,7 +179,11 @@ module.exports = (function () {
         function (id, next) {
           Entry.get(blogID, id, function (entry) {
             if (!entry) return next();
-            dothis(entry, next);
+            try {
+              dothis(entry, next);
+            } catch (err) {
+              next(err);
+            }
           });
         },
         callback

--- a/scripts/blog/rescreenshot-link-posts.js
+++ b/scripts/blog/rescreenshot-link-posts.js
@@ -22,12 +22,21 @@ const main = async (blog, cb) => {
     Entries.each(
       blog.id,
       function (entry, nextEntry) {
+        if (!entry || typeof entry.id !== "string") {
+          return nextEntry();
+        }
+
+        if (entry.deleted) {
+          console.log("Skipping", entry.id, "deleted entry");
+          return nextEntry();
+        }
+
         if (!entry.id.endsWith(".webloc")) {
           console.log("Skipping", entry.id, "not a webloc file");
           return nextEntry();
         }
 
-        if (entry.thumbnail.large) {
+        if (entry.thumbnail && entry.thumbnail.large) {
           console.log("Skipping", entry.id, "already has a thumbnail");
           return nextEntry();
         }

--- a/scripts/entry/search.js
+++ b/scripts/entry/search.js
@@ -15,13 +15,17 @@ if (!handle || !query) {
   return process.exit();
 }
 
+const normalizedQuery = query.trim().toLowerCase();
+
 get(handle, function (user, blog) {
   Entries.each(
     blog.id,
     function (entry, nextEntry) {
-      if (entry.deleted) return nextEntry();
+      if (!entry || entry.deleted || typeof entry.path !== "string") {
+        return nextEntry();
+      }
 
-      if (entry.path.toLowerCase().indexOf(query.trim().toLowerCase()) === 0) {
+      if (entry.path.toLowerCase().indexOf(normalizedQuery) === 0) {
         console.log(entry.path);
       }
 

--- a/scripts/template/randomize-posts.js
+++ b/scripts/template/randomize-posts.js
@@ -24,7 +24,14 @@ get(identifier, function (err, user, blog) {
   Entries.each(
     blog.id,
     function (entry, next) {
-      if (entry.deleted || entry.draft || entry.scheduled || entry.page)
+      if (
+        !entry ||
+        entry.deleted ||
+        entry.draft ||
+        entry.scheduled ||
+        entry.page ||
+        typeof entry.path !== "string"
+      )
         return next();
 
       // if (entry.metadata.date) return next();


### PR DESCRIPTION
## Summary
- wrap the `Entries.each` iterator invocation in a try/catch so synchronous errors bubble through callbacks
- add guard clauses in sync fix utilities and scripts to skip entries missing identifiers or paths instead of crashing
- add a regression test that deletes an entry key and verifies `sync/rebuild` completes without error

## Testing
- Not run (docker-based test harness unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f5f50202a08329b254dee23d573990