### PR TITLE
Add Pandoc div/span guidance to Markdown guide

### DIFF
--- a/app/views/how/files/markdown.html
+++ b/app/views/how/files/markdown.html
@@ -185,3 +185,6 @@ var foo = "bar";
 
 <h2>TextBundle</h2>
 <p>You can use the <a href="https://textbundle.org/">TextBundle</a> format to embed images in Markdown files when using supported apps including <a href="/tools/ulysses">Ulysses</a> and <a href="/tools/bear">Bear</a>.</p>
+
+<h2>Divs and spans (Pandoc)</h2>
+<p>Blot supports Pandoc's native <a href="https://pandoc.org/MANUAL.html#divs-and-spans">Div and Span syntax</a> in Markdown, so you can add attributes with fenced divs and bracketed spans. This makes it possible to create custom features in your template by targeting classes and IDs in your CSS or layout. See the <a href="/templates/developers">developer documentation</a> for more on customizing templates.</p>


### PR DESCRIPTION
### Motivation
- Add an H2 to the Markdown guide explaining Blot's support for Pandoc's Div and Span syntax and link to developer docs so users can create custom template features by targeting classes and IDs.

### Description
- Added a new `Divs and spans (Pandoc)` section at the end of `app/views/how/files/markdown.html` that links to the Pandoc manual and the site `templates/developers` page and explains using fenced divs and bracketed spans to add attributes usable by templates.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967d0835b788329bc3d9965cc42f8e8)