### PR TITLE
Use AJAX for date settings updates

### DIFF
--- a/app/views/dashboard/template/template-editor-sidebar.html
+++ b/app/views/dashboard/template/template-editor-sidebar.html
@@ -392,12 +392,21 @@ document.querySelectorAll('form.boolean').forEach(function(form){
   document.querySelectorAll('#dateSettings').forEach(function(form){
     form.querySelectorAll('input, select').forEach(function(node){
       node.addEventListener('change',  (event) => {
-		// trigger the form submission, e.g. $('#dateSettings').submit();
-		// don't use jquery or fetch or xhr, just use the form submission
-		form.submit();
-		event.preventDefault();
-		return false;
-	  })
+                const body = new URLSearchParams();
+
+                if (node.type === 'checkbox') {
+                        body.append(node.name, node.checked ? 'on' : 'off');
+                } else {
+                        body.append(node.name, node.value);
+                }
+
+                const csrfInput = form.querySelector('input[name="_csrf"]');
+                if (csrfInput) body.append(csrfInput.name, csrfInput.value);
+
+                fetch(withAjax(window.location.href), { method: "post", body }).then(handleAjaxSaveResponse);
+                event.preventDefault();
+                return false;
+          })
     })
   })
 


### PR DESCRIPTION
## Summary
- replace the date settings form submission with an AJAX request
- send updated date settings and CSRF token via URLSearchParams to refresh the preview without reloading

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fba6c7b4448329b16e34c8b985eed3