### PR TITLE
Refresh local-edit package saves before syncing

### DIFF
--- a/app/dashboard/site/template/save/writeChangeToFolder.js
+++ b/app/dashboard/site/template/save/writeChangeToFolder.js
@@ -1,15 +1,25 @@
 const clfdate = require("helper/clfdate");
-const {writeToFolder} = require("models/template");
+const { getMetadata, writeToFolder } = require("models/template");
 
-module.exports = function(blog, template, view, callback) {
+module.exports = function (blog, template, view, callback) {
+  console.log(clfdate(), "writeChangeToFolder", blog.id, template.id, view.name);
 
-    console.log(clfdate(), "writeChangeToFolder", blog.id, template.id, view.name);
-
-    if (!template.localEditing) {
-        console.log(clfdate(), "writeChangeToFolder", "No local editing");
-        return callback();
+  const ensureMetadata = (metadata) => {
+    if (!metadata || !metadata.localEditing) {
+      console.log(clfdate(), "writeChangeToFolder", "No local editing");
+      return callback();
     }
 
     console.log(clfdate(), "writeChangeToFolder", "Writing to folder");
-    writeToFolder(blog.id, template.id, callback);
-}
+    writeToFolder(blog.id, metadata.id || template.id, callback);
+  };
+
+  if (template && template.localEditing) {
+    return ensureMetadata(template);
+  }
+
+  getMetadata(template.id, function (err, metadata) {
+    if (err) return callback(err);
+    ensureMetadata(metadata || template);
+  });
+};

--- a/app/models/template/tests/writeToFolder.js
+++ b/app/models/template/tests/writeToFolder.js
@@ -3,10 +3,12 @@ var join = require("path").join;
 var clients = require("clients");
 
 describe("template", function () {
-  var writeToFolder = require("../index").writeToFolder;
-  var setView = require("../index").setView;
-  var dropView = require("../index").dropView;
-  var setMetadata = require("../index").setMetadata;
+var writeToFolder = require("../index").writeToFolder;
+var setView = require("../index").setView;
+var dropView = require("../index").dropView;
+var setMetadata = require("../index").setMetadata;
+var packageAPI = require("../index").package;
+var writeChangeToFolder = require("../../../dashboard/site/template/save/writeChangeToFolder");
 
   require("./setup")({ createTemplate: true });
 
@@ -80,6 +82,29 @@ describe("template", function () {
         expect(fs.readJsonSync(targetPath).locals).toEqual(metadata.locals);
         done();
       });
+    });
+  });
+
+  it("regenerates package.json in the local folder when local editing is enabled via package save", function (done) {
+    var test = this;
+    var packageMetadata = { localEditing: true, name: "Local Package" };
+    var staleTemplate = Object.assign({}, this.template, { localEditing: false });
+
+    packageAPI.save(this.template.id, packageMetadata, function (err) {
+      if (err) return done.fail(err);
+
+      writeChangeToFolder(
+        test.blog,
+        staleTemplate,
+        { name: "package.json" },
+        function (err) {
+          if (err) return done.fail(err);
+
+          var packagePath = getTemplatePath(test, "package.json");
+          expect(fs.readJsonSync(packagePath).name).toEqual(packageMetadata.name);
+          done();
+        }
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Reload template metadata after package.json saves so local editing state is current before syncing
- Ensure write-to-folder checks the latest localEditing setting and regenerates package.json accordingly
- Add a regression test verifying package.json saves trigger folder regeneration when local editing is enabled

## Testing
- npm test -- app/models/template/tests/writeToFolder.js *(fails: npm unavailable in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693333bce6e88329802f362f654e6051)