### PR TITLE
Add clfdate-stamped error logging to macserver routes and HTTP clients

### DIFF
--- a/app/clients/icloud/macserver/httpClient/mkdir.js
+++ b/app/clients/icloud/macserver/httpClient/mkdir.js
@@ -6,14 +6,24 @@ module.exports = async (...args) => {
   const [blogID, path] = args;
 
   if (!blogID || typeof blogID !== "string") {
+    console.error(clfdate(), "Invalid blogID for mkdir client request", {
+      blogID,
+    });
     throw new Error("Invalid blogID");
   }
 
   if (!path || typeof path !== "string") {
+    console.error(clfdate(), "Invalid path for mkdir client request", {
+      path,
+      blogID,
+    });
     throw new Error("Invalid path");
   }
 
   if (args.length !== 2) {
+    console.error(clfdate(), "Invalid argument count for mkdir client request", {
+      argsLength: args.length,
+    });
     throw new Error("Invalid number of arguments: expected 2");
   }
 
@@ -21,14 +31,23 @@ module.exports = async (...args) => {
 
   const pathBase64 = Buffer.from(path).toString("base64");
   
-  await fetch(`${remoteServer}/mkdir`, {
-    method: "POST",
-    headers: {
-      Authorization, // Use the Authorization header
-      blogID,
-      pathBase64,
-    },
-  });
+  try {
+    await fetch(`${remoteServer}/mkdir`, {
+      method: "POST",
+      headers: {
+        Authorization, // Use the Authorization header
+        blogID,
+        pathBase64,
+      },
+    });
+  } catch (error) {
+    console.error(
+      clfdate(),
+      `Failed to issue external mkdir for blogID ${blogID}, path ${path}`,
+      error
+    );
+    throw error;
+  }
 
   console.log(clfdate(), `Issuing external mkdir successful`);
 };

--- a/app/clients/icloud/macserver/httpClient/notifyServerStarted.js
+++ b/app/clients/icloud/macserver/httpClient/notifyServerStarted.js
@@ -4,16 +4,28 @@ const clfdate = require("../util/clfdate");
 
 module.exports = async (...args) => {
   if (args.length !== 0) {
+    console.error(clfdate(), "Invalid argument count for notifyServerStarted", {
+      argsLength: args.length,
+    });
     throw new Error("Invalid number of arguments: expected 0");
   }
   
   console.log(clfdate(), `Notifying server that the client has started`);
 
-  await fetch(remoteServer + "/started", {
-    headers: {
-      Authorization, // Use the Authorization header
-    },
-  });
+  try {
+    await fetch(remoteServer + "/started", {
+      headers: {
+        Authorization, // Use the Authorization header
+      },
+    });
+  } catch (error) {
+    console.error(
+      clfdate(),
+      "Failed to notify server that the client has started",
+      error
+    );
+    throw error;
+  }
 
   console.log(clfdate(), `Server notified that the client has started`);
 };

--- a/app/clients/icloud/macserver/httpClient/remove.js
+++ b/app/clients/icloud/macserver/httpClient/remove.js
@@ -6,28 +6,47 @@ module.exports = async (...args) => {
   const [blogID, path] = args;
 
   if (!blogID || typeof blogID !== "string") {
+    console.error(clfdate(), "Invalid blogID for remove client request", {
+      blogID,
+    });
     throw new Error("Invalid blogID");
   }
 
   if (!path || typeof path !== "string") {
+    console.error(clfdate(), "Invalid path for remove client request", {
+      path,
+      blogID,
+    });
     throw new Error("Invalid path");
   }
 
   if (args.length !== 2) {
+    console.error(clfdate(), "Invalid argument count for remove client request", {
+      argsLength: args.length,
+    });
     throw new Error("Invalid number of arguments: expected 2");
   }
 
   console.log(clfdate(), `Issuing external delete for blogID: ${blogID}, path: ${path}`);
   const pathBase64 = Buffer.from(path).toString("base64");
 
-  await fetch(`${remoteServer}/delete`, {
-    method: "POST",
-    headers: {
-      Authorization,
-      blogID,
-      pathBase64,
-    },
-  });
+  try {
+    await fetch(`${remoteServer}/delete`, {
+      method: "POST",
+      headers: {
+        Authorization,
+        blogID,
+        pathBase64,
+      },
+    });
+  } catch (error) {
+    console.error(
+      clfdate(),
+      `Failed to issue external delete for blogID ${blogID}, path ${path}`,
+      error
+    );
+    throw error;
+  }
 
   console.log(clfdate(), `Delete successful`);
 };

--- a/app/clients/icloud/macserver/httpClient/status.js
+++ b/app/clients/icloud/macserver/httpClient/status.js
@@ -6,28 +6,47 @@ module.exports = async (...args) => {
   const [blogID, status] = args;
 
   if (!blogID || typeof blogID !== "string") {
+    console.error(clfdate(), "Invalid blogID for status client request", {
+      blogID,
+    });
     throw new Error("Invalid blogID");
   }
 
   if (!status || typeof status !== "object") {
+    console.error(clfdate(), "Invalid status payload for status client request", {
+      blogID,
+      status,
+    });
     throw new Error("Invalid status");
   }
 
   if (args.length !== 2) {
+    console.error(clfdate(), "Invalid argument count for status client request", {
+      argsLength: args.length,
+    });
     throw new Error("Invalid number of arguments: expected 2");
   }
 
   console.log(clfdate(), `Sending status for blogID: ${blogID}`, status);
 
-  await fetch(`${remoteServer}/status`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization, // Use the Authorization header
-      blogID,
-    },
-    body: JSON.stringify(status),
-  });
+  try {
+    await fetch(`${remoteServer}/status`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization, // Use the Authorization header
+        blogID,
+      },
+      body: JSON.stringify(status),
+    });
+  } catch (error) {
+    console.error(
+      clfdate(),
+      `Failed to send status for blogID ${blogID}`,
+      { status, error }
+    );
+    throw error;
+  }
 
   console.log(clfdate(), `Status sent for blogID: ${blogID}`);
 };

--- a/app/clients/icloud/macserver/httpClient/upload.js
+++ b/app/clients/icloud/macserver/httpClient/upload.js
@@ -14,10 +14,18 @@ const { join } = require("path");
 module.exports = async (blogID, path) => {
   // Input validation
   if (!blogID || typeof blogID !== "string") {
+    console.error(clfdate(), "Invalid blogID for upload client request", {
+      blogID,
+      path,
+    });
     throw new Error("Invalid blogID");
   }
 
   if (!path || typeof path !== "string") {
+    console.error(clfdate(), "Invalid path for upload client request", {
+      blogID,
+      path,
+    });
     throw new Error("Invalid path");
   }
 
@@ -30,10 +38,20 @@ module.exports = async (blogID, path) => {
   try {
     stat = await brctl.download(filePath);
   } catch (e) {
+    console.error(
+      clfdate(),
+      `Failed to download file before upload: ${filePath}`,
+      e
+    );
     throw new Error(`Download failed: ${e.message}`);
   }
 
   if (stat.size > maxFileSize) {
+    console.error(
+      clfdate(),
+      `File size exceeds maximum for upload: ${filePath}`,
+      { size: stat.size, maxFileSize }
+    );
     throw new Error(`File size exceeds maximum of ${maxFileSize} bytes`);
   }
 
@@ -50,6 +68,7 @@ module.exports = async (blogID, path) => {
   try {
     fileBuffer = await fs.readFile(filePath);
   } catch (error) {
+    console.error(clfdate(), `Failed to read file for upload: ${filePath}`, error);
     throw new Error(`Failed to read file: ${error.message}`);
   }
 
@@ -57,22 +76,41 @@ module.exports = async (blogID, path) => {
 
   console.log(clfdate(), `Issuing HTTP /upload request to remote server: ${path}`);
 
-  const response = await fetch(`${remoteServer}/upload`, {
-    // we use a larger timeout for uploads since they involve building a potentially expensive entry
-    // even if the upload itself is fast
-    timeout: 60 * 1000,
-    method: "POST",
-    headers: {
-      "Content-Type": "application/octet-stream",
-      Authorization,
-      blogID,
-      pathBase64,
-      modifiedTime,
-    },
-    body: fileBuffer,
-  });
+  let response;
+  try {
+    response = await fetch(`${remoteServer}/upload`, {
+      // we use a larger timeout for uploads since they involve building a potentially expensive entry
+      // even if the upload itself is fast
+      timeout: 60 * 1000,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/octet-stream",
+        Authorization,
+        blogID,
+        pathBase64,
+        modifiedTime,
+      },
+      body: fileBuffer,
+    });
+  } catch (error) {
+    console.error(
+      clfdate(),
+      `Failed to upload file to remote server: ${filePath}`,
+      error
+    );
+    throw error;
+  }
 
   const text = await response.text();
+
+  if (!response.ok) {
+    console.error(
+      clfdate(),
+      `Upload failed with status ${response.status} for file: ${filePath}`,
+      text
+    );
+    throw new Error(`Upload failed with status ${response.status}`);
+  }
 
   console.log(clfdate(), "Upload successful:", text);
 };

--- a/app/clients/icloud/macserver/index.js
+++ b/app/clients/icloud/macserver/index.js
@@ -22,6 +22,11 @@ const startServer = async () => {
     const authorization = req.header("Authorization"); // New header for the Authorization secret
 
     if (authorization !== Authorization) {
+      console.error(clfdate(), "Unauthorized request", {
+        method: req.method,
+        url: req.url,
+        hasAuthorization: Boolean(authorization),
+      });
       return res.status(403).send("Unauthorized");
     }
 

--- a/app/clients/icloud/macserver/routes/disconnect.js
+++ b/app/clients/icloud/macserver/routes/disconnect.js
@@ -9,12 +9,14 @@ module.exports = async (req, res) => {
   const blogID = req.header("blogID");
 
   if (!blogID) {
+    console.error(clfdate(), "Missing blogID header for disconnect request");
     return res.status(400).send("Missing blogID header");
   }
 
   // ensure the blogID doesn't container any characters other than
   // letters, numbers and underscores
   if (!/^[a-zA-Z0-9_]+$/.test(blogID)) {
+    console.error(clfdate(), `Invalid blogID for disconnect request: ${blogID}`);
     return res.status(400).send("Invalid blogID");
   }
 

--- a/app/clients/icloud/macserver/routes/download.js
+++ b/app/clients/icloud/macserver/routes/download.js
@@ -10,6 +10,11 @@ module.exports = async (req, res) => {
   const normalizedPath = normalizeMacserverPath(path);
 
   if (!blogID || !path) {
+    console.error(
+      clfdate(),
+      "Missing blogID or path header for download request",
+      { blogID, path }
+    );
     return res.status(400).send("Missing blogID or path header");
   }
 
@@ -20,7 +25,7 @@ module.exports = async (req, res) => {
     const filePath = resolve(join(basePath, normalizedPath));
 
     if (filePath !== basePath && !filePath.startsWith(`${basePath}${sep}`)) {
-      console.log(clfdate(), 
+      console.error(clfdate(), 
         "Invalid path: attempted to access parent directory",
         basePath,
         filePath

--- a/app/clients/icloud/macserver/routes/recursiveList.js
+++ b/app/clients/icloud/macserver/routes/recursiveList.js
@@ -11,6 +11,7 @@ module.exports = async (req, res) => {
     : "/";
 
   if (!blogID) {
+    console.error(clfdate(), "Missing blogID header for recursiveList request");
     return res.status(400).send("Missing blogID header");
   }
   
@@ -20,7 +21,7 @@ module.exports = async (req, res) => {
   const dirPath = resolve(join(basePath, normalizedPath));
 
   if (dirPath !== basePath && !dirPath.startsWith(basePath + sep)) {
-    console.log(clfdate(), 
+    console.error(clfdate(), 
       `Invalid path: attempted to access parent directory`,
       basePath,
       dirPath

--- a/app/clients/icloud/macserver/routes/watch.js
+++ b/app/clients/icloud/macserver/routes/watch.js
@@ -3,9 +3,19 @@ const clfdate = require("../util/clfdate");
 
 module.exports = async (req, res) => {
   const blogID = req.header("blogID");
-  
-  // watch the blog
-  await watch(blogID);
+
+  if (!blogID) {
+    console.error(clfdate(), "Missing blogID header for watch request");
+    return res.status(400).send("Missing blogID header");
+  }
+
+  try {
+    // watch the blog
+    await watch(blogID);
+  } catch (error) {
+    console.error(clfdate(), `Failed to watch blogID (${blogID}):`, error);
+    return res.status(500).send("Failed to watch blog folder");
+  }
 
   console.log(clfdate(), `Recieved watch request for: ${blogID}`);
   res.sendStatus(200);


### PR DESCRIPTION
### Motivation
- Standardize timestamped, contextual error logging across the macserver to make debugging of header validation, path validation, watcher operations, and HTTP client interactions easier.
- Surface failures in route handlers and HTTP client modules with `clfdate()` prefixes so logs are consistent with existing server logging patterns.
- Ensure authorization failures in the macserver middleware are logged with context for remote diagnostics.

### Description
- Added `console.error(clfdate(), ...)` messages for missing/invalid headers and path validation failures in route handlers including `download`, `mkdir`, `readdir`, `recursiveList`, `watch`, `disconnect`, `setup`, `evict`, `delete`, and `upload` (files under `app/clients/icloud/macserver/routes`).
- Wrapped operations that can fail (e.g. `unwatch`, `watch`, `fs.remove`, `brctl.evict`, AppleScript `exec`) with `try/catch` and logged errors using `clfdate()` before returning appropriate HTTP error responses.
- Added input validation and error logging in macserver HTTP client modules `upload`, `mkdir`, `remove`, `status`, and `notifyServerStarted` (files under `app/clients/icloud/macserver/httpClient`), including logging of failed fetches and non-OK responses.
- Logged unauthorized requests in the macserver middleware (`app/clients/icloud/macserver/index.js`) with `clfdate()` and request context.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962cab56e988329b8348b6711618cfe)