### PR TITLE
Use collision-safe full-view cache key serialization

### DIFF
--- a/app/blog/render/full-view-cache.js
+++ b/app/blog/render/full-view-cache.js
@@ -12,11 +12,12 @@ function createCacheKey(blog, template, viewName) {
   var cacheID = blog && blog.cacheID;
   var templateID = template && template.id;
 
-  return [blogID, cacheID, templateID, viewName]
-    .map(function (part) {
-      return String(part);
-    })
-    .join(":");
+  return JSON.stringify({
+    blogID: String(blogID),
+    cacheID: String(cacheID),
+    templateID: String(templateID),
+    viewName: String(viewName),
+  });
 }
 
 module.exports = function getCachedFullView(options, callback) {

--- a/app/blog/render/tests/full-view-cache.js
+++ b/app/blog/render/tests/full-view-cache.js
@@ -75,6 +75,39 @@ describe("full view cache", function () {
     );
   });
 
+
+  it("does not collide cache keys when input segments contain colons", function () {
+    var firstKey = getCachedFullView._createCacheKey(
+      { id: "foo:bar", cacheID: "baz" },
+      { id: "qux" },
+      "view"
+    );
+
+    var secondKey = getCachedFullView._createCacheKey(
+      { id: "foo", cacheID: "bar:baz" },
+      { id: "qux" },
+      "view"
+    );
+
+    expect(firstKey).not.toBe(secondKey);
+  });
+
+  it("keeps null and undefined cache key behavior stable", function () {
+    var keyWithNull = getCachedFullView._createCacheKey(
+      { id: null, cacheID: undefined },
+      { id: undefined },
+      null
+    );
+
+    expect(keyWithNull).toBe(
+      JSON.stringify({
+        blogID: "null",
+        cacheID: "undefined",
+        templateID: "undefined",
+        viewName: "null",
+      })
+    );
+  });
   it("recomputes when blog.cacheID changes", function (done) {
     spyOn(Template, "getFullView").and.callFake(function (
       blogID,


### PR DESCRIPTION
### Motivation
- The previous cache key used `join(":")` which allows distinct segments containing colons to collide.
- Keys must remain stable for `null`/`undefined` inputs to avoid changing behavior elsewhere.

### Description
- Replace the delimiter-joined key with a structured JSON serialization in `createCacheKey` by returning `JSON.stringify({ blogID: String(blogID), cacheID: String(cacheID), templateID: String(templateID), viewName: String(viewName) })` in `app/blog/render/full-view-cache.js`.
- Preserve prior coercion semantics by explicitly calling `String(...)` for each segment so `null` and `undefined` continue to stringify as before.
- Add two tests to `app/blog/render/tests/full-view-cache.js` that assert colon-containing segments do not collide and that `null`/`undefined` serialization remains stable.

### Testing
- Attempted to run the test suite with `npm test -- app/blog/render/tests/full-view-cache.js`, which failed in this environment because `scripts/tests/invoke.sh` requires Docker and `docker: command not found`.
- Attempted a direct Node invocation with `node tests app/blog/render/tests/full-view-cache.js`, which failed because the repo test harness entrypoint is not present in this environment (`Error: Cannot find module '/workspace/blot/tests'`).
- The new unit tests were added and committed (`app/blog/render/tests/full-view-cache.js`) and are expected to pass when run in the project's normal test environment that provides the Docker-based test harness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f52baf4bc8329908212824f139b9f)