### PR TITLE
Handle template duplicate name collisions

### DIFF
--- a/app/dashboard/site/template/index.js
+++ b/app/dashboard/site/template/index.js
@@ -4,7 +4,7 @@ const formJSON = require("helper/formJSON");
 const Template = require("models/template");
 const Blog = require("models/blog");
 const archiver = require('archiver');
-const createTemplate = require("./save/create-template");
+const duplicateTemplate = require("./save/duplicate-template");
 
 TemplateEditor.param("viewSlug", require("./load/template-views"));
 
@@ -226,15 +226,15 @@ TemplateEditor.route("/:templateSlug/local-editing")
   })
   .post(async (req, res, next) => {
     try {
-      const template = await createTemplate({
-        isPublic: false,
+      const template = await duplicateTemplate({
         owner: req.blog.id,
-        name: req.template.name + ' copy',
-        slug: req.template.slug + '-copy',
-        cloneFrom: req.template.id,
+        template: req.template,
       });
 
-      res.message('/sites/' + req.blog.handle + '/template/' + template.slug, 'Duplicated template <b>' + template.name + '</b>');
+      res.message(
+        '/sites/' + req.blog.handle + '/template/' + template.slug,
+        'Duplicated template <b>' + template.name + '</b>'
+      );
     } catch (err) {
       next(err);
     }

--- a/app/dashboard/site/template/save/constants.js
+++ b/app/dashboard/site/template/save/constants.js
@@ -1,0 +1,5 @@
+module.exports = {
+  // How many times should we append an integer to a template name
+  // before giving up and surfacing the error to the user?
+  MAX_DEDUPLICATION_ATTEMPTS: 999,
+};

--- a/app/dashboard/site/template/save/duplicate-template.js
+++ b/app/dashboard/site/template/save/duplicate-template.js
@@ -1,0 +1,95 @@
+const createTemplate = require("./create-template");
+const { MAX_DEDUPLICATION_ATTEMPTS } = require("./constants");
+
+const COPY_NAME_PATTERN = /^(.*?)(?: copy(?: (\d+))?)$/;
+const COPY_SLUG_PATTERN = /^(.*?)(?:-copy(?:-(\d+))?)$/;
+
+function parseCopyName(name) {
+  const match = (name || "").trim().match(COPY_NAME_PATTERN);
+
+  if (match) {
+    return {
+      base: match[1].trim(),
+      counter: match[2] ? parseInt(match[2], 10) : 1,
+    };
+  }
+
+  return {
+    base: (name || "").trim(),
+    counter: 1,
+  };
+}
+
+function parseCopySlug(slug) {
+  const match = (slug || "").match(COPY_SLUG_PATTERN);
+
+  if (match) {
+    return {
+      base: match[1],
+      counter: match[2] ? parseInt(match[2], 10) : 1,
+    };
+  }
+
+  return {
+    base: slug || "",
+    counter: 1,
+  };
+}
+
+async function duplicateTemplate({ owner, template }) {
+  if (!template || !template.id) {
+    throw new Error("A template is required to duplicate");
+  }
+
+  if (!owner) {
+    throw new Error("An owner is required to duplicate a template");
+  }
+
+  const { base: nameBase, counter: nameCounter } = parseCopyName(template.name);
+  const { base: slugBase, counter: slugCounter } = parseCopySlug(template.slug);
+
+  const baseName = `${nameBase} copy`.trim();
+  const baseSlug = `${slugBase}-copy`;
+
+  let deduplicationCounter = Math.max(nameCounter, slugCounter, 1);
+  let attemptName = baseName;
+  let attemptSlug = baseSlug;
+  let attempts = 0;
+
+  while (attempts < MAX_DEDUPLICATION_ATTEMPTS) {
+    attempts++;
+
+    try {
+      return await createTemplate({
+        isPublic: false,
+        owner,
+        name: attemptName,
+        slug: attemptSlug,
+        cloneFrom: template.id,
+      });
+    } catch (error) {
+      if (
+        error &&
+        error.code === "EEXISTS" &&
+        attempts < MAX_DEDUPLICATION_ATTEMPTS
+      ) {
+        deduplicationCounter = Math.max(deduplicationCounter, 1) + 1;
+        attemptName = `${baseName} ${deduplicationCounter}`;
+        attemptSlug = `${baseSlug}-${deduplicationCounter}`;
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  const err = new Error("Unable to duplicate template after multiple attempts");
+  err.code = "EEXISTS";
+  throw err;
+}
+
+module.exports = duplicateTemplate;
+module.exports._internal = {
+  parseCopyName,
+  parseCopySlug,
+};

--- a/app/dashboard/site/template/save/newTemplate.js
+++ b/app/dashboard/site/template/save/newTemplate.js
@@ -1,15 +1,11 @@
 var Template = require("models/template");
 var makeSlug = require("helper/makeSlug");
 const Blog = require("models/blog");
+const { MAX_DEDUPLICATION_ATTEMPTS } = require("./constants");
 var NO_NAME = "Please choose a name for your new template.";
 var NO_CLONE = "Please choose a template to clone.";
 var SUCCESS = "Created your template succesfully!";
 var SUCCESS_FROM_SHARED_TEMPLATE = "Added template to your blog succesfully!";
-
-// How many times should we append an integer
-// to the name of a new template before giving up
-// and showing an error to the user?
-var MAX_DEDUPLICATION_ATTEMPTS = 999;
 
 module.exports = function (req, res, next) {
   var template, slug, name;

--- a/app/dashboard/site/template/tests/duplicate.js
+++ b/app/dashboard/site/template/tests/duplicate.js
@@ -1,0 +1,51 @@
+describe("duplicate template route", function () {
+  global.test.blog();
+
+  const Template = require("models/template");
+  const duplicateTemplate = require("../save/duplicate-template");
+
+  beforeEach(function (done) {
+    const test = this;
+    const name = "Original";
+
+    Template.create(test.blog.id, name, {}, function (err) {
+      if (err) return done.fail(err);
+
+      Template.getTemplateList(test.blog.id, function (err, templates) {
+        if (err) return done.fail(err);
+
+        test.originalTemplate = templates.filter(function (template) {
+          return template.name === name;
+        })[0];
+
+        done();
+      });
+    });
+  });
+
+  it("deduplicates subsequent copies", async function () {
+    const firstCopy = await duplicateTemplate({
+      owner: this.blog.id,
+      template: this.originalTemplate,
+    });
+
+    expect(firstCopy.name).toEqual("Original copy");
+    expect(firstCopy.slug).toEqual("original-copy");
+
+    const secondCopy = await duplicateTemplate({
+      owner: this.blog.id,
+      template: this.originalTemplate,
+    });
+
+    expect(secondCopy.name).toEqual("Original copy 2");
+    expect(secondCopy.slug).toEqual("original-copy-2");
+
+    const thirdCopy = await duplicateTemplate({
+      owner: this.blog.id,
+      template: this.originalTemplate,
+    });
+
+    expect(thirdCopy.name).toEqual("Original copy 3");
+    expect(thirdCopy.slug).toEqual("original-copy-3");
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable helper that retries template duplication when a name or slug already exists
- share the deduplication attempt limit between new template creation and the duplicate helper
- cover repeated duplication with a regression test to ensure counters are appended to names and slugs

## Testing
- npm test app/dashboard/site/template/tests/duplicate.js *(fails: scripts/tests/test.env is missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f79e5227f08329b057c768067af7f4