### PR TITLE
Add removeDiacritics helper and use it for image cache filenames

### DIFF
--- a/app/build/plugins/image/optimize.js
+++ b/app/build/plugins/image/optimize.js
@@ -8,6 +8,7 @@ var extname = require("path").extname;
 var basename = require("path").basename;
 var debug = require("debug")("blot:entry:build:plugins:image");
 var makeSlug = require("helper/makeSlug");
+var removeDiacritics = require("helper/removeDiacritics");
 var Url = require("url");
 
 // Only cache images with the following file extensions
@@ -35,6 +36,7 @@ module.exports = function (blogID, originalSrc) {
           var baseName = ext ? filename.slice(0, -ext.length) : filename;
           // Apply makeSlug to the base name
           originalFilename = makeSlug(baseName);
+          originalFilename = removeDiacritics(originalFilename);
         }
       } catch (e) {
         debug("Failed to extract filename from originalSrc:", e);

--- a/app/build/prepare/permalink.js
+++ b/app/build/prepare/permalink.js
@@ -1,4 +1,5 @@
 var makeSlug = require("helper/makeSlug");
+var removeDiacritics = require("helper/removeDiacritics");
 var mustache = require("mustache");
 var moment = require("moment");
 var debug = require("debug")("blot:prepare:permalink");
@@ -85,40 +86,6 @@ var allow = [
   "updated",
   "metadata"
 ];
-
-// modified from here: https://gist.github.com/mathewbyrne/1280286
-// also using https://help.ivanti.com/res/help/en_US/IA/2021/Admin/Content/35149.htm
-function removeDiacritics (str) {
-  str = str || "";
-  str = decodeURIComponent(str); // lol we shouldnt do this
-  str = str.toLowerCase();
-
-  var swaps = [
-    { from: "œ", to: "oe" },
-    { from: "ö", to: "oe" },
-    { from: "æ", to: "ae" },
-    { from: "ä", to: "ae" },
-    { from: "å", to: "aa" },
-    { from: "þ", to: "th" },
-    { from: "ü", to: "ue" },
-    { from: "ß", to: "ss" }
-  ];
-
-  for (const item of swaps) {
-    const { from, to } = item;
-    str = str.replace(new RegExp(from, "g"), to);
-  }
-
-  var from = "àáâãåāçćčèéêëēėęîïíīįìłñńôòóøōõśšûùúūųŵÿýŷžźż";
-  var to = "aaaaaaccceeeeeeeiiiiiilnnoooooossuuuuuwyyyzzz";
-
-  for (var i = 0, l = from.length; i < l; i++)
-    str = str.replace(new RegExp(from.charAt(i), "g"), to.charAt(i));
-
-  str = encodeURIComponent(str);
-
-  return str;
-}
 
 module.exports = function (timeZone, format, entry) {
   // Add the permalink automatically if the metadata

--- a/app/helper/removeDiacritics.js
+++ b/app/helper/removeDiacritics.js
@@ -1,0 +1,38 @@
+const ensure = require("helper/ensure");
+
+// modified from here: https://gist.github.com/mathewbyrne/1280286
+// also using https://help.ivanti.com/res/help/en_US/IA/2021/Admin/Content/35149.htm
+module.exports = function removeDiacritics(str) {
+  if (!str) return "";
+
+  ensure(str, "string");
+
+  str = decodeURIComponent(str); // lol we shouldnt do this
+  str = str.toLowerCase();
+
+  var swaps = [
+    { from: "œ", to: "oe" },
+    { from: "ö", to: "oe" },
+    { from: "æ", to: "ae" },
+    { from: "ä", to: "ae" },
+    { from: "å", to: "aa" },
+    { from: "þ", to: "th" },
+    { from: "ü", to: "ue" },
+    { from: "ß", to: "ss" }
+  ];
+
+  for (const item of swaps) {
+    const { from, to } = item;
+    str = str.replace(new RegExp(from, "g"), to);
+  }
+
+  var from = "àáâãåāçćčèéêëēėęîïíīįìłñńôòóøōõśšûùúūųŵÿýŷžźż";
+  var to = "aaaaaaccceeeeeeeiiiiiilnnoooooossuuuuuwyyyzzz";
+
+  for (var i = 0, l = from.length; i < l; i++)
+    str = str.replace(new RegExp(from.charAt(i), "g"), to.charAt(i));
+
+  str = encodeURIComponent(str);
+
+  return str;
+};


### PR DESCRIPTION
### Motivation
- Normalize and strip diacritics from strings to produce predictable, ASCII-only slugs for filenames and permalinks.
- Centralize diacritics conversion into a reusable helper instead of duplicating logic inline.
- Ensure the image caching plugin produces safe, slugified filenames derived from the original `src` when possible.

### Description
- Add new helper `app/helper/removeDiacritics.js` to map accented characters to non-accented equivalents and return an encoded string.
- Replace the inline `removeDiacritics` implementation in `app/build/prepare/permalink.js` with `require("helper/removeDiacritics")`.
- Invoke `removeDiacritics` in `app/build/plugins/image/optimize.js` after `makeSlug(baseName)` so cached image filenames have diacritics stripped.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694684471ab08329b4c819fab609e1f8)