### PR TITLE
Clarify top-level blog template variables

### DIFF
--- a/app/views/developers/reference.yml
+++ b/app/views/developers/reference.yml
@@ -2,21 +2,21 @@
   keys:
     - name: title
       type: string
-      description: Your site’s title, set on the title page of your dashboard.
-      example: <h1>{{blog.title}}</h1>
+      description: Your site’s title, set on the title page of your dashboard. Blog properties are available at the top level of the Mustache context (use `{{title}}`, not `{{blog.title}}`).
+      example: <h1>{{title}}</h1>
 
     - name: avatar
       type: string
       description: The URL to your profile picture, or avatar, uploaded on the Photo page of your dashboard
-      example: <img src="{{{blog.avatar}}}" />
+      example: <img src="{{{avatar}}}" />
 
     - name: menu
       type: array
       description: "A list of links on your site's menu, added on the Links page of your site's dashboard and pages. Each item in the list has the following properties:"
       example: |
-        {{#blog.menu}}
+        {{#menu}}
         <a href="{{url}}">{{label}}</a>
-        {{/blog.menu}}
+        {{/menu}}
       properties:
         - name: id
           type: string


### PR DESCRIPTION
### Motivation
- The developer reference showed blog properties nested under `blog` (for example `{{blog.title}}`) which is incorrect for the Mustache context used by the templates. 
- This could lead to template errors and confusion when authors try to access blog properties from their templates. 

### Description
- Updated `app/views/developers/reference.yml` to state that blog properties are available at the top-level Mustache context and to recommend `{{title}}` instead of `{{blog.title}}`.
- Updated examples for `avatar` and `menu` to use `{{{avatar}}}` and `{{#menu}}...{{/menu}}` respectively instead of `{{{blog.avatar}}}` and `{{#blog.menu}}...{{/blog.menu}}`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69612aec5f9483298ed7ebad57a28645)