### PR TITLE
Site menu links starts empty

### DIFF
--- a/app/models/blog/defaults.js
+++ b/app/models/blog/defaults.js
@@ -10,12 +10,7 @@ module.exports = {
   cssURL: "",
   scriptURL: "",
   template: "SITE:blog",
-  menu: [
-    { id: Date.now() + 1 + "", label: "Home", url: "/" },
-    { id: Date.now() + 2 + "", label: "Archives", url: "/archives" },
-    { id: Date.now() + 3 + "", label: "Search", url: "/search" },
-    { id: Date.now() + 4 + "", label: "Feed", url: "/feed.rss" },
-  ],
+  menu: [],
   domain: "",
   permalink: { format: "{{slug}}", custom: "", isCustom: false },
   timeZone: "UTC",


### PR DESCRIPTION
- [ ] Update all templates to handle new empty menu at start (e.g. reference feed and move search into archives and add archives page link).
