### PR TITLE
Purge CDN assets when templates are dropped

### DIFF
--- a/app/models/template/tests/drop.js
+++ b/app/models/template/tests/drop.js
@@ -6,6 +6,64 @@ describe("template", function () {
   var client = require("models/client");
   var Blog = require("models/blog");
   var key = require("../key");
+  var generateCdnUrl = require("../util/generateCdnUrl");
+  var config = require("config");
+  var fs = require("fs-extra");
+  var path = require("path");
+  var getMetadata = require("../index").getMetadata;
+  var { promisify } = require("util");
+
+  var purgeModulePath = require.resolve("helper/purgeCdnUrls");
+  var cleanupUtilPath = require.resolve("../util/cleanupTemplateCdnAssets");
+  var dropModulePath = require.resolve("../drop");
+  var indexModulePath = require.resolve("../index");
+  var originalPurge = require(purgeModulePath);
+  var getAsync = promisify(client.get).bind(client);
+  var blogSetAsync = promisify(Blog.set).bind(Blog);
+  var getMetadataAsync = promisify(getMetadata).bind(getMetadata);
+  var dropTemplate = function (dropFn, owner, templateName) {
+    return new Promise(function (resolve, reject) {
+      dropFn(owner, templateName, function (err, message) {
+        if (err) return reject(err);
+        resolve(message);
+      });
+    });
+  };
+  var sleep = function (ms) {
+    return new Promise(function (resolve) {
+      setTimeout(resolve, ms);
+    });
+  };
+
+  var getRenderedOutputPath = function (hash, viewName) {
+    const viewBaseName = path.basename(viewName);
+    const dir1 = hash.substring(0, 2);
+    const dir2 = hash.substring(2, 4);
+    const hashRemainder = hash.substring(4);
+    return path.join(
+      config.data_directory,
+      "cdn",
+      "template",
+      dir1,
+      dir2,
+      hashRemainder,
+      viewBaseName
+    );
+  };
+
+  var reloadDrop = function () {
+    delete require.cache[cleanupUtilPath];
+    delete require.cache[dropModulePath];
+    delete require.cache[indexModulePath];
+    return require("../index").drop;
+  };
+
+  afterEach(function () {
+    require.cache[purgeModulePath] = { exports: originalPurge };
+    delete require.cache[cleanupUtilPath];
+    delete require.cache[dropModulePath];
+    delete require.cache[indexModulePath];
+  });
 
   it("drops a template", function (done) {
     drop(this.blog.id, this.template.name, done);
@@ -102,5 +160,114 @@ describe("template", function () {
       expect(typeof message).toBe("string");
       done();
     });
+  });
+
+  it("purges CDN URLs when dropping a template with a manifest", async function () {
+    var test = this;
+
+    await blogSetAsync(test.blog.id, { template: test.template.id });
+
+    await test.setView({
+      name: "entries.html",
+      content: "{{#cdn}}/style.css{{/cdn}}",
+    });
+
+    await test.setView({
+      name: "style.css",
+      content: "body{color:red}",
+    });
+
+    var metadata = await getMetadataAsync(test.template.id);
+    var hash = metadata.cdn["style.css"];
+    var expectedUrl = generateCdnUrl("style.css", hash);
+
+    var purgeSpy = jasmine.createSpy("purgeCdnUrls").and.resolveTo();
+    require.cache[purgeModulePath] = { exports: purgeSpy };
+
+    var dropWithCleanup = reloadDrop();
+
+    await dropTemplate(dropWithCleanup, test.blog.id, test.template.name);
+    await sleep(20);
+
+    expect(purgeSpy).toHaveBeenCalledWith([expectedUrl]);
+  });
+
+  it("continues dropping even if CDN purge fails", async function () {
+    var test = this;
+
+    await blogSetAsync(test.blog.id, { template: test.template.id });
+
+    await test.setView({
+      name: "entries.html",
+      content: "{{#cdn}}/style.css{{/cdn}}",
+    });
+
+    await test.setView({
+      name: "style.css",
+      content: "body{color:red}",
+    });
+
+    var purgeSpy = jasmine
+      .createSpy("purgeCdnUrls")
+      .and.callFake(function () {
+        return Promise.reject(new Error("purge failed"));
+      });
+    require.cache[purgeModulePath] = { exports: purgeSpy };
+
+    var dropWithCleanup = reloadDrop();
+
+    await dropTemplate(dropWithCleanup, test.blog.id, test.template.name);
+
+    expect(purgeSpy).toHaveBeenCalled();
+  });
+
+  it("skips CDN cleanup when no manifest is present", async function () {
+    var test = this;
+
+    await blogSetAsync(test.blog.id, { template: test.template.id });
+
+    var purgeSpy = jasmine.createSpy("purgeCdnUrls").and.resolveTo();
+    require.cache[purgeModulePath] = { exports: purgeSpy };
+
+    var dropWithCleanup = reloadDrop();
+
+    await dropTemplate(dropWithCleanup, test.blog.id, test.template.name);
+
+    expect(purgeSpy).not.toHaveBeenCalled();
+  });
+
+  it("cleans up rendered output files and Redis keys on drop", async function () {
+    var test = this;
+
+    await blogSetAsync(test.blog.id, { template: test.template.id });
+
+    await test.setView({
+      name: "entries.html",
+      content: "{{#cdn}}/style.css{{/cdn}}",
+    });
+
+    await test.setView({
+      name: "style.css",
+      content: "body{color:red}",
+    });
+
+    var metadata = await getMetadataAsync(test.template.id);
+    var hash = metadata.cdn["style.css"];
+    var renderedPath = getRenderedOutputPath(hash, "style.css");
+    var renderedKey = key.renderedOutput(hash);
+
+    var purgeSpy = jasmine.createSpy("purgeCdnUrls").and.resolveTo();
+    require.cache[purgeModulePath] = { exports: purgeSpy };
+
+    var dropWithCleanup = reloadDrop();
+
+    await dropTemplate(dropWithCleanup, test.blog.id, test.template.name);
+    await sleep(20);
+
+    var fileExists = await fs.pathExists(renderedPath);
+    var redisValue = await getAsync(renderedKey);
+
+    expect(fileExists).toBe(false);
+    expect(redisValue).toBeNull();
   });
 });

--- a/app/models/template/util/cleanupTemplateCdnAssets.js
+++ b/app/models/template/util/cleanupTemplateCdnAssets.js
@@ -1,0 +1,65 @@
+const purgeCdnUrls = require("helper/purgeCdnUrls");
+const generateCdnUrl = require("./generateCdnUrl");
+const { cleanupOldHash } = require("./updateCdnManifest");
+
+function isValidHash(hash) {
+  return typeof hash === "string" && /^[a-f0-9]{4,}$/i.test(hash);
+}
+
+async function cleanupTemplateCdnAssets(templateID, metadata) {
+  try {
+    const manifest =
+      metadata && typeof metadata.cdn === "object" ? metadata.cdn : null;
+
+    if (!manifest || Object.keys(manifest).length === 0) return;
+
+    const entries = Object.entries(manifest);
+    const urlsToPurge = [];
+
+    for (const [target, hash] of entries) {
+      if (!target || typeof target !== "string") continue;
+
+      if (!isValidHash(hash)) {
+        console.error(
+          `Skipping CDN cleanup for ${templateID}:${target} due to invalid hash`
+        );
+        continue;
+      }
+
+      try {
+        const url = generateCdnUrl(target, hash);
+        urlsToPurge.push(url);
+      } catch (err) {
+        console.error(
+          `Error generating CDN URL for ${templateID}:${target}:`,
+          err
+        );
+      }
+    }
+
+    if (urlsToPurge.length) {
+      try {
+        await purgeCdnUrls(urlsToPurge);
+      } catch (err) {
+        console.error(`Error purging CDN URLs for ${templateID}:`, err);
+      }
+    }
+
+    await Promise.all(
+      entries.map(async ([target, hash]) => {
+        try {
+          await cleanupOldHash(target, hash);
+        } catch (err) {
+          console.error(
+            `Error cleaning CDN assets for ${templateID}:${target}:`,
+            err
+          );
+        }
+      })
+    );
+  } catch (err) {
+    console.error(`Error cleaning CDN assets for ${templateID}:`, err);
+  }
+}
+
+module.exports = cleanupTemplateCdnAssets;

--- a/app/models/template/util/updateCdnManifest.js
+++ b/app/models/template/util/updateCdnManifest.js
@@ -325,4 +325,6 @@ module.exports = function updateCdnManifest(templateID, callback) {
   })();
 };
 
+module.exports.cleanupOldHash = cleanupOldHash;
+
 


### PR DESCRIPTION
## Summary
- add reusable cleanup helper to purge CDN URLs and remove cached assets when deleting templates
- invoke CDN cleanup during template drops to clear manifests and rendered output
- extend drop tests to cover CDN purging, cleanup resilience, and rendered artifact removal

## Testing
- npm test -- app/models/template/tests/drop.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942cfdaf1f08329b48667403ce5de15)