### PR TITLE
Migrate templates to posts collections

### DIFF
--- a/app/templates/readme.txt
+++ b/app/templates/readme.txt
@@ -316,11 +316,11 @@ remaining_entries:
 
 {{> header}}
 
-{{#entries}}
+{{#posts}}
 
   {{{html}}}
 
-{{/entries}}
+{{/posts}}
 
 {{#pagination}}
 

--- a/app/templates/source/album/_grid_bookshelf.html
+++ b/app/templates/source/album/_grid_bookshelf.html
@@ -134,7 +134,7 @@
 </style>
 <div class="posts">
 
-  {{#entries}}
+  {{#posts}}
   <a href="{{{url}}}" class="post {{#thumbnail.medium}}zoomable{{/thumbnail.medium}} {{^thumbnail.medium}}no-thumbnail{{/thumbnail.medium}}">
   <span class="thumbnail">
     <span class="container">
@@ -177,5 +177,5 @@
   </span>
   
 </a>
-  {{/entries}}
+  {{/posts}}
 </div>

--- a/app/templates/source/album/_grid_square.html
+++ b/app/templates/source/album/_grid_square.html
@@ -136,7 +136,7 @@
   }
 </style>
 <div class="posts">
-  {{#entries}}
+  {{#posts}}
   <a
     href="{{{url}}}"
     class="post {{#thumbnail.medium}}zoomable{{/thumbnail.medium}} {{^thumbnail.medium}}no-thumbnail{{/thumbnail.medium}}">
@@ -202,5 +202,5 @@
       </span>
     </span>
   </a>
-  {{/entries}}
+  {{/posts}}
 </div>

--- a/app/templates/source/album/archive.js
+++ b/app/templates/source/album/archive.js
@@ -2,14 +2,14 @@
   var articles = [
     {{#archives}}
     {{#months}}
-    {{#entries}}
+    {{#posts}}
     { 
       "title": "{{title}}",
       "url": "{{{url}}}",
       "thumbnail": "{{{thumbnail.small.url}}}",
       "date": "{{date}}"
     },
-    {{/entries}}
+    {{/posts}}
     {{/months}}
     {{/archives}}
   ];

--- a/app/templates/source/album/search.html
+++ b/app/templates/source/album/search.html
@@ -40,7 +40,7 @@ input[type=radio] {display: none;}
 
 
     <div id="hyperlist" class="container">
-        {{#entries}}
+        {{#posts}}
         <a href="{{{url}}}">
             <span class="thumbnail">
           <img src="{{{thumbnail.small.url}}}" class="pre-loaded" onload="this.className+=' loaded';" />
@@ -51,7 +51,7 @@ input[type=radio] {display: none;}
       <span class="title">{{title}}</span>
       <span class="date">{{date}}</span>
         </a>
-        {{/entries}}
+        {{/posts}}
         </div>
 
 {{> footer}}

--- a/app/templates/source/blog/archives.html
+++ b/app/templates/source/blog/archives.html
@@ -17,9 +17,9 @@
 
       {{#archives}}
         {{#months}}
-          {{#entries}}
+          {{#posts}}
           <a href="{{{url}}}" title="{{title}}">{{title}}</a> <span class="light">{{date}}</span><br>
-          {{/entries}}
+          {{/posts}}
         {{/months}}
       {{/archives}}
 

--- a/app/templates/source/blog/entries.html
+++ b/app/templates/source/blog/entries.html
@@ -5,7 +5,7 @@
 
     {{> sidebar}}
 
-    {{#entries}}
+    {{#posts}}
 
       <div class="entry">
         {{{html}}}
@@ -19,7 +19,7 @@
 
       <hr class="full"/>
 
-    {{/entries}}
+    {{/posts}}
 
     <p class="entry" style="text-align:center">View <a href="/archives">the archives</a></p>
 

--- a/app/templates/source/blog/search.html
+++ b/app/templates/source/blog/search.html
@@ -12,16 +12,16 @@
       <br>
       <div class="entry">
       {{#query}}
-        {{^entries}}
+        {{^posts}}
         <p>Sorry, no results for “{{query}}”</p>
-        {{/entries}}
+        {{/posts}}
       {{/query}}
 
-      {{#entries}}
+      {{#posts}}
         <a href="{{{url}}}">{{title}}</a>
         <span class="light">{{date}}</span>
         <br>
-      {{/entries}}
+      {{/posts}}
       </div>
 
     <script type="text/javascript">document.getElementById('search').focus();</script>

--- a/app/templates/source/blog/tagged.html
+++ b/app/templates/source/blog/tagged.html
@@ -9,11 +9,11 @@
 
     <div class="entry">
 
-      {{#entries}}
+      {{#posts}}
       <a href="{{{url}}}">{{title}}</a>
       <span class="light">{{date}}</span>
       <br>
-      {{/entries}}
+      {{/posts}}
 
     </div>
 

--- a/app/templates/source/cv/writing.html
+++ b/app/templates/source/cv/writing.html
@@ -15,13 +15,13 @@
 {{#archives}}
 <h2>{{year}}</h2>
 {{#months}}
-{{#entries}}
+{{#posts}}
 <h3>{{date}}</h3>
 <p><a href="{{{url}}}">{{title}}</a></p>
 {{#thumbnail.small}}
 <p><img src="{{url}}" width="{{width}}" height="{{height}}"></p>
 {{/thumbnail.small}}
-{{/entries}}
+{{/posts}}
 {{/months}}
 {{/archives}}
 </div>  

--- a/app/templates/source/documentation/search.html
+++ b/app/templates/source/documentation/search.html
@@ -18,30 +18,30 @@
   </form>
   <div>
 
-    {{#entries.length}}
+    {{#posts.length}}
     <p>Found
-      {{#entries}}
+      {{#posts}}
       {{#first}}
       {{#last}}
-      {{entries.length}} result
+      {{posts.length}} result
       {{/last}}
       {{^last}}
-      {{entries.length}} results
+      {{posts.length}} results
       {{/last}}
       {{/first}}
-      {{/entries}}
+      {{/posts}}
     </p>
-    {{/entries.length}}
-    {{^entries}}
+    {{/posts.length}}
+    {{^posts}}
     {{#query}}
     <p>No results</p>
     {{/query}}
-    {{/entries}}
+    {{/posts}}
 
     <p>
-      {{#entries}}
+      {{#posts}}
       <a class="full-line" href="{{{url}}}"><em>{{title}}</em> &nbsp;<span class="small">{{date}}</span></a>
-      {{/entries}}
+      {{/posts}}
     </p>
 
 

--- a/app/templates/source/event/entries.html
+++ b/app/templates/source/event/entries.html
@@ -11,12 +11,12 @@
     <div class="main">
          <div class="fade-in entry">
             <br>
-            {{#entries}}
+            {{#posts}}
             <center><small>{{date}}</small></center>
             <div class="announcement">
                 {{{html}}}                
             </div>
-            {{/entries}}
+            {{/posts}}
          </div>
      </div>
 </div> 

--- a/app/templates/source/fieldnotes/archives.html
+++ b/app/templates/source/fieldnotes/archives.html
@@ -15,10 +15,10 @@
             {{#archives}}
               <h2>{{year}}</h2>
               {{#months}}
-              {{#entries}}
+              {{#posts}}
             <a href="{{{url}}}">{{title}}</a>&nbsp;&nbsp;<span style="color:#777">{{date}}</span>
               <br>
-                {{/entries}}
+                {{/posts}}
                 {{/months}}
           {{/archives}}
             </div>                      </article>

--- a/app/templates/source/fieldnotes/entries.html
+++ b/app/templates/source/fieldnotes/entries.html
@@ -7,9 +7,9 @@
 	<div id="content" class="site-content">
 		<div id="primary" class="content-area">
 			<main id="main" class="site-main" role="main">
-				{{#entries}}						
+				{{#posts}}						
 				{{> article}}
-				{{/entries}}
+				{{/posts}}
 				<nav class="navigation paging-navigation" role="navigation">
 					<h1 class="screen-reader-text">Posts navigation</h1>
 					<div class="nav-links">

--- a/app/templates/source/fieldnotes/search.html
+++ b/app/templates/source/fieldnotes/search.html
@@ -10,7 +10,7 @@
 						<header class="page-header">
 							<h1 class="page-title">Search Results for: <span>{{query}}</span></h1>
 						</header>
-						{{#entries}} {{> article}} {{/entries}}
+						{{#posts}} {{> article}} {{/posts}}
 					</main>
 					<!-- #main -->
 				</div>

--- a/app/templates/source/fieldnotes/tagged.html
+++ b/app/templates/source/fieldnotes/tagged.html
@@ -10,7 +10,7 @@
                                                 <header class="page-header">
                                                         <h1 class="page-title"><span>{{tag}}</span></h1>
                                                 </header>
-                                                {{#entries}} {{> article}} {{/entries}}
+                                                {{#posts}} {{> article}} {{/posts}}
                                                 {{#pagination}}
                                                 <div class="pagination">
                                                         {{#previous}}

--- a/app/templates/source/gallery/entries.html
+++ b/app/templates/source/gallery/entries.html
@@ -5,9 +5,9 @@
 
     {{> header}}
 
-    {{#entries}}
+    {{#posts}}
       {{> item}}
-    {{/entries}}
+    {{/posts}}
 
     <div class="clear"></div>
 

--- a/app/templates/source/gallery/search.html
+++ b/app/templates/source/gallery/search.html
@@ -12,16 +12,16 @@
         <br><br><br>
         <div class="results" style="max-width:600px;text-align:center;margin:0 auto">
           {{#query}}
-            {{^entries}}
+            {{^posts}}
             <p>Sorry, nothing found for “{{query}}”</p>
-            {{/entries}}
+            {{/posts}}
           {{/query}}
 
-          {{#entries}}
+          {{#posts}}
             <a href="{{{url}}}">{{title}}</a>
             <span class="small">{{date}}</span>
             <br>
-          {{/entries}}
+          {{/posts}}
         </div>
     </div>
   </body>

--- a/app/templates/source/gallery/tagged.html
+++ b/app/templates/source/gallery/tagged.html
@@ -5,9 +5,9 @@
     <div class="container">
     {{> header}}
     <h1>{{tag}}</h1>
-    {{#entries}}
+    {{#posts}}
       {{> item}}
-    {{/entries}}
+    {{/posts}}
 
     {{#pagination}}
     <div class="pagination">

--- a/app/templates/source/index/archives.html
+++ b/app/templates/source/index/archives.html
@@ -10,12 +10,12 @@
     {{#archives}}
       {{#months}}
       <hr>
-      <h3 class="archive">{{month}} {{year}}&nbsp;&nbsp;<small>{{entries.length}} post{{s}}</small></h3>
+      <h3 class="archive">{{month}} {{year}}&nbsp;&nbsp;<small>{{posts.length}} post{{s}}</small></h3>
 
       <small>
-      {{#entries}}
+      {{#posts}}
       <a class="archive" href="{{{url}}}">{{title}}</a>{{^last}}&nbsp;&nbsp;·&nbsp;{{/last}}
-      {{/entries}}
+      {{/posts}}
       </small>
 
       <br>

--- a/app/templates/source/index/entries.html
+++ b/app/templates/source/index/entries.html
@@ -12,9 +12,9 @@
 
     <br><br>
 
-    {{#entries}}
+    {{#posts}}
     <a href="{{{url}}}" class="row"><b>{{title}}</b>&nbsp;{{#date}}&nbsp;·&nbsp;&nbsp;<span style="white-space: nowrap;">{{date}}</span>{{/date}}</a>
-    {{/entries}}
+    {{/posts}}
 
     <br><br><br>
 

--- a/app/templates/source/index/search.html
+++ b/app/templates/source/index/search.html
@@ -12,14 +12,14 @@
     <br>
 
     {{#query}}
-    {{^entries}}
+    {{^posts}}
     <p>Sorry, nothing found for “{{query}}”</p>
-    {{/entries}}
+    {{/posts}}
     {{/query}}
 
-    {{#entries}}
+    {{#posts}}
     <a href="{{{url}}}" class="row"><b>{{title}}</b> {{#date}}&nbsp;·&nbsp; <span style="white-space: nowrap;">{{date}}</span>{{/date}}</a>
-    {{/entries}}
+    {{/posts}}
 
     {{> footer}}
 

--- a/app/templates/source/index/tagged.html
+++ b/app/templates/source/index/tagged.html
@@ -12,9 +12,9 @@
     All posts tagged {{tag}}:
     </small>
 
-      {{#entries}}
+      {{#posts}}
       <a href="{{{url}}}" class="row"><b>{{title}}</b> {{#date}}&nbsp;·&nbsp; <span style="white-space: nowrap;">{{date}}</span>{{/date}}</a>
-      {{/entries}}
+      {{/posts}}
 
       {{#pagination}}
       <div class="pagination">

--- a/app/templates/source/journal/archives.html
+++ b/app/templates/source/journal/archives.html
@@ -10,9 +10,9 @@
         {{#months}}
           <h3>{{month}}</h3>
           <p>
-          {{#entries}}
+          {{#posts}}
           <a href="{{{url}}}">{{title}}</a><br>
-          {{/entries}}
+          {{/posts}}
           <br>
           </p>
         {{/months}}

--- a/app/templates/source/journal/entries.html
+++ b/app/templates/source/journal/entries.html
@@ -5,7 +5,7 @@
     {{> header}}
     <div class="container index">
 
-      {{#entries}}
+      {{#posts}}
       <p>
 
         <a class="first" href="{{{url}}}">{{title}}</a>
@@ -18,7 +18,7 @@
           {{/tags.length}}
 --!>          
       </p>
-      {{/entries}}
+      {{/posts}}
 
       <br><br>
 

--- a/app/templates/source/journal/search.html
+++ b/app/templates/source/journal/search.html
@@ -11,16 +11,16 @@
       <br>
 
       {{#query}}
-        {{^entries}}
+        {{^posts}}
         <p>Sorry, no results for “{{query}}”</p>
-        {{/entries}}
+        {{/posts}}
       {{/query}}
 
-      {{#entries}}
+      {{#posts}}
         <a href="{{{url}}}">{{title}}</a>
         <span class="small">{{date}}</span>
         <br>
-      {{/entries}}
+      {{/posts}}
     </div>
     {{> footer}}
     <script type="text/javascript">document.getElementById('search').focus();</script>

--- a/app/templates/source/journal/tagged.html
+++ b/app/templates/source/journal/tagged.html
@@ -5,11 +5,11 @@
     {{> header}}
     <div class="container">
       <h1>{{tag}}</h1>
-      {{#entries}}
+      {{#posts}}
       <a href="{{{url}}}">{{title}}</a>
       <span class="small">{{date}}</span>
       <br>
-      {{/entries}}
+      {{/posts}}
     </div>
     {{> footer}}
   </body>

--- a/app/templates/source/keynote/entries.html
+++ b/app/templates/source/keynote/entries.html
@@ -6,9 +6,9 @@
 
     <div class="gallery">
 
-    {{#entries}}
+    {{#posts}}
       {{> post}}
-    {{/entries}}
+    {{/posts}}
 
     </div>
 

--- a/app/templates/source/keynote/search.html
+++ b/app/templates/source/keynote/search.html
@@ -27,14 +27,14 @@
 
 
         {{#query}}
-          {{^entries}}
+          {{^posts}}
           <p>Sorry, no results for “{{query}}”</p>
-          {{/entries}}
+          {{/posts}}
         {{/query}}
 
-        {{#entries}}
+        {{#posts}}
           <a href="{{{url}}}">{{title}}</a> {{date}}<br>
-        {{/entries}}
+        {{/posts}}
       </p>
 
 

--- a/app/templates/source/keynote/tagged.html
+++ b/app/templates/source/keynote/tagged.html
@@ -6,9 +6,9 @@
 
     <h1>Posts tagged “{{tag}}”</h1>
 
-    {{#entries}}
+    {{#posts}}
     <a href="{{{url}}}">{{title}}</a> {{date}} <br>
-    {{/entries}}
+    {{/posts}}
 
     {{#pagination}}
     <div class="pagination">

--- a/app/templates/source/links/_footer.html
+++ b/app/templates/source/links/_footer.html
@@ -13,7 +13,7 @@
   <div style="display:flex;align-items: baseline;">
     <span style="text-decoration:none;color:rgba(0,0,0,.25);margin-top:2px;display:inline-block;text-transform:uppercase;font-size:11px">
   {{#pagination}}Page {{current}} of {{total}} {{/pagination}}
-  {{^pagination}}All {{entries.length}} posts{{/pagination}}</span>
+  {{^pagination}}All {{posts.length}} posts{{/pagination}}</span>
     <div style="flex-grow:1;">
 
       <div class="paginator" style=" margin:0 auto;   justify-content: center;">
@@ -24,7 +24,7 @@
     </div>
     <span style="text-decoration:none;color:rgba(0,0,0,.25);margin-top:2px;display:inline-block;text-transform:uppercase;font-size:11px">
   {{#pagination}}Page {{current}} of {{total}} {{/pagination}}
-  {{^pagination}}All {{entries.length}} posts{{/pagination}}</span>
+  {{^pagination}}All {{posts.length}} posts{{/pagination}}</span>
   </div>
 </div>
 

--- a/app/templates/source/links/_toolbar.html
+++ b/app/templates/source/links/_toolbar.html
@@ -8,7 +8,7 @@
 
     <span class="upper">
   {{#pagination}}Page {{current}} of {{total}} {{/pagination}}
-  {{^pagination}}All {{entries.length}} posts{{/pagination}}</span>
+  {{^pagination}}All {{posts.length}} posts{{/pagination}}</span>
   </div>
 
   <div class="tags-container">

--- a/app/templates/source/links/archives.html
+++ b/app/templates/source/links/archives.html
@@ -19,9 +19,9 @@
         </thead>
         {{#archives}}
         {{#months}}
-        {{#entries}}
+        {{#posts}}
         {{> row_link}}
-        {{/entries}}
+        {{/posts}}
         {{/months}}
         {{/archives}}
       </table>

--- a/app/templates/source/links/entries.html
+++ b/app/templates/source/links/entries.html
@@ -4,18 +4,18 @@
 {{> toolbar}}
 {{/pagination}}
 
-{{^entries.length}}
+{{^posts.length}}
 <div class="centered">
   <p>No posts yet.</p>
 </div>
-{{/entries.length}}
+{{/posts.length}}
 
-{{#entries.length}}
+{{#posts.length}}
 <div class="posts">
-  {{#entries}}
+  {{#posts}}
   {{> post}}
-  {{/entries}}
+  {{/posts}}
 </div>
-{{/entries.length}}
+{{/posts.length}}
 
 {{> footer}}

--- a/app/templates/source/links/script.js
+++ b/app/templates/source/links/script.js
@@ -200,11 +200,11 @@ function loadResults() {
     res = JSON.parse(res);
 
     // limit number of results to 15
-    res.entries = res.entries.slice(0, 15);
+    res.posts = res.posts.slice(0, 15);
 
     var result, html;
     html = "";
-    res.entries.forEach(function(entry) {
+    res.posts.forEach(function(entry) {
       result = "";
 
       result += '<a class="result" href="' + entry.url + '">';

--- a/app/templates/source/links/search.html
+++ b/app/templates/source/links/search.html
@@ -5,18 +5,18 @@
   <div style="padding:1.3rem 2rem">
     {{#query}}
     <h1>Search results for {{query}}</h1>
-    {{^entries.length}}
+    {{^posts.length}}
     <p>Nothing found.</p>
-    {{/entries.length}}
-    {{#entries.length}}
-    <small>{{entries.length}} entries found 
+    {{/posts.length}}
+    {{#posts.length}}
+    <small>{{posts.length}} entries found 
 </small>
-    {{/entries.length}}
+    {{/posts.length}}
     {{/query}}
 
     <div class="posts">
 
-      {{#entries}}
+      {{#posts}}
 
       <a class="post {{^thumbnail.medium}}no-thumbnail{{/thumbnail.medium}}" href="{{{url}}}">
 
@@ -40,7 +40,7 @@
   {{/thumbnail.medium}}
 </a>
 
-      {{/entries}}
+      {{/posts}}
 
     </div>
   </div>

--- a/app/templates/source/links/tagged.html
+++ b/app/templates/source/links/tagged.html
@@ -3,9 +3,9 @@
 {{> toolbar}}
 <div class="posts">
 
-  {{#entries}}
+  {{#posts}}
   {{> post}}
-  {{/entries}}
+  {{/posts}}
 
   {{#pagination}}
   <div class="pagination">

--- a/app/templates/source/links/tags.html
+++ b/app/templates/source/links/tags.html
@@ -16,7 +16,7 @@
 <a href="/tagged/{{slug}}" style="color:inherit;text-decoration:none;padding:0 1.3rem 1.3rem">
 
   <h3 style="margin:1.3rem 0 0rem">{{tag}}</h3>
-  <p style="margin:0"><small>{{entries.length}} posts</small></p>
+  <p style="margin:0"><small>{{posts.length}} posts</small></p>
   <div style="clear:both"></div>
 </a>
 {{/allTags}}

--- a/app/templates/source/magazine/archives.html
+++ b/app/templates/source/magazine/archives.html
@@ -17,9 +17,9 @@
     {{#months}}
     	<h3 class="mv0 pv2-5 black-50 bg-background bt b--black-10 fw3 f6 ttu w-20 fl pr4" style="position:sticky;top:-1px"><span style="position:relative;top:1px" class=" relative">{{month}}</span></h3>
 	    <div class="w-80  bt b--black-10 fl ">
-        {{#entries}}
+        {{#posts}}
     	    <a href="{{{url}}}" class="b--black-10 bb pv2-5 db pl2" style="border-color:rgba({{#rgb}}{{text_color}}{{/rgb}}, 0.05);margin-bottom:-1px">{{title}}</a>
-        {{/entries}}
+        {{/posts}}
         </div>
         <div class="cf"></div>
     {{/months}}

--- a/app/templates/source/magazine/entries.html
+++ b/app/templates/source/magazine/entries.html
@@ -1,9 +1,9 @@
 {{> header}}
 
 
-{{^pagination.previous}}{{^entries.length}}
+{{^pagination.previous}}{{^posts.length}}
 <p class="black-50 pt3">Nothing published yet.</p>
-{{/entries.length}}{{/pagination.previous}}
+{{/posts.length}}{{/pagination.previous}}
 
 {{#pagination.previous}}
 <div class="mt5 cf">
@@ -25,20 +25,20 @@
 {{^pagination.previous}}
 
 <div class="clip-1 mt3 featured-entry" style="display:flex;flex-direction:row;flex-wrap:  wrap">
-  {{#entries}}
+  {{#posts}}
   {{#first}}
   {{#thumbnail.large.url}}
   {{> featured}}
   {{/thumbnail.large.url}}
   {{/first}}
-  {{/entries}}
+  {{/posts}}
 </div>
 
-<div style="display:flex;flex-direction:row;flex-wrap:wrap"   {{#entries}} {{#first}} {{#thumbnail.large}} class="skip-1" {{/thumbnail.large}} {{/first}} {{/entries}}>
+<div style="display:flex;flex-direction:row;flex-wrap:wrap"   {{#posts}} {{#first}} {{#thumbnail.large}} class="skip-1" {{/thumbnail.large}} {{/first}} {{/posts}}>
 
-  {{#entries}}
+  {{#posts}}
   {{> entry_line}}
-  {{/entries}}
+  {{/posts}}
 </div>
 
 <div class="cf"></div>
@@ -48,9 +48,9 @@
 {{! All other pages}}
 {{#pagination.previous}}
 
-{{#entries}}
+{{#posts}}
 {{> entry_line}}
-{{/entries}}
+{{/posts}}
 {{/pagination.previous}}
 
 {{#pagination}}

--- a/app/templates/source/magazine/search.html
+++ b/app/templates/source/magazine/search.html
@@ -6,11 +6,11 @@
   <p class="fw5 pt2 mv0 pb4 black-80 bb b--black-10">Search</p>
 </div>
 
-  {{#entries.length}}
+  {{#posts.length}}
   <p class="w-third fl mt0 black-50"></p>
-  <p class="mt0   w-two-thirds fr black-50 ">Found {{entries.length}} results</p>
+  <p class="mt0   w-two-thirds fr black-50 ">Found {{posts.length}} results</p>
 <div class="cf"></div>
-  {{/entries.length}}
+  {{/posts.length}}
 
 <!--
 {{> tag_list}}
@@ -19,13 +19,13 @@
 -->
 
 {{#query}}
-  {{^entries}}
+  {{^posts}}
   <p class="black-50">No results for “{{query}}”</p>
-  {{/entries}}
+  {{/posts}}
 {{/query}}
 
-{{#entries}}
+{{#posts}}
   {{> entry_line}}
-{{/entries}}
+{{/posts}}
 
 {{> footer}}

--- a/app/templates/source/magazine/tagged.html
+++ b/app/templates/source/magazine/tagged.html
@@ -5,9 +5,9 @@
   <a class="fr pt4 black-50 no-underline mb4" href="/tags">All sections →</a>
 </div>
 
-{{#entries}}
+{{#posts}}
 {{> entry_line}}
-{{/entries}}
+{{/posts}}
 
 {{#pagination}}
 <div class="pagination">

--- a/app/templates/source/notebook/entries.html
+++ b/app/templates/source/notebook/entries.html
@@ -4,9 +4,9 @@
   <body>
     {{> header}}
 
-    {{#entries}}
+    {{#posts}}
       {{> post}}
-    {{/entries}}
+    {{/posts}}
 
    {{> footer}}
   </body>

--- a/app/templates/source/notebook/search.html
+++ b/app/templates/source/notebook/search.html
@@ -27,14 +27,14 @@
 
 
         {{#query}}
-          {{^entries}}
+          {{^posts}}
           <p>Sorry, no results for “{{query}}”</p>
-          {{/entries}}
+          {{/posts}}
         {{/query}}
 
-        {{#entries}}
+        {{#posts}}
           <a href="{{{url}}}">{{title}}</a> {{date}}<br>
-        {{/entries}}
+        {{/posts}}
       </p>
 
 

--- a/app/templates/source/notebook/tagged.html
+++ b/app/templates/source/notebook/tagged.html
@@ -6,9 +6,9 @@
 
     <h1>Posts tagged “{{tag}}”</h1>
 
-    {{#entries}}
+    {{#posts}}
     <a href="{{{url}}}">{{title}}</a> {{date}} <br>
-    {{/entries}}
+    {{/posts}}
 
     {{#pagination}}
     <div class="pagination">

--- a/app/templates/source/organization/archives.html
+++ b/app/templates/source/organization/archives.html
@@ -20,7 +20,7 @@
 
           {{#archives}}
           {{#months}}
-          {{#entries}}
+          {{#posts}}
           <div class="mb-2 d-flex justify-content-between main-loop-card">
             <div class="pr-3">
   <a class="text-dark" href="{{{url}}}">{{title}} <small class="text-muted">
@@ -33,7 +33,7 @@
             </div>
             
           </div>
-          {{/entries}}
+          {{/posts}}
           {{/months}}
           {{/archives}}
 

--- a/app/templates/source/organization/entries.html
+++ b/app/templates/source/organization/entries.html
@@ -15,7 +15,7 @@
       {{^pagination.previous}}
       <div class="row remove-site-content-margin">
 
-        {{#entries}}
+        {{#posts}}
         <!-- latest post -->
         {{#first}}
         <div class="col-md-6">
@@ -49,11 +49,11 @@
         </div>
         {{/first}}
 
-        {{/entries}}
+        {{/posts}}
      
         <div class="col-md-6 clip-3">
 
-          {{#entries}}
+          {{#posts}}
           {{^first}}
           <div class="mb-3 d-flex align-items-center">
 
@@ -83,7 +83,7 @@
             </div>
           </div>
           {{/first}}
-          {{/entries}}
+          {{/posts}}
 
         </div>
 
@@ -91,7 +91,7 @@
 
       <!-- Highlight (your own choice of highlighting a link, no post here) -->
       <div class="jumbotron jumbotron-fluid jumbotron-home pt-0 pb-0 mb-2rem bg-lightblue position-relative show-5">
-        {{#entries}}
+        {{#posts}}
         <div class="pl-4 pr-0 h-100 tofront ">
           <div class="row justify-content-between ">
             <div class="col-md-6 pt-6 pb-6 align-self-center">
@@ -104,7 +104,7 @@
             <div class="col-md-6 d-none d-md-block pr-0" style="background-size:cover;background-image:url({{{thumbnail.large.url}}});"> </div>
           </div>
         </div>
-        {{/entries}}
+        {{/posts}}
       </div>
       {{/pagination.previous}}
 
@@ -118,7 +118,7 @@
 
           <h4 class="font-weight-bold spanborder"><span>All Stories</span></h4>
 
-          {{#entries}}
+          {{#posts}}
           <div class="mb-5 d-flex justify-content-between main-loop-card">
             <div class="pr-3">
               <h2 class="mb-1 h4 font-weight-bold">
@@ -145,7 +145,7 @@
   </a>
             </div>
           </div>
-          {{/entries}}
+          {{/posts}}
 
           <div class="mt-5">
             <!-- Pagination links -->

--- a/app/templates/source/organization/search.html
+++ b/app/templates/source/organization/search.html
@@ -18,9 +18,9 @@
 
           <h4 class="font-weight-bold spanborder"><span>{{query}}</span></h4>
 
-          {{#query}}{{^entries.length}} No results.{{/entries.length}}{{/query}}
+          {{#query}}{{^posts.length}} No results.{{/posts.length}}{{/query}}
 
-          {{#entries}}
+          {{#posts}}
           <div class="mb-2 d-flex justify-content-between main-loop-card">
             <div class="pr-3">
   <a class="text-dark" href="{{{url}}}">{{title}} <small class="text-muted">
@@ -33,7 +33,7 @@
             </div>
             
           </div>
-          {{/entries}}
+          {{/posts}}
 
 
         </div>

--- a/app/templates/source/organization/tagged.html
+++ b/app/templates/source/organization/tagged.html
@@ -19,7 +19,7 @@
           <h4 class="font-weight-bold spanborder"><span>{{tag}}</span></h4>
 
 
-          {{#entries}}
+          {{#posts}}
           <div class="mb-2 d-flex justify-content-between main-loop-card">
             <div class="pr-3">
   <a class="text-dark" href="{{{url}}}">{{title}} <small class="text-muted">
@@ -32,7 +32,7 @@
             </div>
 
           </div>
-          {{/entries}}
+          {{/posts}}
 
           {{#pagination}}
           <div class="pagination">

--- a/app/templates/source/portfolio/archives.html
+++ b/app/templates/source/portfolio/archives.html
@@ -23,7 +23,7 @@
 <div class="archives">
   {{#archives}}
   {{#months}}
-  {{#entries}}
+  {{#posts}}
   <a href="{{{url}}}">
     <span class="thumbnail">
     {{#thumbnail.small.url}}
@@ -35,7 +35,7 @@
     </span>
     <span><span class="title">{{title}}</span><span class="date">{{date}}</span></span>
   </a>
-  {{/entries}}
+  {{/posts}}
   {{/months}}
   {{/archives}}
 </div>

--- a/app/templates/source/portfolio/fitted-grid.html
+++ b/app/templates/source/portfolio/fitted-grid.html
@@ -1,5 +1,5 @@
 <div class="posts">
-  {{#entries}}
+  {{#posts}}
 
   <!-- These posts have photos -->
   {{#thumbnail.large.url}}
@@ -27,5 +27,5 @@
   </a>
   {{/thumbnail.large.url}}
   
-  {{/entries}}
+  {{/posts}}
 </div>

--- a/app/templates/source/portfolio/search.html
+++ b/app/templates/source/portfolio/search.html
@@ -21,7 +21,7 @@
 
 <div class="archives">
 
-  {{#entries}}
+  {{#posts}}
   <a href="{{{url}}}">
     <span class="thumbnail">
     {{#thumbnail.small.url}}
@@ -34,7 +34,7 @@
     <span class="title">{{title}}    <span class="date">{{date}}</span>
 </span>
   </a>
-  {{/entries}}
+  {{/posts}}
 </div>
 
 {{> footer}}

--- a/app/templates/source/profile/_post-list.html
+++ b/app/templates/source/profile/_post-list.html
@@ -1,5 +1,5 @@
 <ul id="post-list">
-  {{#entries}}
+  {{#posts}}
   <li>
     <article>
       {{^titleTag}}
@@ -23,7 +23,7 @@
     </article>
   </li>
   <span class="separator"><span class="divider"></span></span>
-  {{/entries}}
+  {{/posts}}
 </ul>
 
 {{> pagination}}

--- a/app/templates/source/profile/archives.html
+++ b/app/templates/source/profile/archives.html
@@ -18,14 +18,14 @@
   {{> navigation}}
 
   <section id="wrapper">
-    {{#archives}}{{#months}}{{#entries}}
+    {{#archives}}{{#months}}{{#posts}}
 
     <p class="h-entry">
       <a href="{{{url}}}" class="u-url"><span class="dt-published" datetime="{{date}}">{{date}}</span></a>:
       <span class="p-name"><b></b></span>
       <span class="p-summary">{{title}}</span>
     </p>
-    {{/entries}}{{/months}}{{/archives}}
+    {{/posts}}{{/months}}{{/archives}}
   </section>
 
   <footer id="footer">

--- a/app/templates/source/profile/search.html
+++ b/app/templates/source/profile/search.html
@@ -24,24 +24,24 @@
     </form>
 
     {{#query}}
-    {{^entries.length}}
+    {{^posts.length}}
     <center>
       <p><small>Nothing found.</small></p>
     </center>
-    {{/entries.length}}
-    {{#entries.length}}
+    {{/posts.length}}
+    {{#posts.length}}
     <center>
-      <p><small>{{entries.length}} entries found </small></p>
+      <p><small>{{posts.length}} entries found </small></p>
     </center>
 
-    {{/entries.length}}
-    {{/query}} {{#entries}}
+    {{/posts.length}}
+    {{/query}} {{#posts}}
     <p class="h-entry">
       <a href="{{{url}}}" class="u-url"><span class="dt-published" datetime="{{date}}">{{date}}</span></a>:
       <span class="p-name"><b></b></span>
       <span class="p-summary">{{title}}</span>
     </p>
-    {{/entries}}
+    {{/posts}}
   </section>
 
   <footer id="footer">

--- a/app/templates/source/studio/archives.html
+++ b/app/templates/source/studio/archives.html
@@ -10,9 +10,9 @@
         {{#months}}
           <h3 class="">{{month}}</h3>
           <p>
-          {{#entries}}
+          {{#posts}}
           <a href="{{{url}}}">{{title}}</a><br>
-          {{/entries}}
+          {{/posts}}
           <br>
           </p>
         {{/months}}

--- a/app/templates/source/studio/entries.html
+++ b/app/templates/source/studio/entries.html
@@ -9,7 +9,7 @@
 
         <div class="grid-sizer"></div>
 
-      {{#entries}}
+      {{#posts}}
         <div class="grid-item">
 
           <a href="{{{url}}}" style="line-height:1.5;display:block;margin:1em 0;font-size:16px">
@@ -26,7 +26,7 @@
 
         </div>
 
-      {{/entries}}
+      {{/posts}}
 
       </div>
 

--- a/app/templates/source/studio/search.html
+++ b/app/templates/source/studio/search.html
@@ -11,16 +11,16 @@
       <br>
 
       {{#query}}
-        {{^entries}}
+        {{^posts}}
         <p>Sorry, no results for “{{query}}”</p>
-        {{/entries}}
+        {{/posts}}
       {{/query}}
 
-      {{#entries}}
+      {{#posts}}
         <a href="{{{url}}}">{{title}}</a>
         <span class="small">{{date}}</span>
         <br>
-      {{/entries}}
+      {{/posts}}
     </div>
     {{> footer}}
     <script type="text/javascript">document.getElementById('search').focus();</script>

--- a/app/templates/source/studio/tagged.html
+++ b/app/templates/source/studio/tagged.html
@@ -10,7 +10,7 @@
 
         <div class="grid-sizer"></div>
 
-      {{#entries}}
+      {{#posts}}
         <div class="grid-item">
 
           <a href="{{{url}}}" style="line-height:1.5;display:block;margin:1em 0;font-size:16px">
@@ -27,7 +27,7 @@
 
         </div>
 
-      {{/entries}}
+      {{/posts}}
 
       </div>
 

--- a/app/templates/source/text/entries.html
+++ b/app/templates/source/text/entries.html
@@ -6,7 +6,7 @@
   {{> header}}
   <div class="container">
     <div class="main">
-      {{#entries}}
+      {{#posts}}
 
       {{#is.index_layout.titles}}
       <p><a href="{{{url}}}">{{title}}</a><br>
@@ -46,7 +46,7 @@
       </div>
       {{/is.index_layout.post_in_full}}
 
-      {{/entries}}
+      {{/posts}}
 
       {{#pagination}}
       <div class="pagination">

--- a/app/templates/source/text/search.html
+++ b/app/templates/source/text/search.html
@@ -11,30 +11,30 @@
       </form>
       <div>
 
-        {{#entries.length}}
+        {{#posts.length}}
         <p>Found
-          {{#entries}}
+          {{#posts}}
           {{#first}}
           {{#last}}
-          {{entries.length}} result
+          {{posts.length}} result
           {{/last}}
           {{^last}}
-          {{entries.length}} results
+          {{posts.length}} results
           {{/last}}
           {{/first}}
-          {{/entries}}
+          {{/posts}}
         </p>
-        {{/entries.length}}
-        {{^entries}}
+        {{/posts.length}}
+        {{^posts}}
         {{#query}}
         <p>No results</p>
         {{/query}}
-        {{/entries}}
+        {{/posts}}
 
         <p>
-          {{#entries}}
+          {{#posts}}
           <a class="full-line" href="{{{url}}}"><em>{{title}}</em> &nbsp;<span class="small">{{date}}</span></a>
-          {{/entries}}
+          {{/posts}}
         </p>
 
 

--- a/app/templates/source/text/tagged.html
+++ b/app/templates/source/text/tagged.html
@@ -8,9 +8,9 @@
     <div class="main">
       <h1>{{tag}}</h1>
       <div>
-        {{#entries}}
+        {{#posts}}
         <a class="full-line" href="{{{url}}}"><em>{{title}}</em> &nbsp;<span class="small">{{date}}</span></a>
-        {{/entries}}
+        {{/posts}}
       </div>
       {{#pagination}}
       <div class="pagination">

--- a/app/templates/source/wireframe/archives.html
+++ b/app/templates/source/wireframe/archives.html
@@ -11,9 +11,9 @@
         <h3>{{month}} - {{year}}</h3>
 
         <p>
-        {{#entries}}
+        {{#posts}}
         <a href="{{{url}}}">{{title}}</a><br>
-        {{/entries}}
+        {{/posts}}
         </p>
 
       {{/months}}

--- a/app/templates/source/wireframe/search.html
+++ b/app/templates/source/wireframe/search.html
@@ -11,14 +11,14 @@
     <br>
 
     {{#query}}
-      {{^entries}}
+      {{^posts}}
       <p>Sorry, no results for “{{query}}”</p>
-      {{/entries}}
+      {{/posts}}
     {{/query}}
 
-    {{#entries}}
+    {{#posts}}
       <a href="{{{url}}}">{{title}}</a> {{date}}<br>
-    {{/entries}}
+    {{/posts}}
 
     {{> footer}}
   </body>

--- a/app/templates/source/wireframe/tagged.html
+++ b/app/templates/source/wireframe/tagged.html
@@ -6,9 +6,9 @@
 
     <h1>Posts tagged “{{tag}}”</h1>
 
-    {{#entries}}
+    {{#posts}}
     <a href="{{{url}}}">{{title}}</a> {{date}} <br>
-    {{/entries}}
+    {{/posts}}
 
     {{#pagination}}
     <div class="pagination">

--- a/app/templates/source/zine/archives.html
+++ b/app/templates/source/zine/archives.html
@@ -9,9 +9,9 @@
         {{#months}}
           <h3>{{month}}</h3>
           <p>
-          {{#entries}}
+          {{#posts}}
           <a href="{{{url}}}">{{title}}</a><br>
-          {{/entries}}
+          {{/posts}}
           <br>
           </p>
         {{/months}}

--- a/app/templates/source/zine/entries.html
+++ b/app/templates/source/zine/entries.html
@@ -5,12 +5,12 @@
     {{> header}}
 
     <p class="entries">
-      {{#entries}}
+      {{#posts}}
       <a href="{{{url}}}" 
         ><span>{{title}}</span>
       </a>
       <span class="light">{{date}} {{^last}}//{{/last}}</span>
-      {{/entries}}
+      {{/posts}}
     </p>
 
     <br><br>

--- a/app/templates/source/zine/search.html
+++ b/app/templates/source/zine/search.html
@@ -11,16 +11,16 @@
       <br>
 
       {{#query}}
-        {{^entries}}
+        {{^posts}}
         <p>Sorry, no results for “{{query}}”</p>
-        {{/entries}}
+        {{/posts}}
       {{/query}}
 
-      {{#entries}}
+      {{#posts}}
         <a href="{{{url}}}">{{title}}</a>
         <span class="small">{{date}}</span>
         <br>
-      {{/entries}}
+      {{/posts}}
     </div>
     {{> footer}}
     <script type="text/javascript">document.getElementById('search').focus();</script>

--- a/app/templates/source/zine/tagged.html
+++ b/app/templates/source/zine/tagged.html
@@ -5,11 +5,11 @@
     {{> header}}
     <div class="container">
       <h1>{{tag}}</h1><br>
-      {{#entries}}
+      {{#posts}}
       <a href="{{{url}}}">{{title}}</a>
       <span class="small">{{date}}</span>
       <br>
-      {{/entries}}
+      {{/posts}}
       <br>
       {{#pagination}}
       <div class="pagination small">


### PR DESCRIPTION
## Summary
- update base templates to use `posts` sections instead of `entries` blocks for post listings
- align pagination/search references and documentation snippet with new `posts` naming
- adjust links search JavaScript to read results from `posts`

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928480f76c883298cdf8096cb4ffe3b)