### PR TITLE
Handle busy sync lock during iCloud resync

### DIFF
--- a/app/clients/icloud/init.js
+++ b/app/clients/icloud/init.js
@@ -78,7 +78,19 @@ const resyncRecentlySynced = async (options = {}) => {
       // Ensure the hourly sync check is always gated by the sync
       // lock to prevent files from being removed from Blot 
       // during an initial setup. This prevents data loss.
-      const { folder, done } = await establishSyncLock(blogID);
+      let folder;
+      let done;
+
+      try {
+        ({ folder, done } = await establishSyncLock(blogID));
+      } catch (error) {
+        console.warn(
+          clfdate(),
+          "Blog is currently syncing elsewhere, skipping resync:",
+          blogID
+        );
+        return;
+      }
       try {
         // We don't sync to iCloud here because we want to respect
         // the state of the iCloud folder. It's possible that Blot


### PR DESCRIPTION
### Motivation
- When `resyncRecentlySynced` attempts to acquire the sync lock with `establishSyncLock(blogID)` it can fail if another sync is running, so the loop should skip that blog and continue rather than erroring.

### Description
- In `app/clients/icloud/init.js` wrap the `await establishSyncLock(blogID)` call in a `try/catch`, declare `let folder` and `let done`, and on failure log a non-error informational message via `console.warn` and `return` to skip the busy blog.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f8d7fe79c8329b846a644ebc71e43)