### PR TITLE
Add table of contents plugin support

### DIFF
--- a/app/blog/tests/toc.js
+++ b/app/blog/tests/toc.js
@@ -1,0 +1,92 @@
+const cheerio = require("cheerio");
+const getEntry = require("../../models/entry/get");
+
+describe("toc plugin", function () {
+
+    require('./util/setup')();
+
+    const getEntryByPath = (blogID, path) =>
+        new Promise((resolve) => getEntry(blogID, path, (entry) => resolve(entry)));
+
+    it("generates a nested toc with unique heading ids", async function () {
+
+        const plugins = { ...this.blog.plugins, toc: { enabled: true, options: {} } };
+        await this.blog.update({ plugins });
+
+        const content = [
+            "# Heading One",
+            "## First Child",
+            "### Deep Dive",
+            "## First Child",
+            "# Heading One",
+            "### Skipped Level",
+        ].join("\n");
+
+        await this.write({ path: '/toc.md', content });
+
+        const entry = await getEntryByPath(this.blog.id, '/toc.md');
+        const $ = cheerio.load(entry.toc);
+
+        const nav = $('#TOC');
+
+        expect(nav.length).toEqual(1);
+
+        const links = nav.find('a');
+        const ids = links.map((_, el) => $(el).attr('id')).get();
+
+        expect(ids).toContain('toc-heading-one');
+        expect(ids).toContain('toc-heading-one-2');
+        expect(ids).toContain('toc-first-child');
+        expect(ids).toContain('toc-first-child-2');
+        expect(ids).toContain('toc-deep-dive');
+
+        const firstHeading = nav.find('> ul > li').first();
+        expect(firstHeading.find('> ul > li').length).toBeGreaterThan(0);
+
+        const skippedHeading = nav.find('a[href="#skipped-level"]');
+        const parentHeading = skippedHeading.parents('li').eq(1).find('> a').attr('href');
+        expect(parentHeading).toEqual('#heading-one-2');
+    });
+
+    it("skips toc generation when the plugin is disabled", async function () {
+
+        const plugins = { ...this.blog.plugins, toc: { enabled: false, options: {} } };
+        await this.blog.update({ plugins });
+
+        await this.write({ path: '/no-toc.html', content: '<h1>Title</h1>' });
+
+        const entry = await getEntryByPath(this.blog.id, '/no-toc.html');
+
+        expect(entry.toc).toEqual("");
+    });
+
+    it("creates toc entries for html files and skips empty headings", async function () {
+
+        const plugins = { ...this.blog.plugins, toc: { enabled: true, options: {} } };
+        await this.blog.update({ plugins });
+
+        const html = [
+            '<h1 id="intro">Intro</h1>',
+            '<h3>Skipped Level</h3>',
+            '<h2>Details</h2>',
+            '<h2> </h2>',
+            '<h3>More Details</h3>',
+        ].join('');
+
+        await this.write({ path: '/html-file.html', content: html });
+
+        const entry = await getEntryByPath(this.blog.id, '/html-file.html');
+        const $ = cheerio.load(entry.toc);
+
+        const nav = $('#TOC');
+        expect(nav.length).toEqual(1);
+
+        expect(nav.find('a[href="#intro"]').attr('id')).toEqual('toc-intro');
+        expect(nav.find('a[href="#details"]').length).toEqual(1);
+        expect(nav.find('a').length).toEqual(4);
+        expect(nav.find('a').filter((_, el) => $(el).text().trim() === '').length).toEqual(0);
+
+        const introList = nav.find('> ul > li').first();
+        expect(introList.find('> ul > li a[href="#skipped-level"]').length).toEqual(1);
+    });
+});

--- a/app/build/index.js
+++ b/app/build/index.js
@@ -68,6 +68,7 @@ module.exports = function build(blog, path, callback) {
             size: stat.size,
             dependencies: dependencies,
             exif: (extras && extras.exif) || {},
+            toc: (extras && extras.toc) || "",
             dateStamp: DateStamp(blog, path, metadata),
             updated: moment.utc(stat.mtime).valueOf(),
           };

--- a/app/build/plugins/index.js
+++ b/app/build/plugins/index.js
@@ -34,6 +34,7 @@ var loaded = loadPlugins({
   linebreaks: require("./linebreaks"),
   mediaPreload: require("./mediaPreload"),
   linkScreenshot: require("./linkScreenshot"),
+  toc: require("./toc"),
   titlecase: require("./titlecase"),
   twitter: require("./twitter"),
   typeset: require("./typeset"),
@@ -56,6 +57,7 @@ function convert (blog, path, contents, callback) {
 
   var enabled = Enabled(blog.plugins);
   var dependencies = [];
+  var extras;
 
   // This is passed to all plugins
   // I need to change this when we move
@@ -149,9 +151,15 @@ function convert (blog, path, contents, callback) {
               time.end(id);
 
               const res = Array.isArray(result) ? { newDependencies: result } : result || {};
+              const { newDependencies, toc } = res;
 
-              if (res.newDependencies) {
-                dependencies = dependencies.concat(res.newDependencies);
+              if (newDependencies) {
+                dependencies = dependencies.concat(newDependencies);
+              }
+
+              if (toc) {
+                extras = extras || {};
+                extras.toc = toc;
               }
 
               clearTimeout(timeout);
@@ -163,7 +171,7 @@ function convert (blog, path, contents, callback) {
         function () {
           // Return the entry's completed HTML
           // pass the HTML so it can be rendered totally tast
-          callback(null, $.html(), dependencies);
+          callback(null, $.html(), dependencies, extras);
         }
       );
     }

--- a/app/build/plugins/toc/index.js
+++ b/app/build/plugins/toc/index.js
@@ -1,0 +1,86 @@
+const makeSlug = require("helper/makeSlug");
+
+function render($, callback) {
+  const headings = $("h1, h2, h3, h4, h5, h6");
+
+  if (!headings.length) return callback(null);
+
+  const nodes = [];
+  const stack = [{ level: 0, children: nodes }];
+  const idCounts = Object.create(null);
+
+  headings.each(function (_, el) {
+    const $heading = $(el);
+    const text = ($heading.text() || "").trim();
+
+    if (!text) return;
+
+    const tagName = ((el && el.name) || "").toUpperCase();
+    const level = +tagName.replace("H", "");
+
+    if (!level) return;
+
+    let id = $heading.attr("id") || makeSlug(text) || "section";
+
+    if (!idCounts[id]) {
+      idCounts[id] = 1;
+    } else {
+      idCounts[id] += 1;
+      id = `${id}-${idCounts[id]}`;
+    }
+
+    $heading.attr("id", id);
+
+    const node = { level, id, text, children: [] };
+
+    while (stack.length > 1 && level <= stack[stack.length - 1].level) {
+      stack.pop();
+    }
+
+    const parent = stack[stack.length - 1];
+    parent.children.push(node);
+    stack.push(node);
+  });
+
+  if (!nodes.length) return callback(null);
+
+  const tocHTML = `<nav id="TOC" role="doc-toc">${toHTML(nodes)}</nav>`;
+
+  callback(null, { toc: tocHTML });
+}
+
+function escapeHTML(string) {
+  return string
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function toHTML(items) {
+  if (!items.length) return "";
+
+  let html = "<ul>";
+
+  items.forEach(function (item) {
+    html += `<li><a href="#${item.id}" id="toc-${item.id}">${escapeHTML(item.text)}</a>`;
+
+    html += toHTML(item.children);
+
+    html += "</li>";
+  });
+
+  html += "</ul>";
+
+  return html;
+}
+
+module.exports = {
+  title: "Table of contents",
+  description: "Automatically generate a table of contents from headings in your posts.",
+  category: "headings",
+  optional: true,
+  isDefault: false,
+  render,
+};

--- a/app/build/tests/plugins/runner.js
+++ b/app/build/tests/plugins/runner.js
@@ -13,9 +13,9 @@ describe("plugin runner", function () {
         { ...blogBase, plugins },
         "/post.html",
         contents,
-        function (err, html, dependencies) {
+        function (err, html, dependencies, extras) {
           if (err) return reject(err);
-          resolve({ html, dependencies });
+          resolve({ html, dependencies, extras });
         }
       );
     });

--- a/app/models/entry/instance.js
+++ b/app/models/entry/instance.js
@@ -1,3 +1,6 @@
 module.exports = function Entry(init) {
+  init = init || {};
   for (var i in init) this[i] = init[i];
+
+  if (this.toc === undefined) this.toc = "";
 };

--- a/app/models/entry/model.js
+++ b/app/models/entry/model.js
@@ -11,6 +11,7 @@ module.exports = {
   teaserBody: "string", // teaser excluding titleTag
   more: "boolean", // whether teaser differs from HTML
   html: "string",
+  toc: "string",
   slug: "string",
   name: "string",
   path: "string",

--- a/app/models/entry/set.js
+++ b/app/models/entry/set.js
@@ -75,6 +75,7 @@ module.exports = function set (blogID, path, updates, callback) {
     if (entry.dependencies === undefined) entry.dependencies = [];
     if (entry.backlinks === undefined) entry.backlinks = [];
     if (entry.internalLinks === undefined) entry.internalLinks = [];
+    if (entry.toc === undefined) entry.toc = "";
     if (!entry.metadata || typeof entry.metadata !== "object") entry.metadata = {};
     if (!entry.exif || typeof entry.exif !== "object") entry.exif = {};
 

--- a/app/views/developers/reference.yml
+++ b/app/views/developers/reference.yml
@@ -93,6 +93,10 @@
       type: string
       description: The full HTML of the blog post.
 
+    - name: toc
+      type: string
+      description: The generated table of contents for the entry, if available.
+
     - name: path
       type: string
       description: The file’s path, with the blog’s folder as root.


### PR DESCRIPTION
- [ ] Tell Omar
---
## Summary
- add a table of contents plugin that builds nested heading navigation and exposes toc metadata
- pass plugin extras through the build pipeline and store toc on entries with default guards
- document the toc field and add tests covering plugin behavior and runner output

## Testing
- npm test -- app/blog/tests/toc.js *(fails: docker not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bea74303083299d57d4eb753cd1c8)