### PR TITLE
Handle multiple URL patterns in template packages

### DIFF
--- a/app/models/template/package.js
+++ b/app/models/template/package.js
@@ -21,8 +21,23 @@ module.exports = {
       var view = views[name];
       var metadataToAddToPackage = {};
 
-      if (view.url && view.url !== "/" + name) {
+      var urlPatterns = null;
+
+      if (type(view.urlPatterns, "array") && view.urlPatterns.length) {
+        urlPatterns = view.urlPatterns;
+      } else if (type(view.url, "array") && view.url.length) {
+        urlPatterns = view.url;
+      }
+
+      if (urlPatterns && urlPatterns.length > 1) {
+        metadataToAddToPackage.url = urlPatterns;
+      } else if (view.url && view.url !== "/" + name) {
         metadataToAddToPackage.url = view.url;
+      } else if (urlPatterns && urlPatterns.length === 1) {
+        var singleUrl = urlPatterns[0];
+        if (singleUrl !== "/" + name) {
+          metadataToAddToPackage.url = singleUrl;
+        }
       }
 
       if (view.locals && objectWithProperties(view.locals)) {

--- a/app/models/template/readFromFolder.js
+++ b/app/models/template/readFromFolder.js
@@ -81,6 +81,12 @@ module.exports = function readFromFolder (blogID, dir, callback) {
                       for (var i in views[name]) view[i] = views[name][i];
 
                     view.content = content;
+                    if (
+                      Array.isArray(view.urlPatterns) &&
+                      view.urlPatterns.length
+                    ) {
+                      view.url = view.urlPatterns;
+                    }
                     view.url = view.url || "/" + view.name;
 
                     setView(id, view, function (err) {


### PR DESCRIPTION
### Motivation

- Support serializing multiple URL patterns for a view into `package.json` so templates can declare multiple routes for a single view.
- Preserve existing behavior by continuing to emit a single string for the common single-url case to avoid breaking consumers.
- Ensure local package loading can read URL arrays from `package.json` and hand them to `setView` without converting them back to a single string.

### Description

- Updated `app/models/template/package.js` `generate()` to prefer `view.urlPatterns` (or `view.url` if it is an array) and emit `metadata.views[name].url` as an array when there are multiple patterns, while still emitting a string when only a single URL applies.
- Updated `app/models/template/readFromFolder.js` to preserve `urlPatterns` by assigning `view.url = view.urlPatterns` when an array is present before falling back to the default `"/" + view.name`.
- Left `app/models/template/setView.js` unchanged because it already accepts `url` as an array and normalizes it into `urlPatterns` (no modifications required).

### Testing

- No automated tests were run for this change.
- No test failures reported (no tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69651e6e3290832987948caf94527849)