### PR TITLE
Add script to set entry datestamp interactively

### DIFF
--- a/scripts/entry/set-datestamp.js
+++ b/scripts/entry/set-datestamp.js
@@ -41,8 +41,8 @@ get(url, async function (err, user, blog, entry) {
 
   console.log(
     "Current dateStamp:",
-    entry.dateStamp,
-    `(${new Date(entry.dateStamp).toUTCString()})`
+    entry.dateStamp ?? "not set",
+    entry.dateStamp ? `(${new Date(entry.dateStamp).toUTCString()})` : ""
   );
 
   const timestamps = [];
@@ -51,7 +51,7 @@ get(url, async function (err, user, blog, entry) {
   if (typeof entry.updated === "number") timestamps.push(entry.updated);
 
   if (timestamps.length) {
-    const earliest = Math.min.apply(null, timestamps);
+    const earliest = Math.min(...timestamps);
     const sourceTimeLabel =
       earliest === entry.created ? "Creation time" : "Last modified time";
 
@@ -74,7 +74,7 @@ get(url, async function (err, user, blog, entry) {
     process.exit(1);
   }
 
-  const parsed = moment(input);
+  const parsed = moment.utc(input);
 
   if (!parsed.isValid()) {
     console.error(


### PR DESCRIPTION
## Summary
- add a script to set an entry's dateStamp based on user-provided input
- validate the parsed date with moment, display changes, and prompt for confirmation before updating

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b2861daec8329931a7119ddad41c9)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an interactive CLI to set an entry's dateStamp with UTC parsing, validation, and confirmation.
> 
> - **CLI script `scripts/entry/set-datestamp.js`**:
>   - Retrieves entry by URL and shows current `dateStamp` plus earliest source timestamp (`created`/`updated`).
>   - Prompts for a new date, parses in UTC with `moment`, validates, and displays the parsed value.
>   - Confirms with the user, then updates `Entry.set` with the new `dateStamp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d84a898198ddfad847837def4e120eb0d5147069. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->