### PR TITLE
Clarify thumbnail size behavior in developer reference

### DIFF
--- a/app/views/developers/reference.yml
+++ b/app/views/developers/reference.yml
@@ -179,7 +179,7 @@
 
     - name: thumbnail
       type: object
-      description: "object containing the thumbnails for the entry, if they exist. Blot will not increase the size of smaller images. The JSON added to each entry looks something like this"
+      description: "object containing the thumbnails for the entry, if they exist. Blot will not increase the size of smaller images. When a thumbnail is generated, each size (small, medium, large, square) is present; if the source image is smaller than a size limit, the thumbnail is still generated at the source image’s dimensions (no upscaling). The JSON added to each entry looks something like this"
       properties:
         - name: small
           type: object
@@ -191,7 +191,7 @@
 
         - name: large
           type: object
-          description: which has a width and height under 1200px.
+          description: which has a width and height under 1200px (or smaller if the source image is smaller).
 
         - name: square
           type: object


### PR DESCRIPTION
### Motivation
- Clarify in the developer reference whether each thumbnail size (e.g. `thumbnail.large`) is present when thumbnails are generated and that thumbnails are never upscaled from smaller source images.

### Description
- Update `app/views/developers/reference.yml` to expand the `thumbnail` description to state that all sizes (`small`, `medium`, `large`, `square`) are included when thumbnails are generated and that a size (including `large`) will be generated at the source image's dimensions if the source is smaller (no upscaling).

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a094ee5508329bd3ef22016e25af0)