### PR TITLE
Validate readdir paths

### DIFF
--- a/app/clients/icloud/macserver/routes/readdir.js
+++ b/app/clients/icloud/macserver/routes/readdir.js
@@ -1,5 +1,5 @@
 const fs = require("fs-extra");
-const { join } = require("path");
+const { join, resolve, sep } = require("path");
 const { iCloudDriveDirectory } = require("../config");
 const { ls } = require("../brctl");
 const shouldIgnoreFile = require('../../../util/shouldIgnoreFile');
@@ -14,7 +14,19 @@ module.exports = async (req, res) => {
 
   console.log(`Received readdir request for blogID: ${blogID}, path: ${path}`);
 
-  const dirPath = join(iCloudDriveDirectory, blogID, path);
+  const basePath = resolve(join(iCloudDriveDirectory, blogID));
+  const dirPath = resolve(join(basePath, path));
+
+  if (dirPath !== basePath && !dirPath.startsWith(`${basePath}${sep}`)) {
+    console.log(
+      "Invalid path: attempted to access parent directory",
+      basePath,
+      dirPath
+    );
+    return res
+      .status(400)
+      .send("Invalid path: attempted to access parent directory");
+  }
 
   // first we issue a request to ls to ensure the directory is downloaded
   // otherwise, files or subdirectories may be missing. if this stops working


### PR DESCRIPTION
### Motivation
- Prevent directory traversal from `readdir` requests by validating decoded paths against the blog directory root.
- Mirror the existing path validation approach used in `mkdir.js` to ensure consistent behavior.
- Stop calling `ls` or `fs.readdir` for paths outside the allowed blog directory to avoid operating on unintended locations.

### Description
- Import `resolve` and `sep` from `path` and compute `basePath` with `resolve(join(iCloudDriveDirectory, blogID))` and `dirPath` with `resolve(join(basePath, path))`.
- Add a validation that rejects requests where `dirPath` is outside `basePath` using `dirPath !== basePath && !dirPath.startsWith(`${basePath}${sep}`)`, logging and returning `400` with a clear error message.
- Keep existing behavior for valid paths, including calling `ls(dirPath)` and `fs.readdir(dirPath)` and filtering results.

### Testing
- No automated tests were run for this change.
- Manual inspection and consistency checks against `mkdir.js` logic were performed during development.
- The change was committed and the updated file is `app/clients/icloud/macserver/routes/readdir.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962627d10388329849dee154c6e2fde)