### PR TITLE
Add tests for src replacement on <source> and <track> elements

### DIFF
--- a/app/blog/render/replaceFolderLinks/tests/html.js
+++ b/app/blog/render/replaceFolderLinks/tests/html.js
@@ -24,6 +24,36 @@ describe("replaceFolderLinks", function () {
     );
   });
 
+  it("should replace src attributes on source and track elements", async function () {
+    await this.write({ path: "/images/picture.jpg", content: "fake image data" });
+    await this.write({ path: "/media/video.mp4", content: "fake video data" });
+    await this.write({ path: "/media/audio.mp3", content: "fake audio data" });
+    await this.write({ path: "/media/subtitles.vtt", content: "fake vtt data" });
+    await this.template({
+      "entries.html": `
+        <picture>
+          <source src="/images/picture.jpg" type="image/jpeg">
+          <img src="/images/picture.jpg">
+        </picture>
+        <video>
+          <source src="/media/video.mp4" type="video/mp4">
+          <track src="/media/subtitles.vtt" kind="subtitles">
+        </video>
+        <audio>
+          <source src="/media/audio.mp3" type="audio/mpeg">
+        </audio>
+      `.trim(),
+    });
+
+    const res = await this.get("/");
+    const result = await res.text();
+
+    expect(result).toMatch(cdnRegex("/images/picture.jpg"));
+    expect(result).toMatch(cdnRegex("/media/video.mp4"));
+    expect(result).toMatch(cdnRegex("/media/subtitles.vtt"));
+    expect(result).toMatch(cdnRegex("/media/audio.mp3"));
+  });
+
   it("should be case-insensitive", async function () {
     await this.write({ path: "/Images/Test.jpg", content: "fake image data" });
     await this.template({


### PR DESCRIPTION
### Motivation
- Ensure `src` attribute replacement covers `<source>` and `<track>` elements used in `<picture>`, `<video>`, and `<audio>` contexts so media sources and captions are correctly rewritten to versioned CDN URLs.

### Description
- Add a regression test in `app/blog/render/replaceFolderLinks/tests/html.js` that writes sample media files and templates an `entries.html` containing `<source>` and `<track>` tags. 
- The test writes `/images/picture.jpg`, `/media/video.mp4`, `/media/audio.mp3`, and `/media/subtitles.vtt` and asserts rewritten URLs match the `cdnRegex` for each path.
- The test reuses the existing `cdnRegex` helper to validate the produced CDN paths.

### Testing
- No automated test run was performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69721b1e27508329bda46bcaf11a8802)