### PR TITLE
Ensure rename test generates unique fake paths

### DIFF
--- a/app/sync/tests/renames.js
+++ b/app/sync/tests/renames.js
@@ -81,12 +81,25 @@ describe("update", function () {
   it("detects a large number of renamed files", function (testDone) {
     var items = [];
     var ctx = this;
+    var usedPaths = new Set();
+
+    function uniquePath(ext) {
+      var path;
+
+      do {
+        path = ctx.fake.path(ext);
+      } while (usedPaths.has(path));
+
+      usedPaths.add(path);
+
+      return path;
+    }
 
     // Create 100 fake files
     for (var i = 0; i < 10; i++)
       items.push({
-        oldPath: this.fake.path(".txt"),
-        newPath: this.fake.path(".txt"),
+        oldPath: uniquePath(".txt"),
+        newPath: uniquePath(".txt"),
         content: this.fake.file({title: i + '-' + Date.now()}),
       });
 


### PR DESCRIPTION
## Summary
- ensure the rename stress test generates unique fake paths for each old and new file
- avoid collisions by tracking generated paths with a set before inserting them into the test cases

## Testing
- npm test *(fails: requires ./scripts/tests/test.env)*

------
https://chatgpt.com/codex/tasks/task_e_68f64019578c8329b8749aeb032636a8