### PR TITLE
Remove limiter entries on blog folder deletion and assert map shrinks

### DIFF
--- a/app/clients/icloud/macserver/limiters.js
+++ b/app/clients/icloud/macserver/limiters.js
@@ -29,7 +29,10 @@ const removeLimiterForBlogID = (blogID) => {
   limiters.delete(blogID);
 };
 
+const getLimiterCount = () => limiters.size;
+
 module.exports = {
   getLimiterForBlogID,
   removeLimiterForBlogID,
+  getLimiterCount,
 };


### PR DESCRIPTION
### Motivation
- Prevent the per-blog limiter map from leaking entries when a blog folder is deleted, which could grow memory usage over time.  
- Add a quick runtime check to catch regressions where the limiter isn't removed after root folder deletion.  

### Description
- Exported `getLimiterCount` from `app/clients/icloud/macserver/limiters.js` to expose the current limiter map size.  
- In `app/clients/icloud/macserver/watcher/index.js` root `unlinkDir` handling, call `removeLimiterForBlogID(blogID)` and verify the map shrinks using a `console.assert` based on `getLimiterCount`.  
- Updated the top-level require in the watcher to import `removeLimiterForBlogID` and `getLimiterCount` in addition to `getLimiterForBlogID`.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962712752588329967ac85e11fb7607)