### PR TITLE
Add Feed import route, view, and progress-aware importer

### DIFF
--- a/app/dashboard/site/import/index.js
+++ b/app/dashboard/site/import/index.js
@@ -81,6 +81,7 @@ Import.post("/delete/:importID", async function (req, res) {
 });
 
 Import.use(require("./sources/arena/router"));
+Import.use(require("./sources/feed/router"));
 Import.use(require("./sources/wordpress/router"));
 
 module.exports = Import;

--- a/app/dashboard/site/import/sources/feed/index.js
+++ b/app/dashboard/site/import/sources/feed/index.js
@@ -1,26 +1,36 @@
 var load = require("./load");
 var parse = require("./parse");
 var fs = require("fs-extra");
+var { join } = require("path");
 
 if (require.main === module)
-  main(process.argv[2], process.argv[3], function (err) {
+  main(process.argv[2], process.argv[3], console.log, {}, function (err) {
     if (err) throw err;
 
     process.exit();
   });
 
-function main(feed_url, output_directory, callback) {
-  load(feed_url, function (err, $) {
-    if (err) return callback(err);
+function main(sourceFile, output_directory, status, options, callback) {
+  (async () => {
+    try {
+      status("Reading feed settings");
+      const { feedUrl } = await fs.readJson(sourceFile);
 
-    fs.emptyDir(output_directory, function (err) {
-      if (err) return callback(err);
+      if (!feedUrl) throw new Error("Missing feed URL");
 
-      fs.outputFileSync(output_directory + "/input.xml", $.html());
+      status("Loading feed");
+      const $ = await load(feedUrl);
 
-      parse($, output_directory, callback);
-    });
-  });
+      await fs.emptyDir(output_directory);
+
+      fs.outputFileSync(join(output_directory, "input.xml"), $.html());
+
+      status("Parsing feed");
+      parse($, output_directory, status, callback);
+    } catch (err) {
+      callback(err);
+    }
+  })();
 }
 
 module.exports = main;

--- a/app/dashboard/site/import/sources/feed/router.js
+++ b/app/dashboard/site/import/sources/feed/router.js
@@ -1,0 +1,48 @@
+const express = require("express");
+const Importer = express.Router();
+
+const fs = require("fs-extra");
+const { join } = require("path");
+
+const init = require("dashboard/site/import/init");
+
+const feed = require("./index");
+
+Importer.route("/feed")
+  .get(function (req, res) {
+    res.locals.breadcrumbs.add("Feed", "feed");
+    res.render("dashboard/import/feed");
+  })
+  .post(function (req, res) {
+    const { importDirectory, outputDirectory, finish, status } = init({
+      blogID: req.blog.id,
+      label: "Feed",
+    });
+
+    res.message(req.baseUrl, "Began import");
+
+    const { feedUrl } = req.body;
+    const sourceFile = join(importDirectory, "feed-url.json");
+
+    fs.outputFileSync(
+      join(importDirectory, "identifier.txt"),
+      feedUrl,
+      "utf-8"
+    );
+
+    fs.outputJsonSync(sourceFile, { feedUrl });
+
+    feed(sourceFile, outputDirectory, status, {}, async function (err) {
+      if (err) {
+        return fs.outputFile(join(importDirectory, "error.txt"), err.message);
+      }
+
+      try {
+        await finish();
+      } catch (err) {
+        fs.outputFile(join(importDirectory, "error.txt"), err.message);
+      }
+    });
+  });
+
+module.exports = Importer;

--- a/app/views/dashboard/import/feed.html
+++ b/app/views/dashboard/import/feed.html
@@ -1,0 +1,28 @@
+{{> close-button}}
+
+<div style="border:1px solid var(--border-color);border-radius: var(--border-radius);padding:20px">
+        <h1>Feed import</h1>
+  <p style="max-width: 600px;">
+    The importer can turn an RSS or Atom feed into an archive (.zip) containing
+    markdown files. The importer downloads images and stores them with the
+    markdown files.
+  </p>
+  <br />
+
+  <form method="POST" action="{{{importBase}}}/feed">
+    <input type="hidden" name="_csrf" value="{{csrftoken}}" />
+
+    <label>Feed URL:</label>
+    <input
+      type="text"
+      name="feedUrl"
+      placeholder="https://example.com/feed.xml"
+    />
+
+    <div class="buttons">
+      <button type="submit">Start import</button>
+      <a href="{{{importBase}}}">Cancel</a>
+    </div>
+  </form>
+
+</div>


### PR DESCRIPTION
### Motivation
- Provide a Feed import flow consistent with the existing Wordpress and Are.na importers so users can import RSS/Atom feeds.
- Allow the importer to be driven by a stored JSON config rather than a raw URL parameter for consistent background processing.
- Surface progress/status updates during feed parsing so the UI can stream progress to users.
- Improve error handling and completion signaling so import results and errors are written into the import directory.

### Description
- Added `app/dashboard/site/import/sources/feed/router.js` which implements `GET /feed` to render the form and `POST /feed` to save `feed-url.json`, write `identifier.txt`, kick off the importer, and write `error.txt` on failure.
- Added the feed form view `app/views/dashboard/import/feed.html` with a CSRF token and a `feedUrl` text input that posts to `{{{importBase}}}/feed`.
- Updated `app/dashboard/site/import/sources/feed/index.js` to read the stored JSON (`feedUrl`) from the `sourceFile`, use async/await to `load` the feed, call `parse` with `status`, and invoke the callback on errors or call `finish()` on success.
- Updated `app/dashboard/site/import/sources/feed/parse.js` to iterate items using `async.eachOfSeries`, emit per-item progress via `status("Processing X of Y …")`, and preserve the existing readability/download/markdown behavior.
- Registered the new router in `app/dashboard/site/import/index.js` via `Import.use(require("./sources/feed/router"));`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960feafd7d08329a07c73645320df7e)