### PR TITLE
Adjust brctl download path in ls deadlock handling

### DIFF
--- a/app/clients/icloud/macserver/brctl/ls.js
+++ b/app/clients/icloud/macserver/brctl/ls.js
@@ -1,3 +1,4 @@
+const { iCloudDriveDirectory } = require("../config");
 const exec = require("../exec");
 
 const CONFIG = {
@@ -45,7 +46,10 @@ module.exports = async (dirPath) => {
     // Handle deadlock by downloading
     try {
       console.log(`Directory not downloaded, downloading: ${dirPath}`);
-      await exec("brctl", ["download", dirPath]);
+      const pathInDrive = dirPath.replace(iCloudDriveDirectory, "").slice(1);
+      await exec("brctl", ["download", pathInDrive], {
+        cwd: iCloudDriveDirectory,
+      });
     } catch (error) {
       console.error(`Error downloading directory ${dirPath}: ${error.message}`);
       return null;


### PR DESCRIPTION
### Motivation
- Fix deadlock handling in `app/clients/icloud/macserver/brctl/ls.js` so `brctl download` is invoked consistently with other brctl helpers.
- Ensure `brctl` receives a drive-relative path instead of the absolute path to avoid command failures when invoked from the iCloud Drive directory.
- Use `iCloudDriveDirectory` from `../config` to compute the relative path and set the `cwd` for the `exec` call.
- Preserve existing polling and error handling behavior for listing directories.

### Description
- Added `const { iCloudDriveDirectory } = require("../config");` to `ls.js`.
- Compute `pathInDrive` via `dirPath.replace(iCloudDriveDirectory, "").slice(1)` and call `exec("brctl", ["download", pathInDrive], { cwd: iCloudDriveDirectory })` in the deadlock recovery path.
- Kept existing logs, timeouts, and polling logic intact when retrying the directory listing.
- Changes are limited to `app/clients/icloud/macserver/brctl/ls.js`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696274564eac8329a9e8bb6d0e7d7f0e)