### PR TITLE
Add Bunny CDN purge retries and throttling

### DIFF
--- a/app/helper/purgeCdnUrls.js
+++ b/app/helper/purgeCdnUrls.js
@@ -1,8 +1,78 @@
 const config = require("config");
 const fetch = require("node-fetch");
 
+const DEFAULT_REQUESTS_PER_SECOND = 10;
+const MAX_RETRIES = 5;
+const BASE_DELAY_MS = 1000;
+const MAX_DELAY_MS = 60000;
+
+function delay(duration) {
+  return new Promise((resolve) => setTimeout(resolve, duration));
+}
+
 /**
- * Purge URLs from Bunny CDN cache
+ * Purge a single URL from Bunny CDN cache with retry and exponential backoff.
+ * Retries up to {@link MAX_RETRIES} times on transient errors such as HTTP 429.
+ * Respects the `Retry-After` header when provided, otherwise falls back to
+ * exponential backoff starting at {@link BASE_DELAY_MS} and capped at
+ * {@link MAX_DELAY_MS}.
+ *
+ * @param {string} urlToPurge - The URL to purge (will be encoded internally)
+ * @param {number} retryCount - Current retry attempt (internal use)
+ * @returns {Promise<boolean>} - Whether the purge succeeded
+ */
+async function purgeSingleUrl(urlToPurge, retryCount = 0) {
+  const url = `https://api.bunny.net/purge?url=${encodeURIComponent(urlToPurge)}&async=false`;
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { AccessKey: config.bunny.secret },
+    });
+
+    if (res.status === 429) {
+      if (retryCount >= MAX_RETRIES) {
+        console.error(`Failed to purge Bunny CDN after max retries: ${urlToPurge}`, res.status);
+        return false;
+      }
+
+      const retryAfterHeader = res.headers && res.headers.get ? res.headers.get("Retry-After") : null;
+      const retryAfterSeconds = retryAfterHeader ? Number.parseInt(retryAfterHeader, 10) : NaN;
+      const backoffDelay = Math.min(MAX_DELAY_MS, BASE_DELAY_MS * Math.pow(2, retryCount));
+      const delayMs = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0 ? retryAfterSeconds * 1000 : backoffDelay;
+
+      console.warn(`Rate limited purging Bunny CDN: ${urlToPurge}. Retrying in ${delayMs}ms (attempt ${retryCount + 1}).`);
+      await delay(delayMs);
+      return purgeSingleUrl(urlToPurge, retryCount + 1);
+    }
+
+    if (res.status !== 200) {
+      console.error(`Failed to purge Bunny CDN: ${urlToPurge}`, res.status);
+      return false;
+    }
+
+    console.log(`Purged Bunny CDN: ${urlToPurge}`);
+    return true;
+  } catch (err) {
+    if (retryCount < MAX_RETRIES) {
+      const delayMs = Math.min(MAX_DELAY_MS, BASE_DELAY_MS * Math.pow(2, retryCount));
+      console.warn(`Error purging Bunny CDN: ${urlToPurge}. Retrying in ${delayMs}ms (attempt ${retryCount + 1}).`, err);
+      await delay(delayMs);
+      return purgeSingleUrl(urlToPurge, retryCount + 1);
+    }
+
+    console.error(`Error purging Bunny CDN after max retries: ${urlToPurge}`, err);
+    return false;
+  }
+}
+
+/**
+ * Purge URLs from Bunny CDN cache with throttling and retry logic.
+ * Requests are spaced out using a configurable rate limit (default 10 rps) to
+ * reduce the likelihood of hitting rate limits. Individual requests will retry
+ * on HTTP 429 responses with exponential backoff and respect the `Retry-After`
+ * header when present.
+ *
  * @param {string[]} urls - Array of URLs to purge (will be encoded internally)
  * @returns {Promise<void>}
  */
@@ -19,24 +89,28 @@ async function purgeCdnUrls(urls) {
     return;
   }
 
-  for (const urlToPurge of urls) {
-    try {
-      const url = `https://api.bunny.net/purge?url=${encodeURIComponent(urlToPurge)}&async=false`;
-      const res = await fetch(url, {
-        method: "POST",
-        headers: { AccessKey: config.bunny.secret },
-      });
+  const requestsPerSecond = Math.max(
+    1,
+    config.bunny.requestsPerSecond || DEFAULT_REQUESTS_PER_SECOND
+  );
+  const minDelayBetweenRequests = 1000 / requestsPerSecond;
+  const startTime = Date.now();
+  let lastRequestTime = startTime - minDelayBetweenRequests;
 
-      if (res.status !== 200) {
-        console.error(`Failed to purge Bunny CDN: ${urlToPurge}`, res.status);
-      } else {
-        console.log(`Purged Bunny CDN: ${urlToPurge}`);
-      }
-    } catch (err) {
-      console.error(`Error purging Bunny CDN: ${urlToPurge}`, err);
+  for (const urlToPurge of urls) {
+    const now = Date.now();
+    const timeSinceLastRequest = now - lastRequestTime;
+
+    if (timeSinceLastRequest < minDelayBetweenRequests) {
+      await delay(minDelayBetweenRequests - timeSinceLastRequest);
     }
+
+    lastRequestTime = Date.now();
+    await purgeSingleUrl(urlToPurge);
   }
 }
 
 module.exports = purgeCdnUrls;
+module.exports._purgeSingleUrl = purgeSingleUrl;
+module.exports._delay = delay;
 

--- a/app/helper/tests/purgeCdnUrls.js
+++ b/app/helper/tests/purgeCdnUrls.js
@@ -1,70 +1,162 @@
 const config = require("config");
-const purgeCdnUrls = require("../purgeCdnUrls");
+
+function loadPurgeCdnUrlsWithFetch(fetchMock) {
+  delete require.cache[require.resolve("../purgeCdnUrls")];
+  delete require.cache[require.resolve("node-fetch")];
+  require.cache[require.resolve("node-fetch")] = { exports: fetchMock };
+  // eslint-disable-next-line global-require
+  return require("../purgeCdnUrls");
+}
 
 describe("purgeCdnUrls", function () {
   const originalEnv = process.env.NODE_ENV;
+  const originalConfigEnv = config.environment;
   const originalBunny = config.bunny;
+  let purgeCdnUrls;
+  let fetchMock;
+  let originalSetTimeout;
+  let originalDateNow;
+  let delayCalls;
+  let currentTime;
+
+  beforeEach(function () {
+    process.env.NODE_ENV = "production";
+    config.environment = "production";
+    fetchMock = jasmine.createSpy("fetch");
+    purgeCdnUrls = loadPurgeCdnUrlsWithFetch(fetchMock);
+    delayCalls = [];
+    originalSetTimeout = global.setTimeout;
+    originalDateNow = Date.now;
+    currentTime = 0;
+
+    global.setTimeout = (fn, ms) => {
+      delayCalls.push(ms);
+      currentTime += ms;
+      return originalSetTimeout(fn, 0);
+    };
+
+    Date.now = () => currentTime;
+  });
 
   afterEach(function () {
     process.env.NODE_ENV = originalEnv;
+    config.environment = originalConfigEnv;
     config.bunny = originalBunny;
+    delete require.cache[require.resolve("../purgeCdnUrls")];
+    delete require.cache[require.resolve("node-fetch")];
+    global.setTimeout = originalSetTimeout;
+    Date.now = originalDateNow;
   });
 
   it("does nothing in non-production environments", async function () {
     process.env.NODE_ENV = "development";
-    
-    // Should not throw or make any requests
+    config.environment = "development";
+    config.bunny = { secret: "test-secret" };
+
     await purgeCdnUrls(["https://example.com/test"]);
-    
-    // No assertions needed - just verify it doesn't throw
-    expect(true).toBe(true);
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("does nothing when bunny secret is missing", async function () {
-    process.env.NODE_ENV = "production";
     config.bunny = null;
-    
+
     await purgeCdnUrls(["https://example.com/test"]);
-    
-    expect(true).toBe(true);
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("does nothing when bunny secret is empty", async function () {
-    process.env.NODE_ENV = "production";
     config.bunny = { secret: "" };
-    
+
     await purgeCdnUrls(["https://example.com/test"]);
-    
-    expect(true).toBe(true);
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("does nothing with empty URL array", async function () {
-    process.env.NODE_ENV = "production";
     config.bunny = { secret: "test-secret" };
-    
+
     await purgeCdnUrls([]);
-    
-    expect(true).toBe(true);
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("does nothing with null/undefined URLs", async function () {
-    process.env.NODE_ENV = "production";
+  it("retries on 429 before succeeding", async function () {
     config.bunny = { secret: "test-secret" };
-    
-    await purgeCdnUrls(null);
-    await purgeCdnUrls(undefined);
-    
-    expect(true).toBe(true);
+    let attempts = 0;
+
+    fetchMock.and.callFake(() => {
+      attempts += 1;
+      if (attempts === 1) {
+        return Promise.resolve({
+          status: 429,
+          headers: { get: () => null },
+        });
+      }
+
+      return Promise.resolve({ status: 200, headers: { get: () => null } });
+    });
+
+    const purgePromise = purgeCdnUrls(["https://example.com/test"]);
+    await purgePromise;
+
+    expect(fetchMock.calls.count()).toBe(2);
+    expect(delayCalls).toContain(1000);
   });
 
-  it("handles invalid URL format gracefully", async function () {
-    process.env.NODE_ENV = "production";
+  it("honors Retry-After header when rate limited", async function () {
     config.bunny = { secret: "test-secret" };
-    
-    // Should not throw even with invalid URLs
-    await purgeCdnUrls(["not-a-valid-url", "also-invalid"]);
-    
-    expect(true).toBe(true);
+    let attempts = 0;
+
+    fetchMock.and.callFake(() => {
+      attempts += 1;
+      if (attempts === 1) {
+        return Promise.resolve({
+          status: 429,
+          headers: { get: (key) => (key === "Retry-After" ? "5" : null) },
+        });
+      }
+
+      return Promise.resolve({ status: 200, headers: { get: () => null } });
+    });
+
+    const purgePromise = purgeCdnUrls(["https://example.com/test"]);
+    await purgePromise;
+
+    expect(fetchMock.calls.count()).toBe(2);
+    expect(delayCalls).toContain(5000);
+  });
+
+  it("stops after max retries on repeated 429s", async function () {
+    config.bunny = { secret: "test-secret" };
+
+    fetchMock.and.returnValue(
+      Promise.resolve({ status: 429, headers: { get: () => null } })
+    );
+
+    const purgePromise = purgeCdnUrls(["https://example.com/test"]);
+    await purgePromise;
+
+    expect(fetchMock.calls.count()).toBe(6);
+    expect(delayCalls).toEqual([1000, 2000, 4000, 8000, 16000]);
+  });
+
+  it("throttles requests between URLs", async function () {
+    config.bunny = { secret: "test-secret", requestsPerSecond: 10 };
+
+    fetchMock.and.returnValue(
+      Promise.resolve({ status: 200, headers: { get: () => null } })
+    );
+
+    const purgePromise = purgeCdnUrls([
+      "https://example.com/one",
+      "https://example.com/two",
+    ]);
+    await purgePromise;
+
+    expect(fetchMock.calls.count()).toBe(2);
+    expect(delayCalls).toContain(100);
   });
 });
 


### PR DESCRIPTION
## Summary
- add retry and exponential backoff handling for Bunny CDN purge requests, including respect for Retry-After headers
- throttle purge requests to avoid hitting rate limits
- add tests covering retry, backoff, retry-after, and throttling scenarios

## Testing
- NODE_PATH=. npx jasmine app/helper/tests/purgeCdnUrls.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942cfb943a083299eb6ef29e1933f73)