### PR TITLE
Validate macserver file paths

### DIFF
--- a/app/clients/icloud/macserver/routes/upload.js
+++ b/app/clients/icloud/macserver/routes/upload.js
@@ -1,5 +1,5 @@
 const fs = require("fs-extra");
-const { join } = require("path");
+const { join, resolve, sep, isAbsolute } = require("path");
 const { iCloudDriveDirectory } = require("../config");
 const { watch, unwatch } = require("../watcher");
 
@@ -14,7 +14,23 @@ module.exports = async (req, res) => {
 
   console.log(`Received upload request for blogID: ${blogID}, path: ${path}`);
 
-  const filePath = join(iCloudDriveDirectory, blogID, path);
+  if (isAbsolute(path)) {
+    return res.status(400).send("Invalid path: absolute paths are not allowed");
+  }
+
+  const basePath = resolve(join(iCloudDriveDirectory, blogID));
+  const filePath = resolve(join(basePath, path));
+
+  if (filePath !== basePath && !filePath.startsWith(`${basePath}${sep}`)) {
+    console.log(
+      "Invalid path: attempted to access parent directory",
+      basePath,
+      filePath
+    );
+    return res
+      .status(400)
+      .send("Invalid path: attempted to access parent directory");
+  }
 
   // first unwatch the blogID to prevent further events from being triggered
   await unwatch(blogID);


### PR DESCRIPTION
### Motivation

- Prevent directory traversal and absolute-path usage so macserver operations remain confined to `iCloudDriveDirectory/<blogID>`.
- Ensure invalid paths are rejected early and do not reach filesystem or brctl operations.
- Make validation consistent with existing checks in `routes/mkdir.js` and `routes/readdir.js`.

### Description

- Added imports `isAbsolute`, `resolve`, and `sep` from `path` and reject absolute paths with `isAbsolute(path)` in the upload, delete, and download routes.
- Compute `basePath = resolve(join(iCloudDriveDirectory, blogID))` and `filePath = resolve(join(basePath, path))` and enforce containment via the `filePath !== basePath && !filePath.startsWith(`${basePath}${sep}`)` check.
- Applied the validation to `app/clients/icloud/macserver/routes/upload.js`, `app/clients/icloud/macserver/routes/delete.js`, and `app/clients/icloud/macserver/routes/download.js`.
- Return HTTP 400 for invalid paths before any filesystem operations or `brctl` calls, and log attempted parent-directory access.

### Testing

- No automated tests were run for this change.
- Changes were linted/compiled implicitly by committing, but no test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962674ed3148329bec3a61ecc5aa412)