### PR TITLE
Mock Vimeo oEmbed in video embed tests

### DIFF
--- a/app/build/plugins/videoEmbeds/tests/index.js
+++ b/app/build/plugins/videoEmbeds/tests/index.js
@@ -12,8 +12,37 @@ describe("video-embed plugin", function () {
       <body></body>
     </html>`;
 
+  beforeEach(function () {
+    nock.disableNetConnect();
+
+    nock("https://vimeo.com")
+      .get("/api/oembed.json")
+      .query(true)
+      .reply(function (uri) {
+        const requestUrl = new URL(`https://vimeo.com${uri}`).searchParams.get(
+          "url"
+        );
+
+        if (requestUrl && requestUrl.startsWith("https://vimeo.com/87952436")) {
+          return [
+            200,
+            {
+              video_id: 87952436,
+              width: 640,
+              height: 360,
+              thumbnail_url:
+                "https://i.vimeocdn.com/video/466717816-33ad450eea4c71be9149dbe2e0d18673874917cadd5f1af29de3731e4d22a77f-d_295x166?region=us",
+            },
+          ];
+        }
+
+        return [404, { error: "Not found" }];
+      });
+  });
+
   afterEach(function () {
     nock.cleanAll();
+    nock.enableNetConnect();
   });
 
   it("embeds videos from youtube, vimeo and music from bandcamp", function (done) {

--- a/app/build/plugins/videoEmbeds/tests/vimeo.js
+++ b/app/build/plugins/videoEmbeds/tests/vimeo.js
@@ -1,5 +1,39 @@
 describe("vimeo embeds", function () {
   const vimeo = require("../vimeo");
+  const nock = require("nock");
+
+  beforeEach(function () {
+    nock.disableNetConnect();
+
+    nock("https://vimeo.com")
+      .get("/api/oembed.json")
+      .query(true)
+      .reply(function (uri) {
+        const requestUrl = new URL(`https://vimeo.com${uri}`).searchParams.get(
+          "url"
+        );
+
+        if (requestUrl && requestUrl.startsWith("https://vimeo.com/87952436")) {
+          return [
+            200,
+            {
+              video_id: 87952436,
+              width: 640,
+              height: 360,
+              thumbnail_url:
+                "https://i.vimeocdn.com/video/466717816-33ad450eea4c71be9149dbe2e0d18673874917cadd5f1af29de3731e4d22a77f-d_295x166?region=us",
+            },
+          ];
+        }
+
+        return [404, { error: "Not found" }];
+      });
+  });
+
+  afterEach(function () {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
   it("handles an empty href", function (done) {
     const href = "";
     vimeo(href, (err, template) => {


### PR DESCRIPTION
### Motivation
- Prevent real network requests from Vimeo during tests and make the Vimeo-related expectations deterministic.
- Keep the Vimeo mock consistent with the existing Flickr/Twitter/Bandcamp test patterns so `videoEmbed.render` doesn't hit the network.

### Description
- Add `const nock = require("nock")`, `beforeEach` that calls `nock.disableNetConnect()` and a mock for `https://vimeo.com/api/oembed.json` in `app/build/plugins/videoEmbeds/tests/vimeo.js` that returns `video_id`, `width`, `height`, and `thumbnail_url` for the exact URL `https://vimeo.com/87952436`.
- Add `afterEach` to `vimeo.js` that calls `nock.cleanAll()` and `nock.enableNetConnect()`.
- Stub the same Vimeo oEmbed endpoint with an identical mocked response in `app/build/plugins/videoEmbeds/tests/index.js` (the aggregate video-embed test) and disable/enable network access around each test so `videoEmbed.render` does not hit the network.
- The mocked `thumbnail_url` and response fields were chosen to preserve the existing expected iframe HTML (including the thumbnail transformation to `-d.jpg`).

### Testing
- No automated test suite was executed as part of this change in the rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968c44af4488329a90d6839e7dc67e2)