### PR TITLE
Standardize Dropbox and iCloud resync scripts

### DIFF
--- a/scripts/dropbox/resync.js
+++ b/scripts/dropbox/resync.js
@@ -51,11 +51,16 @@ const processBlog = async (blog) => {
     `INFO: Starting Dropbox resync for ${blog.id} (${blog.handle || "no handle"})`
   );
 
+  let folder;
+  let done;
+
   try {
-    const { done, folder } = await establishSyncLock(blog.id);
+    const syncLock = await establishSyncLock(blog.id);
+    folder = syncLock.folder;
+    done = syncLock.done;
 
     try {
-      folder.status("Resyncing");
+      folder.status("Dropbox resyncing");
 
       await resetToBlot(blog.id, publish);
       try {

--- a/scripts/icloud/resync.js
+++ b/scripts/icloud/resync.js
@@ -41,7 +41,8 @@ const processBlog = async (blog) => {
     `INFO: Starting iCloud resync for ${blog.id} (${blog.handle || "no handle"})`
   );
 
-  let syncLock;
+  let folder;
+  let done;
 
   try {
     const account = await database.get(blog.id);
@@ -53,7 +54,9 @@ const processBlog = async (blog) => {
 
     totalIcloudBlogs++;
 
-    const { folder, done } = await establishSyncLock(blog.id);
+    const syncLock = await establishSyncLock(blog.id);
+    folder = syncLock.folder;
+    done = syncLock.done;
 
     await fromiCloud(blog.id, folder.status, folder.update);
 


### PR DESCRIPTION
### Motivation
- Make Dropbox and iCloud resync scripts share a common structure for locking, progress reporting, error collection, and summary output.
- Ensure sync locks are always released even if per-blog processing throws, and keep client-specific checks (e.g., iCloud `setupComplete`).
- Run the `sync` fix step after a successful reset/sync without letting fix failures fail the whole resync.
- Replace emoji-only status markers with consistent text prefixes for clearer logs.

### Description
- Updated `scripts/dropbox/resync.js` to add `const { promisify } = require("util")`, `const sync = promisify(require("sync"))`, `const fix = promisify(require("sync/fix"))`, a `formatError` helper, periodic progress logging (`PROGRESS_INTERVAL_MS`), and a `releaseSyncLock` wrapper that always attempts to release the sync lock in a `finally` block.
- Updated `scripts/icloud/resync.js` to add `const { promisify } = require("util")`, `const fix = promisify(require("sync/fix"))`, shared progress tracking, `formatError`, and to wrap `establishSyncLock` usage so `done()`/`syncLock.done()` is invoked in a `finally` block and errors releasing the lock are logged.
- Both scripts call `await fix(blog)` after a successful `resetToBlot`/`fromiCloud` and log fix errors as warnings rather than failing the run, and both emit consistent `INFO`/`WARN`/`SUCCESS`/`ERROR` prefixed logs and a consistent summary block.
- Kept client-specific behavior such as the iCloud `account.setupComplete` check intact.

### Testing
- No automated tests were run for these script-only changes.
- Files modified: `scripts/dropbox/resync.js`, `scripts/icloud/resync.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964fb1507b08329aec0c316fba00b8c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns `scripts/dropbox/resync.js` and `scripts/icloud/resync.js` to a shared pattern for reliability and observability.
> 
> - Use common `sync/establishSyncLock` with `finally` to always release locks; add explicit handling for lock acquisition/release errors
> - Add periodic progress reporting and a final summary with collected errors; replace emoji statuses with `INFO`/`WARN`/`ERROR`/`SUCCESS` logs
> - Introduce `formatError` helper and standardized messages across both scripts
> - Run `await fix(blog)` after successful `resetToBlot`/`fromiCloud`, logging failures as warnings
> - Preserve iCloud-specific check for `account.setupComplete` before processing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49133ed67215940acedacf57e36c70fd5d0d2e98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->