### PR TITLE
Fix iCloud /cancel delete call and error handling

### DIFF
--- a/app/clients/icloud/routes/dashboard.js
+++ b/app/clients/icloud/routes/dashboard.js
@@ -123,10 +123,14 @@ dashboard
     }
   });
 
-dashboard.post("/cancel", async function (req, res) {
-  await database.blog.delete(req.blog.id);
+dashboard.post("/cancel", async function (req, res, next) {
+  try {
+    await database.delete(req.blog.id);
 
-  res.message(req.baseUrl, "Cancelled the creation of your new folder");
+    res.message(req.baseUrl, "Cancelled the creation of your new folder");
+  } catch (error) {
+    next(error);
+  }
 });
 
 module.exports = dashboard;


### PR DESCRIPTION
### Motivation
- The `/cancel` POST handler used `database.blog.delete(...)` which is incorrect and must call `database.delete(...)` for removing the blog record.
- Rejected promises in the async handler were not being forwarded to Express error handling, risking unhandled rejections.
- The route should still redirect and show the existing success message when deletion succeeds.

### Description
- Updated `app/clients/icloud/routes/dashboard.js` `/cancel` POST handler to call `database.delete(req.blog.id)` instead of `database.blog.delete(...)`.
- Wrapped the async handler body in a `try/catch` and call `next(error)` on failure to forward errors to Express.
- Preserved the existing success response `res.message(req.baseUrl, "Cancelled the creation of your new folder")` on successful deletion.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a3ffa7fc8329bf16dd359324982d)