### PR TITLE
Render date format strings before formatting

### DIFF
--- a/app/blog/render/load/augment.js
+++ b/app/blog/render/load/augment.js
@@ -143,7 +143,7 @@ function FormatDate(dateStamp, zone) {
   return function () {
     return function (text, render) {
       try {
-        text = text.trim();
+        text = render(text).trim();
         text = moment.utc(dateStamp).tz(zone).format(text);
       } catch (e) {
         text = "";


### PR DESCRIPTION
## Summary
- render formatDate block content before formatting so Mustache values such as locals are expanded
- continue trimming rendered content prior to formatting the date string

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef41ce7908329a8e84e70a4b01f1c)