### PR TITLE
Always read featured JSON from disk

### DIFF
--- a/app/documentation/featured/index.js
+++ b/app/documentation/featured/index.js
@@ -6,9 +6,6 @@
 // once per day to ensure sites are fresh.
 const fs = require("fs-extra");
 const config = require("config");
-const check = require("./check");
-
-let featured = { sites: [] };
 
 const modify = i => {
 
@@ -21,30 +18,28 @@ const modify = i => {
   return i;
 }
 
-let lastCheck = 0;
-
 const loadFeatured = async () => {
-  
-  if (featured.sites.length) return featured;
+  const featuredPath = config.data_directory + "/featured/featured.json";
 
-  // if the JSON file doesn't exist, attempt to create it using await check()
-  // and only try again if it's been more than a day since the last attempt
-  if (!fs.existsSync(config.data_directory + "/featured/featured.json") && Date.now() - lastCheck > 86400000) {    
-    await fs.copy(__dirname + '/featured.json', config.data_directory + "/featured/featured.json");
+  // if the JSON file doesn't exist, attempt to create it by copying the seed data
+  if (!fs.existsSync(featuredPath)) {
+    await fs.copy(__dirname + '/featured.json', featuredPath);
   }
 
-  
   try {
-    const json = await fs.readFile(config.data_directory + "/featured/featured.json", "utf-8");
-    featured = JSON.parse(json);
-    featured.sites = featured.sites.map(i => {
+    const json = await fs.readFile(featuredPath, "utf-8");
+    const parsed = JSON.parse(json);
+
+    return {
+      ...parsed,
+      sites: parsed.sites.map(i => {
         return {
           ...i,
           bio: modify(i.bio),
           host_without_www: i.host.replace(/^www\./, "")
         };
-      });
-    return featured;
+      })
+    };
   } catch (e) {
     console.error(e);
   }


### PR DESCRIPTION
## Summary
- remove the throttled lastCheck guard and always read the featured JSON from disk on each request
- keep the seed file fallback by copying it whenever the JSON file is missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f760e2a9bc8329bb887b000e80d31f