### PR TITLE
Add bounded retries to iCloud watcher upload/mkdir/remove

### DIFF
--- a/app/clients/icloud/macserver/watcher/index.js
+++ b/app/clients/icloud/macserver/watcher/index.js
@@ -12,6 +12,33 @@ const upload = require("../httpClient/upload");
 const mkdir = require("../httpClient/mkdir");
 const remove = require("../httpClient/remove");
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const withRetries = async (label, operation, options = {}) => {
+  const { attempts = 4, baseDelayMs = 200 } = options;
+
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts) {
+        break;
+      }
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      console.warn(
+        `${label} failed on attempt ${attempt}/${attempts}, retrying in ${delayMs}ms:`,
+        error
+      );
+      await sleep(delayMs);
+    }
+  }
+
+  console.error(`${label} failed after ${attempts} attempts:`, lastError);
+  throw lastError;
+};
+
 const extractBlogID = (filePath) => {
   if (!filePath.startsWith(iCloudDriveDirectory)) {
     return null;
@@ -82,11 +109,20 @@ const handleFileEvent = async (event, blogID, filePath) => {
     // Schedule the event handler to run within the limiter
     await limiter.schedule(async () => {
       if (event === "add" || event === "change") {
-        await upload(blogID, pathInBlogDirectory);
+        await withRetries(
+          `upload ${blogID}/${pathInBlogDirectory}`,
+          () => upload(blogID, pathInBlogDirectory)
+        );
       } else if (event === "unlink" || event === "unlinkDir") {
-        await remove(blogID, pathInBlogDirectory);
+        await withRetries(
+          `remove ${blogID}/${pathInBlogDirectory}`,
+          () => remove(blogID, pathInBlogDirectory)
+        );
       } else if (event === "addDir") {
-        await mkdir(blogID, pathInBlogDirectory);
+        await withRetries(
+          `mkdir ${blogID}/${pathInBlogDirectory}`,
+          () => mkdir(blogID, pathInBlogDirectory)
+        );
       }
     });
   } catch (error) {


### PR DESCRIPTION
### Motivation
- Prevent transient errors from causing silent drops of iCloud operations like `upload`, `mkdir`, and `remove`.
- Surface failures to logs and propagate them so higher-level monitoring can react.
- Reduce flakiness by retrying transient failures with exponential backoff.

### Description
- Add a `sleep` helper and a `withRetries(label, operation, options)` helper that does bounded retries with exponential backoff and logging on each retry and final failure.
- Wrap calls to `upload`, `remove`, and `mkdir` inside the watcher with `withRetries` so those operations are retried and errors are not swallowed.
- Default retry behavior is 4 attempts with a `baseDelayMs` of `200` and exponential backoff, and the helper rethrows the final error after logging.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962714698ac8329803799ad3fcdc62a)