### PR TITLE
Add subscription pause and resume support

### DIFF
--- a/app/dashboard/account/delete.js
+++ b/app/dashboard/account/delete.js
@@ -508,6 +508,7 @@ Delete.exports = {
   refund: issueDeletionRefund,
   email: emailUser,
   ensureRefund: ensureIssueDeletionRefund,
+  buildPaypalAuthHeader,
 };
 
 Delete._setStripeClient = function (client) {

--- a/app/dashboard/account/tests/subscription.js
+++ b/app/dashboard/account/tests/subscription.js
@@ -1,0 +1,185 @@
+const { promisify } = require("util");
+const config = require("config");
+const Blog = require("models/blog");
+const User = require("models/user");
+const Subscription = require("dashboard/account/subscription");
+
+const setUser = promisify(User.set);
+const getUser = promisify(User.getById);
+const getBlog = promisify(Blog.get);
+
+describe("Dashboard subscription pause and resume", function () {
+  global.test.blog();
+
+  beforeEach(function () {
+    this.originalFetch = global.fetch;
+  });
+
+  afterEach(function () {
+    Subscription._resetStripeClient();
+    global.fetch = this.originalFetch;
+  });
+
+  it("pauses and resumes Stripe subscriptions", async function () {
+    const subscriptionId = `sub_test_${Date.now()}`;
+    const customerId = `cus_test_${Date.now()}`;
+
+    await setUser(this.user.uid, {
+      subscription: {
+        id: subscriptionId,
+        customer: customerId,
+        status: "active",
+        plan: { amount: 500, interval: "month" },
+        quantity: 1,
+      },
+      pause: { active: false },
+    });
+
+    const stripeResponses = [
+      {
+        status: "active",
+        pause_collection: { behavior: "mark_uncollectible" },
+        plan: { amount: 500, interval: "month" },
+        quantity: 1,
+      },
+      {
+        status: "active",
+        pause_collection: null,
+        plan: { amount: 500, interval: "month" },
+        quantity: 1,
+      },
+    ];
+
+    const stripeClient = {
+      subscriptions: {
+        update: jasmine
+          .createSpy("update")
+          .and.callFake(async (id, params) => {
+            expect(id).toBe(subscriptionId);
+            expect(params).toBeDefined();
+            const next = stripeResponses.shift();
+            if (!next) throw new Error("No mocked response available");
+
+            if (next.pause_collection) {
+              expect(params.pause_collection).toEqual(
+                jasmine.objectContaining({ behavior: "mark_uncollectible" })
+              );
+            } else {
+              expect(params).toEqual(jasmine.objectContaining({ pause_collection: null }));
+            }
+
+            return Object.assign({ id, customer: customerId }, next);
+          }),
+      },
+    };
+
+    Subscription._setStripeClient(stripeClient);
+
+    const activeUser = await getUser(this.user.uid);
+    await Subscription.exports.pauseStripe(activeUser);
+
+    const pausedUser = await getUser(this.user.uid);
+    expect(pausedUser.pause).toEqual(
+      jasmine.objectContaining({ active: true, provider: "stripe" })
+    );
+    expect(pausedUser.isDisabled).toBe(true);
+
+    const pausedBlog = await getBlog({ id: this.blog.id });
+    expect(pausedBlog.isDisabled).toBe(true);
+
+    await Subscription.exports.resumeStripe(await getUser(this.user.uid));
+
+    const resumedUser = await getUser(this.user.uid);
+    expect(resumedUser.pause).toEqual(
+      jasmine.objectContaining({ active: false, provider: "stripe" })
+    );
+    expect(resumedUser.isDisabled).toBe(false);
+
+    const resumedBlog = await getBlog({ id: this.blog.id });
+    expect(resumedBlog.isDisabled).toBe(false);
+
+    expect(stripeClient.subscriptions.update.calls.count()).toBe(2);
+  });
+
+  it("pauses and resumes PayPal subscriptions", async function () {
+    const subscriptionId = `I-${Date.now()}`;
+
+    await setUser(this.user.uid, {
+      paypal: {
+        id: subscriptionId,
+        status: "ACTIVE",
+        plan_id: "P-123",
+        quantity: "1",
+        billing_info: {},
+      },
+    });
+
+    const expectedAuth = `Basic ${Buffer.from(
+      `${config.paypal.client_id}:${config.paypal.secret}`
+    ).toString("base64")}`;
+
+    const fetchQueue = [
+      { status: 204 },
+      { status: 200, body: { id: subscriptionId, status: "SUSPENDED" } },
+      { status: 204 },
+      { status: 200, body: { id: subscriptionId, status: "ACTIVE" } },
+    ];
+
+    global.fetch = jasmine
+      .createSpy("fetch")
+      .and.callFake(async (url, options = {}) => {
+        if (!fetchQueue.length) throw new Error("No mocked PayPal responses left");
+        const next = fetchQueue.shift();
+
+        if (url.endsWith("/suspend")) {
+          expect(options.method).toBe("POST");
+          expect(options.headers.Authorization).toBe(expectedAuth);
+          expect(options.body).toBe(
+            JSON.stringify({ reason: "Customer requested pause" })
+          );
+        } else if (url.endsWith("/activate")) {
+          expect(options.method).toBe("POST");
+          expect(options.headers.Authorization).toBe(expectedAuth);
+          expect(options.body).toBe(
+            JSON.stringify({ reason: "Customer requested resume" })
+          );
+        } else {
+          expect(url).toContain(`/v1/billing/subscriptions/${subscriptionId}`);
+          expect(options.headers.Authorization).toBe(expectedAuth);
+        }
+
+        const body = next.body;
+
+        return {
+          ok: next.status >= 200 && next.status < 300,
+          status: next.status,
+          json: async () => body || {},
+          text: async () => (body ? JSON.stringify(body) : ""),
+        };
+      });
+
+    await Subscription.exports.pausePaypal(await getUser(this.user.uid));
+
+    const pausedUser = await getUser(this.user.uid);
+    expect(pausedUser.pause).toEqual(
+      jasmine.objectContaining({ active: true, provider: "paypal" })
+    );
+    expect(pausedUser.isDisabled).toBe(true);
+
+    const pausedBlog = await getBlog({ id: this.blog.id });
+    expect(pausedBlog.isDisabled).toBe(true);
+
+    await Subscription.exports.resumePaypal(await getUser(this.user.uid));
+
+    const resumedUser = await getUser(this.user.uid);
+    expect(resumedUser.pause).toEqual(
+      jasmine.objectContaining({ active: false, provider: "paypal" })
+    );
+    expect(resumedUser.isDisabled).toBe(false);
+
+    const resumedBlog = await getBlog({ id: this.blog.id });
+    expect(resumedBlog.isDisabled).toBe(false);
+
+    expect(global.fetch.calls.count()).toBe(4);
+  });
+});

--- a/app/models/user/model.js
+++ b/app/models/user/model.js
@@ -6,7 +6,8 @@ var MODEL = {
   lastSession: "string",
   passwordHash: "string",
   subscription: "object",
-  paypal: "object"
+  paypal: "object",
+  pause: "object"
 };
 
 module.exports = MODEL;

--- a/app/views/dashboard/account/resume.html
+++ b/app/views/dashboard/account/resume.html
@@ -1,0 +1,17 @@
+<form class="account" action="/sites/account/subscription/resume" method="post" style="padding: 0; max-width: none;">
+  <input type="hidden" name="_csrf" value="{{csrftoken}}" />
+  <p style="padding: 33px 20px; max-width: 600px;">
+    Your subscription is currently paused, so your site{{user.s}} are offline.
+    Resume your subscription to bring everything back online immediately.
+    If you no longer need your sites, you can still
+    <a href="/sites/account/subscription/delete">delete your account</a> at any time.
+  </p>
+  <button
+    class="line"
+    type="submit"
+    style="background: none; border: none; width: 100%; padding: 0; text-align: left; cursor: pointer;"
+  >
+    <span class="label">Resume</span>
+    <span class="center"><span class="link">Resume subscription</span></span>
+  </button>
+</form>

--- a/app/views/dashboard/account/subscription.html
+++ b/app/views/dashboard/account/subscription.html
@@ -14,8 +14,15 @@
     site{{user.s}} will shut down.</span></div
     >
     {{/user.cancel_at_period_end}}
-    
-    {{#user.isSubscribed}} 
+
+    {{#user.isPaused}}
+    <div class="line"
+      ><span class="label">Paused</span
+      ><span class="center">Your subscription is paused. Your site{{user.s}} are offline until you resume.</span></div
+    >
+    {{/user.isPaused}}
+
+    {{#user.isSubscribed}}
 
     {{#user.pretty.amount}}
 
@@ -49,6 +56,7 @@
     >
     {{/user.isFreeForLife}}
 
+    {{^user.isPaused}}
     {{#user.willCancel}}
     <a class="line" href="/dashboard/account/subscription/restart"
       ><span class="label">Restart</span
@@ -57,11 +65,13 @@
       ></a
     >
     {{/user.willCancel}}
+    {{/user.isPaused}}
 
     {{#user.isSubscribed}}
 
     <div class="clear"></div>
 
+    {{^user.isPaused}}
     {{^user.paypal.status}}
     <a class="line" href="/dashboard/account/subscription/billing-interval"
       ><span class="label">Billing interval</span
@@ -71,6 +81,7 @@
       <span class="right">Switch to {{#monthly}}annual{{/monthly}}{{^monthly}}monthly{{/monthly}} billing</span>
     </a>
     {{/user.paypal.status}}
+    {{/user.isPaused}}
 
     {{#user.subscription.status}}
     <a class="line" href="/dashboard/account/subscription/payment-method"
@@ -81,6 +92,33 @@
     >
     {{/user.subscription.status}}
 
+    {{^user.isPaused}}
+    <button
+      class="line"
+      type="submit"
+      formaction="/sites/account/subscription/pause"
+      formmethod="post"
+      style="background: none; border: none; width: 100%; padding: 0; text-align: left; cursor: pointer;"
+    >
+      <span class="label">Pause</span>
+      <span class="center"><span class="link">Pause subscription</span></span>
+    </button>
+    {{/user.isPaused}}
+
+    {{#user.isPaused}}
+    <button
+      class="line"
+      type="submit"
+      formaction="/sites/account/subscription/resume"
+      formmethod="post"
+      style="background: none; border: none; width: 100%; padding: 0; text-align: left; cursor: pointer;"
+    >
+      <span class="label">Resume</span>
+      <span class="center"><span class="link">Resume subscription</span></span>
+    </button>
+    {{/user.isPaused}}
+
+    {{^user.isPaused}}
     {{^user.paypal.status}}
     <a class="line" href="/dashboard/account/subscription/cancel"
       ><span class="label">Cancel</span
@@ -89,6 +127,7 @@
       ></a
     >
     {{/user.paypal.status}}
+    {{/user.isPaused}}
 
 
     {{/user.isSubscribed}}


### PR DESCRIPTION
## Summary
- add dashboard routes and helpers to pause or resume Stripe and PayPal subscriptions while reusing the PayPal auth helper
- persist pause metadata on the user model and honor it across load-user plus Stripe and PayPal webhooks
- surface pause/resume controls in the dashboard, add a resume screen, and cover the flows with new tests

## Testing
- npm test -- app/dashboard/account/tests/subscription.js *(fails: missing scripts/tests/test.env)*

------
https://chatgpt.com/codex/tasks/task_e_690cb83dc4008329bcc376fa7476876e