### PR TITLE
Add secondary domain support

### DIFF
--- a/app/dashboard/site/domain/index.js
+++ b/app/dashboard/site/domain/index.js
@@ -11,6 +11,7 @@ const Domain = express.Router();
 const ip = config.ip;
 const ipv6 = config.ipv6;
 const host = config.host;
+const hosts = config.hosts;
 
 Domain.use((req, res, next) => {
     res.locals.breadcrumbs.add('Domain', '/domain');
@@ -25,6 +26,7 @@ Domain.use((req, res, next) => {
     res.locals.apexDomain = domain;
     res.locals.customDomain = customDomain;
     res.locals.host = host;
+    res.locals.hosts = hosts;
     res.locals.ip = ip;
     res.locals.ipv6 = ipv6;
         
@@ -83,7 +85,7 @@ Domain.route('/')
         }
 
         try {
-            const isValid = await verify({ hostname, handle: req.blog.handle, ourIP: ip, ourIPv6: ipv6, ourHost: host });
+            const isValid = await verify({ hostname, handle: req.blog.handle, ourIP: ip, ourIPv6: ipv6, ourHost: host, ourHosts: hosts });
 
             if (isValid) {
                 // Clear the blog session

--- a/app/models/blog/validate/domain.js
+++ b/app/models/blog/validate/domain.js
@@ -35,7 +35,11 @@ module.exports = function (blogID, domain, callback) {
     return callback(INVALID);
   }
 
-  if (domain.endsWith(config.host)) {
+  const blotHost = config.hosts.some(function (host) {
+    return domain === host || domain.endsWith("." + host);
+  });
+
+  if (blotHost) {
     return callback(SUBDOMAIN);
   }
 

--- a/app/server.js
+++ b/app/server.js
@@ -89,6 +89,10 @@ server.use(require('./request-logger'));
 // only ever be served for request to the host
 server.use(vhost(config.host, site));
 
+if (config.secondary_host) {
+  server.use(vhost(config.secondary_host, site));
+}
+
 // The Webhook forwarder
 // -------------
 // Forwards webhooks to development environment

--- a/app/site/index.js
+++ b/app/site/index.js
@@ -45,6 +45,9 @@ site.locals.cacheID = cacheID;
 
 site.locals.cdnURL = config.cdn.origin;
 site.locals.cdn = cdnURLHelper({cacheID, viewDirectory: VIEW_DIRECTORY});
+site.locals.host = config.host;
+site.locals.secondary_host = config.secondary_host;
+site.locals.hosts = config.hosts;
 
 site.get("/health", (req, res) => {
   res.send("OK");

--- a/app/views/dashboard/site/domain/record-guide-cloudflare.html
+++ b/app/views/dashboard/site/domain/record-guide-cloudflare.html
@@ -21,7 +21,7 @@
                 <button type="button" class="copy"><span class="icon-copy"></span> Copy</button>
             </td>
             <td>
-                blot.im <button type="button" class="copy"><span class="icon-copy"></span> Copy</button>
+                {{host}} <button type="button" class="copy"><span class="icon-copy"></span> Copy</button>
             </td>
             <td>✓</td>
             <td>

--- a/app/views/dashboard/site/domain/record-guide-other.html
+++ b/app/views/dashboard/site/domain/record-guide-other.html
@@ -12,7 +12,7 @@
         <tr>
             <td>CNAME</td>
             <td>{{subdomain}} <button type="button" class="copy"><span class="icon-copy"></span> Copy</button></td>
-            <td>blot.im <button type="button" class="copy"><span class="icon-copy"></span> Copy</button></td>
+            <td>{{host}} <button type="button" class="copy"><span class="icon-copy"></span> Copy</button></td>
             <td>Auto <button type="button" class="copy"><span class="icon-copy"></span> Copy</button></td>
         </tr>
         {{/subdomain}}

--- a/app/views/how/configure/domain.html
+++ b/app/views/how/configure/domain.html
@@ -18,7 +18,8 @@
     <p>
       Go to your domain&apos;s DNS page. This is usually where you bought the
       domain. Create a <code>CNAME</code> record for the subdomain you&apos;d
-      like to use and set its value to <code>blot.im</code>.
+      like to use and set its value to <code>{{host}}</code>{{#secondary_host}}
+      or <code>{{secondary_host}}</code>{{/secondary_host}}.
     </p>
   </li>
   <li>
@@ -36,7 +37,8 @@
     <p>
       Go to your domain&apos;s DNS page. This is usually where you bought the
       domain. Create an <code>ALIAS</code> record which points to
-      <code>blot.im</code>.
+      <code>{{host}}</code>{{#secondary_host}} or
+      <code>{{secondary_host}}</code>{{/secondary_host}}.
     </p>
   </li>
   <li>
@@ -77,12 +79,18 @@
     <tr>
       <td>CNAME</td>
       <td>www</td>
-      <td>blot.im</td>
+      <td>
+        {{host}}
+        {{#secondary_host}}or {{secondary_host}}{{/secondary_host}}
+      </td>
     </tr>
     <tr>
       <td>ALIAS</td>
       <td>@</td>
-      <td>blot.im</td>
+      <td>
+        {{host}}
+        {{#secondary_host}}or {{secondary_host}}{{/secondary_host}}
+      </td>
     </tr>
     <tr>
       <td>A</td>
@@ -106,7 +114,9 @@
     Are the domain's name servers pointing to the registrar's DNS service?
   </li>
   <li>
-    Are the host (e.g. <code>www</code>) and value (e.g. <code>blot.im</code>)
+    Are the host (e.g. <code>www</code>) and value (e.g.
+    <code>{{host}}</code>{{#secondary_host}} or
+    <code>{{secondary_host}}</code>{{/secondary_host}})
     fields in the DNS record reversed?
   </li>
 </ul>

--- a/config/index.js
+++ b/config/index.js
@@ -8,6 +8,7 @@ const BLOT_DIRECTORY =
 const BLOT_DATA_DIRECTORY =
   process.env.BLOT_DATA_DIRECTORY || BLOT_DIRECTORY + "/data";
 const BLOT_HOST = process.env.BLOT_HOST || "localhost";
+const BLOT_SECONDARY_HOST = process.env.BLOT_SECONDARY_HOST || null;
 const BLOT_PORT = process.env.BLOT_PORT || "8080";
 const BLOT_PROTOCOL = process.env.BLOT_PROTOCOL || "https";
 const BLOT_IPV6 = process.env.BLOT_IPV6 || null;
@@ -26,6 +27,8 @@ module.exports = {
   // codebase expects either 'production' or 'development'
   environment,
   host: BLOT_HOST,
+  secondary_host: BLOT_SECONDARY_HOST,
+  hosts: [BLOT_HOST, BLOT_SECONDARY_HOST].filter(Boolean),
   reverse_proxies,
   protocol: BLOT_PROTOCOL + "://",
   master: process.env.CONTAINER_NAME === "blot-container-green",

--- a/config/openresty/build-config.js
+++ b/config/openresty/build-config.js
@@ -83,7 +83,8 @@ const webhooks_client_max_body_size = `${
 }M`;
 
 const locals = {
-  host: "blot.im",
+  host: config.host,
+  secondary_host: config.secondary_host,
   blot_directory: config.blot_directory,
   disable_http2: process.env.DISABLE_HTTP2,
   node_ip: NODE_SERVER_IP,

--- a/config/openresty/conf/blot-site.conf
+++ b/config/openresty/conf/blot-site.conf
@@ -13,7 +13,7 @@ location = /health {
 
 # redirect for /cdn/XYZ to cdn.blot.im/XYZ
 location ~ ^/cdn/(.*)$ {
-  return 301 https://cdn.blot.im/$1;
+  return 301 https://cdn.{{host}}/$1;
 }
 
 # bypass cache, long timeout

--- a/config/openresty/conf/server.conf
+++ b/config/openresty/conf/server.conf
@@ -58,6 +58,108 @@ http {
         ~*(^-$|^$) 1;
     }
 
+    {{#secondary_host}}
+    # blot.site -> blot.im
+    server {
+        listen 443 ssl;
+
+        {{^disable_http2}}
+        http2 on;
+        {{/disable_http2}}
+
+        server_name {{secondary_host}};
+
+        {{> restrict-bot-uas.conf}}
+
+        {{> wildcard-ssl.conf}}
+
+        return 301 https://{{host}}$request_uri;
+    }
+
+    # blot.site -> blot.im
+    server {
+        listen 80;
+
+        server_name {{secondary_host}};
+
+        return 301 https://{{host}}$request_uri;
+    }
+
+    # blot subdomains (e.g. david.blot.site)
+    server {
+        listen 80;
+        listen 443 ssl;
+
+        {{^disable_http2}}
+        http2 on;
+        {{/disable_http2}}
+
+        # match all subdomains of blot.site which do not start with preview-
+        server_name "~^(?!preview-)[^.]+\.{{secondary_host}}$";
+
+        {{> restrict-bot-uas.conf}}
+
+        {{> wildcard-ssl.conf}}
+
+        {{> blot-blogs.conf}}
+    }
+
+    # preview subdomains (e.g. preview-of-blog-on-david.blot.site)
+    # these skip the cache and are passed directly to node
+    server {
+        listen 80;
+        listen 443 ssl;
+
+        {{^disable_http2}}
+        http2 on;
+        {{/disable_http2}}
+
+        server_name "~^preview-[^.]+\.{{secondary_host}}$";
+
+        {{> restrict-bot-uas.conf}}
+
+        {{> wildcard-ssl.conf}}
+
+        location / {
+            set $upstream_server blot_blogs_node;
+            {{> reverse-proxy.conf}}
+        }
+    }
+
+    # cdn subdomain (e.g. cdn.blot.site)
+    # these skip the cache and redirect to the primary cdn
+    server {
+        listen 80;
+        listen 443 ssl;
+
+        {{^disable_http2}}
+        http2 on;
+        {{/disable_http2}}
+
+        server_name cdn.{{secondary_host}};
+
+        {{> wildcard-ssl.conf}}
+
+        return 301 https://cdn.{{host}}$request_uri;
+    }
+
+    # webhooks relay at webhooks.blot.site
+    server {
+        listen 80;
+        listen 443 ssl;
+
+        {{^disable_http2}}
+        http2 on;
+        {{/disable_http2}}
+
+        server_name webhooks.{{secondary_host}};
+
+        {{> wildcard-ssl.conf}}
+
+        return 301 https://webhooks.{{host}}$request_uri;
+    }
+    {{/secondary_host}}
+
     # blot subdomains (e.g. david.blot.im)
     server {
         listen 80;


### PR DESCRIPTION
## Summary
- add configuration for a secondary host along with shared host helpers
- update OpenResty and application routing to serve and redirect the secondary domain alongside the primary
- expand dashboard/domain validation and docs to accept the secondary host and avoid hardcoded primary references

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b3e81c27c83299742d38d574350e1)