### PR TITLE
Fix news TODO rendering to exclude outer HTML wrapper

### DIFF
--- a/app/documentation/news.js
+++ b/app/documentation/news.js
@@ -240,7 +240,7 @@ function loadToDo (req, res, next) {
       );
     });
 
-    res.locals.todo = $.html();
+    res.locals.todo = $("body").html();
     return next();
   });
 }


### PR DESCRIPTION
## Summary
- update the TODO loader to store only the body markup produced by Cheerio

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff4328b2e083299f7b05aa29f22d26