### PR TITLE
Mock Vimeo oEmbed in video embed tests

### DIFF
--- a/app/build/plugins/videoEmbeds/tests/index.js
+++ b/app/build/plugins/videoEmbeds/tests/index.js
@@ -1,6 +1,37 @@
 describe("video-embed plugin", function () {
   const videoEmbed = require("../index");
   const cheerio = require("cheerio");
+  const nock = require("nock");
+
+  beforeEach(function () {
+    nock("https://vimeo.com")
+      .get("/api/oembed.json")
+      .query(true)
+      .reply(function (uri) {
+        const requestUrl = new URL(`https://vimeo.com${uri}`).searchParams.get(
+          "url"
+        );
+
+        if (requestUrl && requestUrl.startsWith("https://vimeo.com/87952436")) {
+          return [
+            200,
+            {
+              video_id: 87952436,
+              width: 16,
+              height: 9,
+              thumbnail_url:
+                "https://i.vimeocdn.com/video/466717816-33ad450eea4c71be9149dbe2e0d18673874917cadd5f1af29de3731e4d22a77f-d_295x166?region=us",
+            },
+          ];
+        }
+
+        return [404, {}];
+      });
+  });
+
+  afterEach(function () {
+    nock.cleanAll();
+  });
 
   it("embeds videos from youtube, vimeo and music from bandcamp", function (done) {
     const $ = cheerio.load(

--- a/app/build/plugins/videoEmbeds/tests/vimeo.js
+++ b/app/build/plugins/videoEmbeds/tests/vimeo.js
@@ -1,5 +1,39 @@
 describe("vimeo embeds", function () {
   const vimeo = require("../vimeo");
+  const nock = require("nock");
+
+  beforeEach(function () {
+    nock.disableNetConnect();
+
+    nock("https://vimeo.com")
+      .get("/api/oembed.json")
+      .query(true)
+      .reply(function (uri) {
+        const requestUrl = new URL(`https://vimeo.com${uri}`).searchParams.get(
+          "url"
+        );
+
+        if (requestUrl && requestUrl.startsWith("https://vimeo.com/87952436")) {
+          return [
+            200,
+            {
+              video_id: 87952436,
+              width: 16,
+              height: 9,
+              thumbnail_url:
+                "https://i.vimeocdn.com/video/466717816-33ad450eea4c71be9149dbe2e0d18673874917cadd5f1af29de3731e4d22a77f-d_295x166?region=us",
+            },
+          ];
+        }
+
+        return [404, {}];
+      });
+  });
+
+  afterEach(function () {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
   it("handles an empty href", function (done) {
     const href = "";
     vimeo(href, (err, template) => {


### PR DESCRIPTION
### Motivation
- Prevent tests from making real network calls to Vimeo so test runs are deterministic and isolated.
- Ensure the existing expected iframe HTML for the Vimeo sample remains unchanged by returning the same oEmbed-derived values.

### Description
- Add `nock` setup in `app/build/plugins/videoEmbeds/tests/vimeo.js` that calls `nock.disableNetConnect()`, mocks `https://vimeo.com/api/oembed.json` for requests for `https://vimeo.com/87952436` and returns a JSON payload with `video_id: 87952436`, `width: 16`, `height: 9`, and the matching `thumbnail_url`, and add teardown with `nock.cleanAll()` and `nock.enableNetConnect()`.
- Add the same `nock` mock to the aggregate test in `app/build/plugins/videoEmbeds/tests/index.js` so `videoEmbed.render` does not hit the network and tear down with `nock.cleanAll()`.
- Use the exact Vimeo URL `https://vimeo.com/87952436` when matching the oEmbed request so the mocked response produces the same iframe HTML the tests expect.

### Testing
- No automated tests were executed as part of this change.
- Existing unit tests that reference the mocked Vimeo URL should now run without contacting the network (manual test not run here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69666b930d80832984d30c9efd4dd08f)