### PR TITLE
Normalize typeset plugin option parsing

### DIFF
--- a/app/build/plugins/typeset/index.js
+++ b/app/build/plugins/typeset/index.js
@@ -1,4 +1,5 @@
 var typeset = require("typeset");
+var parseBoolean = require("helper/parseBoolean");
 
 function prerender(html, callback, options) {
   // would be nice to add options. hyphenate in future
@@ -9,6 +10,15 @@ function prerender(html, callback, options) {
   // Pandoc does a lot of this shit too
 
   var disable = ["ligatures", "hyphenate"];
+
+  options = options || {};
+
+  for (var key in options) {
+    if (Object.prototype.hasOwnProperty.call(options, key)) {
+      var parsed = parseBoolean(options[key]);
+      options[key] = typeof parsed === "boolean" ? parsed : options[key];
+    }
+  }
 
   options.spaces = options.quotes = options.punctuation;
 

--- a/app/build/tests/plugins/typeset.js
+++ b/app/build/tests/plugins/typeset.js
@@ -1,0 +1,33 @@
+describe("typeset plugin", function () {
+  require("./util/setup")();
+
+  beforeEach(function () {
+    this.blog.plugins.typeset = {
+      enabled: true,
+      options: {
+        punctuation: "off",
+        smallCaps: "false",
+        hangingPunctuation: true,
+      },
+    };
+  });
+
+  afterEach(function () {
+    this.blog.plugins.typeset = {
+      enabled: true,
+      options: {
+        hangingPunctuation: true,
+        punctuation: true,
+        smallCaps: true,
+      },
+    };
+  });
+
+  it("disables punctuation and small caps when option strings are falsey", function (done) {
+    const path = "/typeset.txt";
+    const contents = '"NASA"';
+    const html = '<p>"NASA"</p>';
+
+    this.buildAndCheck({ path, contents }, { html }, done);
+  });
+});

--- a/app/dashboard/site/save/format.js
+++ b/app/dashboard/site/save/format.js
@@ -2,6 +2,7 @@ var Blog = require("models/blog");
 var formJSON = require("helper/formJSON");
 var extend = require("helper/extend");
 var normalizeImageExif = require("models/blog/util/imageExif").normalize;
+var parseBoolean = require("helper/parseBoolean");
 
 module.exports = function (req, res, next) {
   try {
@@ -46,14 +47,18 @@ module.exports = function (req, res, next) {
     // this bullshit below is because I haven't properly declared
     // the model for blog.plugins so formJSON needs a little help...
     for (var i in req.updates.plugins) {
-      req.updates.plugins[i].enabled = req.updates.plugins[i].enabled === "on";
-      if (!req.updates.plugins[i].options) req.updates.plugins[i].options = {};
-    }
+      var plugin = req.updates.plugins[i];
 
-    if (req.updates.plugins.typeset) {
-      for (var x in req.updates.plugins.typeset.options)
-        req.updates.plugins.typeset.options[x] =
-          req.updates.plugins.typeset.options[x] === "on";
+      plugin.enabled = parseBoolean(plugin.enabled) === true;
+
+      if (!plugin.options) plugin.options = {};
+
+      for (var option in plugin.options) {
+        if (Object.prototype.hasOwnProperty.call(plugin.options, option)) {
+          var parsed = parseBoolean(plugin.options[option]);
+          if (typeof parsed === "boolean") plugin.options[option] = parsed;
+        }
+      }
     }
 
     extend(req.updates.plugins).and(req.blog.plugins);

--- a/app/helper/parseBoolean.js
+++ b/app/helper/parseBoolean.js
@@ -1,0 +1,37 @@
+function parseBoolean(value) {
+  if (typeof value === "boolean") return value;
+  if (value === null) return false;
+  if (typeof value === "undefined") return value;
+
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+    return value;
+  }
+
+  if (typeof value === "string") {
+    var normalized = value.trim().toLowerCase();
+
+    if (!normalized) return false;
+
+    if (normalized === "true" || normalized === "on" || normalized === "1")
+      return true;
+
+    if (
+      normalized === "false" ||
+      normalized === "off" ||
+      normalized === "0" ||
+      normalized === "no" ||
+      normalized === "n" ||
+      normalized === "null" ||
+      normalized === "undefined"
+    )
+      return false;
+
+    return value;
+  }
+
+  return value;
+}
+
+module.exports = parseBoolean;


### PR DESCRIPTION
## Summary
- add a regression test covering string-based toggles for the typeset plugin
- normalize typeset plugin options with a shared boolean parser so falsy strings disable modules
- reuse the boolean parser on dashboard plugin saves to coerce boolean-like strings before persisting

## Testing
- npm test -- app/build/tests/plugins/typeset.js *(fails: ./scripts/tests/test.env missing)*
- npm test -- app/build/tests/plugins *(fails: ./scripts/tests/test.env missing)*

------
https://chatgpt.com/codex/tasks/task_e_69091faf10a08329bbdb3cfb6e38f96e