### PR TITLE
Add Playwright screenshot endpoint to macserver

### DIFF
--- a/app/clients/icloud/macserver/SCREENSHOT.md
+++ b/app/clients/icloud/macserver/SCREENSHOT.md
@@ -1,0 +1,41 @@
+# Screenshot endpoint setup
+
+## Dependencies
+1. Install Node dependencies in `app/clients/icloud/macserver/` so Playwright and the ad blocker are available:
+   ```bash
+   npm install
+   ```
+2. Install the Chromium runtime used by Playwright:
+   ```bash
+   npx playwright install chromium
+   ```
+
+## System requirements
+- At least 2 vCPUs and 2–4 GB RAM are recommended to support concurrent Chromium contexts.
+- Ensure sufficient disk space for temporary browser data and screenshots.
+- Keep the host patched so the bundled Chromium can launch without sandbox issues.
+
+## Configuration
+- The endpoint inherits the existing `Authorization` header check; no additional environment variables are required beyond the existing macserver `.env` values.
+- Default behavior:
+  - Viewport: 1440x900
+  - Device scale factor: 2 (Retina)
+  - Global concurrency: 4 captures
+  - Per-domain concurrency: 2 captures
+  - Timeout: 30 seconds (clamped between 1–120 seconds)
+  - User agent: macOS Chrome
+  - Locale: en-US
+
+## Monitoring and operations
+- The Chromium instance is long-lived. Monitor memory/CPU for the `macserver` process and restart if usage grows unexpectedly.
+- The adblocker filter lists refresh daily; temporary failures log warnings but do not crash the server.
+- Browser lifecycle ties into `SIGTERM`/`SIGINT` to ensure graceful shutdowns during deploys.
+
+## Troubleshooting
+- **Chromium fails to launch**: re-run `npx playwright install chromium` and confirm the host allows Playwright to download/execute the browser binary.
+- **High resource usage**: lower the global/per-domain concurrency in `screenshot/limiters.js` or scale the host vertically.
+- **Repeated capture failures**: validate the target URL is public and reachable, confirm the Authorization header is set, and inspect server logs for adblocker initialization errors.
+- **Stuck browser state**: restart the macserver process to force a clean Chromium instance.
+
+## Optional additions
+- Run `npx playwright install webkit` if future WebKit support is desired; update the launch code before switching engines.

--- a/app/clients/icloud/macserver/index.js
+++ b/app/clients/icloud/macserver/index.js
@@ -2,6 +2,8 @@ const express = require("express");
 const { raw } = express;
 const { Authorization, maxFileSize } = require("./config");
 const { initialize } = require("./watcher");
+const { initializeBlocker } = require("./screenshot/blocker");
+const { initializeBrowser } = require("./screenshot/browser");
 const notifyServerStarted = require("./httpClient/notifyServerStarted");
 
 const monitorer = require("./monitorer");
@@ -48,6 +50,8 @@ const startServer = async () => {
 
   app.post("/setup", require("./routes/setup"));
 
+  app.post("/screenshot", require("./routes/screenshot"));
+
   app.listen(3000, () => {
     console.log("Macserver is running on port 3000");
   });
@@ -66,6 +70,12 @@ const startServer = async () => {
     }
 
     // Start the local server
+    console.log("Initializing screenshot browser...");
+    await initializeBrowser();
+
+    console.log("Initializing screenshot adblocker...");
+    await initializeBlocker();
+
     console.log("Starting macserver...");
     await startServer();
 

--- a/app/clients/icloud/macserver/package.json
+++ b/app/clients/icloud/macserver/package.json
@@ -14,6 +14,9 @@
     "dotenv": "16.4.7",
     "express": "4.21.2",
     "fs-extra": "11.3.0",
-    "node-fetch": "2.6.7"    
+    "node-fetch": "2.6.7",
+    "@cliqz/adblocker-playwright": "^1.26.0",
+    "cross-fetch": "^4.0.0",
+    "playwright": "^1.40.0"
   }
 }

--- a/app/clients/icloud/macserver/routes/screenshot.js
+++ b/app/clients/icloud/macserver/routes/screenshot.js
@@ -1,0 +1,64 @@
+const { captureScreenshot } = require("../screenshot/capture");
+const { domainLimiter, globalLimiter } = require("../screenshot/limiters");
+const { validateUrl } = require("../screenshot/utils");
+
+const clampDimension = (value, fallback) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+
+  const bounded = Math.min(Math.max(Math.round(numeric), 100), 4000);
+  return bounded;
+};
+
+const clampTimeout = (value, fallback) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+
+  return Math.min(Math.max(Math.round(numeric), 1000), 120000);
+};
+
+module.exports = async (req, res) => {
+  try {
+    const { url, width, height, fullPage, timeout } = req.body || {};
+    const normalizedUrl = validateUrl(url);
+    const viewportWidth = clampDimension(width, undefined);
+    const viewportHeight = clampDimension(height, undefined);
+    const navigationTimeout = clampTimeout(timeout, undefined);
+    const hostname = new URL(normalizedUrl).hostname;
+
+    const captureTask = async () =>
+      captureScreenshot({
+        url: normalizedUrl,
+        width: viewportWidth,
+        height: viewportHeight,
+        fullPage: Boolean(fullPage),
+        timeout: navigationTimeout,
+      });
+
+    const runWithDomainLimiter = () =>
+      domainLimiter.key(hostname).schedule(captureTask);
+
+    const buffer = await globalLimiter.schedule(runWithDomainLimiter);
+
+    res.setHeader("Content-Type", "image/png");
+    res.setHeader("Cache-Control", "public, max-age=3600");
+    res.send(buffer);
+  } catch (error) {
+    if (error.code === "INVALID_URL") {
+      return res.status(400).json({
+        error: "invalid_url",
+        message: error.message,
+      });
+    }
+
+    console.error("Failed to capture screenshot:", error);
+    res.status(500).json({
+      error: "capture_failed",
+      message: error.message,
+    });
+  }
+};

--- a/app/clients/icloud/macserver/screenshot/blocker.js
+++ b/app/clients/icloud/macserver/screenshot/blocker.js
@@ -1,0 +1,41 @@
+const { PlaywrightBlocker } = require("@cliqz/adblocker-playwright");
+const fetch = require("cross-fetch");
+
+let blocker;
+let refreshTimer;
+
+const loadBlocker = async () => {
+  blocker = await PlaywrightBlocker.fromPrebuiltAdsAndTracking(fetch);
+  return blocker;
+};
+
+const scheduleRefresh = () => {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+  }
+
+  refreshTimer = setInterval(async () => {
+    try {
+      await loadBlocker();
+    } catch (error) {
+      console.error("Failed to refresh adblocker filters:", error);
+    }
+  }, 24 * 60 * 60 * 1000);
+};
+
+const initializeBlocker = async () => {
+  try {
+    await loadBlocker();
+    scheduleRefresh();
+  } catch (error) {
+    console.error("Failed to initialize adblocker:", error);
+    blocker = null;
+  }
+};
+
+const getBlocker = () => blocker;
+
+module.exports = {
+  getBlocker,
+  initializeBlocker,
+};

--- a/app/clients/icloud/macserver/screenshot/browser.js
+++ b/app/clients/icloud/macserver/screenshot/browser.js
@@ -1,0 +1,59 @@
+const { chromium } = require("playwright");
+const { defaultUserAgent } = require("./utils");
+
+let browser;
+let hasRegisteredShutdownHandlers = false;
+
+const initializeBrowser = async () => {
+  if (browser) {
+    return browser;
+  }
+
+  browser = await chromium.launch({
+    headless: true,
+    args: [
+      "--disable-dev-shm-usage",
+      "--disable-features=IsolateOrigins,site-per-process",
+      "--disable-blink-features=AutomationControlled",
+    ],
+    chromiumSandbox: false,
+  });
+
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 2,
+    userAgent: defaultUserAgent,
+  });
+  await context.close();
+
+  if (!hasRegisteredShutdownHandlers) {
+    hasRegisteredShutdownHandlers = true;
+    const shutdown = async () => {
+      if (browser) {
+        await browser.close();
+      }
+      process.exit(0);
+    };
+
+    process.on("SIGTERM", shutdown);
+    process.on("SIGINT", shutdown);
+  }
+
+  return browser;
+};
+
+const getBrowser = () => {
+  if (!browser) {
+    throw new Error("Browser has not been initialized");
+  }
+
+  return browser;
+};
+
+const isBrowserHealthy = () => Boolean(browser && browser.isConnected());
+
+module.exports = {
+  getBrowser,
+  initializeBrowser,
+  isBrowserHealthy,
+};

--- a/app/clients/icloud/macserver/screenshot/capture.js
+++ b/app/clients/icloud/macserver/screenshot/capture.js
@@ -1,0 +1,83 @@
+const { getBrowser } = require("./browser");
+const { getBlocker } = require("./blocker");
+const { defaultUserAgent, getAntiDetectionScript } = require("./utils");
+
+const DEFAULT_WIDTH = 1440;
+const DEFAULT_HEIGHT = 900;
+const MIN_DIMENSION = 100;
+const MAX_DIMENSION = 4000;
+const DEFAULT_TIMEOUT = 30000;
+const MAX_TIMEOUT = 120000;
+const MIN_TIMEOUT = 1000;
+
+const clampNumber = (value, min, max, fallback) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+
+  return Math.min(Math.max(Math.round(numeric), min), max);
+};
+
+const captureScreenshot = async (options) => {
+  const browser = getBrowser();
+  const blocker = getBlocker();
+
+  const width = clampNumber(options?.width, MIN_DIMENSION, MAX_DIMENSION, DEFAULT_WIDTH);
+  const height = clampNumber(options?.height, MIN_DIMENSION, MAX_DIMENSION, DEFAULT_HEIGHT);
+  const timeout = clampNumber(options?.timeout, MIN_TIMEOUT, MAX_TIMEOUT, DEFAULT_TIMEOUT);
+  const fullPage = Boolean(options?.fullPage);
+  const url = options?.url;
+
+  if (!url) {
+    throw new Error("A URL is required to capture a screenshot");
+  }
+
+  const context = await browser.newContext({
+    viewport: { width, height },
+    deviceScaleFactor: 2,
+    locale: "en-US",
+    userAgent: defaultUserAgent,
+  });
+
+  let page;
+  try {
+    page = await context.newPage();
+
+    if (blocker) {
+      await blocker.enableBlockingInPage(page);
+    }
+
+    await page.addInitScript(getAntiDetectionScript());
+    page.setDefaultNavigationTimeout(timeout);
+    page.setDefaultTimeout(timeout);
+
+    await page.goto(url, {
+      waitUntil: "networkidle",
+      timeout,
+    });
+
+    const randomDelay = 200 + Math.floor(Math.random() * 300);
+    await page.waitForTimeout(randomDelay);
+
+    await page.evaluate(() => {
+      window.scrollBy(0, 100);
+    });
+
+    const buffer = await page.screenshot({
+      fullPage,
+      type: "png",
+    });
+
+    return buffer;
+  } finally {
+    if (page) {
+      await page.close();
+    }
+    await context.close();
+  }
+};
+
+module.exports = {
+  captureScreenshot,
+};

--- a/app/clients/icloud/macserver/screenshot/limiters.js
+++ b/app/clients/icloud/macserver/screenshot/limiters.js
@@ -1,0 +1,15 @@
+const Bottleneck = require("bottleneck");
+
+const globalLimiter = new Bottleneck({
+  maxConcurrent: 4,
+  minTime: 100,
+});
+
+const domainLimiter = new Bottleneck.Group({
+  maxConcurrent: 2,
+});
+
+module.exports = {
+  domainLimiter,
+  globalLimiter,
+};

--- a/app/clients/icloud/macserver/screenshot/utils.js
+++ b/app/clients/icloud/macserver/screenshot/utils.js
@@ -1,0 +1,92 @@
+const PRIVATE_IP_REGEX = /^(127\.\d{1,3}\.\d{1,3}\.\d{1,3}|10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3})$/;
+const LOCALHOSTS = ["localhost", "::1", "0.0.0.0"];
+
+const defaultUserAgent =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36";
+
+const getBannerHidingCSS = () => `
+  [id*="cookie" i],
+  [class*="cookie" i],
+  [id*="consent" i],
+  [class*="consent" i],
+  .announcement,
+  .modal-backdrop,
+  .newsletter,
+  .privacy-banner,
+  .tracking-consent,
+  .gdpr,
+  .Toast,
+  .toast,
+  .popup,
+  .modal,
+  .overlay {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+  }
+`;
+
+const getAntiDetectionScript = () => `
+  Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+  Object.defineProperty(navigator, 'platform', { get: () => 'MacIntel' });
+  Object.defineProperty(navigator, 'vendor', { get: () => 'Apple Computer, Inc.' });
+  Object.defineProperty(navigator, 'language', { get: () => 'en-US' });
+  Object.defineProperty(navigator, 'languages', { get: () => ['en-US', 'en'] });
+  Object.defineProperty(navigator, 'deviceMemory', { get: () => 8 });
+  Object.defineProperty(navigator, 'hardwareConcurrency', { get: () => 8 });
+
+  window.chrome = window.chrome || { runtime: {} };
+  Object.defineProperty(navigator, 'plugins', { get: () => [1, 2, 3, 4, 5] });
+  Object.defineProperty(navigator, 'permissions', {
+    get: () => ({
+      query: ({ name }) => {
+        if (name === 'notifications') {
+          return Promise.resolve({ state: 'denied' });
+        }
+        return Promise.resolve({ state: 'prompt' });
+      },
+    }),
+  });
+
+  const style = document.createElement('style');
+  style.textContent = ${JSON.stringify(getBannerHidingCSS())};
+  document.documentElement.appendChild(style);
+`;
+
+const createUrlError = (message) => {
+  const error = new Error(message);
+  error.code = "INVALID_URL";
+  return error;
+};
+
+const validateUrl = (input) => {
+  if (!input || typeof input !== "string") {
+    throw createUrlError("Invalid URL provided");
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(input);
+  } catch (error) {
+    throw createUrlError("Invalid URL provided");
+  }
+
+  const protocol = parsed.protocol.toLowerCase();
+  if (protocol !== "http:" && protocol !== "https:") {
+    throw createUrlError("URL must use http or https");
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (LOCALHOSTS.includes(hostname) || PRIVATE_IP_REGEX.test(hostname)) {
+    throw createUrlError("URL points to a disallowed host");
+  }
+
+  return parsed.toString();
+};
+
+module.exports = {
+  defaultUserAgent,
+  getAntiDetectionScript,
+  getBannerHidingCSS,
+  validateUrl,
+};


### PR DESCRIPTION
## Summary
- add Playwright-powered screenshot module with browser lifecycle, ad blocking, validation, and rate limiting
- expose a /screenshot route that validates inputs and streams captured PNGs with caching headers
- document setup steps and defaults for the screenshot endpoint

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b3b272d6c83299376c84b241abcfa)