### PR TITLE
Ensure iCloud evict re-watches blog

### DIFF
--- a/app/clients/icloud/macserver/routes/evict.js
+++ b/app/clients/icloud/macserver/routes/evict.js
@@ -22,12 +22,14 @@ module.exports = async (req, res) => {
   // first unwatch the blogID to prevent further events from being triggered
   await unwatch(blogID);
 
-  await brctl.evict(filePath);
+  try {
+    await brctl.evict(filePath);
 
-  console.log(`Handled file eviction: ${filePath}`);
-
-  // re-watch the blogID
-  await watch(blogID);
+    console.log(`Handled file eviction: ${filePath}`);
+  } finally {
+    // re-watch the blogID
+    await watch(blogID);
+  }
 
   res.sendStatus(200);
 };


### PR DESCRIPTION
### Motivation
- Guarantee that `watch(blogID)` is re-established after handling an eviction, even if `brctl.evict` throws, so the blog watcher invariant holds after the handler finishes.
- Avoid leaving a blog unwatched due to an exception during eviction which could cause missed filesystem events or stale state.
- Preserve existing response and error behavior so callers still receive errors as before.

### Description
- Wrapped `await brctl.evict(filePath)` in a `try`/`finally` in `app/clients/icloud/macserver/routes/evict.js` to ensure `await watch(blogID)` always runs.
- Moved the `console.log` for successful eviction inside the `try` block and placed the `await watch(blogID)` call in the `finally` block.
- Left the initial `await unwatch(blogID)` and the final `res.sendStatus(200)` semantics unchanged.

### Testing
- No automated tests were run for this change.
- Manual verification was not recorded as part of the automated test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696266e250348329aadb2faf8bbd50b5)