### PR TITLE
Enforce template view size limits

### DIFF
--- a/app/models/template/index.js
+++ b/app/models/template/index.js
@@ -1,5 +1,7 @@
 var siteOwner = "SITE";
 
+const setView = require("./setView");
+
 module.exports = {
   create: require("./create"),
   update: require("./update"),
@@ -9,7 +11,7 @@ module.exports = {
   getFullView: require("./getFullView"),
   getView: require("./getView"),
   getViewByURL: require("./getViewByURL"),
-  setView: require("./setView"),
+  setView,
   dropView: require("./dropView"),
   getPartials: require("./getPartials"),
   getAllViews: require("./getAllViews"),
@@ -33,4 +35,7 @@ module.exports = {
   package: require("./package"),
   viewModel: require("./viewModel"),
   metadataModel: require("./metadataModel"),
+  MAX_VIEW_CONTENT_BYTES: setView.MAX_VIEW_CONTENT_BYTES,
+  VIEW_TOO_LARGE_ERROR_CODE: setView.VIEW_TOO_LARGE_ERROR_CODE,
+  VIEW_TOO_LARGE_MESSAGE: setView.VIEW_TOO_LARGE_MESSAGE,
 };

--- a/app/views/dashboard/template/js/error-display.js
+++ b/app/views/dashboard/template/js/error-display.js
@@ -1,0 +1,28 @@
+function getErrorElement(doc) {
+  if (!doc || typeof doc.querySelector !== "function") return null;
+  return doc.querySelector(".error");
+}
+
+function showError(doc, msg) {
+  const el = getErrorElement(doc);
+  if (!el) return false;
+
+  el.textContent = msg || "An error occurred";
+  el.style.display = "block";
+  el.style.opacity = "1";
+  return true;
+}
+
+function hideError(doc) {
+  const el = getErrorElement(doc);
+  if (!el) return false;
+
+  el.style.display = "none";
+  return true;
+}
+
+module.exports = {
+  getErrorElement,
+  showError,
+  hideError,
+};

--- a/app/views/dashboard/template/js/source-code-editor.js
+++ b/app/views/dashboard/template/js/source-code-editor.js
@@ -1,5 +1,6 @@
 const CodeMirror = require("./codemirror/codemirror.js");
 const initSidebarActionMenu = require("./sidebar-action-menu");
+const { showError, hideError } = require("./error-display");
 
 require("./codemirror/active-line.js");
 require("./codemirror/mode-css.js");
@@ -65,20 +66,6 @@ function initializeSourceEditor() {
     saveButton.classList.toggle("disabled", !!disabledClass);
   }
 
-  function showError(msg) {
-    var el = document.querySelector(".error");
-    if (!el) return;
-    el.textContent = msg || "An error occurred";
-    el.style.display = "block";
-    el.style.opacity = "1";
-  }
-
-  function hideError() {
-    var el = document.querySelector(".error");
-    if (!el) return;
-    el.style.display = "none";
-  }
-
   function fadeOutSuccessAfter(ms) {
     var el = document.querySelector(".success");
     if (!el) return;
@@ -115,7 +102,7 @@ function initializeSourceEditor() {
     var contentInput = form.querySelector('input[name="content"]');
     if (contentInput) contentInput.value = editor.getValue();
 
-    hideError();
+    hideError(document);
 
     try {
       const body = serializeForm(form);
@@ -144,7 +131,7 @@ function initializeSourceEditor() {
           working: false,
           disabledClass: false,
         });
-        showError(text);
+        showError(document, text);
         return false;
       }
 
@@ -156,7 +143,7 @@ function initializeSourceEditor() {
         disabledClass: true,
       });
 
-      hideError();
+      hideError(document);
       fadeOutSuccessAfter(3000);
     } catch (err) {
       setButtonState({
@@ -166,7 +153,10 @@ function initializeSourceEditor() {
         working: false,
         disabledClass: false,
       });
-      showError(String(err && err.message ? err.message : err));
+      showError(
+        document,
+        String(err && err.message ? err.message : err)
+      );
     }
 
     return false;

--- a/app/views/dashboard/template/js/tests/error-display.js
+++ b/app/views/dashboard/template/js/tests/error-display.js
@@ -1,0 +1,32 @@
+describe("template source editor error display", function () {
+  const { showError, hideError } = require("../error-display");
+  const { VIEW_TOO_LARGE_MESSAGE } = require("../../../../../models/template/setView");
+
+  function createDoc() {
+    const el = { style: {}, textContent: "" };
+    return {
+      el,
+      querySelector: (selector) => (selector === ".error" ? el : null),
+    };
+  }
+
+  it("shows the provided message in the error container", function () {
+    const doc = createDoc();
+    const handled = showError(doc, VIEW_TOO_LARGE_MESSAGE);
+
+    expect(handled).toBe(true);
+    expect(doc.el.textContent).toBe(VIEW_TOO_LARGE_MESSAGE);
+    expect(doc.el.style.display).toBe("block");
+    expect(doc.el.style.opacity).toBe("1");
+  });
+
+  it("hides the error container when requested", function () {
+    const doc = createDoc();
+
+    showError(doc, "Oops");
+    const handled = hideError(doc);
+
+    expect(handled).toBe(true);
+    expect(doc.el.style.display).toBe("none");
+  });
+});


### PR DESCRIPTION
## Summary
- add a 512 KB content limit to template view persistence with exported constants
- return clear 400 responses for oversized template saves and reuse a shared editor error display helper
- add backend and UI-facing tests covering the new validation and error messaging

## Testing
- npm test -- app/models/template/tests/setView.js *(fails: missing ./scripts/tests/test.env)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69296300a19083299ebf3d773f5ad75e)