### PR TITLE
Add pre/post network diagnostics around Mac server stats fetch

### DIFF
--- a/app/clients/icloud/util/monitorMacServerStats.js
+++ b/app/clients/icloud/util/monitorMacServerStats.js
@@ -2,9 +2,15 @@ const config = require("config");
 const email = require("helper/email");
 const clfdate = require("helper/clfdate");
 const prettySize = require("helper/prettySize");
+const { execFile } = require("child_process");
 
 const MAC_SERVER_ADDRESS = config.icloud.server_address;
 const Authorization = config.icloud.secret;
+const macServerUrl = new URL(MAC_SERVER_ADDRESS);
+const macServerHostname = macServerUrl.hostname;
+const macServerPort =
+  macServerUrl.port ||
+  (macServerUrl.protocol === "https:" ? "443" : "80");
 
 const DISK_SPACE_WARNING_THRESHOLD = config.icloud.diskSpaceWarning;
 const DISK_SPACE_LIMIT = config.icloud.diskSpaceLimit;
@@ -13,78 +19,131 @@ const ICLOUD_SPACE_WARNING_THRESHOLD = config.icloud.iCloudSpaceWarning;
 const ICLOUD_SPACE_LIMIT = config.icloud.iCloudSpaceLimit;
 
 const POLLING_INTERVAL = 60 * 1000; // 1 minute
+const COMMAND_TIMEOUT_MS = 5000;
 
 // map to keep track of which notifications have been sent
 const notificationsSent = {};
+
+const runCommand = (command, args, { timeout = COMMAND_TIMEOUT_MS } = {}) =>
+  new Promise((resolve) => {
+    execFile(
+      command,
+      args,
+      { timeout, encoding: "utf8", windowsHide: true },
+      (error, stdout = "", stderr = "") => {
+        resolve({
+          stdout,
+          stderr,
+          exitCode:
+            typeof error?.code === "number" ? error.code : error ? 1 : 0,
+        });
+      }
+    );
+  });
+
+const logCommandResult = (label, command, args, result) => {
+  console.log(clfdate(), label, `${command} ${args.join(" ")}`, {
+    exitCode: result.exitCode,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  });
+};
+
+const runDiagnostics = async (label) => {
+  const netcatResult = await runCommand("nc", [
+    "-vz",
+    macServerHostname,
+    macServerPort,
+  ]);
+  logCommandResult(
+    label,
+    "nc",
+    ["-vz", macServerHostname, macServerPort],
+    netcatResult
+  );
+
+  const routeResult = await runCommand("ip", ["route", "get", macServerHostname]);
+  logCommandResult(
+    label,
+    "ip",
+    ["route", "get", macServerHostname],
+    routeResult
+  );
+};
 
 module.exports = () => {
   setInterval(async () => {
     console.log(clfdate(), "Checking Mac server stats");
     try {
-      // fetching stats
-      const res = await fetch(MAC_SERVER_ADDRESS + "/stats", {
-        headers: { Authorization },
-      });
+      await runDiagnostics("Mac server pre-check");
+      try {
+        // fetching stats
+        const res = await fetch(MAC_SERVER_ADDRESS + "/stats", {
+          headers: { Authorization },
+        });
 
-      if (!res.ok) {
-        throw new Error(`HTTP error! Status: ${res.status}`);
-      }
-
-      const stats = await res.json();
-
-      if (
-        !stats ||
-        !stats.disk_bytes_available ||
-        !stats.icloud_bytes_available
-      ) {
-        throw new Error("No stats returned");
-      }
-
-      stats.disk_available_human = prettySize(
-        stats.disk_bytes_available / 1000
-      );
-      stats.icloud_available_human = prettySize(
-        stats.icloud_bytes_available / 1000
-      );
-
-      console.log(clfdate(), "Mac server stats: ", stats);
-
-      if (notificationsSent.icloud_server_down) {
-        if (!notificationsSent.icloud_server_recovered) {
-          email.ICLOUD_SERVER_RECOVERED();
-          notificationsSent.icloud_server_recovered = true;
+        if (!res.ok) {
+          throw new Error(`HTTP error! Status: ${res.status}`);
         }
-        notificationsSent.icloud_server_down = false;
-      }
 
-      if (stats.disk_bytes_available < DISK_SPACE_LIMIT) {
-        console.log(clfdate(), "Disk space is low");
-        if (!notificationsSent.disk_space_low) {
-          email.ICLOUD_DISK_LIMIT(null, stats);
-          notificationsSent.disk_space_low = true;
-        }
-      } else if (stats.disk_bytes_available < DISK_SPACE_WARNING_THRESHOLD) {
-        console.log(clfdate(), "Disk space is running out");
-        if (!notificationsSent.disk_space_warning) {
-          email.ICLOUD_APPROACHING_DISK_LIMIT(null, stats);
-          notificationsSent.disk_space_warning = true;
-        }
-      }
+        const stats = await res.json();
 
-      if (stats.icloud_bytes_available < ICLOUD_SPACE_LIMIT) {
-        console.log(clfdate(), "iCloud drive space is low");
-        if (!notificationsSent.icloud_space_low) {
-          email.ICLOUD_QUOTA_LIMIT(null, stats);
-          notificationsSent.icloud_space_low = true;
+        if (
+          !stats ||
+          !stats.disk_bytes_available ||
+          !stats.icloud_bytes_available
+        ) {
+          throw new Error("No stats returned");
         }
-      } else if (
-        stats.icloud_bytes_available < ICLOUD_SPACE_WARNING_THRESHOLD
-      ) {
-        console.log(clfdate(), "iCloud drive space is running out");
-        if (!notificationsSent.icloud_space_warning) {
-          email.ICLOUD_APPROACHING_QUOTA_LIMIT(null, stats);
-          notificationsSent.icloud_space_warning = true;
+
+        stats.disk_available_human = prettySize(
+          stats.disk_bytes_available / 1000
+        );
+        stats.icloud_available_human = prettySize(
+          stats.icloud_bytes_available / 1000
+        );
+
+        console.log(clfdate(), "Mac server stats: ", stats);
+
+        if (notificationsSent.icloud_server_down) {
+          if (!notificationsSent.icloud_server_recovered) {
+            email.ICLOUD_SERVER_RECOVERED();
+            notificationsSent.icloud_server_recovered = true;
+          }
+          notificationsSent.icloud_server_down = false;
         }
+
+        if (stats.disk_bytes_available < DISK_SPACE_LIMIT) {
+          console.log(clfdate(), "Disk space is low");
+          if (!notificationsSent.disk_space_low) {
+            email.ICLOUD_DISK_LIMIT(null, stats);
+            notificationsSent.disk_space_low = true;
+          }
+        } else if (stats.disk_bytes_available < DISK_SPACE_WARNING_THRESHOLD) {
+          console.log(clfdate(), "Disk space is running out");
+          if (!notificationsSent.disk_space_warning) {
+            email.ICLOUD_APPROACHING_DISK_LIMIT(null, stats);
+            notificationsSent.disk_space_warning = true;
+          }
+        }
+
+        if (stats.icloud_bytes_available < ICLOUD_SPACE_LIMIT) {
+          console.log(clfdate(), "iCloud drive space is low");
+          if (!notificationsSent.icloud_space_low) {
+            email.ICLOUD_QUOTA_LIMIT(null, stats);
+            notificationsSent.icloud_space_low = true;
+          }
+        } else if (
+          stats.icloud_bytes_available < ICLOUD_SPACE_WARNING_THRESHOLD
+        ) {
+          console.log(clfdate(), "iCloud drive space is running out");
+          if (!notificationsSent.icloud_space_warning) {
+            email.ICLOUD_APPROACHING_QUOTA_LIMIT(null, stats);
+            notificationsSent.icloud_space_warning = true;
+          }
+        }
+      } finally {
+        await runDiagnostics("Mac server post-check");
       }
     } catch (error) {
       console.log(clfdate(), "Error connecting to mac server: ", error);


### PR DESCRIPTION
### Motivation

- Collect network-level diagnostics (`nc` and `ip route`) to help diagnose intermittent failures contacting the Mac server.
- Ensure diagnostics always run after the stats fetch so post-checks execute even on errors by using `try { ... } finally { ... }`.
- Run external commands safely with a timeout and avoid throwing from non-zero exits so the polling interval does not break.

### Description

- Parse `MAC_SERVER_ADDRESS` with `new URL(...)` and derive `macServerHostname` and `macServerPort` (defaulting port to `443` for `https:` and `80` otherwise).
- Add a `runCommand` helper that wraps `execFile` with a timeout and resolves with `{ stdout, stderr, exitCode }` even when the command exits non-zero or errors.
- Add `runDiagnostics` which runs `nc -vz <host> <port>` and `ip route get <host>` and logs timestamped results via `logCommandResult`.
- Execute `runDiagnostics("Mac server pre-check")` before the `fetch(MAC_SERVER_ADDRESS + "/stats")` and `runDiagnostics("Mac server post-check")` in a `finally` block so post-checks always run.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69612575f3208329ba4537a4d861823f)