### PR TITLE
Fix font picker CSRF submission

### DIFF
--- a/app/views/dashboard/template/template-editor-sidebar.html
+++ b/app/views/dashboard/template/template-editor-sidebar.html
@@ -333,9 +333,8 @@ Array.from(document.querySelectorAll('form[id^="font_picker"]')).forEach(functio
 					body.append(node.name, node.value);
 					
 					// append the hidden inputs
-					form.querySelector('input[name="_csrf"]').forEach(function(hidden){
-						body.append(hidden.name, hidden.value);
-					});
+                                        const csrfInput = form.querySelector('input[name="_csrf"]');
+                                        if (csrfInput) body.append(csrfInput.name, csrfInput.value);
 					
 		
                                         fetch(withAjax(window.location.href), { method: "post", body }).then(handleAjaxSaveResponse);


### PR DESCRIPTION
## Summary
- ensure the font picker submit handler appends the CSRF token value instead of iterating on the input node

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb99538fb88329ba2cb0e49483843b