### PR TITLE
Filter empty question and reply bodies from search results

### DIFF
--- a/app/models/question/search.js
+++ b/app/models/question/search.js
@@ -52,6 +52,8 @@ const sortAndPaginate = (questions, page_size, page) => {
   return questions.slice(startIndex, endIndex + 1);
 };
 
+const hasNonEmptyBody = body => typeof body === "string" && body.trim().length > 0;
+
 const load = ids => {
   return new Promise((resolve, reject) => {
     const batch = client.batch();
@@ -83,10 +85,15 @@ const load = ids => {
         }
 
         const questions = results
-          .filter(result => !result.parent)
+          .filter(result => result && !result.parent && hasNonEmptyBody(result.body))
           .map(result => {
             result.replies = results
-              .filter(reply => reply.parent === result.id)
+              .filter(
+                reply =>
+                  reply &&
+                  reply.parent === result.id &&
+                  hasNonEmptyBody(reply.body)
+              )
               .map(reply => {
                 return { body: reply.body };
               });

--- a/app/models/question/tests/search.js
+++ b/app/models/question/tests/search.js
@@ -59,4 +59,28 @@ describe("questions.search", function () {
     expect(results.length).toBe(1);
     expect(results[0].id).toBe(one.id);
   });
+
+  it("omits questions with empty bodies", async function () {
+    const emptyBody = await create({ title: "How", body: "   " });
+    const valid = await create({ title: "How", body: "Yes" });
+
+    const results = await search({ query: "how" });
+
+    const ids = results.map(result => result.id);
+    expect(ids).toContain(valid.id);
+    expect(ids).not.toContain(emptyBody.id);
+  });
+
+  it("ignores replies with empty bodies", async function () {
+    const withoutReplyMatch = await create({ title: "One", body: "Hello" });
+    await create({ body: "   ", parent: withoutReplyMatch.id });
+
+    const withReplyMatch = await create({ title: "Two", body: "Hello" });
+    await create({ body: "Test reply", parent: withReplyMatch.id });
+
+    const results = await search({ query: "test" });
+
+    expect(results.length).toBe(1);
+    expect(results[0].id).toBe(withReplyMatch.id);
+  });
 });


### PR DESCRIPTION
## Summary
- skip indexing questions with empty or whitespace bodies when loading search candidates
- exclude replies lacking body content from the search scoring pipeline
- extend the question search tests to cover empty-body questions and replies

## Testing
- npm test *(fails: ./scripts/tests/test.env does not exist in the tests directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ff46c5cfe483299b195d946a9a93a0