### PR TITLE
Serve CDN assets from nginx using static directories

### DIFF
--- a/config/openresty/build-config.js
+++ b/config/openresty/build-config.js
@@ -85,6 +85,8 @@ const webhooks_client_max_body_size = `${
 const locals = {
   host: "blot.im",
   blot_directory: config.blot_directory,
+  blog_static_files_dir: config.blog_static_files_dir,
+  global_static_files_dir: config.blot_directory + "/app/blog/static",
   disable_http2: process.env.DISABLE_HTTP2,
   node_ip: NODE_SERVER_IP,
   node_port: "8088",

--- a/config/openresty/conf/server.conf
+++ b/config/openresty/conf/server.conf
@@ -119,6 +119,14 @@ http {
         }
 
         location / {
+            root {{{blog_static_files_dir}}};
+            try_files $uri $uri/ {{{global_static_files_dir}}}$uri {{{global_static_files_dir}}}$uri/ @cdn_node;
+            add_header Access-Control-Allow-Origin "*";
+            add_header Cache-Control "public, max-age=31536000";
+            expires 1y;
+        }
+
+        location @cdn_node {
             set $upstream_server blot_node;
             {{> reverse-proxy.conf}}
         }


### PR DESCRIPTION
## Summary
- expose blog and global static directories to the OpenResty template renderer
- update the CDN server configuration to serve static assets directly from disk before proxying to Node
- add caching headers so nginx responses mirror the Express configuration

## Testing
- NODE_PATH=. node config/openresty/build-config.js *(fails: external CDN IP fetch blocked in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918a056238483298f7cae2f5aea005e)