### PR TITLE
Add error handling to iCloud routes

### DIFF
--- a/app/clients/icloud/routes/dashboard.js
+++ b/app/clients/icloud/routes/dashboard.js
@@ -14,8 +14,12 @@ const MACSERVER_URL = config.icloud.server_address; // The Macserver base URL fr
 const MACSERVER_AUTH = config.icloud.secret; // The Macserver Authorization secret from config
 
 dashboard.use(async function (req, res, next) {
-  res.locals.account = await database.get(req.blog.id);
-  next();
+  try {
+    res.locals.account = await database.get(req.blog.id);
+    next();
+  } catch (error) {
+    next(error);
+  }
 });
 
 dashboard.get("/", function (req, res) {

--- a/app/clients/icloud/routes/site/index.js
+++ b/app/clients/icloud/routes/site/index.js
@@ -21,15 +21,22 @@ const maxNotifications = 2;
 site.get("/started", async function (req, res) {
   res.sendStatus(200);
 
-  if (totalNotificationsSent < maxNotifications) {
-    email.ICLOUD_SERVER_STARTED();
-    totalNotificationsSent++;
-    await resyncRecentlySynced();
-  } else if (!panicNotificationsSent) {
-    panicNotificationsSent = true;
-    email.ICLOUD_SERVER_PANIC();
-  } else {
-    console.log("iCloud server restart: not sending any more notifications");
+  try {
+    if (totalNotificationsSent < maxNotifications) {
+      email.ICLOUD_SERVER_STARTED();
+      totalNotificationsSent++;
+      await resyncRecentlySynced();
+    } else if (!panicNotificationsSent) {
+      panicNotificationsSent = true;
+      email.ICLOUD_SERVER_PANIC();
+    } else {
+      console.log("iCloud server restart: not sending any more notifications");
+    }
+  } catch (error) {
+    console.error("Error handling /started notification:", error);
+    if (!res.headersSent) {
+      res.status(500).send("Failed to process /started notification");
+    }
   }
 });
 

--- a/app/clients/icloud/routes/site/middleware/loadAccount.js
+++ b/app/clients/icloud/routes/site/middleware/loadAccount.js
@@ -1,21 +1,25 @@
 const database = require("clients/icloud/database");
 
 module.exports = async function validateBlog(req, res, next) {
-  const blogID = req.header("blogID");
+  try {
+    const blogID = req.header("blogID");
 
-  if (!blogID) {
-    console.log("Missing blogID header");
-    return res.status(400).send("Missing blogID header");
+    if (!blogID) {
+      console.log("Missing blogID header");
+      return res.status(400).send("Missing blogID header");
+    }
+
+    // Check with the database that the blog is connected to the iCloud Drive
+    const account = await database.get(blogID);
+
+    if (!account || !account.sharingLink) {
+      console.log("Blog is not connected to iCloud Drive");
+      return res.status(400).send("Blog is not connected to iCloud Drive");
+    }
+
+    req.account = account;
+    next();
+  } catch (error) {
+    next(error);
   }
-
-  // Check with the database that the blog is connected to the iCloud Drive
-  const account = await database.get(blogID);
-
-  if (!account || !account.sharingLink) {
-    console.log("Blog is not connected to iCloud Drive");
-    return res.status(400).send("Blog is not connected to iCloud Drive");
-  }
-
-  req.account = account;
-  next();
 };


### PR DESCRIPTION
### Motivation
- Prevent unhandled promise rejections in iCloud client routes by ensuring asynchronous errors are caught.  
- Ensure middleware forwards errors to the Express error handler via `next(error)`.  
- Make the `/started` notification endpoint robust when calling `resyncRecentlySynced()` so failures are logged and do not cause unhandled rejections.  

### Description
- Wrap the dashboard account-loading middleware in `app/clients/icloud/routes/dashboard.js` with a `try/catch` and call `next(error)` on failure.  
- Wrap the `validateBlog` middleware in `app/clients/icloud/routes/site/middleware/loadAccount.js` with a `try/catch` and call `next(error)` on failure.  
- Guard the `/started` handler in `app/clients/icloud/routes/site/index.js` with a `try/catch`, log errors, and send a 5xx response when headers are not already sent while preserving the immediate `200` response.  
- No behavioral changes beyond improved error handling and logging.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962717668e883299f2232b67ac0174a)