### PR TITLE
Add Fix checks to Dropbox and iCloud hourly validations

### DIFF
--- a/app/clients/dropbox/init.js
+++ b/app/clients/dropbox/init.js
@@ -5,6 +5,7 @@ const clfdate = require("helper/clfdate");
 const email = require("helper/email");
 const resetToBlot = require("./sync/reset-to-blot");
 const { get: getAccount } = require("./database");
+const Fix = require("sync/fix");
 
 const getAllIDs = promisify(Blog.getAllIDs);
 const getBlog = promisify(Blog.get);
@@ -67,6 +68,20 @@ const runValidation = async () => {
           changeCountPlural: changeCount !== 1,
         });
       }
+
+      await new Promise((resolve) => {
+        Fix(blog, (fixError) => {
+          if (fixError) {
+            console.error(
+              clfdate(),
+              "Dropbox: Fix error for blog",
+              blogID,
+              fixError
+            );
+          }
+          resolve();
+        });
+      });
     } catch (err) {
       console.error(
         clfdate(),

--- a/app/clients/icloud/init.js
+++ b/app/clients/icloud/init.js
@@ -9,6 +9,7 @@ const initialTransfer = require("./sync/initialTransfer");
 const database = require("./database");
 const syncFromiCloud = require("./sync/fromiCloud");
 const syncToiCloud = require("./sync/toiCloud");
+const Fix = require("sync/fix");
 
 const getBlog = promisify(Blog.get);
 
@@ -149,6 +150,20 @@ const runValidation = async ({ notify = true } = {}) => {
             createdDirs: summary.createdDirs || 0
           });
         }
+
+        await new Promise((resolve) => {
+          Fix(blog, (fixError) => {
+            if (fixError) {
+              console.error(
+                clfdate(),
+                "iCloud: Fix error for blog",
+                blogID,
+                fixError
+              );
+            }
+            resolve();
+          });
+        });
       } catch (error) {
         console.error(
           clfdate(),


### PR DESCRIPTION
### Motivation
- Ensure site integrity checks run after hourly sync validation so any issues discovered during validation are fixed automatically.
- Align background validation flows with the manual dashboard flow that calls `Fix` after resync/rebuild.

### Description
- Import `Fix` via `const Fix = require("sync/fix");` in `app/clients/dropbox/init.js` and `app/clients/icloud/init.js`.
- Invoke `Fix(blog, callback)` (wrapped in a `Promise` and awaited) after `resetToBlot` in Dropbox's `runValidation` loop to run fixes for each validated blog.
- Invoke `Fix(blog, callback)` (wrapped in a `Promise` and awaited) after `syncFromiCloud` in iCloud's `runValidation` loop to run fixes during the hourly validation flow.
- Log any `Fix` errors with `console.error` including `clfdate()` and a contextual message similar to existing validation error logging.

### Testing
- No automated tests were executed for this change.
- Files modified and committed: `app/clients/dropbox/init.js` and `app/clients/icloud/init.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962aea22ffc832996326de6bf114566)