### PR TITLE
fix: leading period in scheduled message

### DIFF
--- a/app/views/dashboard/folder/file.html
+++ b/app/views/dashboard/folder/file.html
@@ -53,7 +53,7 @@
   {{^draft}}
   <!-- File is scheduled for future publication -->
   <p>    <i><span class="icon-small-check"></span></i>
-    <b>Scheduled for future publication</b>. The publish date of this {{type}} is in the future. This {{type}} will be published to your site {{toNow}} on {{date}}.</p>
+    <b>Scheduled for future publication</b>The publish date of this {{type}} is in the future. This {{type}} will be published to your site {{toNow}} on {{date}}.</p>
  
   {{/draft}}
   {{/scheduled}}


### PR DESCRIPTION
Noticed this tiny copy bug. Quick fix for it.

<img width="645" height="93" alt="image" src="https://github.com/user-attachments/assets/a2aed01f-d59d-4441-9aa5-b9dcb612f44e" />
