### PR TITLE
Switch Dropbox validation to hourly cadence

### DIFF
--- a/app/clients/dropbox/init.js
+++ b/app/clients/dropbox/init.js
@@ -10,7 +10,7 @@ const getAllIDs = promisify(Blog.getAllIDs);
 const getBlog = promisify(Blog.get);
 const getDropboxAccount = promisify(getAccount);
 
-const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
+const ONE_HOUR_IN_MS = 60 * 60 * 1000;
 const FIFTEEN_MINUTES_IN_MS = 15 * 60 * 1000;
 
 const countChanges = (summary = {}) => {
@@ -23,11 +23,11 @@ const countChanges = (summary = {}) => {
 
 const hasRecentSync = (account) => {
   if (!account || typeof account.last_sync !== "number") return false;
-  return Date.now() - account.last_sync <= ONE_DAY_IN_MS;
+  return Date.now() - account.last_sync <= ONE_HOUR_IN_MS;
 };
 
 const runValidation = async () => {
-  console.log(clfdate(), "Dropbox: Running daily sync validation");
+  console.log(clfdate(), "Dropbox: Running hourly sync validation");
 
   let blogIDs = [];
 
@@ -155,8 +155,8 @@ const resyncRecentSyncsOnStartup = async () => {
 };
 
 module.exports = async function init() {
-  console.log(clfdate(), "Dropbox: Scheduling daily sync validation");
-  scheduler.scheduleJob({ hour: 7, minute: 0 }, runValidation);
+  console.log(clfdate(), "Dropbox: Scheduling hourly sync validation");
+  scheduler.scheduleJob("0 * * * *", runValidation);
   resyncRecentSyncsOnStartup().catch(function (err) {
     console.error(clfdate(), "Dropbox: Startup resync failed", err);
   });


### PR DESCRIPTION
### Motivation
- Reduce the sync validation window from a day to an hour so only very recent Dropbox syncs are considered.
- Run validation on an hourly cadence instead of once per day to detect issues sooner.
- Update logging and naming to accurately reflect the new hourly behavior in `app/clients/dropbox/init.js`.

### Description
- Replaced `ONE_DAY_IN_MS` with `ONE_HOUR_IN_MS` and updated `hasRecentSync` to use the hourly window.
- Updated the validation log message in `runValidation` to `"Dropbox: Running hourly sync validation"`.
- Changed the scheduled job from the daily `{ hour: 7, minute: 0 }` schedule to an hourly cron `"0 * * * *"` via `scheduler.scheduleJob("0 * * * *", runValidation)`.
- Adjusted the startup log to `"Dropbox: Scheduling hourly sync validation"` so naming matches behavior.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a38886808329a22ecc1356f2043f)