### PR TITLE
Handle oversized macserver uploads as non-retriable

### DIFF
--- a/app/clients/icloud/macserver/httpClient/upload.js
+++ b/app/clients/icloud/macserver/httpClient/upload.js
@@ -10,6 +10,20 @@ import * as brctl from "../brctl/index.js";
 import fetch from "./rateLimitedFetchWithRetriesAndTimeout.js";
 import { join } from "path";
 
+const OVERSIZE_FILE_ERROR_CODE = "ERR_FILE_TOO_LARGE";
+
+class OversizeFileError extends Error {
+  constructor({ filePath, relativePath, size, maxFileSize }) {
+    super(`File size exceeds maximum of ${maxFileSize} bytes`);
+    this.name = "OversizeFileError";
+    this.code = OVERSIZE_FILE_ERROR_CODE;
+    this.filePath = filePath;
+    this.relativePath = relativePath;
+    this.size = size;
+    this.maxFileSize = maxFileSize;
+  }
+}
+
 export default async (blogID, path) => {
   // Input validation
   if (!blogID || typeof blogID !== "string") {
@@ -51,7 +65,12 @@ export default async (blogID, path) => {
       `File size exceeds maximum for upload: ${filePath}`,
       { size: stat.size, maxFileSize }
     );
-    throw new Error(`File size exceeds maximum of ${maxFileSize} bytes`);
+    throw new OversizeFileError({
+      filePath,
+      relativePath: path,
+      size: stat.size,
+      maxFileSize,
+    });
   }
 
   const modifiedTime = stat.mtime.toISOString();
@@ -113,3 +132,5 @@ export default async (blogID, path) => {
 
   console.log(clfdate(), "Upload successful:", text);
 };
+
+export { OVERSIZE_FILE_ERROR_CODE, OversizeFileError };

--- a/app/clients/icloud/macserver/watcher/actions.js
+++ b/app/clients/icloud/macserver/watcher/actions.js
@@ -3,9 +3,39 @@ import { getLimiterForBlogID } from "../limiters.js";
 import mkdir from "../httpClient/mkdir.js";
 import remove from "../httpClient/remove.js";
 import resync from "../httpClient/resync.js";
-import upload from "../httpClient/upload.js";
+import upload, { OVERSIZE_FILE_ERROR_CODE } from "../httpClient/upload.js";
+
+const OVERSIZE_IGNORE_TTL_MS = 60 * 1000;
+const oversizeIgnoreCache = new Map();
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const isNonRetriableOversizeError = (error) =>
+  error && (error.code === OVERSIZE_FILE_ERROR_CODE || error.name === "OversizeFileError");
+
+const getOversizeCacheKey = (blogID, pathInBlogDirectory) =>
+  `${blogID}:${pathInBlogDirectory}`;
+
+const isOversizeFileIgnored = (blogID, pathInBlogDirectory, now = Date.now()) => {
+  const cacheKey = getOversizeCacheKey(blogID, pathInBlogDirectory);
+  const until = oversizeIgnoreCache.get(cacheKey);
+
+  if (!until) {
+    return false;
+  }
+
+  if (until <= now) {
+    oversizeIgnoreCache.delete(cacheKey);
+    return false;
+  }
+
+  return true;
+};
+
+const rememberOversizeFile = (blogID, pathInBlogDirectory, now = Date.now()) => {
+  const cacheKey = getOversizeCacheKey(blogID, pathInBlogDirectory);
+  oversizeIgnoreCache.set(cacheKey, now + OVERSIZE_IGNORE_TTL_MS);
+};
 
 const withRetries = async (label, operation, options = {}) => {
   const { attempts = 4, baseDelayMs = 200 } = options;
@@ -16,6 +46,21 @@ const withRetries = async (label, operation, options = {}) => {
       return await operation();
     } catch (error) {
       lastError = error;
+
+      if (isNonRetriableOversizeError(error)) {
+        console.warn(
+          clfdate(),
+          `${label} intentionally skipped: file exceeds configured upload size limit.`,
+          {
+            code: error.code,
+            path: error.relativePath,
+            size: error.size,
+            maxFileSize: error.maxFileSize,
+          }
+        );
+        throw error;
+      }
+
       if (attempt === attempts) {
         break;
       }
@@ -33,12 +78,26 @@ const withRetries = async (label, operation, options = {}) => {
   throw lastError;
 };
 
-const performAction = async (blogID, pathInBlogDirectory, action) => {
+const performAction = async (
+  blogID,
+  pathInBlogDirectory,
+  action,
+  dependencies = { upload, remove, mkdir, resync }
+) => {
+  const validActions = ["upload", "remove", "mkdir"];
 
-  const validActions = ['upload', 'remove', 'mkdir'];
-  
   if (!validActions.includes(action)) {
-    throw new Error(`Invalid action: ${action}. Must be one of: ${validActions.join(', ')}`);
+    throw new Error(
+      `Invalid action: ${action}. Must be one of: ${validActions.join(", ")}`
+    );
+  }
+
+  if (action === "upload" && isOversizeFileIgnored(blogID, pathInBlogDirectory)) {
+    console.warn(
+      clfdate(),
+      `Skipping upload for ${blogID}/${pathInBlogDirectory}: oversized file is in cooldown window.`
+    );
+    return;
   }
 
   const limiter = getLimiterForBlogID(blogID);
@@ -46,35 +105,38 @@ const performAction = async (blogID, pathInBlogDirectory, action) => {
   await limiter.schedule(async () => {
     try {
       if (action === "upload") {
-        await withRetries(
-          `upload ${blogID}/${pathInBlogDirectory}`,
-          () => upload(blogID, pathInBlogDirectory)
+        await withRetries(`upload ${blogID}/${pathInBlogDirectory}`, () =>
+          dependencies.upload(blogID, pathInBlogDirectory)
         );
       } else if (action === "remove") {
-        await withRetries(
-          `remove ${blogID}/${pathInBlogDirectory}`,
-          () => remove(blogID, pathInBlogDirectory)
+        await withRetries(`remove ${blogID}/${pathInBlogDirectory}`, () =>
+          dependencies.remove(blogID, pathInBlogDirectory)
         );
       } else if (action === "mkdir") {
-        await withRetries(
-          `mkdir ${blogID}/${pathInBlogDirectory}`,
-          () => mkdir(blogID, pathInBlogDirectory)
+        await withRetries(`mkdir ${blogID}/${pathInBlogDirectory}`, () =>
+          dependencies.mkdir(blogID, pathInBlogDirectory)
         );
       }
     } catch (error) {
-      resync(
-        blogID,
-        `${action} for ${pathInBlogDirectory} failed after retries`
-      ).catch((resyncError) => {
-        console.error(
-          clfdate(),
-          `Unexpected error requesting resync for blogID: ${blogID}`,
-          resyncError
-        );
-      });
+      if (action === "upload" && isNonRetriableOversizeError(error)) {
+        rememberOversizeFile(blogID, pathInBlogDirectory);
+        return;
+      }
+
+      dependencies
+        .resync(blogID, `${action} for ${pathInBlogDirectory} failed after retries`)
+        .catch((resyncError) => {
+          console.error(
+            clfdate(),
+            `Unexpected error requesting resync for blogID: ${blogID}`,
+            resyncError
+          );
+        });
       throw error;
     }
   });
 };
 
-export { performAction };
+const clearOversizeIgnoreCache = () => oversizeIgnoreCache.clear();
+
+export { performAction, withRetries, clearOversizeIgnoreCache };

--- a/app/clients/icloud/macserver/watcher/tests.js
+++ b/app/clients/icloud/macserver/watcher/tests.js
@@ -1,0 +1,65 @@
+describe("macserver watcher performAction oversized upload handling", function () {
+  let performAction;
+  let clearOversizeIgnoreCache;
+  let OVERSIZE_FILE_ERROR_CODE;
+
+  beforeAll(async function () {
+    const actionsModule = await import("./actions.js");
+    ({ performAction, clearOversizeIgnoreCache } = actionsModule);
+
+    const uploadModule = await import("../httpClient/upload.js");
+    ({ OVERSIZE_FILE_ERROR_CODE } = uploadModule);
+  });
+
+  afterEach(function () {
+    clearOversizeIgnoreCache();
+  });
+
+  it("does not retry oversize upload errors and does not request resync", async function () {
+    let uploadCalls = 0;
+    let resyncCalls = 0;
+
+    await performAction("blog-1", "large.bin", "upload", {
+      upload: async () => {
+        uploadCalls += 1;
+        const error = new Error("File size exceeds maximum");
+        error.name = "OversizeFileError";
+        error.code = OVERSIZE_FILE_ERROR_CODE;
+        error.relativePath = "large.bin";
+        error.size = 1024;
+        error.maxFileSize = 100;
+        throw error;
+      },
+      remove: async () => {},
+      mkdir: async () => {},
+      resync: async () => {
+        resyncCalls += 1;
+      },
+    });
+
+    expect(uploadCalls).toBe(1);
+    expect(resyncCalls).toBe(0);
+  });
+
+  it("suppresses repeated fs events for oversized uploads during cooldown", async function () {
+    let uploadCalls = 0;
+
+    const dependencies = {
+      upload: async () => {
+        uploadCalls += 1;
+        const error = new Error("File size exceeds maximum");
+        error.name = "OversizeFileError";
+        error.code = OVERSIZE_FILE_ERROR_CODE;
+        throw error;
+      },
+      remove: async () => {},
+      mkdir: async () => {},
+      resync: async () => {},
+    };
+
+    await performAction("blog-2", "large-again.bin", "upload", dependencies);
+    await performAction("blog-2", "large-again.bin", "upload", dependencies);
+
+    expect(uploadCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent wasted retries and unnecessary resyncs when a local file is larger than the configured upload limit by classifying that condition as a deliberate, non-retriable error. 

### Description
- Add a typed error `OversizeFileError` and stable error code `ERR_FILE_TOO_LARGE` in `httpClient/upload.js` and include file/path/size/limit metadata when throwing on `stat.size > maxFileSize`. 
- Update watcher retry logic in `watcher/actions.js` to detect the oversized error and skip exponential backoff retries while emitting a clear warning that the file was intentionally skipped. 
- Prevent `resync(...)` from being triggered for oversized-file errors and add a short-lived ignore cache (keyed by `blogID:path`) with a cooldown to suppress repeated fs events for the same oversized file. 
- Add tests at `app/clients/icloud/macserver/watcher/tests.js` to verify `performAction` does not retry oversized upload errors and that repeated events are suppressed during the cooldown window. 

### Testing
- Ran syntax/type checks with `node --check` on the modified files (`httpClient/upload.js`, `watcher/actions.js`, `watcher/tests.js`) which completed successfully. 
- Attempted to run the test suite with `npm test -- app/clients/icloud/macserver/watcher/tests.js`, but it failed in this environment because Docker is not available. 
- Executed a small automated script exercising `performAction` which failed in this environment due to missing runtime dependency (`dotenv`) when importing the macserver config, indicating full integration tests require the normal Docker/test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69933530c63c8329bfaf94ae726262b7)