### PR TITLE
Defer setup response until iCloud link acceptance completes

### DIFF
--- a/app/clients/icloud/macserver/routes/setup.js
+++ b/app/clients/icloud/macserver/routes/setup.js
@@ -179,14 +179,14 @@ module.exports = async (req, res) => {
     `Received setup request for blogID: ${blogID}, sharingLink: ${sharingLink}`
   );
 
-  res.sendStatus(200);
-
   try {
     await setupBlog(blogID, sharingLink);
     console.log(`Setup complete for blogID: ${blogID}`);
     await status(blogID, { acceptedSharingLink: true, error: null });
+    return res.sendStatus(200);
   } catch (error) {
     console.error(`Setup failed for blogID (${blogID}):`, error);
     await status(blogID, { acceptedSharingLink: false, error: error.message });
+    return res.status(500).json({ error: error.message });
   }
 };


### PR DESCRIPTION
### Motivation
- Prevent the client from marking a blog as connected before the iCloud sharing link is actually accepted and the local folder is set up.
- Surface failures to the client so it can distinguish success from failure and avoid incorrect state.

### Description
- Removed the early `res.sendStatus(200)` in `app/clients/icloud/macserver/routes/setup.js` so the response is not sent before setup completes.
- Wrapped `await setupBlog(blogID, sharingLink)` in a `try/catch` and only call `status(blogID, { acceptedSharingLink: true, error: null })` on success followed by `res.sendStatus(200)`.
- On failure update status with `acceptedSharingLink: false` and return a `500` JSON response via `res.status(500).json({ error: error.message })` so clients can handle errors.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696262586ca4832980d46f5b6dc64c69)