### PR TITLE
Add error handling to disconnect route

### DIFF
--- a/app/clients/icloud/macserver/routes/disconnect.js
+++ b/app/clients/icloud/macserver/routes/disconnect.js
@@ -2,6 +2,7 @@ const fs = require("fs-extra");
 const { join } = require("path");
 const { iCloudDriveDirectory } = require("../config");
 const { removeLimiterForBlogID } = require("../limiters");
+const { unwatch } = require("../watcher");
 
 module.exports = async (req, res) => {
   const blogID = req.header("blogID");
@@ -20,8 +21,14 @@ module.exports = async (req, res) => {
 
   // remove the blogid folder and the limiter
   removeLimiterForBlogID(blogID);
-  
-  await fs.remove(join(iCloudDriveDirectory, blogID));
+
+  try {
+    await unwatch(blogID);
+    await fs.remove(join(iCloudDriveDirectory, blogID));
+  } catch (error) {
+    console.error(`Failed to disconnect blogID ${blogID}:`, error);
+    return res.status(500).send(error.message);
+  }
 
   console.log(`Disconnected blogID: ${blogID}`);
 


### PR DESCRIPTION
## Summary
- unwatch the blog before removing its directory and remove its limiter
- wrap directory removal in error handling with logging and 500 responses

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a74c5d9c8329b75351da796fea4c)