### PR TITLE
Mock Bluesky oEmbed in tests

### DIFF
--- a/app/build/plugins/bluesky/tests.js
+++ b/app/build/plugins/bluesky/tests.js
@@ -1,8 +1,29 @@
 describe("bluesky plugin", function () {
   const replaceURLsWithEmbeds = require("./index.js").render;
   const cheerio = require("cheerio");
+  const nock = require("nock");
 
   global.test.timeout(10000); // 10 seconds
+
+  beforeEach(function () {
+    nock.disableNetConnect();
+
+    const html =
+      "<blockquote class=\"bluesky-embed\" data-bluesky-uri=\"at://example.test/post/123\">" +
+      "<p lang=\"en\">Example Bluesky post</p>" +
+      "</blockquote>";
+
+    nock("https://embed.bsky.app")
+      .persist()
+      .get("/oembed")
+      .query(true)
+      .reply(200, { html });
+  });
+
+  afterEach(function () {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
   
   it("works", function (done) {
     // html bare link to a post on bluesky


### PR DESCRIPTION
### Motivation
- Prevent the Bluesky plugin tests from making real network requests to `embed.bsky.app`.
- Match the existing Flickr/Twitter tests' mocking strategy using `nock` for deterministic behavior.
- Ensure embeds are replaced using a stable, representative oEmbed response in CI and local runs.

### Description
- Add `const nock = require("nock")` to `app/build/plugins/bluesky/tests.js`.
- Add a `beforeEach` that calls `nock.disableNetConnect()` and stubs `https://embed.bsky.app/oembed` with `nock(...).persist().get("/oembed").query(true).reply(200, { html })` returning a representative `<blockquote>` snippet.
- Add an `afterEach` that calls `nock.cleanAll()` and `nock.enableNetConnect()` to restore network behavior.
- Keep existing test cases unchanged so they use the mocked oEmbed response.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966697c7e1c8329addde3613e8dd2b7)