### PR TITLE
Store deployment logs remotely and limit retention

### DIFF
--- a/scripts/deploy/index.js
+++ b/scripts/deploy/index.js
@@ -41,7 +41,7 @@ async function storeRemoteContainerLogs(containerName, reason) {
   const remoteDir = `${remoteTempDir}/blot-deploy-logs/${containerName}`;
   const remotePath = `${remoteDir}/${containerName}-${reason}-${timestamp}.logs`;
 
-  const pruneCommand = `(cd '${remoteDir}' && ls -1t | awk 'NR>${MAX_REMOTE_LOGS}' | while read file; do [ -n "$file" ] && rm -f -- "$file"; done)`;
+  const pruneCommand = `(cd '${remoteDir}' && ls -1t | awk 'NR>${MAX_REMOTE_LOGS}' | while read file; do [ -n "\\$file" ] && rm -f -- "\\$file"; done)`;
 
   const captureCommand = [
     `mkdir -p '${remoteDir}'`,


### PR DESCRIPTION
## Summary
- capture deployment logs on the remote server instead of streaming them locally to avoid exceeding ssh stdout buffers
- keep only the five most recent log archives per container in a rotating fashion under the remote temp directory
- log an scp command so operators can retrieve archived log files when needed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f6474a52c48329a252868a21b809b8