### PR TITLE
Add in-memory hot document poller for Google Drive webhook handling

### DIFF
--- a/app/clients/google-drive/init.js
+++ b/app/clients/google-drive/init.js
@@ -6,6 +6,7 @@ const createDriveActivityClient = require("./serviceAccount/createDriveActivityC
 const fetchStorageInfo = require("./serviceAccount/fetchStorageInfo");
 const watchChanges = require("./serviceAccount/watchChanges");
 const pollDriveActivity = require("./serviceAccount/pollDriveActivity");
+const hotDocPoller = require("./serviceAccount/hotDocPoller");
 const { restartSetupProcesses } = require("./routes/setup");
 
 const main = async (initial = false) => {
@@ -25,6 +26,8 @@ const main = async (initial = false) => {
     try {
       const drive = await createDriveClient(serviceAccountId);
       const driveactivity = await createDriveActivityClient(serviceAccountId);
+
+      hotDocPoller.registerDriveClient(serviceAccountId, drive);
 
       console.log(prefix(), "Fetching storage usage of service account");
       await fetchStorageInfo(serviceAccountId, drive);
@@ -50,6 +53,7 @@ const main = async (initial = false) => {
 };
 
 module.exports = async () => {
+  hotDocPoller.start();
   main(true);
   // we do this repeatedly every 10 minutes
   // to refresh the service account data

--- a/app/clients/google-drive/routes/site.js
+++ b/app/clients/google-drive/routes/site.js
@@ -5,49 +5,133 @@ const site = new express.Router();
 
 const sync = require("clients/google-drive/sync");
 const database = require("clients/google-drive/database");
+const hotDocPoller = require("clients/google-drive/serviceAccount/hotDocPoller");
 
-site
-  .route("/webhook/changes.watch/:serviceAccountId")
-  .post(async function (req, res) {
-    console.log(
-      `${clfdate()} Google Drive client: Received changes.watch webhook for service account ${
-        req.params.serviceAccountId
-      }`
-    );
+const parseCandidateIds = (req) => {
+  const fileIds = new Set();
+  const folderIds = new Set();
 
-    const blogIDs = [];
-
-    await database.blog.iterateByServiceAccountId(
-      req.params.serviceAccountId,
-      async function (blogID, account) {
-        blogIDs.push(blogID);
-      }
-    );
-
-    if (!blogIDs.length) {
-      console.log(
-        `${clfdate()} Google Drive client: No blogs found for service account ${
-          req.params.serviceAccountId
-        }`
-      );
-      return res.sendStatus(200);
+  const pushIfString = (collection, value) => {
+    if (typeof value === "string" && value.trim()) {
+      collection.add(value.trim());
     }
+  };
 
-    // sync all blogs in parallel but if one errors don't stop the others
-    await Promise.all(
-      blogIDs.map(async (blogID) => {
-        try {
-          console.log(
-            `${clfdate()} Google Drive client: Syncing blog ${blogID}`
-          );
-          await sync(blogID);
-        } catch (e) {
-          console.error("Google Drive client:", e.message);
-        }
-      })
-    );
+  const resourceUri = req.headers["x-goog-resource-uri"];
+  if (typeof resourceUri === "string") {
+    const fileMatch = resourceUri.match(/files\/([a-zA-Z0-9_-]+)/);
+    const folderMatch = resourceUri.match(/folders\/([a-zA-Z0-9_-]+)/);
 
-    res.sendStatus(200);
+    if (fileMatch) pushIfString(fileIds, fileMatch[1]);
+    if (folderMatch) pushIfString(folderIds, folderMatch[1]);
+  }
+
+  const body = req.body || {};
+
+  [body.fileId, body.fileID, body.id, body.resourceId].forEach((value) =>
+    pushIfString(fileIds, value)
+  );
+
+  [body.folderId, body.folderID, body.parentId].forEach((value) =>
+    pushIfString(folderIds, value)
+  );
+
+  const files = Array.isArray(body.files) ? body.files : [];
+  files.forEach((file) => {
+    if (file && typeof file === "object") {
+      pushIfString(fileIds, file.id || file.fileId);
+      const parents = Array.isArray(file.parents) ? file.parents : [];
+      parents.forEach((parent) => pushIfString(folderIds, parent));
+    }
   });
+
+  return { fileIds: [...fileIds], folderIds: [...folderIds] };
+};
+
+site.route("/webhook/changes.watch/:serviceAccountId").post(async function (req, res) {
+  const { serviceAccountId } = req.params;
+
+  console.log(
+    `${clfdate()} Google Drive client: Received changes.watch webhook for service account ${serviceAccountId}`
+  );
+
+  const blogAccounts = [];
+
+  await database.blog.iterateByServiceAccountId(serviceAccountId, async function (blogID, account) {
+    blogAccounts.push({
+      blogID,
+      folderId: account.folderId,
+    });
+  });
+
+  if (!blogAccounts.length) {
+    console.log(
+      `${clfdate()} Google Drive client: No blogs found for service account ${serviceAccountId}`
+    );
+    return res.sendStatus(200);
+  }
+
+  const { fileIds, folderIds } = parseCandidateIds(req);
+  const hasSignals = fileIds.length > 0 || folderIds.length > 0;
+  let enqueuedCount = 0;
+
+  if (config.google_drive.hot_doc_poller.enabled) {
+    try {
+      for (const { blogID, folderId } of blogAccounts) {
+        const folderMatched = folderIds.includes(folderId);
+
+        if (fileIds.length) {
+          if (!folderIds.length || folderMatched) {
+            for (const fileId of fileIds) {
+              hotDocPoller.enqueue({
+                blogID,
+                serviceAccountId,
+                fileId,
+                folderId,
+              });
+              enqueuedCount += 1;
+            }
+          }
+          continue;
+        }
+
+        if (!hasSignals || folderMatched) {
+          hotDocPoller.enqueue({
+            blogID,
+            serviceAccountId,
+            folderId,
+          });
+          enqueuedCount += 1;
+        }
+      }
+
+      if (enqueuedCount > 0) {
+        console.log(
+          `${clfdate()} Google Drive client: hotDocPoller enqueued ${enqueuedCount} candidates for service account ${serviceAccountId}`
+        );
+        return res.sendStatus(200);
+      }
+    } catch (err) {
+      console.error(
+        `${clfdate()} Google Drive client: hotDocPoller enqueue failed for service account ${serviceAccountId}`,
+        err.message
+      );
+    }
+  }
+
+  // fallback path: if we're uncertain or polling is disabled, sync all blogs in parallel.
+  await Promise.all(
+    blogAccounts.map(async ({ blogID }) => {
+      try {
+        console.log(`${clfdate()} Google Drive client: Syncing blog ${blogID}`);
+        await sync(blogID);
+      } catch (e) {
+        console.error("Google Drive client:", e.message);
+      }
+    })
+  );
+
+  res.sendStatus(200);
+});
 
 module.exports = site;

--- a/app/clients/google-drive/serviceAccount/hotDocPoller.js
+++ b/app/clients/google-drive/serviceAccount/hotDocPoller.js
@@ -1,0 +1,380 @@
+const Bottleneck = require("bottleneck");
+const config = require("config");
+const clfdate = require("helper/clfdate");
+const sync = require("clients/google-drive/sync");
+
+const DEFAULTS = {
+  enabled: false,
+  per_service_account_min_time_ms: 600,
+  per_service_account_max_concurrent: 1,
+  global_max_concurrent: 4,
+  jitter_ms: 500,
+  tick_interval_ms: 1000,
+  max_items_global: 2000,
+  max_items_per_service_account: 300,
+  sync_cooldown_ms: 8000,
+  rate_limit_backoff_ms: 20000,
+};
+
+const tiers = [
+  { maxAgeMs: 10 * 1000, cadenceMs: 2 * 1000 },
+  { maxAgeMs: 40 * 1000, cadenceMs: 3 * 1000 },
+  { maxAgeMs: 120 * 1000, cadenceMs: 10 * 1000 },
+];
+
+const prefix = () => `${clfdate()} Google Drive hotDocPoller:`;
+
+class HotDocPoller {
+  constructor() {
+    this.config = {
+      ...DEFAULTS,
+      ...(config.google_drive && config.google_drive.hot_doc_poller
+        ? config.google_drive.hot_doc_poller
+        : {}),
+    };
+
+    this.items = new Map();
+    this.itemsByServiceAccount = new Map();
+    this.driveClients = new Map();
+    this.lastSyncAtByBlog = new Map();
+    this.metrics = {
+      enqueueCount: 0,
+      pollAttempts: 0,
+      changeDetectedCount: 0,
+      syncTriggerCount: 0,
+      evictions: 0,
+      rateLimitEvents: 0,
+    };
+
+    this.globalLimiter = new Bottleneck({
+      maxConcurrent: this.config.global_max_concurrent,
+    });
+
+    this.serviceLimiterGroup = new Bottleneck.Group({
+      minTime: this.config.per_service_account_min_time_ms,
+      maxConcurrent: this.config.per_service_account_max_concurrent,
+    });
+
+    this.rateLimitBackoffUntil = 0;
+    this._timer = null;
+  }
+
+  start() {
+    if (!this.config.enabled || this._timer) return;
+
+    this._timer = setInterval(() => {
+      this.tick().catch((err) => {
+        console.error(prefix(), "tick failed", err.message);
+      });
+    }, this.config.tick_interval_ms);
+
+    console.log(prefix(), "started", {
+      tickInterval: this.config.tick_interval_ms,
+      globalMaxConcurrent: this.config.global_max_concurrent,
+      perServiceAccountMinTime: this.config.per_service_account_min_time_ms,
+    });
+  }
+
+  stop() {
+    if (!this._timer) return;
+    clearInterval(this._timer);
+    this._timer = null;
+  }
+
+  registerDriveClient(serviceAccountId, driveClient) {
+    if (!serviceAccountId || !driveClient) return;
+    this.driveClients.set(serviceAccountId, driveClient);
+  }
+
+  keyOf(blogID, fileId) {
+    return `${blogID}::${fileId || "*"}`;
+  }
+
+  enqueue({ blogID, serviceAccountId, fileId, folderId }) {
+    if (!this.config.enabled) return;
+
+    if (!blogID || !serviceAccountId) {
+      console.warn(prefix(), "enqueue missing identifiers", {
+        blogID,
+        serviceAccountId,
+        fileId,
+        folderId,
+      });
+      return;
+    }
+
+    const key = this.keyOf(blogID, fileId);
+    const now = Date.now();
+    const existing = this.items.get(key);
+
+    this.metrics.enqueueCount += 1;
+
+    if (existing) {
+      existing.lastSeen = now;
+      existing.nextDueAt = now + tiers[0].cadenceMs;
+      existing.state = "queued";
+      if (folderId && !existing.folderId) {
+        existing.folderId = folderId;
+      }
+      console.log(prefix(), "re-enqueued item", {
+        blogID,
+        serviceAccountId,
+        fileId,
+      });
+      return;
+    }
+
+    const item = {
+      blogID,
+      serviceAccountId,
+      fileId,
+      folderId,
+      firstSeen: now,
+      lastSeen: now,
+      lastPolledAt: null,
+      pollCount: 0,
+      nextDueAt: now,
+      lastKnownModifiedTime: null,
+      lastKnownRevision: null,
+      state: "queued",
+    };
+
+    this.items.set(key, item);
+
+    if (!this.itemsByServiceAccount.has(serviceAccountId)) {
+      this.itemsByServiceAccount.set(serviceAccountId, new Set());
+    }
+    this.itemsByServiceAccount.get(serviceAccountId).add(key);
+
+    this.applyCaps();
+  }
+
+  applyCaps() {
+    while (this.items.size > this.config.max_items_global) {
+      this.evictOldest("global-cap");
+    }
+
+    for (const [serviceAccountId, keys] of this.itemsByServiceAccount.entries()) {
+      while (keys.size > this.config.max_items_per_service_account) {
+        this.evictOldest(`service-account-cap:${serviceAccountId}`, serviceAccountId);
+      }
+    }
+  }
+
+  evictOldest(reason, serviceAccountId) {
+    let oldestKey = null;
+    let oldest = null;
+
+    for (const [key, item] of this.items.entries()) {
+      if (serviceAccountId && item.serviceAccountId !== serviceAccountId) {
+        continue;
+      }
+      if (!oldest || item.firstSeen < oldest.firstSeen) {
+        oldest = item;
+        oldestKey = key;
+      }
+    }
+
+    if (!oldestKey) return;
+
+    this.removeItem(oldestKey);
+    this.metrics.evictions += 1;
+    console.warn(prefix(), "evicted hot item", {
+      reason,
+      blogID: oldest.blogID,
+      serviceAccountId: oldest.serviceAccountId,
+      fileId: oldest.fileId,
+    });
+  }
+
+  removeItem(key) {
+    const item = this.items.get(key);
+    if (!item) return;
+
+    this.items.delete(key);
+    const keys = this.itemsByServiceAccount.get(item.serviceAccountId);
+    if (keys) {
+      keys.delete(key);
+      if (!keys.size) {
+        this.itemsByServiceAccount.delete(item.serviceAccountId);
+      }
+    }
+  }
+
+  tierForAge(ageMs) {
+    return tiers.find((tier) => ageMs <= tier.maxAgeMs) || null;
+  }
+
+  async tick() {
+    const now = Date.now();
+    const dueItems = [];
+
+    for (const [key, item] of this.items.entries()) {
+      const ageMs = now - item.firstSeen;
+      const tier = this.tierForAge(ageMs);
+
+      if (!tier) {
+        this.removeItem(key);
+        this.metrics.evictions += 1;
+        continue;
+      }
+
+      if (item.nextDueAt <= now && item.state !== "polling") {
+        dueItems.push(item);
+      }
+    }
+
+    for (const item of dueItems) {
+      item.state = "polling";
+      this.pollItem(item).finally(() => {
+        item.state = "queued";
+      });
+    }
+  }
+
+  async pollItem(item) {
+    const now = Date.now();
+    const ageMs = now - item.firstSeen;
+    const tier = this.tierForAge(ageMs);
+
+    if (!tier) {
+      this.removeItem(this.keyOf(item.blogID, item.fileId));
+      return;
+    }
+
+    item.lastPolledAt = now;
+    item.pollCount += 1;
+    item.nextDueAt = now + tier.cadenceMs;
+
+    const limiter = this.serviceLimiterGroup.key(item.serviceAccountId);
+
+    try {
+      this.metrics.pollAttempts += 1;
+      await this.globalLimiter.schedule(() =>
+        limiter.schedule(async () => {
+          await this.sleep(Math.floor(Math.random() * (this.config.jitter_ms + 1)));
+          await this.probeAndSyncIfChanged(item);
+        })
+      );
+    } catch (err) {
+      if (this.isRateLimitError(err)) {
+        this.handleRateLimitError(err);
+      } else {
+        console.error(prefix(), "poll failed", {
+          blogID: item.blogID,
+          serviceAccountId: item.serviceAccountId,
+          fileId: item.fileId,
+          error: err.message,
+        });
+      }
+    }
+  }
+
+  async probeAndSyncIfChanged(item) {
+    if (Date.now() < this.rateLimitBackoffUntil) {
+      item.nextDueAt = Math.max(item.nextDueAt, this.rateLimitBackoffUntil);
+      return;
+    }
+
+    if (!item.fileId) {
+      await this.triggerSyncWithCooldown(item, "coarse-fallback");
+      return;
+    }
+
+    const drive = this.driveClients.get(item.serviceAccountId);
+    if (!drive) {
+      console.warn(prefix(), "missing drive client", {
+        serviceAccountId: item.serviceAccountId,
+        blogID: item.blogID,
+        fileId: item.fileId,
+      });
+      return;
+    }
+
+    const response = await drive.files.get({
+      fileId: item.fileId,
+      fields: "id,modifiedTime,version,mimeType",
+      supportsAllDrives: true,
+    });
+
+    const data = response && response.data ? response.data : {};
+
+    if (data.mimeType && data.mimeType !== "application/vnd.google-apps.document") {
+      return;
+    }
+
+    const changed =
+      (item.lastKnownModifiedTime && item.lastKnownModifiedTime !== data.modifiedTime) ||
+      (item.lastKnownRevision && item.lastKnownRevision !== data.version);
+
+    const firstProbe = !item.lastKnownModifiedTime && !item.lastKnownRevision;
+
+    item.lastKnownModifiedTime = data.modifiedTime || null;
+    item.lastKnownRevision = data.version || null;
+
+    if (!firstProbe && changed) {
+      this.metrics.changeDetectedCount += 1;
+      console.log(prefix(), "change detected", {
+        blogID: item.blogID,
+        serviceAccountId: item.serviceAccountId,
+        fileId: item.fileId,
+        modifiedTime: data.modifiedTime,
+        version: data.version,
+      });
+      await this.triggerSyncWithCooldown(item, "doc-change");
+    }
+  }
+
+  async triggerSyncWithCooldown(item, reason) {
+    const now = Date.now();
+    const lastSyncAt = this.lastSyncAtByBlog.get(item.blogID) || 0;
+
+    if (now - lastSyncAt < this.config.sync_cooldown_ms) {
+      return;
+    }
+
+    this.lastSyncAtByBlog.set(item.blogID, now);
+    this.metrics.syncTriggerCount += 1;
+
+    console.log(prefix(), "triggering sync", {
+      reason,
+      blogID: item.blogID,
+      serviceAccountId: item.serviceAccountId,
+      fileId: item.fileId,
+    });
+
+    await sync(item.blogID);
+  }
+
+  isRateLimitError(err) {
+    const status = err && (err.code || (err.response && err.response.status));
+    return status === 429 || status === 403;
+  }
+
+  handleRateLimitError(err) {
+    const now = Date.now();
+    this.metrics.rateLimitEvents += 1;
+    this.rateLimitBackoffUntil = now + this.config.rate_limit_backoff_ms;
+
+    for (const item of this.items.values()) {
+      item.nextDueAt = Math.max(item.nextDueAt, this.rateLimitBackoffUntil);
+    }
+
+    console.warn(prefix(), "rate limit encountered", {
+      error: err.message,
+      status: err.code || (err.response && err.response.status),
+      backoffUntil: new Date(this.rateLimitBackoffUntil).toISOString(),
+      rateLimitEvents: this.metrics.rateLimitEvents,
+    });
+  }
+
+  sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  getMetrics() {
+    return { ...this.metrics, items: this.items.size };
+  }
+}
+
+module.exports = new HotDocPoller();

--- a/config/index.js
+++ b/config/index.js
@@ -171,6 +171,28 @@ module.exports = {
   },
 
   google_drive: {
+    hot_doc_poller: {
+      enabled: process.env.BLOT_GOOGLEDRIVE_HOT_DOC_POLLER_ENABLED === "true",
+      per_service_account_min_time_ms:
+        parseInt(process.env.BLOT_GOOGLEDRIVE_HOT_DOC_POLLER_PER_ACCOUNT_MIN_TIME_MS, 10) || 600,
+      per_service_account_max_concurrent:
+        parseInt(process.env.BLOT_GOOGLEDRIVE_HOT_DOC_POLLER_PER_ACCOUNT_MAX_CONCURRENT, 10) || 1,
+      global_max_concurrent:
+        parseInt(process.env.BLOT_GOOGLEDRIVE_HOT_DOC_POLLER_GLOBAL_MAX_CONCURRENT, 10) || 4,
+      jitter_ms:
+        parseInt(process.env.BLOT_GOOGLEDRIVE_HOT_DOC_POLLER_JITTER_MS, 10) || 500,
+      tick_interval_ms:
+        parseInt(process.env.BLOT_GOOGLEDRIVE_HOT_DOC_POLLER_TICK_INTERVAL_MS, 10) || 1000,
+      max_items_global:
+        parseInt(process.env.BLOT_GOOGLEDRIVE_HOT_DOC_POLLER_MAX_ITEMS_GLOBAL, 10) || 2000,
+      max_items_per_service_account:
+        parseInt(process.env.BLOT_GOOGLEDRIVE_HOT_DOC_POLLER_MAX_ITEMS_PER_SERVICE_ACCOUNT, 10) || 300,
+      sync_cooldown_ms:
+        parseInt(process.env.BLOT_GOOGLEDRIVE_HOT_DOC_POLLER_SYNC_COOLDOWN_MS, 10) || 8000,
+      rate_limit_backoff_ms:
+        parseInt(process.env.BLOT_GOOGLEDRIVE_HOT_DOC_POLLER_RATE_LIMIT_BACKOFF_MS, 10) || 20000,
+    },
+
     service_accounts: (() => {
       try {
         // Check if the environment variable is defined and not empty


### PR DESCRIPTION
### Motivation

- Reduce unnecessary full-blog syncs by quickly probing likely-changed documents reported by Drive webhooks. 
- Provide a short-lived, adaptive polling window for recently signaled files to detect edits and trigger targeted syncs. 
- Protect Drive quota and sync infrastructure with throttling, caps, cooldowns and backoff on rate limits.

### Description

- Add a single-process `HotDocPoller` service at `app/clients/google-drive/serviceAccount/hotDocPoller.js` that exposes `enqueue({ blogID, serviceAccountId, fileId, folderId })` and maintains an internal `(blogID,fileId)` keyed map with `firstSeen`, `lastSeen`, `lastPolledAt`, `pollCount`, `nextDueAt`, cached metadata, and `state`. 
- Implement adaptive polling tiers (0–10s => 2s, 10–40s => 3s, 40–120s => 10s) and eviction after the final tier, with re-enqueue de-duplication that refreshes items into the fast tier. 
- Use `bottleneck` for a per-service-account limiter (`minTime`/`maxConcurrent`) via `Bottleneck.Group` and a global concurrency limiter, and add jitter before each probe to avoid burst alignment. 
- Wire Drive clients into the poller (`registerDriveClient`) and start the poller from `app/clients/google-drive/init.js`. 
- Feed the poller from the webhook handler by parsing headers/body in `app/clients/google-drive/routes/site.js` to extract likely `fileId`/`folderId` candidates and enqueue targeted or coarse fallback items while retaining the full-sync fallback path. 
- Add a lightweight probe that calls `drive.files.get` with `fields: "id,modifiedTime,version,mimeType"` for Google Docs and compares against cached metadata to only invoke `sync(blogID)` via the existing sync path when a change is confirmed. 
- Add guardrails including global and per-service-account caps with oldest-item eviction, a per-blog sync cooldown, global backoff on 429/403 rate-limit errors, and in-memory metrics/logging counters (enqueue, polls, changes detected, sync triggers, evictions, rate-limit events) with contextual identifiers. 
- Add rollout/config flags under `config.google_drive.hot_doc_poller` (defaults to disabled) with tunables for caps, intervals, concurrency and backoff.

### Testing

- Performed static syntax checks using `node --check` on `app/clients/google-drive/serviceAccount/hotDocPoller.js`, `app/clients/google-drive/routes/site.js`, `app/clients/google-drive/init.js`, and `config/index.js`, all of which passed. 
- No unit tests were added per instruction and no automated runtime integration tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c9bf815348329afa75c7a6fa4c882)