### PR TITLE
Guard Dropbox batch move when no entries

### DIFF
--- a/app/clients/dropbox/routes/setup/createFolder.js
+++ b/app/clients/dropbox/routes/setup/createFolder.js
@@ -95,6 +95,15 @@ function moveExistingFiles(client, otherBlog) {
             };
           });
 
+        if (entries.length === 0) {
+          await set(otherBlog.id, {
+            folder,
+            folder_id,
+            cursor: "",
+          });
+          return done(null, resolve);
+        }
+
         const {
           result: { async_job_id },
         } = await client.filesMoveBatch({


### PR DESCRIPTION
### Motivation
- Prevent Dropbox API errors when the app folder contains no eligible items to move by avoiding unnecessary batch operations.
- Ensure the other blog's folder metadata is persisted immediately when there are no files to relocate.

### Description
- Updated `app/clients/dropbox/routes/setup/createFolder.js` to add an early-exit after computing `entries` in `moveExistingFiles`.
- Added a check `if (entries.length === 0)` that calls `set(otherBlog.id, { folder, folder_id, cursor: "" })` and returns before invoking `client.filesMoveBatch`.
- This bypasses the `client.filesMoveBatch` / `client.filesMoveBatchCheck` loop when there are no entries to move, avoiding Dropbox errors.

### Testing
- No automated tests were run for this change.
- The change is a small defensive check and was committed successfully to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa999c29c8329b17a0525e5489182)