### PR TITLE
Render DNS record guide without nameserver check

### DIFF
--- a/app/views/dashboard/settings/domain/record-guide.html
+++ b/app/views/dashboard/settings/domain/record-guide.html
@@ -4,14 +4,12 @@
         We can't identify the nameservers which control {{customDomain}}. Do you own this domain? If not, please purchase it from a domain registrar.
     </p>
     {{/nameservers.length}}
-    {{#nameservers.length}}
-
 
     <p style="margin: 0">
-        {{#revalidation}} Domain does not point to Blot.{{/revalidation}} 
+        {{#revalidation}} Domain does not point to Blot.{{/revalidation}}
         Please create this DNS record{{#dnsProvider}} on <a target="_blank" href="{{{URL}}}">{{name}}</a>{{/dnsProvider}}:
     </p>
-    
+
     {{#dnsProvider.is.cloudflare}}
     {{> record-guide-cloudflare}}
     {{/dnsProvider.is.cloudflare}}
@@ -19,8 +17,6 @@
     {{^dnsProvider.is.cloudflare}}
     {{> record-guide-other}}
     {{/dnsProvider.is.cloudflare}}
-          
-    {{/nameservers.length}}
     <br>
     <button class="revalidate" type="submit">Revalidate domain
         <span class="icon-refresh"></span>


### PR DESCRIPTION
## Summary
- always display the DNS record instructions and table even when nameservers cannot be detected while keeping the warning visible
- continue selecting the Cloudflare-specific guidance when available and fall back to the generic partial otherwise

## Testing
- node - <<'NODE' (rendered the record guide with an empty nameserver list to confirm the generic table is shown)


------
https://chatgpt.com/codex/tasks/task_e_690246970ad4832992584fd3c393f001