### PR TITLE
Increase large thumbnail size to 1200px and update related code/docs

### DIFF
--- a/app/build/plugins/linkScreenshot/index.js
+++ b/app/build/plugins/linkScreenshot/index.js
@@ -7,8 +7,8 @@ const uuid = require("uuid/v4");
 const { is } = require("build/converters/webloc");
 const clfdate = require("helper/clfdate");
 const SCREENSHOT_DIR = "_bookmark_screenshots";
-const SCREENSHOT_WIDTH = 1060;
-const SCREENSHOT_HEIGHT = 1060;
+const SCREENSHOT_WIDTH = 1200;
+const SCREENSHOT_HEIGHT = 1200;
 
 function render($, callback, { blogID, path }) {
   if (!is(path)) return callback();

--- a/app/build/thumbnail/config.js
+++ b/app/build/thumbnail/config.js
@@ -6,7 +6,7 @@ module.exports = {
   THUMBNAILS: {
     small: { size: 160 },
     medium: { size: 640 },
-    large: { size: 1060 },
+    large: { size: 1200 },
     square: { size: 160, crop: true },
   },
 };

--- a/app/templates/screenshots.js
+++ b/app/templates/screenshots.js
@@ -5,6 +5,10 @@ const root = require("helper/rootDir");
 const fs = require("fs-extra");
 const TEMPLATES_DIRECTORY = root + "/app/templates/source";
 const IMAGE_DIRECTORY = root + "/app/views/images/examples";
+// Template gallery previews use a fixed 1060x780 viewport; this is independent
+// of entry thumbnail sizing or OG image dimensions.
+const TEMPLATE_SCREENSHOT_WIDTH = 1060;
+const TEMPLATE_SCREENSHOT_HEIGHT = 780;
 
 
 const templates = fs
@@ -56,7 +60,10 @@ const takeScreenshot = async ({ url, destination }) => {
   const path = `${destination}.png`;
 
   console.log(`Taking screenshot of ${url} to ${path}`);
-  await screenshot(url, path, { width: 1060, height: 780 });
+  await screenshot(url, path, {
+    width: TEMPLATE_SCREENSHOT_WIDTH,
+    height: TEMPLATE_SCREENSHOT_HEIGHT,
+  });
 
   const mobilePath = `${destination}.mobile.png`;
   console.log(`Taking mobile screenshot of ${url} to ${mobilePath}`);

--- a/app/views/developers/reference.yml
+++ b/app/views/developers/reference.yml
@@ -191,7 +191,7 @@
 
         - name: large
           type: object
-          description: which has a width and height under 1060px.
+          description: which has a width and height under 1200px.
 
         - name: square
           type: object


### PR DESCRIPTION
### Motivation
- Align the configured large thumbnail/OG image limit to `1200px` instead of the previous `1060px` to support higher-resolution thumbnails.
- Ensure bookmark screenshot generation and developer docs reflect the new large thumbnail sizing.
- Preserve and document that template gallery preview screenshots intentionally use a separate `1060x780` viewport so they are not conflated with entry thumbnail sizing.

### Description
- Updated `THUMBNAILS.large.size` from `1060` to `1200` in `app/build/thumbnail/config.js`.
- Updated bookmark screenshot dimensions from `1060x1060` to `1200x1200` by changing `SCREENSHOT_WIDTH`/`SCREENSHOT_HEIGHT` in `app/build/plugins/linkScreenshot/index.js`.
- Updated the developer reference text in `app/views/developers/reference.yml` to document the large thumbnail limit as `1200px`.
- Added `TEMPLATE_SCREENSHOT_WIDTH` and `TEMPLATE_SCREENSHOT_HEIGHT` constants and a clarifying comment in `app/templates/screenshots.js`, and wired those constants into the screenshot call to document that template previews remain `1060x780`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f242fec483298d7196b5ddf1c6a2)