### PR TITLE
Add LRU caching to popular tags retrieval

### DIFF
--- a/app/blog/render/retrieve/popular_tags.js
+++ b/app/blog/render/retrieve/popular_tags.js
@@ -1,25 +1,95 @@
 var Tags = require("models/tags");
+var LRUCache = require("lru-cache").LRUCache;
+
+// Safe cache key includes blog/cache identity and query pagination options.
+var popularTagsCache = new LRUCache({
+  max: 1000,
+});
+
+function cloneDeep(value) {
+  if (Array.isArray(value)) {
+    return value.map(cloneDeep);
+  }
+
+  if (value && typeof value === "object") {
+    var clone = {};
+
+    Object.keys(value).forEach(function (key) {
+      clone[key] = cloneDeep(value[key]);
+    });
+
+    return clone;
+  }
+
+  return value;
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) {
+    return value;
+  }
+
+  Object.keys(value).forEach(function (key) {
+    deepFreeze(value[key]);
+  });
+
+  return Object.freeze(value);
+}
+
+function createCacheKey(blog, options) {
+  var blogID = blog && blog.id;
+  var cacheID = blog && blog.cacheID;
+  var limit = options && options.limit;
+  var offset = options && options.offset;
+
+  return JSON.stringify({
+    blogID: String(blogID),
+    cacheID: String(cacheID),
+    limit: Number(limit),
+    offset: Number(offset),
+  });
+}
 
 module.exports = function (req, res, callback) {
-  req.log('Listing popular tags');
-  
+  req.log("Listing popular tags");
+
   // We could make this limit configurable through req.query or config
-  const limit = 100;
-  
-  Tags.popular(req.blog.id, { limit: limit, offset: 0 }, function(err, tags) {
-    if (err) return callback(err);
+  var options = { limit: 100, offset: 0 };
+  var key = createCacheKey(req.blog, options);
+
+  if (popularTagsCache.has(key)) {
+    req.log("Retrieved popular tags from cache");
+
+    return callback(null, cloneDeep(popularTagsCache.get(key)));
+  }
+
+  Tags.popular(req.blog.id, options, function (err, tags) {
+    if (err) {
+      return callback(err);
+    }
 
     // Map to match expected format
-    req.log('Formatting popular tags');
-    tags = tags.map((tag) => ({
-      name: tag.name,
-      tag: tag.name, // for backward compatibility
-      entries: tag.entries,
-      total: tag.count,
-      slug: tag.slug
-    }));
+    req.log("Formatting popular tags");
+    tags = tags.map(function (tag) {
+      return {
+        name: tag.name,
+        tag: tag.name, // for backward compatibility
+        entries: tag.entries,
+        total: tag.count,
+        slug: tag.slug,
+      };
+    });
 
-    req.log('Listed popular tags');
-    callback(null, tags);
+    var immutableCopy = deepFreeze(cloneDeep(tags));
+
+    popularTagsCache.set(key, immutableCopy);
+
+    req.log("Listed popular tags");
+    return callback(null, cloneDeep(immutableCopy));
   });
+};
+
+module.exports._createCacheKey = createCacheKey;
+module.exports._clear = function () {
+  popularTagsCache.clear();
 };


### PR DESCRIPTION
### Motivation
- Reduce repeated `Tags.popular` lookups by introducing an in-memory LRU cache for popular tags and follow the safety pattern used by the full-view cache so cached values can’t be mutated by callers.

### Description
- Add an `LRUCache` instance (`popularTagsCache`) with `max: 1000` and helper functions `cloneDeep` and `deepFreeze` to protect cached values.
- Add `createCacheKey(blog, options)` that encodes `blog.id`, `blog.cacheID`, `limit`, and `offset` into a stable cache key.
- Update the handler to check the cache and return a deep-cloned cached value when present; otherwise call `Tags.popular`, map results into the expected format, store a deep-frozen copy in the cache, and return a cloned copy.
- Export `_createCacheKey` and `_clear` for cache-focused tests and utilities.

### Testing
- Ran `node -e "require('./app/blog/render/retrieve/popular_tags')"` to validate module load, which failed because the standalone environment cannot resolve the app module alias `models/tags`, so runtime integration tests were not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f5e0a68988329ba44e240a37465e4)