### PR TITLE
Clear featured cache before setup

### DIFF
--- a/app/setup.js
+++ b/app/setup.js
@@ -1,5 +1,6 @@
 const config = require("config");
 const fs = require("fs-extra");
+const path = require("path");
 
 const client = require("models/client");
 const documentation = require("./documentation/build");
@@ -152,6 +153,16 @@ async function runPostListenTasks() {
 function main(callback) {
   async.series(
     [
+      async function () {
+        const featuredDir = path.join(config.data_directory, "featured");
+        const featuredFile = path.join(featuredDir, "featured.json");
+
+        log("Clearing featured cache file");
+        await fs.ensureDir(featuredDir);
+        await fs.remove(featuredFile);
+        log("Cleared featured cache file");
+      },
+
       async function () {
         log("Creating required directories");
         await fs.ensureDir(config.blog_folder_dir);


### PR DESCRIPTION
## Summary
- ensure the setup process clears the featured cache file before running other tasks
- create the featured directory if missing and remove the stale cache file with consistent logging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f78c2a099c8329b48ebaeca642cda0