### PR TITLE
Add reset template links for mirror templates

### DIFF
--- a/app/views/dashboard/template/source-code/source-code-sidebar.html
+++ b/app/views/dashboard/template/source-code/source-code-sidebar.html
@@ -4,7 +4,13 @@
 	<a style="text-decoration:none;display: block;padding: 5px 20px;color:#666;font-size: 14px" href="{{{base}}}/source-code/create">+ Create new file</a>
  </div>
 
-	{{#views}}
-	<a class="{{selected}}" href="{{{base}}}/source-code/{{name}}/edit">{{name}}</a>
-	{{/views}}
+        {{#views}}
+        <a class="{{selected}}" href="{{{base}}}/source-code/{{name}}/edit">{{name}}</a>
+        {{/views}}
+
+        {{#template.isMirror}}
+        <div style="margin-top: 1rem;">
+                <a class="reset" style="text-decoration:none;display: block;padding: 5px 20px;color:#666;font-size: 14px" href="{{{base}}}/reset">Reset template</a>
+        </div>
+        {{/template.isMirror}}
 </div>

--- a/app/views/dashboard/template/template-editor-sidebar.html
+++ b/app/views/dashboard/template/template-editor-sidebar.html
@@ -71,8 +71,16 @@
 
 	{{> date}}
 
-	{{#syntax_themes}}
-		{{> highlighter}}
-	{{/syntax_themes}}
+{{#syntax_themes}}
+                {{> highlighter}}
+        {{/syntax_themes}}
 </div>
+
+{{#template.isMirror}}
+<div class="settings-group">
+        <a class="line" href="{{{base}}}/reset" style="padding: 11px 20px;">
+                <span class="center">Reset template</span>
+        </a>
+</div>
+{{/template.isMirror}}
 


### PR DESCRIPTION
## Summary
- add a reset template shortcut to the template editor sidebar when editing mirror templates
- surface the reset template link in the source code sidebar for mirror templates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff4693aa788329830fb204f1193e42