### PR TITLE
Resolve iCloud case conflicts before initial transfer

### DIFF
--- a/app/clients/icloud/sync/initialTransfer.js
+++ b/app/clients/icloud/sync/initialTransfer.js
@@ -3,6 +3,7 @@ const MACSERVER_URL = config.icloud.server_address; // The Macserver base URL fr
 const MACSERVER_AUTH = config.icloud.secret; // The Macserver Authorization secret from config
 const database = require("../database");
 const syncToiCloud = require("./toiCloud");
+const resolveCaseConflicts = require("./resolveCaseConflicts");
 const establishSyncLock = require("../util/establishSyncLock");
 const fetch = require("../util/rateLimitedFetchWithRetriesAndTimeout");
 
@@ -13,6 +14,8 @@ module.exports = async function initialTransfer(blogID) {
   try {
     folder.status("Setting up iCloud sync");
     await database.store(blogID, { transferringToiCloud: true, error: null });
+    folder.status("Resolving case conflicts");
+    await resolveCaseConflicts(blogID, folder.status, folder.update);
     await syncToiCloud(blogID, folder.status, folder.update);
 
     // Now that the transfer is complete, notify the Macserver to begin watching the iCloud folder

--- a/app/clients/icloud/sync/resolveCaseConflicts.js
+++ b/app/clients/icloud/sync/resolveCaseConflicts.js
@@ -1,0 +1,252 @@
+const fs = require("fs-extra");
+const path = require("path");
+const localPath = require("helper/localPath");
+const clfdate = require("helper/clfdate");
+
+const prefix = () => `${clfdate()} iCloud case-conflict:`;
+
+const canonicalName = (name) => name.normalize("NFC").toLowerCase();
+
+const sortByName = (entries) =>
+  entries.sort((a, b) =>
+    a.name.localeCompare(b.name, "en", { sensitivity: "variant" })
+  );
+
+const listEntries = async (blogID, relDir) => {
+  const absDir = localPath(blogID, relDir);
+  const names = await fs.readdir(absDir);
+
+  const entries = await Promise.all(
+    names.map(async (name) => {
+      const stat = await fs.stat(path.join(absDir, name));
+      return { name, isDirectory: stat.isDirectory() };
+    })
+  );
+
+  return sortByName(entries);
+};
+
+const getParentPaths = (relPath) => {
+  const parents = [];
+  let current = path.posix.dirname(relPath);
+  while (current && current !== ".") {
+    parents.push(current);
+    if (current === "/") break;
+    current = path.posix.dirname(current);
+  }
+  return parents;
+};
+
+const updatePathAndParents = async (update, relPath) => {
+  const unique = new Set([relPath, ...getParentPaths(relPath)]);
+  for (const entry of unique) {
+    await update(entry);
+  }
+};
+
+const collectTreePaths = async (blogID, relDir) => {
+  const entries = await listEntries(blogID, relDir);
+  const paths = [relDir];
+
+  for (const entry of entries) {
+    const childRel = path.posix.join(relDir, entry.name);
+    paths.push(childRel);
+    if (entry.isDirectory) {
+      const childPaths = await collectTreePaths(blogID, childRel);
+      paths.push(...childPaths.filter((p) => p !== childRel));
+    }
+  }
+
+  return paths;
+};
+
+const updateTree = async (blogID, update, relDir) => {
+  const paths = await collectTreePaths(blogID, relDir);
+  for (const entry of paths) {
+    await update(entry);
+  }
+  const parents = getParentPaths(relDir);
+  for (const parent of parents) {
+    await update(parent);
+  }
+};
+
+const splitName = (name) => {
+  const lastDot = name.lastIndexOf(".");
+  if (lastDot > 0) {
+    return { base: name.slice(0, lastDot), ext: name.slice(lastDot) };
+  }
+  return { base: name, ext: "" };
+};
+
+const generateConflictName = (existingLowerSet, originalName) => {
+  const { base, ext } = splitName(originalName);
+  let suffix = " (conflict)";
+  let counter = 2;
+  let candidate = `${base}${suffix}${ext}`;
+
+  while (existingLowerSet.has(canonicalName(candidate))) {
+    suffix = ` (conflict ${counter})`;
+    candidate = `${base}${suffix}${ext}`;
+    counter += 1;
+  }
+
+  existingLowerSet.add(canonicalName(candidate));
+  return candidate;
+};
+
+module.exports = async function resolveCaseConflicts(blogID, publish, update) {
+  if (!publish) {
+    publish = () => {};
+  }
+  if (!update) {
+    update = () => {};
+  }
+
+  const renameEntry = async (relDir, originalName, newName) => {
+    const fromRel = path.posix.join(relDir, originalName);
+    const toRel = path.posix.join(relDir, newName);
+    const fromAbs = localPath(blogID, fromRel);
+    const fromStat = await fs.stat(fromAbs);
+    const fromTreePaths = fromStat.isDirectory()
+      ? await collectTreePaths(blogID, fromRel)
+      : null;
+    await fs.move(localPath(blogID, fromRel), localPath(blogID, toRel));
+    console.log(prefix(), "Renamed conflict", fromRel, "->", toRel);
+    publish("Renamed conflict", fromRel, "->", toRel);
+    await updatePathAndParents(update, fromRel);
+    await updatePathAndParents(update, toRel);
+    if (fromTreePaths) {
+      for (const entry of fromTreePaths) {
+        await update(entry);
+      }
+      await updateTree(blogID, update, toRel);
+    }
+  };
+
+  const moveEntry = async (fromRel, toRel) => {
+    const fromAbs = localPath(blogID, fromRel);
+    const fromStat = await fs.stat(fromAbs);
+    const fromTreePaths = fromStat.isDirectory()
+      ? await collectTreePaths(blogID, fromRel)
+      : null;
+    await fs.move(fromAbs, localPath(blogID, toRel));
+    await updatePathAndParents(update, fromRel);
+    await updatePathAndParents(update, toRel);
+    if (fromTreePaths) {
+      for (const entry of fromTreePaths) {
+        await update(entry);
+      }
+      await updateTree(blogID, update, toRel);
+    }
+  };
+
+  const mergeDirectory = async (targetRel, sourceRel) => {
+    const entries = await listEntries(blogID, sourceRel);
+
+    for (const entry of entries) {
+      const sourceChildRel = path.posix.join(sourceRel, entry.name);
+      const targetChildRel = path.posix.join(targetRel, entry.name);
+      const targetChildAbs = localPath(blogID, targetChildRel);
+
+      if (await fs.pathExists(targetChildAbs)) {
+        const targetStat = await fs.stat(targetChildAbs);
+
+        if (targetStat.isDirectory() && entry.isDirectory) {
+          await mergeDirectory(targetChildRel, sourceChildRel);
+        } else if (targetStat.isDirectory() && !entry.isDirectory) {
+          const targetEntries = await listEntries(blogID, targetRel);
+          const existingLowerSet = new Set(
+            targetEntries.map((item) => canonicalName(item.name))
+          );
+          const conflictName = generateConflictName(existingLowerSet, entry.name);
+          await moveEntry(sourceChildRel, path.posix.join(targetRel, conflictName));
+        } else if (!targetStat.isDirectory() && entry.isDirectory) {
+          const targetEntries = await listEntries(blogID, targetRel);
+          const existingLowerSet = new Set(
+            targetEntries.map((item) => canonicalName(item.name))
+          );
+          const conflictName = generateConflictName(existingLowerSet, entry.name);
+          await renameEntry(targetRel, entry.name, conflictName);
+          await moveEntry(sourceChildRel, targetChildRel);
+        } else {
+          const targetEntries = await listEntries(blogID, targetRel);
+          const existingLowerSet = new Set(
+            targetEntries.map((item) => canonicalName(item.name))
+          );
+          const conflictName = generateConflictName(existingLowerSet, entry.name);
+          await moveEntry(sourceChildRel, path.posix.join(targetRel, conflictName));
+        }
+      } else {
+        await moveEntry(sourceChildRel, targetChildRel);
+      }
+    }
+
+    await fs.remove(localPath(blogID, sourceRel));
+    await updatePathAndParents(update, sourceRel);
+    await updateTree(blogID, update, targetRel);
+  };
+
+  const resolveDir = async (relDir) => {
+    const entries = await listEntries(blogID, relDir);
+    const existingLowerSet = new Set(
+      entries.map((entry) => canonicalName(entry.name))
+    );
+    const groups = new Map();
+    const orderedKeys = [];
+
+    for (const entry of entries) {
+      const key = canonicalName(entry.name);
+      if (!groups.has(key)) {
+        groups.set(key, []);
+        orderedKeys.push(key);
+      }
+      groups.get(key).push(entry);
+    }
+
+    const resolvedDirs = new Set();
+
+    for (const key of orderedKeys) {
+      const group = groups.get(key);
+      if (!group || group.length < 2) continue;
+
+      const dirs = group.filter((entry) => entry.isDirectory);
+      const files = group.filter((entry) => !entry.isDirectory);
+
+      if (dirs.length > 0) {
+        const canonicalDir = dirs[0];
+        const canonicalRel = path.posix.join(relDir, canonicalDir.name);
+
+        for (const entry of dirs.slice(1)) {
+          const sourceRel = path.posix.join(relDir, entry.name);
+          await mergeDirectory(canonicalRel, sourceRel);
+        }
+
+        for (const entry of files) {
+          const conflictName = generateConflictName(existingLowerSet, entry.name);
+          await renameEntry(relDir, entry.name, conflictName);
+        }
+
+        await resolveDir(canonicalRel);
+        resolvedDirs.add(canonicalRel);
+      } else {
+        const winner = files[0];
+        for (const entry of files.slice(1)) {
+          const conflictName = generateConflictName(existingLowerSet, entry.name);
+          await renameEntry(relDir, entry.name, conflictName);
+        }
+        resolvedDirs.add(path.posix.join(relDir, winner.name));
+      }
+    }
+
+    const updatedEntries = await listEntries(blogID, relDir);
+    for (const entry of updatedEntries) {
+      if (!entry.isDirectory) continue;
+      const childRel = path.posix.join(relDir, entry.name);
+      if (resolvedDirs.has(childRel)) continue;
+      await resolveDir(childRel);
+    }
+  };
+
+  await resolveDir("/");
+};


### PR DESCRIPTION
### Motivation
- Ensure the initial iCloud transfer does not fail or lose data due to case-insensitive filename collisions on the server filesystem.
- Make conflict resolution deterministic so identical inputs yield predictable canonical names and merges.
- Run conflict resolution while holding the global iCloud sync lock so no concurrent sync mutates the tree during fixes.

### Description
- Add `app/clients/icloud/sync/resolveCaseConflicts.js` which walks the local blog tree, groups entries by a canonical form (`name.normalize("NFC").toLowerCase()`), and deterministically resolves conflicts by stable ordering, directory merging, and conflict-name generation.
- Directory conflicts are merged (contents combined into the chosen canonical directory) and file conflicts are renamed to ` (conflict)`, ` (conflict 2)`, etc., inserted before the last `.` if present, with uniqueness enforced under case-insensitive comparison.
- After each move/rename/merge the code calls the provided `update` callback (the sync `folder.update`) for the modified paths and affected parent/child paths using `updatePathAndParents`, `collectTreePaths`, and `updateTree` to ensure downstream sync logic is notified.
- Invoke `resolveCaseConflicts(blogID, folder.status, folder.update)` from `initialTransfer` while the sync lock is held and emit minimal audit logging via `publish`/`console.log` for renamed/moved paths.

### Testing
- No automated tests were run against the modified code in this change.
- Manual verification steps are recommended: exercise case-variant directory/file setups and confirm deterministic renames, merges, and `folder.update` calls complete before `syncToiCloud` runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69627fa641fc832983d00710dc6f59ba)