### PR TITLE
Handle plugin render result objects

### DIFF
--- a/app/build/plugins/index.js
+++ b/app/build/plugins/index.js
@@ -140,13 +140,20 @@ function convert (blog, path, contents, callback) {
           timeout = Timeout(id, next);
           time(id);
 
+          // Plugins should call their render callbacks with
+          // cb(null, { newDependencies }) to allow us to extend
+          // the result object with future fields (e.g. toc).
           plugin.render(
             $,
-            function (err, newDependencies) {
+            function (err, result) {
               time.end(id);
-              if (newDependencies) {
-                dependencies = dependencies.concat(newDependencies);
+
+              const res = Array.isArray(result) ? { newDependencies: result } : result || {};
+
+              if (res.newDependencies) {
+                dependencies = dependencies.concat(res.newDependencies);
               }
+
               clearTimeout(timeout);
               next();
             },

--- a/app/build/plugins/wikilinks/index.js
+++ b/app/build/plugins/wikilinks/index.js
@@ -152,7 +152,7 @@ function render($, callback, { blogID, path }) {
       });
     },
     function () {
-      callback(null, dependencies);
+      callback(null, { newDependencies: dependencies });
     }
   );
 }

--- a/app/build/tests/plugins/runner.js
+++ b/app/build/tests/plugins/runner.js
@@ -1,0 +1,41 @@
+const { convert } = require("../../plugins");
+
+describe("plugin runner", function () {
+  const blogBase = {
+    domain: "example.com",
+    handle: "plugin-runner",
+    id: "plugin-runner-test",
+  };
+
+  function runPlugins(plugins, contents) {
+    return new Promise((resolve, reject) => {
+      convert(
+        { ...blogBase, plugins },
+        "/post.html",
+        contents,
+        function (err, html, dependencies) {
+          if (err) return reject(err);
+          resolve({ html, dependencies });
+        }
+      );
+    });
+  }
+
+  it("collects newDependencies from plugin results", async function () {
+    const plugins = { wikilinks: { enabled: true, options: {} } };
+    const contents = '<a href="target" title="wikilink">wikilink</a>';
+
+    const { dependencies } = await runPlugins(plugins, contents);
+
+    expect(dependencies).toContain("/target");
+  });
+
+  it("ignores plugins that return no result", async function () {
+    const plugins = { autoImage: { enabled: true, options: {} } };
+    const contents = "<p><a href='https://example.com/image.jpg'>https://example.com/image.jpg</a></p>";
+
+    const { dependencies } = await runPlugins(plugins, contents);
+
+    expect(dependencies.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize plugin render callbacks to accept result objects and preserve dependency aggregation
- update wikilinks plugin to return dependencies via the new result shape
- add tests covering dependency aggregation and empty results in the plugin runner

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693be383ed4c8329a6722a53d69c93d8)