### PR TITLE
Track reset-to-blot action counts and return summary

### DIFF
--- a/app/clients/dropbox/sync/reset-to-blot.js
+++ b/app/clients/dropbox/sync/reset-to-blot.js
@@ -75,7 +75,14 @@ async function resetToBlot(blogID, publish) {
   // This means that future syncs will be fast
   await set(blogID, { cursor });
 
-  await walk(blogID, client, publish, dropboxRoot, "/");
+  const summary = {
+    downloaded: 0,
+    removed: 0,
+    createdDirs: 0,
+    skipped: 0,
+  };
+
+  await walk(blogID, client, publish, dropboxRoot, "/", summary);
 
   await set(blogID, {
     error_code: 0,
@@ -83,9 +90,11 @@ async function resetToBlot(blogID, publish) {
   });
 
   publish("Finished processing folder");
+
+  return summary;
 }
 
-const walk = async (blogID, client, publish, dropboxRoot, dir) => {
+const walk = async (blogID, client, publish, dropboxRoot, dir, summary) => {
   const localRoot = localPath(blogID, "/");
   publish("Checking", dir);
   const [remoteContents, localContents] = await Promise.all([
@@ -100,6 +109,7 @@ const walk = async (blogID, client, publish, dropboxRoot, dir) => {
       publish("Removing ignored", path_display);
       try {
         await fs.remove(join(localRoot, dir, name));
+        summary.removed += 1;
       } catch (e) {
         publish("Failed to remove ignored", path_display, e.message);
       }
@@ -114,6 +124,7 @@ const walk = async (blogID, client, publish, dropboxRoot, dir) => {
       publish("Removing", path_display);
       try {
         await fs.remove(join(localRoot, dir, name));
+        summary.removed += 1;
       } catch (e) {
         publish("Failed to remove", path_display, e.message);
       }
@@ -136,17 +147,28 @@ const walk = async (blogID, client, publish, dropboxRoot, dir) => {
       if (localCounterpart && !localCounterpart.is_directory) {
         publish("Removing", pathOnDisk);
         await fs.remove(pathOnDisk);
+        summary.removed += 1;
         publish("Creating directory", pathOnDisk);
         await fs.mkdir(pathOnDisk);
+        summary.createdDirs += 1;
       } else if (!localCounterpart) {
         publish("Creating directory", pathOnBlot);
         await fs.mkdir(pathOnDisk);
+        summary.createdDirs += 1;
       }
 
-      await walk(blogID, client, publish, dropboxRoot, join(dir, name));
+      await walk(
+        blogID,
+        client,
+        publish,
+        dropboxRoot,
+        join(dir, name),
+        summary
+      );
     } else {
       if (hasUnsupportedExtension(pathOnDropbox)) {
         publish("Skipping unsupported file", pathOnBlot);
+        summary.skipped += 1;
         try {
           await fs.outputFile(pathOnDisk, "");
         } catch (err) {
@@ -163,6 +185,7 @@ const walk = async (blogID, client, publish, dropboxRoot, dir) => {
           "Skipping oversized file",
           `${pathOnBlot} (${remoteItem.size} bytes > ${MAX_FILE_SIZE} byte limit)`
         );
+        summary.skipped += 1;
         try {
           await fs.outputFile(pathOnDisk, "");
         } catch (err) {
@@ -179,6 +202,7 @@ const walk = async (blogID, client, publish, dropboxRoot, dir) => {
         publish("Downloading", pathOnBlot);
         try {
           await download(client, pathOnDropbox, pathOnDisk);
+          summary.downloaded += 1;
         } catch (e) {
           continue;
         }
@@ -186,6 +210,7 @@ const walk = async (blogID, client, publish, dropboxRoot, dir) => {
         publish("Downloading", pathOnBlot);
         try {
           await download(client, pathOnDropbox, pathOnDisk);
+          summary.downloaded += 1;
         } catch (e) {
           continue;
         }


### PR DESCRIPTION
### Motivation

- Provide a concrete, machine-readable summary of what `resetToBlot` did instead of relying on log diffs for validation.
- Make it possible for callers to inspect counts for downloads, removals, directory creations, and skipped files.

### Description

- Add a `summary` object in `resetToBlot` containing `downloaded`, `removed`, `createdDirs`, and `skipped` counters and return it at the end of the function.
- Propagate `summary` into the `walk` function by updating its signature to `walk(..., summary)` and passing it through recursive calls.
- Increment the corresponding counters at points where files/dirs are removed, directories are created, files are downloaded, or files are skipped (unsupported/oversized), and create placeholder files where applicable.
- Changes are in `app/clients/dropbox/sync/reset-to-blot.js` and touch the `resetToBlot` return value and `walk` behavior for counting.

### Testing

- No automated tests were run against this change.
- Manual/static checks: file updated and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc6741a788329b44f706f88776b8d)