### PR TITLE
Add timeout handling to macserver exec and AppleScript setup

### DIFF
--- a/app/clients/icloud/macserver/routes/setup.js
+++ b/app/clients/icloud/macserver/routes/setup.js
@@ -146,7 +146,7 @@ async function acceptSharingLink(sharingLink) {
   const { stdout, stderr } = await exec("osascript", [
     "-e",
     appleScript(sharingLink),
-  ]);
+  ], { timeout: 15000 });
 
   if (stderr && stderr.trim()) {
     throw new Error(`Unexpected AppleScript stderr: ${stderr}`);


### PR DESCRIPTION
### Motivation
- Ensure spawned child processes do not hang indefinitely by adding an optional timeout to `exec` so long-running processes are killed and the promise rejects.
- Make the iCloud sharing link acceptance fail fast so a hung `osascript` does not block the single-concurrency `setupLimiter` during setup.

### Description
- Update `app/clients/icloud/macserver/exec.js` to accept an `options.timeout` value (destructured away from spawn options) and start a timer that kills the child with `SIGTERM` and rejects with a `Command timed out after ${timeout}ms` error.
- Add a `finalize` helper to ensure the promise is only resolved or rejected once and to clear the timeout when finished.
- Update `app/clients/icloud/macserver/routes/setup.js` to pass `{ timeout: 15000 }` to `exec("osascript", ...)` when running the AppleScript in `acceptSharingLink`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696266bb5ed0832987881720b02aa286)