### PR TITLE
Handle unexpected iCloud quota output and return null fallback

### DIFF
--- a/app/clients/icloud/macserver/brctl/quota.js
+++ b/app/clients/icloud/macserver/brctl/quota.js
@@ -10,5 +10,10 @@ module.exports = async () => {
     throw new Error("Failed to get iCloud Drive quota");
   }
 
-  return parseInt(stdout.match(/(\d+) bytes of quota remaining/)[1]);
+  const match = stdout.match(/(\d+) bytes of quota remaining/);
+  if (!match || !match[1]) {
+    throw new Error(`Unexpected iCloud Drive quota output: ${stdout}`);
+  }
+
+  return parseInt(match[1], 10);
 };

--- a/app/clients/icloud/macserver/routes/stats.js
+++ b/app/clients/icloud/macserver/routes/stats.js
@@ -12,6 +12,7 @@ module.exports = async (req, res) => {
     result.icloud_bytes_available = await brctl.quota();
   } catch (error) {
     console.error(`Error getting iCloud Drive quota: ${error}`);
+    result.icloud_bytes_available = null;
   }
 
   try {


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash when `brctl quota` returns output that doesn't match the expected regex.
- Surface the raw `stdout` in the thrown error to make unexpected formats visible in logs.
- Ensure the stats endpoint returns a consistent shape when the quota is unavailable by providing a fallback value.

### Description
- In `app/clients/icloud/macserver/brctl/quota.js` the regex match is stored in `const match` and validated before access.
- If the match is missing or malformed the code now throws `new Error` containing the raw `stdout` for debugging. 
- `parseInt(match[1], 10)` is only called after the guard to avoid accessing `[1]` on an undefined match. 
- In `app/clients/icloud/macserver/routes/stats.js` the `icloud_bytes_available` field is set to `null` in the catch block so clients receive a consistent response shape.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69626297e7b0832985b3c79898afb373)