### PR TITLE
Handle folder descendant deletes for Dropbox case-only renames

### DIFF
--- a/app/clients/dropbox/delta.js
+++ b/app/clients/dropbox/delta.js
@@ -257,8 +257,12 @@ async function injectCaseOnlyDeletes(entries, blogID, client) {
         entries.splice(index + 1, 0, ...descendantDeletes);
         index += descendantDeletes.length;
       }
+      // Skip past the original entry (which is now at index + 1 after parent delete insertion)
+      index++;
+      continue;
     }
 
+    // For non-folder case, skip past the original entry (which is now at index + 1 after parent delete insertion)
     index++;
   }
 


### PR DESCRIPTION
### Motivation
- Ensure case-only folder renames also produce `deleted` entries for on-disk descendants so downstream processing removes moved files correctly.
- Preserve the original on-disk casing for descendant paths when synthesizing Dropbox `path_display` values.
- Avoid injecting duplicate delete entries while keeping the processing order consistent with existing insert behavior.

### Description
- Added `listDescendantPaths(rootPath)` which recursively enumerates files and folders using `fs.readdir(..., { withFileTypes: true })` and returns absolute descendant paths.
- Reworked the delete-existence check into a `deleteExists(relativePath)` helper that performs case-insensitive comparisons of `relative_path`.
- After injecting a folder-level `deleted` entry, the code now computes `oldFolderPath` and blog root (via `localPath`), enumerates descendants, computes each descendant's relative path (preserving on-disk casing), converts path separators to POSIX, and synthesizes a `path_display` using `Path.posix.join` or `"/" + relativePath` as needed.
- Injects descendant `deleted` entries immediately after the folder delete (keeping order) and increments the loop index to avoid reprocessing, skipping any duplicates detected by `deleteExists`.

### Testing
- No automated tests were executed for this change.
- Manual runtime logging was added via existing `console.log` statements to aid debugging at runtime.
- Static checks or linters were not run as part of this rollout.
- Further unit/integration tests should be added to validate nested-folder rename scenarios and path casing behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e94f9b9988329a8a7f4ff134df9fd)