### PR TITLE
Improve iCloud resync error handling

### DIFF
--- a/app/clients/icloud/sync/fromiCloud.js
+++ b/app/clients/icloud/sync/fromiCloud.js
@@ -28,6 +28,7 @@ module.exports = async (blogID, publish, update) => {
   } catch (error) {
     console.error("Failed to sync folder tree", error);
     publish("Failed to sync folder tree", error.message);
+    throw error;
   }
 
   const walk = async (dir) => {
@@ -111,6 +112,6 @@ module.exports = async (blogID, publish, update) => {
     await walk("/");
   } catch (err) {
     publish("Sync failed", err.message);
-    // Possibly rethrow or handle
+    throw err;
   }
 };

--- a/app/clients/icloud/sync/util/remoteReaddir.js
+++ b/app/clients/icloud/sync/util/remoteReaddir.js
@@ -9,6 +9,27 @@ module.exports = async (blogID, path) => {
   const res = await fetch(MAC_SERVER_ADDRESS + "/readdir", {
     headers: { Authorization: MACSERVER_AUTH, blogID, pathBase64 },
   });
+
+  if (!res.ok) {
+    let errorMessage = `Failed to read remote directory (${res.status} ${res.statusText})`;
+
+    try {
+      const errorResponse = await res.json();
+      errorMessage = errorResponse.error || errorResponse.message || errorMessage;
+    } catch (_) {
+      try {
+        const errorText = await res.text();
+        if (errorText) errorMessage = `${errorMessage}: ${errorText}`;
+      } catch (__) {
+        // Ignore secondary errors while building the message
+      }
+    }
+
+    const error = new Error(errorMessage);
+    error.status = res.status;
+    throw error;
+  }
+
   const json = await res.json();
   return json;
 };


### PR DESCRIPTION
## Summary
- return clear JSON errors from the macserver readdir route when folders are missing or unreadable
- validate macserver responses in remoteReaddir and propagate failures through the iCloud sync flow
- bubble sync errors to the dashboard resync route so user-friendly messages are stored and the lock is released

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d120e5eec8329bbc12741e59ecda7)