### PR TITLE
Escape sharingLink before interpolating into AppleScript

### DIFF
--- a/app/clients/icloud/macserver/routes/setup.js
+++ b/app/clients/icloud/macserver/routes/setup.js
@@ -81,6 +81,12 @@ const setupBlog = setupLimiter.wrap(async (blogID, sharingLink) => {
   );
   throw new Error("Invalid sharing link");
 });
+const escapeAppleScriptString = (value) =>
+  String(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, "\\\"")
+    .replace(/\r\n|\r|\n/g, "\\n");
+
 // Used the accessibility inspector to find the UI elements to interact with
 const appleScript = (sharingLink) => `
 -- Open the specified sharing link in Finder
@@ -142,10 +148,11 @@ end try
 
 async function acceptSharingLink(sharingLink) {
   console.log(`Running AppleScript to accept sharing link: ${sharingLink}`);
+  const escapedSharingLink = escapeAppleScriptString(sharingLink);
 
   const { stdout, stderr } = await exec("osascript", [
     "-e",
-    appleScript(sharingLink),
+    appleScript(escapedSharingLink),
   ]);
 
   if (stderr && stderr.trim()) {


### PR DESCRIPTION
### Motivation
- Prevent execution of unintended AppleScript when `sharingLink` contains characters that could break out of a string literal. 
- Treat any `sharingLink` strictly as a Finder URL string and disallow injection of additional AppleScript statements. 
- Make `acceptSharingLink` feed only a sanitized string into the `osascript -e` invocation to reduce risk when calling `open location`.

### Description
- Add `escapeAppleScriptString` utility that escapes backslashes, double quotes, and newline sequences before interpolation. 
- Use the escaped value (`escapedSharingLink`) when generating the AppleScript and call `appleScript(escapedSharingLink)` in `acceptSharingLink`. 
- Change is localized to `app/clients/icloud/macserver/routes/setup.js` and preserves the existing AppleScript control flow and behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696268c0060c83298b03fa09be41c074)