### PR TITLE
Add Dropbox script to restore deleted git folders

### DIFF
--- a/scripts/dropbox/restore-deleted-git-folders.js
+++ b/scripts/dropbox/restore-deleted-git-folders.js
@@ -79,17 +79,19 @@ const findDeletedGitFolders = async (client, templatePath) => {
 };
 
 const listDeletedGitFiles = async (client, gitPath) => {
+  const parentPath = posixJoin(gitPath, "..", "");
   const entries = await listAllEntries(client, {
-    path: gitPath,
+    path: parentPath,
     recursive: true,
     include_deleted: true,
   });
 
-  return entries.filter(
-    (entry) =>
-      entry.path_lower !== gitPath &&
-      (entry[".tag"] === "file" || entry[".tag"] === "deleted")
-  );
+  return entries.filter((entry) => {
+    if (!entry.path_lower.startsWith(gitPath + "/")) return false;
+    if (entry.path_lower === gitPath) return false;
+
+    return entry[".tag"] === "file" || entry[".tag"] === "deleted";
+  });
 };
 
 const getLatestRevision = async (client, filePath) => {


### PR DESCRIPTION
## Summary
- add a script to iterate Dropbox blogs and locate deleted .git folders within template directories
- fetch deleted file revisions via the Dropbox API and prompt before restoring them

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad642b5c08329ac32ac8c577acbd4)