### PR TITLE
Handle unsupported Dropbox Paper files

### DIFF
--- a/app/clients/dropbox/util/constants.js
+++ b/app/clients/dropbox/util/constants.js
@@ -1,0 +1,14 @@
+const UNSUPPORTED_FILE_EXTENSIONS = [".paper"];
+
+const hasUnsupportedExtension = (filePath = "") => {
+  const normalizedPath = String(filePath).toLowerCase();
+  return UNSUPPORTED_FILE_EXTENSIONS.some((extension) =>
+    normalizedPath.endsWith(extension)
+  );
+};
+
+module.exports = {
+  MAX_FILE_SIZE: 50 * 1024 * 1024, // 50 MB
+  UNSUPPORTED_FILE_EXTENSIONS,
+  hasUnsupportedExtension,
+};


### PR DESCRIPTION
## Summary
- add shared helpers for identifying unsupported Dropbox file extensions (currently Dropbox Paper)
- skip Dropbox Paper documents in both reset-to-blot and incremental sync while still creating placeholders
- prevent the download helper from attempting to fetch Dropbox Paper documents and preserve metadata when possible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6337374688329bc0b90177f9a5abc