### PR TITLE
Normalize macserver paths before resolving files

### DIFF
--- a/app/clients/icloud/macserver/routes/delete.js
+++ b/app/clients/icloud/macserver/routes/delete.js
@@ -1,13 +1,15 @@
 const fs = require("fs-extra");
-const { join, resolve, sep, isAbsolute } = require("path");
+const { join, resolve, sep } = require("path");
 const { iCloudDriveDirectory } = require("../config");
 const clfdate = require("../util/clfdate");
+const normalizeMacserverPath = require("./normalizeMacserverPath");
 
 const { watch, unwatch } = require("../watcher");
 
 module.exports = async (req, res) => {
   const blogID = req.header("blogID");
   const path = Buffer.from(req.header("pathBase64"), "base64").toString("utf8");
+  const normalizedPath = normalizeMacserverPath(path);
 
   // Validate required headers
   if (!blogID || !path) {
@@ -16,12 +18,8 @@ module.exports = async (req, res) => {
 
   console.log(clfdate(), `Received delete request for blogID: ${blogID}, path: ${path}`);
 
-  if (isAbsolute(path)) {
-    return res.status(400).send("Invalid path: absolute paths are not allowed");
-  }
-
   const basePath = resolve(join(iCloudDriveDirectory, blogID));
-  const filePath = resolve(join(basePath, path));
+  const filePath = resolve(join(basePath, normalizedPath));
 
   if (filePath !== basePath && !filePath.startsWith(`${basePath}${sep}`)) {
     console.log(clfdate(), 

--- a/app/clients/icloud/macserver/routes/evict.js
+++ b/app/clients/icloud/macserver/routes/evict.js
@@ -1,6 +1,7 @@
-const { join, resolve, isAbsolute, sep } = require("path");
+const { join, resolve, sep } = require("path");
 const { iCloudDriveDirectory } = require("../config");
 const clfdate = require("../util/clfdate");
+const normalizeMacserverPath = require("./normalizeMacserverPath");
 
 const brctl = require("../brctl");
 
@@ -12,6 +13,7 @@ module.exports = async (req, res) => {
   const path = pathBase64
     ? Buffer.from(pathBase64, "base64").toString("utf8")
     : "";
+  const normalizedPath = normalizeMacserverPath(path);
 
   // Validate required headers
   if (!blogID || !pathBase64 || !path) {
@@ -20,14 +22,10 @@ module.exports = async (req, res) => {
       .send("Missing required headers: blogID or path");
   }
 
-  if (isAbsolute(path)) {
-    return res.status(400).send("Absolute paths are not allowed");
-  }
-
   console.log(clfdate(), `Received evict request for blogID: ${blogID}, path: ${path}`);
 
   const basePath = resolve(join(iCloudDriveDirectory, blogID));
-  const filePath = resolve(basePath, path);
+  const filePath = resolve(basePath, normalizedPath);
 
   if (filePath !== basePath && !filePath.startsWith(basePath + sep)) {
     return res.status(400).send("Path escapes blog directory");

--- a/app/clients/icloud/macserver/routes/normalizeMacserverPath.js
+++ b/app/clients/icloud/macserver/routes/normalizeMacserverPath.js
@@ -1,0 +1,3 @@
+const normalizeMacserverPath = (path) => path.replace(/^\/+/, "");
+
+module.exports = normalizeMacserverPath;


### PR DESCRIPTION
### Motivation
- macOS client can send paths with leading slashes (e.g. `/Posts/foo`) which caused incorrect resolution or download naming. 
- Stripping leading slashes ensures `join`/`resolve` operate on relative paths like `Posts/foo` without breaking existing traversal checks. 
- Avoid rejecting paths simply because they start with `/` while still preventing directory traversal. 
- Reduce duplication by centralizing normalization logic for all macserver routes.

### Description
- Added a small helper `app/clients/icloud/macserver/routes/normalizeMacserverPath.js` which strips leading slashes via `path.replace(/^\/+/, "")`.
- Updated `upload.js`, `delete.js`, `download.js`, and `evict.js` to call `normalizeMacserverPath(path)` and use the resulting `normalizedPath` when building `filePath` with `join/resolve`.
- Removed the `isAbsolute(path)` rejections and adjusted `download.js` to pass `normalizedPath` (not the raw `path`) into `res.download` to avoid leading-slash issues.
- Kept the existing `basePath` / `startsWith` checks intact to prevent directory traversal.

### Testing
- No automated tests were run for this change.
- Changes were committed and files modified: `upload.js`, `delete.js`, `download.js`, `evict.js`, and new `normalizeMacserverPath.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962c9c0036c8329bc89ed12783b3550)