### PR TITLE
Add consistent pagination to tagged templates

### DIFF
--- a/app/templates/latest/magazine/tagged.html
+++ b/app/templates/latest/magazine/tagged.html
@@ -9,4 +9,16 @@
 {{> entry_line}}
 {{/entries}}
 
+{{#pagination}}
+<div class="pagination">
+  {{#previous}}
+  <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+  {{/previous}}
+  Page {{current}} of {{total}}
+  {{#next}}
+  <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+  {{/next}}
+</div>
+{{/pagination}}
+
 {{> footer}}

--- a/app/templates/latest/portfolio/tagged.html
+++ b/app/templates/latest/portfolio/tagged.html
@@ -3,6 +3,17 @@
 <div class="entries">
   <h1>{{tag}}</h1>
   {{> fitted-grid}}
+  {{#pagination}}
+  <div class="pagination">
+    {{#previous}}
+    <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+    {{/previous}}
+    Page {{current}} of {{total}}
+    {{#next}}
+    <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+    {{/next}}
+  </div>
+  {{/pagination}}
 </div>
 
 {{> footer}}

--- a/app/templates/past/blank/tagged.html
+++ b/app/templates/past/blank/tagged.html
@@ -8,7 +8,18 @@
     {{#entries}}
         <a href="{{{url}}}">{{title}}</a>
         <p>{{date}}</p>
-    {{/entries}}          
+    {{/entries}}
+    {{#pagination}}
+    <div class="pagination">
+      {{#previous}}
+      <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+      {{/previous}}
+      Page {{current}} of {{total}}
+      {{#next}}
+      <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+      {{/next}}
+    </div>
+    {{/pagination}}
     {{> footer}}
     </div>
   </body>

--- a/app/templates/past/empty/tagged.html
+++ b/app/templates/past/empty/tagged.html
@@ -10,6 +10,18 @@
     <a href="{{{url}}}">{{title}}</a> {{date}} <br />
     {{/entries}}
 
+    {{#pagination}}
+    <div class="pagination">
+      {{#previous}}
+      <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+      {{/previous}}
+      Page {{current}} of {{total}}
+      {{#next}}
+      <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+      {{/next}}
+    </div>
+    {{/pagination}}
+
     {{> footer}}
   </body>
 </html>

--- a/app/templates/past/essay-old/tagged.html
+++ b/app/templates/past/essay-old/tagged.html
@@ -8,7 +8,18 @@
     {{#entries}}
         <a href="{{{url}}}">{{title}}</a>
         <p>{{date}}</p>
-    {{/entries}}          
+    {{/entries}}
+    {{#pagination}}
+    <div class="pagination">
+      {{#previous}}
+      <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+      {{/previous}}
+      Page {{current}} of {{total}}
+      {{#next}}
+      <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+      {{/next}}
+    </div>
+    {{/pagination}}
     {{> footer}}
     </div>
   </body>

--- a/app/templates/past/essay-two/tagged.html
+++ b/app/templates/past/essay-two/tagged.html
@@ -10,6 +10,17 @@
       <span class="small">{{date}}</span>
       <br />
       {{/entries}}
+      {{#pagination}}
+      <div class="pagination">
+        {{#previous}}
+        <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+        {{/previous}}
+        Page {{current}} of {{total}}
+        {{#next}}
+        <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+        {{/next}}
+      </div>
+      {{/pagination}}
     </div>
     {{> footer}}
   </body>

--- a/app/templates/past/grid/tagged.html
+++ b/app/templates/past/grid/tagged.html
@@ -9,6 +9,18 @@
       {{> item}}
     {{/entries}}
 
+    {{#pagination}}
+    <div class="pagination">
+      {{#previous}}
+      <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+      {{/previous}}
+      Page {{current}} of {{total}}
+      {{#next}}
+      <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+      {{/next}}
+    </div>
+    {{/pagination}}
+
     {{> footer}}
     </div>
   </body>

--- a/app/templates/past/index/tagged.html
+++ b/app/templates/past/index/tagged.html
@@ -12,11 +12,23 @@
     All posts tagged {{tag}}:
     </small>
 
-    {{#entries}}
-    <a href="{{{url}}}" class="row"><b>{{title}}</b> {{#date}}&nbsp;·&nbsp; <span style="white-space: nowrap;">{{date}}</span>{{/date}}</a>
-    {{/entries}}
+      {{#entries}}
+      <a href="{{{url}}}" class="row"><b>{{title}}</b> {{#date}}&nbsp;·&nbsp; <span style="white-space: nowrap;">{{date}}</span>{{/date}}</a>
+      {{/entries}}
 
-    {{> footer}}
+      {{#pagination}}
+      <div class="pagination">
+        {{#previous}}
+        <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+        {{/previous}}
+        Page {{current}} of {{total}}
+        {{#next}}
+        <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+        {{/next}}
+      </div>
+      {{/pagination}}
+
+      {{> footer}}
 
   </body>
 </html>

--- a/app/templates/past/isola/tagged.html
+++ b/app/templates/past/isola/tagged.html
@@ -7,13 +7,24 @@
 			<div id="content" class="site-content">
 				<div id="primary" class="content-area">
 					<main id="main" class="site-main" role="main">
-						<header class="page-header">
-							<h1 class="page-title"><span>{{tag}}</span></h1>
-						</header>
-						{{#entries}} {{> article}} {{/entries}}
-					</main>
-					<!-- #main -->
-				</div>
+                                                <header class="page-header">
+                                                        <h1 class="page-title"><span>{{tag}}</span></h1>
+                                                </header>
+                                                {{#entries}} {{> article}} {{/entries}}
+                                                {{#pagination}}
+                                                <div class="pagination">
+                                                        {{#previous}}
+                                                        <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+                                                        {{/previous}}
+                                                        Page {{current}} of {{total}}
+                                                        {{#next}}
+                                                        <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+                                                        {{/next}}
+                                                </div>
+                                                {{/pagination}}
+                                        </main>
+                                        <!-- #main -->
+                                </div>
 				<!-- #primary -->
 			</div>
 			<!-- #content -->

--- a/app/templates/past/log/tagged.html
+++ b/app/templates/past/log/tagged.html
@@ -10,6 +10,18 @@
     <a href="{{{url}}}">{{title}}</a> {{date}} <br />
     {{/entries}}
 
+    {{#pagination}}
+    <div class="pagination">
+      {{#previous}}
+      <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+      {{/previous}}
+      Page {{current}} of {{total}}
+      {{#next}}
+      <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+      {{/next}}
+    </div>
+    {{/pagination}}
+
     {{> footer}}
   </body>
 </html>

--- a/app/templates/past/mira/tagged.html
+++ b/app/templates/past/mira/tagged.html
@@ -10,6 +10,18 @@
     <a href="{{{url}}}">{{title}}</a> {{date}} <br />
     {{/entries}}
 
+    {{#pagination}}
+    <div class="pagination">
+      {{#previous}}
+      <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+      {{/previous}}
+      Page {{current}} of {{total}}
+      {{#next}}
+      <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+      {{/next}}
+    </div>
+    {{/pagination}}
+
     {{> footer}}
   </body>
 </html>

--- a/app/templates/past/mono/tagged.html
+++ b/app/templates/past/mono/tagged.html
@@ -8,7 +8,18 @@
     {{#entries}}
         <a href="{{{url}}}">{{title}}</a>
         <p>{{date}}</p>
-    {{/entries}}          
+    {{/entries}}
+    {{#pagination}}
+    <div class="pagination">
+      {{#previous}}
+      <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+      {{/previous}}
+      Page {{current}} of {{total}}
+      {{#next}}
+      <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+      {{/next}}
+    </div>
+    {{/pagination}}
     {{> footer}}
     </div>
   </body>

--- a/app/templates/past/moving/tagged.html
+++ b/app/templates/past/moving/tagged.html
@@ -22,6 +22,17 @@
                 </a>
             </li>
             {{/entries}}
+            {{#pagination}}
+            <div class="pagination">
+              {{#previous}}
+              <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+              {{/previous}}
+              Page {{current}} of {{total}}
+              {{#next}}
+              <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+              {{/next}}
+            </div>
+            {{/pagination}}
           </ul>
         </ul>
       </div>

--- a/app/templates/past/mundana/tagged.html
+++ b/app/templates/past/mundana/tagged.html
@@ -25,14 +25,26 @@
   <a class="text-dark" href="{{{url}}}">{{title}} <small class="text-muted">
             {{#formatDate}}MMM DD, YYYY{{/formatDate}}
   </small></a>
-             
-              
+
+
   </small>
-              
+
             </div>
-            
+
           </div>
           {{/entries}}
+
+          {{#pagination}}
+          <div class="pagination">
+            {{#previous}}
+            <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+            {{/previous}}
+            Page {{current}} of {{total}}
+            {{#next}}
+            <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+            {{/next}}
+          </div>
+          {{/pagination}}
 
 
         </div>

--- a/app/templates/past/old-default/tagged.html
+++ b/app/templates/past/old-default/tagged.html
@@ -11,8 +11,19 @@
           <a href="{{url}}">{{title}}</a>
           <span class="small">{{date}}</span>
           <br />
-          {{/entries}}          
+          {{/entries}}
         </div>
+        {{#pagination}}
+        <div class="pagination">
+          {{#previous}}
+          <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+          {{/previous}}
+          Page {{current}} of {{total}}
+          {{#next}}
+          <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+          {{/next}}
+        </div>
+        {{/pagination}}
       </div>
     </div>
     {{> footer}}

--- a/app/templates/past/original/tagged.html
+++ b/app/templates/past/original/tagged.html
@@ -18,6 +18,17 @@
           </a>
           {{/entries}}
         </section>
+        {{#pagination}}
+        <div class="pagination">
+          {{#previous}}
+          <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+          {{/previous}}
+          Page {{current}} of {{total}}
+          {{#next}}
+          <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+          {{/next}}
+        </div>
+        {{/pagination}}
         {{> footer}}
       </section>
     </section>

--- a/app/templates/past/photo-old/tagged.html
+++ b/app/templates/past/photo-old/tagged.html
@@ -9,6 +9,17 @@
         <a href="{{{url}}}">{{title}}</a>
         <p>{{date}}</p>
     {{/entries}}
+    {{#pagination}}
+    <div class="pagination">
+      {{#previous}}
+      <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+      {{/previous}}
+      Page {{current}} of {{total}}
+      {{#next}}
+      <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+      {{/next}}
+    </div>
+    {{/pagination}}
     {{> footer}}
     </div>
   </body>

--- a/app/templates/past/photo/tagged.html
+++ b/app/templates/past/photo/tagged.html
@@ -14,4 +14,16 @@
 {{> grid_fitted}}
 {{/is.grid_layout.fitted}}
 
+{{#pagination}}
+<div class="pagination">
+  {{#previous}}
+  <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+  {{/previous}}
+  Page {{current}} of {{total}}
+  {{#next}}
+  <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+  {{/next}}
+</div>
+{{/pagination}}
+
 {{> footer}}

--- a/app/templates/past/reference/tagged.html
+++ b/app/templates/past/reference/tagged.html
@@ -7,6 +7,18 @@
   {{> post}}
   {{/entries}}
 
+  {{#pagination}}
+  <div class="pagination">
+    {{#previous}}
+    <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+    {{/previous}}
+    Page {{current}} of {{total}}
+    {{#next}}
+    <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+    {{/next}}
+  </div>
+  {{/pagination}}
+
 </div>
 <div style="clear:both"></div>
 

--- a/app/templates/past/rosa/tagged.html
+++ b/app/templates/past/rosa/tagged.html
@@ -17,6 +17,18 @@
 
     </div>
 
+    {{#pagination}}
+    <div class="pagination">
+      {{#previous}}
+      <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+      {{/previous}}
+      Page {{current}} of {{total}}
+      {{#next}}
+      <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+      {{/next}}
+    </div>
+    {{/pagination}}
+
     {{> footer}}
   </body>
 </html>

--- a/app/templates/past/scroll/tagged.html
+++ b/app/templates/past/scroll/tagged.html
@@ -10,6 +10,18 @@
     <a href="{{{url}}}">{{title}}</a> {{date}} <br />
     {{/entries}}
 
+    {{#pagination}}
+    <div class="pagination">
+      {{#previous}}
+      <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+      {{/previous}}
+      Page {{current}} of {{total}}
+      {{#next}}
+      <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+      {{/next}}
+    </div>
+    {{/pagination}}
+
     {{> footer}}
   </body>
 </html>

--- a/app/templates/past/serif/tagged.html
+++ b/app/templates/past/serif/tagged.html
@@ -10,6 +10,17 @@
       <span class="small">{{date}}</span>
       <br />
       {{/entries}}
+      {{#pagination}}
+      <div class="pagination">
+        {{#previous}}
+        <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+        {{/previous}}
+        Page {{current}} of {{total}}
+        {{#next}}
+        <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+        {{/next}}
+      </div>
+      {{/pagination}}
     </div>
     {{> footer}}
   </body>

--- a/app/templates/past/terminal/tagged.html
+++ b/app/templates/past/terminal/tagged.html
@@ -10,6 +10,17 @@
       <span class="small">{{date}}</span>
       <br />
       {{/entries}}
+      {{#pagination}}
+      <div class="pagination">
+        {{#previous}}
+        <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+        {{/previous}}
+        Page {{current}} of {{total}}
+        {{#next}}
+        <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+        {{/next}}
+      </div>
+      {{/pagination}}
     </div>
     {{> footer}}
   </body>

--- a/app/templates/past/twentytwelve/tagged.html
+++ b/app/templates/past/twentytwelve/tagged.html
@@ -15,7 +15,19 @@
           {{#entries}}
           <a href="{{{url}}}">{{title}}</a> <small>{{date}}</small><br>
           {{/entries}}
-          
+
+          {{#pagination}}
+          <div class="pagination">
+            {{#previous}}
+            <a href="/tagged/{{slug}}/page/{{previous}}">&larr; Newer</a>
+            {{/previous}}
+            Page {{current}} of {{total}}
+            {{#next}}
+            <a href="/tagged/{{slug}}/page/{{next}}">Older &rarr;</a>
+            {{/next}}
+          </div>
+          {{/pagination}}
+
           <br><br><br>
 
         </div>


### PR DESCRIPTION
## Summary
- replicate the pagination markup from `latest/blog/tagged.html` across all tagged listing templates in the latest and past themes to restore older/newer navigation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f687b345688329a38a4042c3b08962