### PR TITLE
Allow query parameter pagination fallback

### DIFF
--- a/app/blog/entries.js
+++ b/app/blog/entries.js
@@ -6,7 +6,7 @@ module.exports = function (req, res, next) {
   const options = {
     sortBy: req?.template?.locals?.sort_by,
     order: req?.template?.locals?.sort_order,
-    pageNumber: req?.params?.page,
+    pageNumber: req?.params?.page ?? req?.query?.page,
     pageSize: req?.template?.locals?.page_size,
   };
 

--- a/app/blog/render/retrieve/posts.js
+++ b/app/blog/render/retrieve/posts.js
@@ -6,7 +6,7 @@ module.exports = function (req, res, callback) {
   const options = {
     sortBy: req?.template?.locals?.sort_by,
     order: req?.template?.locals?.sort_order,
-    pageNumber: req?.params?.page,
+    pageNumber: req?.params?.page ?? req?.query?.page,
     pageSize: req?.template?.locals?.page_size,
   };
 


### PR DESCRIPTION
## Summary
- allow pagination requests to fall back to the `page` query parameter when the route parameter is absent
- update entry list and posts retrieval to pass the resolved page number to `getPage`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e4b1e817883298bb0a860c71fffe5)