### PR TITLE
Protect full-view cache from caller mutations

### DIFF
--- a/app/blog/render/full-view-cache.js
+++ b/app/blog/render/full-view-cache.js
@@ -7,6 +7,36 @@ var fullViewCache = new LRUCache({
   max: 1000,
 });
 
+function cloneDeep(value) {
+  if (Array.isArray(value)) {
+    return value.map(cloneDeep);
+  }
+
+  if (value && typeof value === "object") {
+    var clone = {};
+
+    Object.keys(value).forEach(function (key) {
+      clone[key] = cloneDeep(value[key]);
+    });
+
+    return clone;
+  }
+
+  return value;
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) {
+    return value;
+  }
+
+  Object.keys(value).forEach(function (key) {
+    deepFreeze(value[key]);
+  });
+
+  return Object.freeze(value);
+}
+
 function createCacheKey(blog, template, viewName) {
   var blogID = blog && blog.id;
   var cacheID = blog && blog.cacheID;
@@ -27,7 +57,7 @@ module.exports = function getCachedFullView(options, callback) {
   var key = createCacheKey(blog, template, viewName);
 
   if (fullViewCache.has(key)) {
-    return callback(null, fullViewCache.get(key));
+    return callback(null, cloneDeep(fullViewCache.get(key)));
   }
 
   Template.getFullView(blog.id, template.id, viewName, function (err, response) {
@@ -35,9 +65,11 @@ module.exports = function getCachedFullView(options, callback) {
       return callback(err);
     }
 
-    fullViewCache.set(key, response);
+    var immutableCopy = deepFreeze(cloneDeep(response));
 
-    return callback(null, response);
+    fullViewCache.set(key, immutableCopy);
+
+    return callback(null, cloneDeep(immutableCopy));
   });
 };
 

--- a/app/blog/render/tests/full-view-cache.js
+++ b/app/blog/render/tests/full-view-cache.js
@@ -26,11 +26,52 @@ describe("full view cache", function () {
 
     getCachedFullView(options, function (err, firstResult) {
       expect(err).toBeNull();
-      expect(firstResult).toBe(response);
+      expect(firstResult).toEqual(response);
+      expect(firstResult).not.toBe(response);
 
       getCachedFullView(options, function (secondErr, secondResult) {
         expect(secondErr).toBeNull();
-        expect(secondResult).toBe(response);
+        expect(secondResult).toEqual(response);
+        expect(secondResult).not.toBe(response);
+        expect(secondResult).not.toBe(firstResult);
+        expect(Template.getFullView).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+
+  it("returns isolated copies so caller mutations do not taint cache", function (done) {
+    spyOn(Template, "getFullView").and.callFake(function (
+      blogID,
+      templateID,
+      viewName,
+      callback
+    ) {
+      callback(null, [
+        { title: "Original" },
+        { head: "" },
+        [{ id: "asset-1" }],
+        "text/html",
+        "{{title}}",
+      ]);
+    });
+
+    var options = {
+      blog: { id: "blog-1", cacheID: 111 },
+      template: { id: "template-1" },
+      viewName: "entry.html",
+    };
+
+    getCachedFullView(options, function (err, firstResult) {
+      expect(err).toBeNull();
+
+      firstResult[0].title = "Mutated";
+      firstResult[2][0].id = "asset-2";
+
+      getCachedFullView(options, function (secondErr, secondResult) {
+        expect(secondErr).toBeNull();
+        expect(secondResult[0].title).toBe("Original");
+        expect(secondResult[2][0].id).toBe("asset-1");
         expect(Template.getFullView).toHaveBeenCalledTimes(1);
         done();
       });


### PR DESCRIPTION
### Motivation
- Prevent callers from accidentally mutating cached full-view responses and thereby corrupting shared cache state.
- Ensure callers continue to receive the same `callback(err, responseLike)` contract while making cached data safe to share.

### Description
- Add `cloneDeep` and `deepFreeze` helpers to `app/blog/render/full-view-cache.js` and use them to store an immutable copy in the LRU cache and return fresh clones to callers on both cache hits and misses.
- Preserve the callback signature `callback(err, responseLike)` while ensuring values returned to callers are isolated from the stored cached copy.
- Update the existing test in `app/blog/render/tests/full-view-cache.js` to assert value equality and object isolation rather than strict identity.
- Add a new test in `app/blog/render/tests/full-view-cache.js` that mutates the first returned result and verifies a subsequent fetch is unaffected.

### Testing
- Ran the targeted specs with `NODE_PATH=app npx jasmine app/blog/render/tests/full-view-cache.js`, which passed: `4 specs, 0 failures` (the run logs show Redis connection warnings in this environment but the specs passed).
- No other automated test suites were executed in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f52d6d5bc8329a856df1750f4e46c)