### PR TITLE
Harden brctl quota parsing and add contextual stats logging

### DIFF
--- a/app/clients/icloud/macserver/brctl/quota.js
+++ b/app/clients/icloud/macserver/brctl/quota.js
@@ -4,15 +4,41 @@ module.exports = async () => {
   // use brctl quota to get the iCloud Drive quota and usage
   // e.g. '1899909948243 bytes of quota remaining in personal account'
   const { stdout, stderr } = await exec("brctl", ["quota"]);
-  
-  if (stderr) {
-    console.error(`Error getting iCloud Drive quota: ${stderr}`);
+
+  const trimmedStdout = typeof stdout === "string" ? stdout.trim() : "";
+  const trimmedStderr = typeof stderr === "string" ? stderr.trim() : "";
+
+  if (trimmedStderr) {
+    console.error("Error getting iCloud Drive quota", {
+      stdout: trimmedStdout,
+      stderr: trimmedStderr,
+    });
     throw new Error("Failed to get iCloud Drive quota");
   }
 
-  const match = stdout.match(/(\d+) bytes of quota remaining/);
-  if (!match || !match[1]) {
-    throw new Error(`Unexpected iCloud Drive quota output: ${stdout}`);
+  if (!trimmedStdout) {
+    console.error("iCloud Drive quota parse failure", {
+      stdout: trimmedStdout,
+      stderr: trimmedStderr,
+    });
+    const error = new Error(
+      `Unexpected iCloud Drive quota output: ${trimmedStdout || "<empty>"} | stderr: ${trimmedStderr || "<empty>"}`
+    );
+    error.name = "QuotaParseError";
+    throw error;
+  }
+
+  const match = trimmedStdout.match(/(\d+) bytes of quota remaining/);
+  if (!match?.[1]) {
+    console.error("iCloud Drive quota parse failure", {
+      stdout: trimmedStdout,
+      stderr: trimmedStderr,
+    });
+    const error = new Error(
+      `Unexpected iCloud Drive quota output: ${trimmedStdout || "<empty>"} | stderr: ${trimmedStderr || "<empty>"}`
+    );
+    error.name = "QuotaParseError";
+    throw error;
   }
 
   return parseInt(match[1], 10);

--- a/app/clients/icloud/macserver/routes/stats.js
+++ b/app/clients/icloud/macserver/routes/stats.js
@@ -11,7 +11,11 @@ module.exports = async (req, res) => {
     // get iCloud Drive free space in bytes
     result.icloud_bytes_available = await brctl.quota();
   } catch (error) {
-    console.error(`Error getting iCloud Drive quota: ${error}`);
+    if (error?.name === "QuotaParseError") {
+      console.error(`Error getting iCloud Drive quota (quota parse failure): ${error.message}`);
+    } else {
+      console.error(`Error getting iCloud Drive quota: ${error}`);
+    }
     result.icloud_bytes_available = null;
   }
 


### PR DESCRIPTION
### Motivation
- Prevent crashes caused by unexpected or empty `brctl quota` output when accessing regex capture groups.  
- Ensure logs include the exact raw `stdout`/`stderr` so parsing issues are diagnosable.  
- Surface a descriptive failure mode instead of letting a `TypeError` or vague error propagate.  
- Allow the stats route to handle parse failures gracefully while providing contextual logs.

### Description
- Add trimmed `stdout`/`stderr` guards and only attempt regex parsing when `stdout` is a non-empty string in `app/clients/icloud/macserver/brctl/quota.js`.  
- Log structured parse-failure details including both `stdout` and `stderr` and throw a `QuotaParseError` with the raw output when parsing fails.  
- Preserve existing non-`stderr` failure behavior by throwing on `stderr` while logging structured output.  
- Enhance `app/clients/icloud/macserver/routes/stats.js` to detect `error.name === "QuotaParseError"` and log a contextual message (`quota parse failure`) while still setting `result.icloud_bytes_available = null`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962afd30b6c8329a754b6dd63c2cabe)