### PR TITLE
Validate recursiveList paths against base directory

### DIFF
--- a/app/clients/icloud/macserver/routes/recursiveList.js
+++ b/app/clients/icloud/macserver/routes/recursiveList.js
@@ -1,4 +1,4 @@
-const { join } = require("path");
+const { join, resolve, sep } = require("path");
 const { iCloudDriveDirectory } = require("../config");
 const recursiveList = require("../util/recursiveList");
 
@@ -13,9 +13,21 @@ module.exports = async (req, res) => {
     return res.status(400).send("Missing blogID header");
   }
   
-  // Remove leading slash if present, or ensure it's relative
-  const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
-  const dirPath = join(iCloudDriveDirectory, blogID, normalizedPath);
+  // Validate path
+  const basePath = resolve(join(iCloudDriveDirectory, blogID));
+  const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
+  const dirPath = resolve(join(basePath, normalizedPath));
+
+  if (dirPath !== basePath && !dirPath.startsWith(basePath + sep)) {
+    console.log(
+      `Invalid path: attempted to access parent directory`,
+      basePath,
+      dirPath
+    );
+    return res
+      .status(400)
+      .send("Invalid path: attempted to access parent directory");
+  }
 
   console.log(
     `Received recursiveList request for blogID: ${blogID}, path: ${path}`


### PR DESCRIPTION
### Motivation
- Prevent directory traversal by resolving both the base directory and requested path before use.
- Keep `recursiveList` behavior consistent with `mkdir` by applying the same path validation logic.
- Ensure requests that escape the blog's iCloud directory are rejected with a 400 error.

### Description
- Require `resolve` and `sep` from `path` and compute `basePath` with `resolve(join(iCloudDriveDirectory, blogID))`.
- Normalize the requested path and resolve `dirPath` with `resolve(join(basePath, normalizedPath))`.
- Validate that `dirPath` equals `basePath` or starts with `basePath + sep`, returning `400` and logging when it does not.
- Otherwise call `recursiveList(dirPath, 0)` and return a `200` JSON success response.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962628659448329b2bada2d3a8c271d)