### PR TITLE
Configure the number of posts per page on the tagged page

### DIFF
--- a/app/blog/loadTemplate.js
+++ b/app/blog/loadTemplate.js
@@ -40,10 +40,12 @@ module.exports = async function (req, res, next) {
         return res.status(400).send(html);
     }
 
-    req.template = {
+    const template = {
         locals: metadata.locals,
         id: req.blog.template
     };
+
+    req.template = template;
 
     req.log("Loaded template", req.blog.template);
     return next();

--- a/app/blog/render/retrieve/tagged.js
+++ b/app/blog/render/retrieve/tagged.js
@@ -168,10 +168,18 @@ module.exports = function (req, callback) {
   let page = parseInt(req.params.page, 10);
   if (!page || page < 1) page = 1;
 
-  let limit =
-    req.template && req.template.locals
-      ? parseInt(req.template.locals.page_size, 10)
-      : undefined;
+  const templateLocals = (req.template && req.template.locals) || {};
+
+  let preferredLimit;
+
+  if (templateLocals.tagged_page_size !== undefined) {
+    preferredLimit = templateLocals.tagged_page_size;
+  } else {
+    preferredLimit = templateLocals.page_size;
+  }
+
+  let limit = parseInt(preferredLimit, 10);
+  if (!Number.isFinite(limit)) limit = undefined;
 
   if (!limit || limit < 1 || limit > 500) limit = 100;
 


### PR DESCRIPTION
## Summary
- stop loading tagged view locals during template initialization
- rely on the template-level tagged_page_size override with a fallback to page_size when paging tagged routes
- update tagged route tests to validate the new fallback behavior without tagged view locals

## Testing
- npm test -- app/blog/tests/tagged.js *(fails: ./scripts/tests/test.env does not exist in the tests directory.)*

------
https://chatgpt.com/codex/tasks/task_e_68f74597d38c83298758485abc5d8631