### PR TITLE
Add tests for tagged template block

### DIFF
--- a/app/blog/render/retrieve/tests/tagged.js
+++ b/app/blog/render/retrieve/tests/tagged.js
@@ -1,0 +1,50 @@
+describe("tagged block", function () {
+    require('blog/tests/util/setup')();
+
+    it("lists entries for a single tag", async function () {
+        await this.write({ path: '/first.txt', content: 'Title: First\nTags: foo\n\nFirst body' });
+        await this.write({ path: '/second.txt', content: 'Title: Second\nTags: foo\n\nSecond body' });
+        await this.write({ path: '/other.txt', content: 'Title: Other\nTags: bar\n\nOther body' });
+
+        await this.template({
+            'tagged.html': `<ul>{{#tagged}}{{#entries}}<li>{{title}}</li>{{/entries}}{{/tagged}}</ul>`
+        });
+
+        const res = await this.get('/tagged/foo');
+        const body = await res.text();
+
+        expect(res.status).toEqual(200);
+        expect(body.trim()).toEqual('<ul><li>Second</li><li>First</li></ul>');
+    });
+
+    it("exposes metadata and helpers for the current tag", async function () {
+        await this.write({ path: '/a.txt', content: 'Tags: Featured\n\nAlpha' });
+
+        await this.template({
+            'tagged.html': `{{#tagged}}{{tag}}|{{#tagged.Featured}}upper{{/tagged.Featured}}|{{#tagged.featured}}lower{{/tagged.featured}}|{{#is.featured}}alias{{/is.featured}}{{/tagged}}`
+        });
+
+        const res = await this.get('/tagged/Featured');
+        const body = await res.text();
+
+        expect(res.status).toEqual(200);
+        expect(body.trim()).toEqual('Featured|upper|lower|alias');
+    });
+
+    it("filters entries by the intersection of multiple tags", async function () {
+        await this.write({ path: '/one.txt', content: 'Title: One\nTags: foo\n\nOne body' });
+        await this.write({ path: '/two.txt', content: 'Title: Two\nTags: foo, bar\n\nTwo body' });
+        await this.write({ path: '/three.txt', content: 'Title: Three\nTags: bar\n\nThree body' });
+        await this.write({ path: '/four.txt', content: 'Title: Four\nTags: foo, bar\n\nFour body' });
+
+        await this.template({
+            'entries.html': `<p>{{#tagged}}{{tag}}:{{#entries}}{{title}}|{{/entries}}{{/tagged}}</p>`
+        });
+
+        const res = await this.get('/?tag=foo&tag=bar');
+        const body = await res.text();
+
+        expect(res.status).toEqual(200);
+        expect(body.trim()).toEqual('<p>foo + bar:Four|Two|</p>');
+    });
+});


### PR DESCRIPTION
## Summary
- add coverage for the {{#tagged}} template block in the render/retrieve suite
- verify tagged pages list the correct entries and expose metadata helpers
- ensure multi-tag queries produce the expected intersection of posts

## Testing
- `npm test -- app/blog/render/retrieve/tests/tagged.js` *(fails: scripts/tests/test.env missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f68fbc5c9c8329974ddedbab1460bc