### PR TITLE
Restrict font picker opening to explicit activation

### DIFF
--- a/app/views/dashboard/template/controls/font.js
+++ b/app/views/dashboard/template/controls/font.js
@@ -51,8 +51,12 @@ Array.from(document.querySelectorAll('[data-font-picker-form]')).forEach(form =>
     openPicker();
   });
 
-  trigger.addEventListener('focus', openPicker);
-  trigger.addEventListener('mouseenter', openPicker);
+  trigger.addEventListener('keydown', event => {
+    const activationKeys = ['Enter', ' ', 'Spacebar'];
+    if (!activationKeys.includes(event.key)) return;
+    event.preventDefault();
+    openPicker();
+  });
 
   trigger.addEventListener('blur', event => {
     const next = event.relatedTarget;


### PR DESCRIPTION
## Summary
- remove hover/focus automatic opening for the template font picker
- add keyboard activation so Enter/Space on the trigger mimics a click

## Testing
- not run (manual verification required but not possible in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6904adf6fcd083298bb68c1bccf76507