### PR TITLE
Point menu link edits to template editor in Pages guide

### DIFF
--- a/app/views/how/sub-folders/pages.html
+++ b/app/views/how/sub-folders/pages.html
@@ -2,7 +2,7 @@
 
 <p>
   Files inside a sub-folder called <em>Pages</em> become pages instead of
-  posts. Links to each page appear on your site’s menu. You can change the order of the pages on your menu and add external links under <a href="/settings/links">Settings &rarr; Links</a> on your site's dashboard.
+  posts. Links to each page appear on your site’s menu. To change the order of the pages on your menu or add external links, open the <a href="/settings/template">template editor</a> from your site's dashboard and edit the menu links.
 </p>
 
   <pre class="folder" title="Your site"><code>Pages
@@ -39,19 +39,19 @@ This page will not appear on your site‘s menu. It is accessible only by its UR
 
 This page will replace your site‘s homepage. 
 
-If you still want your readers to access the list of your posts, consider adding a link to ‘/page/1’ to your site’s menu. You can edit your site's menu on the dashboard under ‘Settings &rarr; Links’.
+If you still want your readers to access the list of your posts, consider adding a link to ‘/page/1’ to your site’s menu. You can edit your site's menu links in the <a href="/settings/template">template editor</a> on the dashboard.
 </code></pre>
 
 <h2>External links</h2>
 
 <p>
-  You can add external links to your menu on the
-  <a href="/settings/links">Settings &rarr; Links</a> page of your site's dashboard.
+  You can add external links to your menu in the
+  <a href="/settings/template">template editor</a> on your site's dashboard.
 </p>
 
 <h2>Edit the order of the links on your menu</h2>
 
 <p>
-  You can change the order of the links on your menu on the
-  <a href="/settings/links">Settings &rarr; Links</a> page of your site's dashboard.
+  You can change the order of the links on your menu in the
+  <a href="/settings/template">template editor</a> on your site's dashboard.
 </p>


### PR DESCRIPTION
### Motivation
- Documentation incorrectly instructed users to edit menu links under `Settings > Links`; the correct workflow is to open the web `template editor`, so the guide needs updating to avoid confusion.

### Description
- Replace references to `/settings/links` / `Settings &rarr; Links` with the `template editor` and link to `/settings/template` in `app/views/how/sub-folders/pages.html`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e5b4af9c8329ad70a321b442946a)