### PR TITLE
Add daily new customers report to admin update

### DIFF
--- a/app/helper/email/admin/DAILY_UPDATE.txt
+++ b/app/helper/email/admin/DAILY_UPDATE.txt
@@ -6,6 +6,13 @@ Recurring revenue: {{annual_recurring_revenue}} per year, {{monthly_percentage}}
 
 Newsletter subscribers: {{newsletter_subscribers}}
 
+{{#new_customers.length}}
+New customers:
+{{#new_customers}}
+- [{{email}}](https://www.google.com/search?udm=14&q={{email}}) {{#sites}} {{{url}}} {{/sites}}
+{{/new_customers}}
+{{/new_customers.length}}
+
 {{#blogs_with_new_posts.length}}
 New posts:
 

--- a/app/scheduler/daily/index.js
+++ b/app/scheduler/daily/index.js
@@ -24,6 +24,8 @@ function main (callback) {
       require("./new-posts"),
       log("Checking number of newsletter subscribers"),
       require("./newsletter-subscribers"),
+      log("Checking for new customers"),
+      require("./new-customers"),
       log("Finished daily update")
     ],
     function (fn, next) {

--- a/app/scheduler/daily/new-customers.js
+++ b/app/scheduler/daily/new-customers.js
@@ -1,0 +1,87 @@
+const { promisify } = require("util");
+const User = require("models/user");
+const Blog = require("models/blog");
+
+const getAllUserIds = promisify(User.getAllIds);
+const getUserById = promisify(User.getById);
+const getBlog = promisify(Blog.get);
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+async function main(callback) {
+  try {
+    const userIds = await getAllUserIds();
+    const new_customers = [];
+    const cutoff = Date.now() - ONE_DAY_MS;
+
+    for (const userId of userIds) {
+      try {
+        const user = await getUserById(userId);
+
+        if (!user) continue;
+
+        const stripeCreatedMs = toMs(user.subscription?.created);
+        const paypalStartMs = toMs(user.paypal?.start_time);
+
+        const isNewStripe = Boolean(stripeCreatedMs && stripeCreatedMs >= cutoff);
+        const isNewPaypal = Boolean(paypalStartMs && paypalStartMs >= cutoff);
+
+        if (!isNewStripe && !isNewPaypal) continue;
+
+        const sites = [];
+
+        if (Array.isArray(user.blogs)) {
+          for (const blogId of user.blogs) {
+            try {
+              const blog = await getBlog({ id: blogId });
+
+              if (!blog || blog.isDisabled) continue;
+
+              const extendedBlog = Blog.extend(blog);
+
+              if (extendedBlog?.url) {
+                sites.push({ url: extendedBlog.url });
+              }
+            } catch (err) {
+              continue;
+            }
+          }
+        }
+
+        new_customers.push({
+          email: user.email,
+          sites,
+        });
+      } catch (err) {
+        continue;
+      }
+    }
+
+    callback(null, { new_customers });
+  } catch (err) {
+    callback(err);
+  }
+}
+
+function toMs(timestamp) {
+  if (!timestamp) return null;
+
+  if (timestamp instanceof Date) return timestamp.getTime();
+
+  if (typeof timestamp === "number") {
+    if (!Number.isFinite(timestamp)) return null;
+
+    return timestamp < 1e12 ? timestamp * 1000 : timestamp;
+  }
+
+  if (typeof timestamp === "string") {
+    const parsed = Date.parse(timestamp);
+
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  return null;
+}
+
+module.exports = main;
+if (require.main === module) require("./cli")(main);


### PR DESCRIPTION
### Motivation

- Provide admins with a daily list of newly subscribed customers and their site URLs for quick review.
- Reuse existing timestamp parsing/normalization logic (`toMs`) from account deletion refund logic to reliably detect new Stripe and PayPal subscriptions.

### Description

- Add a new daily scheduler task `app/scheduler/daily/new-customers.js` that loads all user IDs with `User.getAllIds`, fetches each user with `User.getById`, uses a `toMs` parser to check `user.subscription.created` and `user.paypal.start_time`, and marks users as new if either timestamp is within the last 24 hours, collecting their sites via `Blog.get` and `Blog.extend` while skipping missing or disabled blogs; the task returns a view payload of `{ new_customers: [{ email, sites: [{ url }] }] }`.
- Wire the new task into the daily pipeline by requiring `./new-customers` in `app/scheduler/daily/index.js` before the final email send so the returned `new_customers` are merged into the daily view.
- Update the admin daily email template `app/helper/email/admin/DAILY_UPDATE.txt` to include a Mustache block that renders the new customers list.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697233722ec88329a8402938c020313a)