### PR TITLE
Use “site(s)” terminology in admin email templates

### DIFF
--- a/app/helper/email/admin/BILLING_INTERVAL.txt
+++ b/app/helper/email/admin/BILLING_INTERVAL.txt
@@ -1,3 +1,3 @@
 User switched to {{subscription.plan.interval}}ly billing
 
-{{email}} now pays {{pretty.price}} per {{subscription.plan.interval}} for {{blogs.length}} blog{{s}}
+{{email}} now pays {{pretty.price}} per {{subscription.plan.interval}} for {{blogs.length}} site{{s}}

--- a/app/helper/email/admin/CANCELLED.txt
+++ b/app/helper/email/admin/CANCELLED.txt
@@ -1,3 +1,3 @@
 User cancelled subscription{{andDisabled}}
 
-{{email}} used to pay {{pretty.price}} per {{subscription.plan.interval}} for {{pretty.amount}} blog{{pretty.s}}
+{{email}} used to pay {{pretty.price}} per {{subscription.plan.interval}} for {{pretty.amount}} site{{pretty.s}}

--- a/app/helper/email/admin/CANCELLED_FIRST_PERIOD.txt
+++ b/app/helper/email/admin/CANCELLED_FIRST_PERIOD.txt
@@ -1,5 +1,5 @@
 User cancelled subscription in first period
 
-{{email}} used to pay {{pretty.price}} per {{subscription.plan.interval}} for {{pretty.amount}} blog{{pretty.s}}
+{{email}} used to pay {{pretty.price}} per {{subscription.plan.interval}} for {{pretty.amount}} site{{pretty.s}}
 
 Because they cancelled their subscription within the first month they were offered a refund.

--- a/app/helper/email/admin/CREATED_BLOG.txt
+++ b/app/helper/email/admin/CREATED_BLOG.txt
@@ -1,3 +1,3 @@
-User created blog
+User created site
 
-{{email}} {{#isSubscribed}} now pays {{pretty.price}} per {{pretty.interval}} {{#paypal.status}}via PayPal{{/paypal.status}} for{{/isSubscribed}} {{pretty.amount}} blog{{pretty.s}} 
+{{email}} {{#isSubscribed}} now pays {{pretty.price}} per {{pretty.interval}} {{#paypal.status}}via PayPal{{/paypal.status}} for{{/isSubscribed}} {{pretty.amount}} site{{pretty.s}} 

--- a/app/helper/email/admin/DELETED.txt
+++ b/app/helper/email/admin/DELETED.txt
@@ -1,3 +1,3 @@
 User deleted account
 
-{{email}} used to pay {{pretty.price}} per {{pretty.interval}} for {{pretty.amount}} blog{{pretty.s}}
+{{email}} used to pay {{pretty.price}} per {{pretty.interval}} for {{pretty.amount}} site{{pretty.s}}

--- a/app/helper/email/admin/DELETED_FIRST_PERIOD.txt
+++ b/app/helper/email/admin/DELETED_FIRST_PERIOD.txt
@@ -1,5 +1,5 @@
 User deleted account with refund
 
-{{email}} used to pay {{pretty.price}} per {{pretty.interval}} for {{pretty.amount}} blog{{pretty.s}}
+{{email}} used to pay {{pretty.price}} per {{pretty.interval}} for {{pretty.amount}} site{{pretty.s}}
 
 Because they deleted their account within the first month they received a {{refund.amountPretty}}{{#refund.currency}} ({{refund.currency}}){{/refund.currency}} refund via {{refund.providerPretty}}.

--- a/app/helper/email/admin/DISABLED.txt
+++ b/app/helper/email/admin/DISABLED.txt
@@ -1,3 +1,3 @@
 User disabled account
 
-{{email}} used to pay {{pretty.price}} per {{subscription.plan.interval}} for {{pretty.amount}} blog{{pretty.s}}
+{{email}} used to pay {{pretty.price}} per {{subscription.plan.interval}} for {{pretty.amount}} site{{pretty.s}}

--- a/app/helper/email/admin/ICLOUD_RESYNC_REQUESTED.txt
+++ b/app/helper/email/admin/ICLOUD_RESYNC_REQUESTED.txt
@@ -1,3 +1,3 @@
 iCloud resync requested
 
-A resync was requested for blog {{blogID}}.
+A resync was requested for site {{blogID}}.

--- a/app/helper/email/admin/OVERDUE.txt
+++ b/app/helper/email/admin/OVERDUE.txt
@@ -1,3 +1,3 @@
 User is overdue paying for Blot
 
-{{email}} used to pay {{pretty.price}} per {{subscription.plan.interval}} for {{pretty.amount}} blog{{pretty.s}}
+{{email}} used to pay {{pretty.price}} per {{subscription.plan.interval}} for {{pretty.amount}} site{{pretty.s}}

--- a/app/helper/email/admin/OVERDUE_CLOSURE.txt
+++ b/app/helper/email/admin/OVERDUE_CLOSURE.txt
@@ -1,3 +1,3 @@
 User account has been closed after for late payments
 
-{{email}} used to pay {{pretty.price}} per {{subscription.plan.interval}} for {{pretty.amount}} blog{{pretty.s}}
+{{email}} used to pay {{pretty.price}} per {{subscription.plan.interval}} for {{pretty.amount}} site{{pretty.s}}

--- a/app/helper/email/admin/RECOVERED.txt
+++ b/app/helper/email/admin/RECOVERED.txt
@@ -1,3 +1,3 @@
 User restarted overdue subscription
 
-{{email}} pays {{pretty.price}} per {{subscription.plan.interval}} for {{pretty.amount}} blog{{pretty.s}}
+{{email}} pays {{pretty.price}} per {{subscription.plan.interval}} for {{pretty.amount}} site{{pretty.s}}

--- a/app/helper/email/admin/RESTART.txt
+++ b/app/helper/email/admin/RESTART.txt
@@ -1,3 +1,3 @@
 User restarted subscription
 
-{{email}} now pays {{pretty.price}} per {{subscription.plan.interval}} for {{pretty.amount}} blog{{pretty.s}}
+{{email}} now pays {{pretty.price}} per {{subscription.plan.interval}} for {{pretty.amount}} site{{pretty.s}}

--- a/app/helper/email/admin/SUBSCRIPTION_DECREASE.txt
+++ b/app/helper/email/admin/SUBSCRIPTION_DECREASE.txt
@@ -1,3 +1,3 @@
-User deleted blog
+User deleted site
 
-{{email}} now pays {{pretty.price}} per {{pretty.interval}} for {{pretty.amount}} blog{{pretty.s}}
+{{email}} now pays {{pretty.price}} per {{pretty.interval}} for {{pretty.amount}} site{{pretty.s}}

--- a/app/helper/email/admin/SYNC_REPORT.txt
+++ b/app/helper/email/admin/SYNC_REPORT.txt
@@ -1,6 +1,6 @@
 Sync fix report
 
-We found the following reported issues when attempting to verify the sync for all the blogs:
+We found the following reported issues when attempting to verify the sync for all the sites:
 
 ```
 {{{report}}}

--- a/app/helper/email/admin/UPCOMING_EXPIRY.txt
+++ b/app/helper/email/admin/UPCOMING_EXPIRY.txt
@@ -1,3 +1,3 @@
 User notified of subscription expiry in 7 days
 
-{{email}} ({{blogs.length}} blog{{s}} – {{pretty.price}} total) was notified that their subscription will expire next week and their account will close. They were offered a chance to restart their subscipriont.
+{{email}} ({{blogs.length}} site{{s}} – {{pretty.price}} total) was notified that their subscription will expire next week and their account will close. They were offered a chance to restart their subscipriont.

--- a/app/helper/email/admin/UPCOMING_RENEWAL.txt
+++ b/app/helper/email/admin/UPCOMING_RENEWAL.txt
@@ -1,3 +1,3 @@
 User notified of subscription renewal in 7 days
 
-{{email}} ({{blogs.length}} blog{{s}} – {{pretty.price}} total) was notified that their subscription will renew next week. They were offered a chance to cancel their subscription or update their billing information.
+{{email}} ({{blogs.length}} site{{s}} – {{pretty.price}} total) was notified that their subscription will renew next week. They were offered a chance to cancel their subscription or update their billing information.

--- a/app/helper/email/admin/UPDATE_BILLING.txt
+++ b/app/helper/email/admin/UPDATE_BILLING.txt
@@ -1,3 +1,3 @@
 User changed payment method
 
-{{email}} ({{blogs.length}} blog{{s}} – {{pretty.price}} total) was updated their billing information.
+{{email}} ({{blogs.length}} site{{s}} – {{pretty.price}} total) was updated their billing information.

--- a/app/helper/email/admin/WELCOME.txt
+++ b/app/helper/email/admin/WELCOME.txt
@@ -1,3 +1,3 @@
 User sent welcome email
 
-{{email}} ({{blogs.length}} blog{{s}} – {{pretty.price}} total) was sent the welcome email.
+{{email}} ({{blogs.length}} site{{s}} – {{pretty.price}} total) was sent the welcome email.


### PR DESCRIPTION
### Motivation
- Align admin-facing email subjects and bodies to use “site(s)” instead of “blog(s)” for clearer terminology.
- Preserve existing template variable placeholders and pluralization tokens while updating human-facing words.

### Description
- Replaced occurrences of phrasing such as `blog{{pretty.s}}`, `{{blogs.length}} blog{{s}}`, and `for all the blogs` with `site{{pretty.s}}`, `{{blogs.length}} site{{s}}`, and `for all the sites` across admin email templates in `app/helper/email/admin`.
- Renamed subject/body lines like `User created blog` and `User deleted blog` to `User created site` and `User deleted site` respectively.
- Updated `ICLOUD_RESYNC_REQUESTED.txt` message to say `A resync was requested for site {{blogID}}.` while keeping the `{{blogID}}` placeholder intact.
- Changes touch 18 template files and avoid altering template variables or control blocks.

### Testing
- Verified occurrences before and after with `rg -n "blog" app/helper/email/admin`, confirming human-facing instances were updated and placeholders retained, and the check succeeded.
- Inspected sample files using `sed -n`/`nl -ba` to confirm subject and body line updates, and the checks succeeded.
- Ran `git status` and committed the changes; the commit completed successfully showing 18 files changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a3457ce948329809ec681ea2aa2f5)