### PR TITLE
test(video-embeds): mock Bandcamp requests with nock

### DIFF
--- a/app/build/plugins/videoEmbeds/tests/bandcamp.js
+++ b/app/build/plugins/videoEmbeds/tests/bandcamp.js
@@ -1,5 +1,24 @@
 describe("bandcamp embeds", function () {
   const bandcamp = require("../bandcamp");
+  const nock = require("nock");
+  const bandcampOgHtml = ({ src, width, height }) => `<!doctype html>
+    <html>
+      <head>
+        <meta property="og:video" content="${src}">
+        <meta property="og:video:width" content="${width}">
+        <meta property="og:video:height" content="${height}">
+      </head>
+      <body></body>
+    </html>`;
+
+  beforeEach(function () {
+    nock.disableNetConnect();
+  });
+
+  afterEach(function () {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
 
   it("handles an empty href", function (done) {
     const href = "";
@@ -30,6 +49,16 @@ describe("bandcamp embeds", function () {
 
   it("handles a valid link to an album on a bandcamp subdomain", function (done) {
     const href = "https://oliviachaney.bandcamp.com/album/circus-of-desire";
+    nock("https://oliviachaney.bandcamp.com")
+      .get("/album/circus-of-desire")
+      .reply(
+        200,
+        bandcampOgHtml({
+          src: "https://bandcamp.com/EmbeddedPlayer/v=2/album=2447688282/size=large/tracklist=false/artwork=small/",
+          width: 400,
+          height: 120,
+        })
+      );
     bandcamp(href, (err, template) => {
       expect(err).toEqual(null);
       expect(template).toEqual(
@@ -41,6 +70,16 @@ describe("bandcamp embeds", function () {
 
   it("handles a valid link to a track on a bandcamp subdomain", function (done) {
     const href = "https://cloquet.bandcamp.com/track/new-drugs";
+    nock("https://cloquet.bandcamp.com")
+      .get("/track/new-drugs")
+      .reply(
+        200,
+        bandcampOgHtml({
+          src: "https://bandcamp.com/EmbeddedPlayer/v=2/track=2483181576/size=large/tracklist=false/artwork=small/",
+          width: 400,
+          height: 120,
+        })
+      );
     bandcamp(href, (err, template) => {
       expect(err).toEqual(null);
       expect(template).toEqual(

--- a/app/build/plugins/videoEmbeds/tests/index.js
+++ b/app/build/plugins/videoEmbeds/tests/index.js
@@ -1,8 +1,42 @@
 describe("video-embed plugin", function () {
   const videoEmbed = require("../index");
   const cheerio = require("cheerio");
+  const nock = require("nock");
+  const bandcampOgHtml = ({ src, width, height }) => `<!doctype html>
+    <html>
+      <head>
+        <meta property="og:video" content="${src}">
+        <meta property="og:video:width" content="${width}">
+        <meta property="og:video:height" content="${height}">
+      </head>
+      <body></body>
+    </html>`;
+
+  afterEach(function () {
+    nock.cleanAll();
+  });
 
   it("embeds videos from youtube, vimeo and music from bandcamp", function (done) {
+    nock("https://oliviachaney.bandcamp.com")
+      .get("/album/circus-of-desire")
+      .reply(
+        200,
+        bandcampOgHtml({
+          src: "https://bandcamp.com/EmbeddedPlayer/v=2/album=2447688282/size=large/tracklist=false/artwork=small/",
+          width: 400,
+          height: 120,
+        })
+      );
+    nock("https://cloquet.bandcamp.com")
+      .get("/track/new-drugs")
+      .reply(
+        200,
+        bandcampOgHtml({
+          src: "https://bandcamp.com/EmbeddedPlayer/v=2/track=2483181576/size=large/tracklist=false/artwork=small/",
+          width: 400,
+          height: 120,
+        })
+      );
     const $ = cheerio.load(
       `<a href="https://www.youtube.com/watch?v=MJ62hh0a9U4">https://www.youtube.com/watch?v=MJ62hh0a9U4</a>
         <a href="https://vimeo.com/87952436">https://vimeo.com/87952436</a>


### PR DESCRIPTION
### Motivation

- Prevent tests from making real outbound HTTP requests to Bandcamp and make embed tests deterministic.
- Ensure aggregate plugin test does not reach the network so CI remains reliable and reproducible.

### Description

- Add `nock` to `app/build/plugins/videoEmbeds/tests/bandcamp.js` and install test hooks using `nock.disableNetConnect()` in `beforeEach` and `nock.cleanAll()`/`nock.enableNetConnect()` in `afterEach` to block real network calls.
- Introduce a small helper `bandcampOgHtml` (a template string) to generate HTML containing `og:video`, `og:video:width`, and `og:video:height` meta tags used by the Bandcamp embed parser.
- Stub Bandcamp album and track endpoints with `nock(...)` in both the Bandcamp-specific tests and the aggregate `app/build/plugins/videoEmbeds/tests/index.js` test so the rendering path uses mocked OG responses instead of live requests.

### Testing

- No automated tests were executed as part of this change (no test runner was invoked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967d0ad8d6083298dade7d4a61469be)