### PR TITLE
Add 15s timeout to osascript call in iCloud setup

### DIFF
--- a/app/clients/icloud/macserver/routes/setup.js
+++ b/app/clients/icloud/macserver/routes/setup.js
@@ -150,10 +150,11 @@ async function acceptSharingLink(sharingLink) {
   console.log(`Running AppleScript to accept sharing link: ${sharingLink}`);
   const escapedSharingLink = escapeAppleScriptString(sharingLink);
 
-  const { stdout, stderr } = await exec("osascript", [
-    "-e",
-    appleScript(escapedSharingLink),
-  ]);
+  const { stdout, stderr } = await exec(
+    "osascript",
+    ["-e", appleScript(escapedSharingLink)],
+    { timeout: 15000 }
+  );
 
   if (stderr && stderr.trim()) {
     throw new Error(`Unexpected AppleScript stderr: ${stderr}`);


### PR DESCRIPTION
### Motivation
- Prevent a hung AppleScript from blocking `setupBlog` and holding the Bottleneck `setupLimiter` indefinitely.
- Ensure the `acceptSharingLink` flow fails fast when `osascript` hangs so the limiter can release for other requests.
- Follow the suggested 10–15s timeout window for interactive OS-level dialogs.
- Use the existing `exec` helper which supports a `timeout` option to implement the change.

### Description
- Added a timeout option to the `exec` call that invokes `osascript` inside `acceptSharingLink` in `app/clients/icloud/macserver/routes/setup.js`.
- The `exec` invocation now passes `{ timeout: 15000 }`, enforcing a 15 second limit when running `osascript`.
- No other logic was modified; error handling for `stdout`/`stderr` remains unchanged.
- This makes hung AppleScripts reject the promise and free the Bottleneck limiter.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69626e9ff8fc83298775da82ac4367cd)