### PR TITLE
Default development compose to BuildKit bake

### DIFF
--- a/README
+++ b/README
@@ -18,6 +18,11 @@ Then start the server:
 
 npm start
 
+By default, the development scripts use Docker's BuildKit with Compose's Bake integration
+for faster builds. Make sure you have Docker Buildx and Docker Compose v2 installed.
+If you need to opt out, unset `COMPOSE_DOCKER_CLI_BUILD` or set it to `docker`, and set
+`DOCKER_BUILDKIT=0` before running the scripts.
+
 Before you begin working on the code, you'll need to open up the following URLs in your browser and add an exception for the self-signed SSL certificates which we've generated:
 
 https://localhost/ - The dashboard

--- a/scripts/development/start.js
+++ b/scripts/development/start.js
@@ -34,8 +34,20 @@ spawnProcess("node", [path.join(__dirname, "open-folder-server.js")], {
   env: process.env,
 });
 
+const composeEnv = {
+  ...process.env,
+};
+
+if (composeEnv.COMPOSE_DOCKER_CLI_BUILD == null) {
+  composeEnv.COMPOSE_DOCKER_CLI_BUILD = "bake";
+}
+
+if (composeEnv.DOCKER_BUILDKIT == null) {
+  composeEnv.DOCKER_BUILDKIT = "1";
+}
+
 const compose = spawnProcess("docker-compose", composeArgs, {
-  env: process.env,
+  env: composeEnv,
 });
 
 function shutdown() {


### PR DESCRIPTION
## Summary
- default the local docker-compose process to BuildKit and Bake while allowing overrides
- document the Bake-enabled workflow and how to opt out in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f7535d1dcc8329ae8b08c1a5465824