### PR TITLE
Handle transformer URL download failures with cached fallback

### DIFF
--- a/app/helper/transformer/index.js
+++ b/app/helper/transformer/index.js
@@ -212,7 +212,10 @@ function Transformer(blogID, name) {
         // Now we try and download the URL, passing in previously
         // stored headers if any. This module interprets 304
         // responses nicely.
-        if (err) return callback(err);
+        if (err) {
+          if (result) return callback(null, result);
+          return callback(err);
+        }
 
         if (!Array.isArray(results)) results = [];
 


### PR DESCRIPTION
## Summary
- return the last successful transform when a URL download attempt fails
- add a configurable test route for sequencing remote responses in transformer tests
- cover initial caching, cache overwrite, and failure fallback scenarios for URL downloads

## Testing
- `npm test -- app/helper/transformer` *(fails: scripts/tests/test.env is missing in this environment)*
- `NODE_PATH=app node scripts/tests/index.js app/helper/transformer` *(fails: Redis is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fb7ad992188329b23ae1873eaaadae