### PR TITLE
Ensure iCloud initial transfer cleans up on failures

### DIFF
--- a/app/clients/icloud/sync/initialTransfer.js
+++ b/app/clients/icloud/sync/initialTransfer.js
@@ -10,26 +10,34 @@ module.exports = async function initialTransfer(blogID) {
   // establish sync lock
   const { folder, done } = await establishSyncLock(blogID);
 
-  folder.status("Setting up iCloud sync");
-  await database.store(blogID, { transferringToiCloud: true, error: null });
-  await syncToiCloud(blogID, folder.status, folder.update);
-  await database.store(blogID, { transferringToiCloud: false, error: null });
+  try {
+    folder.status("Setting up iCloud sync");
+    await database.store(blogID, { transferringToiCloud: true, error: null });
+    await syncToiCloud(blogID, folder.status, folder.update);
 
-  // Now that the transfer is complete, notify the Macserver to begin watching the iCloud folder
-  // for changes. This will let us know when the user has changed their folder on iCloud.
-  await fetch(`${MACSERVER_URL}/watch`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: MACSERVER_AUTH,
-      blogID: blogID,
-    },
-  });
-  folder.status("Setup complete");
-  await database.store(blogID, {
-    setupComplete: true,
-    transferringToiCloud: false,
-    error: null,
-  });
-  await done();
+    // Now that the transfer is complete, notify the Macserver to begin watching the iCloud folder
+    // for changes. This will let us know when the user has changed their folder on iCloud.
+    await fetch(`${MACSERVER_URL}/watch`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: MACSERVER_AUTH,
+        blogID: blogID,
+      },
+    });
+    folder.status("Setup complete");
+    await database.store(blogID, {
+      setupComplete: true,
+      transferringToiCloud: false,
+      error: null,
+    });
+  } catch (error) {
+    await database.store(blogID, {
+      transferringToiCloud: false,
+      error: error?.message || String(error),
+    });
+    throw error;
+  } finally {
+    await done();
+  }
 };


### PR DESCRIPTION
### Motivation
- Ensure `done()` always executes so the sync lock is released even if `syncToiCloud` or the `/watch` request fails.
- Make the UI reflect failures by clearing `transferringToiCloud` and recording an `error` message in the database when the transfer fails.
- Preserve the successful setup path so `setupComplete` is set and `transferringToiCloud` is cleared after the `/watch` call succeeds.

### Description
- Wrap the initial transfer flow in a `try/catch/finally` block around the existing logic to guarantee cleanup.
- Set `transferringToiCloud: true` at the start, and on success store `setupComplete: true`, `transferringToiCloud: false`, and `error: null`.
- On error, store `transferringToiCloud: false` and the error message to the blog record and rethrow the error.
- Always call `done()` in the `finally` block to release the sync lock.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962616463cc8329892424f1e23967c7)