### PR TITLE
Fix Firefox dashboard preview scrolling

### DIFF
--- a/app/views/dashboard/template/css/template-editor.css
+++ b/app/views/dashboard/template/css/template-editor.css
@@ -370,7 +370,7 @@ form.upload-control:last-of-type {
     width: 100%;
     position: relative;
     height: calc(100vh - 148px);
-    overflow: hidden;
+    overflow: auto;
     padding: 1px;
     box-sizing: border-box;
     border-radius: var(--border-radius);


### PR DESCRIPTION
## Summary
- allow the dashboard template preview container to scroll so content is accessible in Firefox

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928479ceb608329beb95d8c174c0e80)