### PR TITLE
Handle template slug collisions when archiving

### DIFF
--- a/scripts/template/archive.js
+++ b/scripts/template/archive.js
@@ -3,6 +3,7 @@ var Template = require("models/template");
 var Blog = require("models/blog");
 var fs = require("fs-extra");
 var templateDir = require("path").resolve(__dirname + "/../../app/templates");
+var makeSlug = require("helper/makeSlug");
 
 // This script is used to archive one of Blot's included templates
 // It will create a copy of the template for each blog on which it
@@ -57,9 +58,7 @@ function main (name, callback) {
       function (user, blog, next) {
         if (blog.template !== templateID) return next();
 
-        var newTemplateID = blog.id + ":" + name;
-
-        Template.create(
+        createCloneWithUniqueSlug(
           blog.id,
           name,
           {
@@ -67,25 +66,25 @@ function main (name, callback) {
             name: name,
             cloneFrom: blog.template
           },
-          function (err) {
+          function (err, cloneMetadata) {
             if (err) return next(err);
 
             // We rename the template to include the case-preserved
             // original name. If we do this initially, there is a strange
             // duplicate template bug for unknown reasons.
             Template.setMetadata(
-              newTemplateID,
+              cloneMetadata.id,
               { name: template.name },
               function (err) {
                 if (err) return next(err);
 
-                Template.getMetadata(newTemplateID, function (err, template) {
-                  if (err || !template)
+                Template.getMetadata(cloneMetadata.id, function (err, clonedTemplate) {
+                  if (err || !clonedTemplate)
                     return next(err || new Error("no template"));
 
                   Blog.set(
                     blog.id,
-                    { template: newTemplateID },
+                    { template: cloneMetadata.id },
                     function (err) {
                       if (err) return next(err);
 
@@ -95,7 +94,10 @@ function main (name, callback) {
                         "used",
                         templateID,
                         "so I created a clone",
-                        template.id,
+                        clonedTemplate.id,
+                        "(deduplicated slug:",
+                        clonedTemplate.slug,
+                        ")",
                         "\nhttp://" + blog.handle + "." + process.env.BLOT_HOST
                       );
 
@@ -131,6 +133,36 @@ function main (name, callback) {
       }
     );
   });
+}
+
+// Template slugs must be unique per blog, so retry with a suffixed slug when
+// cloning into a namespace that already owns the target slug.
+function createCloneWithUniqueSlug (owner, name, metadata, callback) {
+  var baseSlug = makeSlug(name).slice(0, 30);
+  var attempt = 1;
+
+  function tryCreate () {
+    var suffix = attempt === 1 ? "" : "-" + attempt;
+    var trimmedBase = attempt === 1 ? baseSlug : baseSlug.slice(0, 30 - suffix.length);
+    var attemptSlug = makeSlug((trimmedBase || baseSlug) + suffix).slice(0, 30);
+    var attemptMetadata = Object.assign({}, metadata, {
+      slug: attemptSlug
+    });
+    var attemptName = attemptSlug;
+
+    Template.create(owner, attemptName, attemptMetadata, function (err, meta) {
+      if (err && err.code === "EEXISTS") {
+        attempt += 1;
+        return tryCreate();
+      }
+
+      if (err) return callback(err);
+
+      callback(null, meta);
+    });
+  }
+
+  tryCreate();
 }
 
 module.exports = main;


### PR DESCRIPTION
## Summary
- add a helper to retry template cloning with suffixed slugs when collisions occur
- rely on the metadata returned by Template.create for follow-up updates and logging
- log the deduplicated slug that was chosen for each cloned template

## Testing
- NODE_PATH=app node scripts/template/archive.js blog *(fails: Redis connection refused in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fb2fa399248329af4d9a03d79d2448