### PR TITLE
Handle poster attributes in replaceFolderLinks

### DIFF
--- a/app/blog/render/replaceFolderLinks/html.js
+++ b/app/blog/render/replaceFolderLinks/html.js
@@ -37,7 +37,7 @@ module.exports = async function replaceFolderLinks(blog, html, log = () => {}) {
         let hasMatchingAttr = false;
         for (let i = 0; i < node.attrs.length; i++) {
           const attr = node.attrs[i];
-          if (attr.name === "href" || attr.name === "src") {
+          if (attr.name === "href" || attr.name === "src" || attr.name === "poster") {
 
             // Ensure attr.value is a string
             if (typeof attr.value !== "string") {
@@ -69,7 +69,7 @@ module.exports = async function replaceFolderLinks(blog, html, log = () => {}) {
 
     for (const node of elements) {
       for (const attr of node.attrs) {
-        if (attr.name === "href" || attr.name === "src") {
+        if (attr.name === "href" || attr.name === "src" || attr.name === "poster") {
           let value = attr.value;
             
           // Remove host if it matches any of the patterns

--- a/app/blog/render/replaceFolderLinks/tests/html.js
+++ b/app/blog/render/replaceFolderLinks/tests/html.js
@@ -24,6 +24,22 @@ describe("replaceFolderLinks", function () {
     );
   });
 
+  it("should replace poster attributes with versioned CDN URLs", async function () {
+    await this.write({ path: "/images/poster.jpg", content: "fake image data" });
+    await this.template({
+      "entries.html": '<video poster="/images/poster.jpg"></video>',
+    });
+
+    const res = await this.get("/");
+    const result = await res.text();
+
+    expect(result).toMatch(
+      new RegExp(
+        `<video poster="${config.cdn.origin}/folder/v-[a-f0-9]{8}/[^"]+/images/poster.jpg"></video>`
+      )
+    );
+  });
+
   it("should be case-insensitive", async function () {
     await this.write({ path: "/Images/Test.jpg", content: "fake image data" });
     await this.template({


### PR DESCRIPTION
### Motivation
- Ensure media poster images (the `poster` attribute on `<video>` tags) are discovered and rewritten to the versioned CDN URL the same way `href` and `src` files are.

### Description
- Update the attribute discovery loop to include `poster` in the `attr.name` check so nodes with poster attributes are collected for processing.
- Update the replacement loop to include `poster` so poster URLs are passed through `lookupFile` and rewritten when appropriate.
- Add a test `should replace poster attributes with versioned CDN URLs` that writes `/images/poster.jpg`, templates `<video poster="/images/poster.jpg"></video>`, requests the page, and asserts the poster attribute is rewritten to the versioned CDN URL.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69721cc459f48329a642e3ea7c5a7d10)