### PR TITLE
Coordinate iCloud eviction with file system events

### DIFF
--- a/app/clients/icloud/macserver/watcher/index.js
+++ b/app/clients/icloud/macserver/watcher/index.js
@@ -44,7 +44,7 @@ const evictionSuppressionMap = new Map();
 const CHOKIDAR_EVENT_WINDOW_MS = 60_000;
 const CHOKIDAR_PRUNE_INTERVAL_MS = 30_000;
 const EVICTION_SUPPRESSION_POST_MS = 2_000;
-const EVICTION_SUPPRESSION_TTL_MS = 10_000;
+const EVICTION_SUPPRESSION_TTL_MS = 30_000;
 let chokidarPruneInterval = null;
 const FS_WATCH_SETTLE_DELAY_MS = 300;
 
@@ -61,7 +61,7 @@ const markEvictionSuppressed = (blogID, pathInBlogDirectory) => {
   const key = buildEvictionSuppressionKey(blogID, pathInBlogDirectory);
   const now = Date.now();
   evictionSuppressionMap.set(key, {
-    suppressUntil: now + EVICTION_SUPPRESSION_POST_MS,
+    suppressUntil: Number.POSITIVE_INFINITY,
     expiresAt: now + EVICTION_SUPPRESSION_TTL_MS,
   });
 };
@@ -73,9 +73,8 @@ const extendEvictionSuppression = (blogID, pathInBlogDirectory) => {
 
   const key = buildEvictionSuppressionKey(blogID, pathInBlogDirectory);
   const now = Date.now();
-  const existing = evictionSuppressionMap.get(key);
-  const suppressUntil = Math.max(existing?.suppressUntil ?? 0, now + EVICTION_SUPPRESSION_POST_MS);
-  const expiresAt = Math.max(existing?.expiresAt ?? 0, now + EVICTION_SUPPRESSION_TTL_MS);
+  const suppressUntil = now + EVICTION_SUPPRESSION_POST_MS;
+  const expiresAt = now + EVICTION_SUPPRESSION_TTL_MS;
   evictionSuppressionMap.set(key, { suppressUntil, expiresAt });
 };
 


### PR DESCRIPTION
### Motivation
- Prevent eviction-triggered fs events from being treated as new uploads/downloads by the fs.watch reconciliation flow.

### Description
- Add an in-memory, path-scoped suppression map (`evictionSuppressionMap`) and timing constants in `app/clients/icloud/macserver/watcher/index.js` keyed by `blogID:pathInBlogDirectory` to track short-lived eviction windows.
- Implement helper functions `buildEvictionSuppressionKey`, `markEvictionSuppressed`, `extendEvictionSuppression`, and `isEvictionSuppressed` to manage suppression state per path.
- Prune expired suppression entries via `pruneEvictionSuppressions` and wire it into the existing chokidar prune loop to keep memory bounded.
- Mark a path suppressed immediately before calling `brctl.evict(...)` and extend suppression in the `finally` block, and make `reconcileFsWatchEvent` ignore fs-watch events for paths currently suppressed.

### Testing
- Ran `node --check app/clients/icloud/macserver/watcher/index.js` and it completed without parser/type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de25f8c7083298601cc8e5f26f83c)