### PR TITLE
Skip ignored iCloud paths before sync work

### DIFF
--- a/app/clients/icloud/routes/site/mkdir.js
+++ b/app/clients/icloud/routes/site/mkdir.js
@@ -2,6 +2,7 @@ const localPath = require("helper/localPath");
 const establishSyncLock = require("sync/establishSyncLock");
 const fs = require("fs-extra");
 const { handleSyncLockError } = require("../lock");
+const shouldIgnoreFile = require("clients/util/shouldIgnoreFile");
 
 module.exports = async function (req, res) {
   try {
@@ -13,6 +14,10 @@ module.exports = async function (req, res) {
     // Validate required headers
     if (!blogID || !dirPath) {
       return res.status(400).send("Missing required headers: blogID or path");
+    }
+
+    if (shouldIgnoreFile(dirPath)) {
+      return res.sendStatus(204);
     }
 
     console.log(`Creating directory for blogID: ${blogID}, path: ${dirPath}`);

--- a/app/clients/icloud/routes/site/upload.js
+++ b/app/clients/icloud/routes/site/upload.js
@@ -2,6 +2,7 @@ const localPath = require("helper/localPath");
 const establishSyncLock = require("sync/establishSyncLock");
 const fs = require("fs-extra");
 const { handleSyncLockError } = require("../lock");
+const shouldIgnoreFile = require("clients/util/shouldIgnoreFile");
 
 module.exports = async function (req, res) {
   try {
@@ -10,13 +11,18 @@ module.exports = async function (req, res) {
       "utf8"
     );
     const modifiedTime = req.header("modifiedTime");
-    const pathOnDisk = localPath(blogID, filePath);
 
     // Validate required headers
     if (!blogID || !filePath) {
       console.warn("Missing required headers: blogID or path");
       return res.status(400).send("Missing required headers: blogID or path");
     }
+
+    if (shouldIgnoreFile(filePath)) {
+      return res.sendStatus(204);
+    }
+
+    const pathOnDisk = localPath(blogID, filePath);
 
     console.log(
       `Uploading binary file for blogID: ${blogID}, path: ${filePath}`


### PR DESCRIPTION
### Motivation
- Avoid unnecessary work for known-ignored files/paths coming from iCloud by short-circuiting request handling early.
- Prevent acquiring sync locks, touching the filesystem, or invoking `folder.update()` for ignored items. 
- Ensure the ignore decision is made after header validation but before any local path or fs operations so ignored paths are fully ignored.

### Description
- Import `clients/util/shouldIgnoreFile` into both `app/clients/icloud/routes/site/mkdir.js` and `app/clients/icloud/routes/site/upload.js`.
- In `mkdir.js` perform `shouldIgnoreFile(dirPath)` after header validation and return HTTP `204` immediately when true.
- In `upload.js` perform `shouldIgnoreFile(filePath)` after header validation and return HTTP `204` immediately when true, and move the `localPath(...)` call to after this check.
- These checks ensure no `localPath`, `fs` operations, or `establishSyncLock` are executed for ignored paths.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973566217f08329bbdb747f9e0060b9)