### PR TITLE
Handle Bunny CDN purge rate limits

### DIFF
--- a/app/helper/purgeCdnUrls.js
+++ b/app/helper/purgeCdnUrls.js
@@ -1,6 +1,76 @@
 const config = require("config");
 const fetch = require("node-fetch");
 
+const MAX_URLS_PER_REQUEST = 100;
+const MAX_RETRIES = 3;
+const INITIAL_BACKOFF_MS = 500;
+const PURGE_ENDPOINT = "https://api.bunny.net/purge";
+
+function sleep(durationMs) {
+  return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
+function normalizeUrls(urls) {
+  if (!Array.isArray(urls)) return [];
+
+  const uniqueUrls = new Set();
+
+  for (const url of urls) {
+    if (typeof url !== "string") continue;
+
+    try {
+      uniqueUrls.add(new URL(url).toString());
+    } catch (err) {
+      console.error(`Skipping invalid URL for Bunny CDN purge: ${url}`);
+    }
+  }
+
+  return Array.from(uniqueUrls);
+}
+
+function toBatches(items, size) {
+  const batches = [];
+
+  for (let i = 0; i < items.length; i += size) {
+    batches.push(items.slice(i, i + size));
+  }
+
+  return batches;
+}
+
+async function purgeBatch(batch, attempt = 0, backoffMs = INITIAL_BACKOFF_MS) {
+  try {
+    const res = await fetch(PURGE_ENDPOINT, {
+      method: "POST",
+      headers: {
+        AccessKey: config.bunny.secret,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ urls: batch.map(encodeURIComponent), async: false }),
+    });
+
+    if (res.status === 200) {
+      console.log(`Purged Bunny CDN URLs: ${batch.join(", ")}`);
+      return;
+    }
+
+    if (res.status === 429 && attempt < MAX_RETRIES) {
+      const retryAfterHeader = res.headers.get("retry-after");
+      const retryDelayMs = retryAfterHeader
+        ? Number(retryAfterHeader) * 1000
+        : backoffMs;
+
+      await sleep(retryDelayMs);
+
+      return purgeBatch(batch, attempt + 1, backoffMs * 2);
+    }
+
+    console.error(`Failed to purge Bunny CDN: ${batch.join(", ")}`, res.status);
+  } catch (err) {
+    console.error(`Error purging Bunny CDN: ${batch.join(", ")}`, err);
+  }
+}
+
 /**
  * Purge URLs from Bunny CDN cache
  * @param {string[]} urls - Array of URLs to purge (will be encoded internally)
@@ -15,26 +85,16 @@ async function purgeCdnUrls(urls) {
     return;
   }
 
-  if (!Array.isArray(urls) || urls.length === 0) {
+  const normalizedUrls = normalizeUrls(urls);
+
+  if (normalizedUrls.length === 0) {
     return;
   }
 
-  for (const urlToPurge of urls) {
-    try {
-      const url = `https://api.bunny.net/purge?url=${encodeURIComponent(urlToPurge)}&async=false`;
-      const res = await fetch(url, {
-        method: "POST",
-        headers: { AccessKey: config.bunny.secret },
-      });
+  const batches = toBatches(normalizedUrls, MAX_URLS_PER_REQUEST);
 
-      if (res.status !== 200) {
-        console.error(`Failed to purge Bunny CDN: ${urlToPurge}`, res.status);
-      } else {
-        console.log(`Purged Bunny CDN: ${urlToPurge}`);
-      }
-    } catch (err) {
-      console.error(`Error purging Bunny CDN: ${urlToPurge}`, err);
-    }
+  for (const batch of batches) {
+    await purgeBatch(batch);
   }
 }
 

--- a/app/helper/tests/purgeCdnUrls.js
+++ b/app/helper/tests/purgeCdnUrls.js
@@ -1,18 +1,29 @@
 const config = require("config");
 const purgeCdnUrls = require("../purgeCdnUrls");
+const nock = require("nock");
 
 describe("purgeCdnUrls", function () {
   const originalEnv = process.env.NODE_ENV;
   const originalBunny = config.bunny;
+  const originalConfigEnvironment = config.environment;
+
+  beforeEach(function () {
+    nock.cleanAll();
+    nock.disableNetConnect();
+  });
 
   afterEach(function () {
     process.env.NODE_ENV = originalEnv;
     config.bunny = originalBunny;
+    config.environment = originalConfigEnvironment;
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 
   it("does nothing in non-production environments", async function () {
     process.env.NODE_ENV = "development";
-    
+    config.environment = "development";
+
     // Should not throw or make any requests
     await purgeCdnUrls(["https://example.com/test"]);
     
@@ -22,8 +33,9 @@ describe("purgeCdnUrls", function () {
 
   it("does nothing when bunny secret is missing", async function () {
     process.env.NODE_ENV = "production";
+    config.environment = "production";
     config.bunny = null;
-    
+
     await purgeCdnUrls(["https://example.com/test"]);
     
     expect(true).toBe(true);
@@ -31,8 +43,9 @@ describe("purgeCdnUrls", function () {
 
   it("does nothing when bunny secret is empty", async function () {
     process.env.NODE_ENV = "production";
+    config.environment = "production";
     config.bunny = { secret: "" };
-    
+
     await purgeCdnUrls(["https://example.com/test"]);
     
     expect(true).toBe(true);
@@ -40,8 +53,9 @@ describe("purgeCdnUrls", function () {
 
   it("does nothing with empty URL array", async function () {
     process.env.NODE_ENV = "production";
+    config.environment = "production";
     config.bunny = { secret: "test-secret" };
-    
+
     await purgeCdnUrls([]);
     
     expect(true).toBe(true);
@@ -49,8 +63,9 @@ describe("purgeCdnUrls", function () {
 
   it("does nothing with null/undefined URLs", async function () {
     process.env.NODE_ENV = "production";
+    config.environment = "production";
     config.bunny = { secret: "test-secret" };
-    
+
     await purgeCdnUrls(null);
     await purgeCdnUrls(undefined);
     
@@ -59,12 +74,53 @@ describe("purgeCdnUrls", function () {
 
   it("handles invalid URL format gracefully", async function () {
     process.env.NODE_ENV = "production";
+    config.environment = "production";
     config.bunny = { secret: "test-secret" };
-    
+
     // Should not throw even with invalid URLs
     await purgeCdnUrls(["not-a-valid-url", "also-invalid"]);
-    
+
     expect(true).toBe(true);
+  });
+
+  it("batches urls into a single purge request", async function () {
+    process.env.NODE_ENV = "production";
+    config.environment = "production";
+    config.bunny = { secret: "test-secret" };
+
+    const scope = nock("https://api.bunny.net")
+      .post("/purge", (body) => {
+        expect(body.urls).toEqual([
+          encodeURIComponent("https://example.com/a"),
+          encodeURIComponent("https://example.com/b"),
+        ]);
+        expect(body.async).toBe(false);
+        return true;
+      })
+      .reply(200, { success: true });
+
+    await purgeCdnUrls([
+      "https://example.com/a",
+      "https://example.com/b",
+    ]);
+
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it("retries purge requests after receiving 429 responses", async function () {
+    process.env.NODE_ENV = "production";
+    config.environment = "production";
+    config.bunny = { secret: "test-secret" };
+
+    const scope = nock("https://api.bunny.net")
+      .post("/purge")
+      .reply(429, {}, { "Retry-After": "0" })
+      .post("/purge")
+      .reply(200, { success: true });
+
+    await purgeCdnUrls(["https://example.com/rate-limited"]);
+
+    expect(scope.isDone()).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- normalize Bunny CDN purge inputs and send URLs in batches to the purge endpoint
- add retry and backoff handling for HTTP 429 responses during purge requests
- expand purgeCdnUrls tests to cover batching and rate limit retries with mocked responses

## Testing
- NODE_PATH=app node scripts/tests/index.js app/helper/tests/purgeCdnUrls.js *(fails: Redis connection refused outside test container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692848354c04832980ae0f1b45a91988)