### PR TITLE
Use `{{date}}` for primary visible dates in templates

### DIFF
--- a/app/templates/source/fieldnotes/article.html
+++ b/app/templates/source/fieldnotes/article.html
@@ -31,7 +31,7 @@
 					><time
 						class="entry-date published"
 						datetime="{{#formatDate}}YYYY-MM-DD[T]HH:mm:ssZ{{/formatDate}}"
-						>{{#formatDate}}MMMM D, YYYY{{/formatDate}}</time
+						>{{#date}}{{date}}{{/date}}</time
 					><time
 						class="updated"
 						datetime="{{#formatUpdated}}YYYY-MM-DD[T]HH:mm:ssZ{{/formatUpdated}}"

--- a/app/templates/source/fieldnotes/entry.html
+++ b/app/templates/source/fieldnotes/entry.html
@@ -69,7 +69,7 @@
 											><time
 												class="entry-date published"
 												datetime="{{#formatDate}}YYYY-MM-DD[T]HH:mm:ssZ{{/formatDate}}"
-												>{{#formatDate}}MMMM D, YYYY{{/formatDate}}</time
+												>{{#date}}{{date}}{{/date}}</time
 											><time
 												class="updated"
 												datetime="{{#formatUpdated}}YYYY-MM-DD[T]HH:mm:ssZ{{/formatUpdated}}"

--- a/app/templates/source/hypertext/archives.html
+++ b/app/templates/source/hypertext/archives.html
@@ -10,7 +10,7 @@
          {{#allEntries}}
          <div class="archive-item">
            <a href="{{{url}}}" class="archive-title">{{title}}</a>
-           <span class="archive-date">{{#formatDate}}MMM D, YYYY{{/formatDate}}</span>
+           <span class="archive-date">{{#date}}{{date}}{{/date}}</span>
          </div>
          {{/allEntries}}
        </div>

--- a/app/templates/source/hypertext/search.html
+++ b/app/templates/source/hypertext/search.html
@@ -12,7 +12,7 @@
         {{#entries}}
         <div class="archive-item">
            <a href="{{{url}}}" class="archive-title">{{title}}</a>
-           <span class="archive-date">{{#formatDate}}MMM D, YYYY{{/formatDate}}</span>
+           <span class="archive-date">{{#date}}{{date}}{{/date}}</span>
          </div>
         {{/entries}}
         </div>

--- a/app/templates/source/keynote/_post.html
+++ b/app/templates/source/keynote/_post.html
@@ -4,7 +4,7 @@
 
   {{#date}}
   <a class="date" href="{{{url}}}">
-    {{#formatDate}}MMMM D YYYY{{/formatDate}}
+    {{date}}
   </a>
   {{/date}}
 

--- a/app/templates/source/organization/archives.html
+++ b/app/templates/source/organization/archives.html
@@ -24,7 +24,7 @@
           <div class="mb-2 d-flex justify-content-between main-loop-card">
             <div class="pr-3">
   <a class="text-dark" href="{{{url}}}">{{title}} <small class="text-muted">
-            {{#formatDate}}MMM DD, YYYY{{/formatDate}}
+            {{#date}}{{date}}{{/date}}
   </small></a>
              
               

--- a/app/templates/source/organization/entries.html
+++ b/app/templates/source/organization/entries.html
@@ -41,7 +41,7 @@
                 </span>                   
         </small>
                 <small class="text-muted">
-            {{#formatDate}}MMM DD, YYYY{{/formatDate}}
+            {{#date}}{{date}}{{/date}}
         </small>
               </div>
             </div>
@@ -78,7 +78,7 @@
                         </span>                   
                     </small>
               <small class="text-muted">
-            {{#formatDate}}MMM DD, YYYY{{/formatDate}}
+            {{#date}}{{date}}{{/date}}
                     </small>
             </div>
           </div>
@@ -136,7 +136,7 @@
     </span>
   </small>
               <small class="text-muted">
-            {{#formatDate}}MMM DD, YYYY{{/formatDate}}
+            {{#date}}{{date}}{{/date}}
   </small>
             </div>
             <div class="col-md-3 pr-0 text-right">

--- a/app/templates/source/organization/entry.html
+++ b/app/templates/source/organization/entry.html
@@ -27,7 +27,7 @@
               <h1 class="display-4 mb-4 article-headline">{{title}}</h1>
               <div class="d-flex align-items-center">
 
-                <span  style="display:block" class="w-100 text-muted d-block mt-1">{{#formatDate}}MMM DD, YYYY{{/formatDate}} 
+                <span  style="display:block" class="w-100 text-muted d-block mt-1">{{#date}}{{date}}{{/date}} 
   
 </span>
                 </span>

--- a/app/templates/source/organization/search.html
+++ b/app/templates/source/organization/search.html
@@ -24,7 +24,7 @@
           <div class="mb-2 d-flex justify-content-between main-loop-card">
             <div class="pr-3">
   <a class="text-dark" href="{{{url}}}">{{title}} <small class="text-muted">
-            {{#formatDate}}MMM DD, YYYY{{/formatDate}}
+            {{#date}}{{date}}{{/date}}
   </small></a>
              
               

--- a/app/templates/source/organization/tagged.html
+++ b/app/templates/source/organization/tagged.html
@@ -23,7 +23,7 @@
           <div class="mb-2 d-flex justify-content-between main-loop-card">
             <div class="pr-3">
   <a class="text-dark" href="{{{url}}}">{{title}} <small class="text-muted">
-            {{#formatDate}}MMM DD, YYYY{{/formatDate}}
+            {{#date}}{{date}}{{/date}}
   </small></a>
 
 


### PR DESCRIPTION
### Motivation
- Make user-visible primary date text come from the entry `date` context (`{{date}}`) instead of hardcoded `{{#formatDate}}...{{/formatDate}}` so templates respect the provided `date` text and existing `{{#date}}` guards. 
- Preserve `formatDate` where machine-readable timestamps are required (e.g. `datetime` attributes) and keep any intentional secondary date styles unchanged.

### Description
- Replaced visible `{{#formatDate}}...{{/formatDate}}` occurrences with `{{#date}}{{date}}{{/date}}` (or `{{date}}` in the keynote partial) in organization templates: `app/templates/source/organization/entry.html`, `entries.html`, `archives.html`, `search.html`, and `tagged.html`.
- Updated fieldnotes templates `app/templates/source/fieldnotes/article.html` and `app/templates/source/fieldnotes/entry.html` to keep `formatDate` for `datetime` attributes while changing visible published date text to `{{#date}}{{date}}{{/date}}`.
- Updated hypertext listing templates `app/templates/source/hypertext/archives.html` and `app/templates/source/hypertext/search.html` to render visible dates from `{{#date}}{{date}}{{/date}}`.
- Updated keynote partial `app/templates/source/keynote/_post.html` to render the visible date as `{{date}}` inside the existing `{{#date}}` guard, and ensured all edits keep `{{#date}}` guards in place.

### Testing
- Ran search checks with `rg` to verify date tokens were replaced and `{{#date}}` guards are present; those checks returned the updated files and lines containing `{{#date}}{{date}}{{/date}}` or `{{date}}` (success).
- Executed the replacement script used to perform edits (Python-based replacements) and validated diffs with `git diff`/`git status --short` to confirm the expected files were modified (verification succeeded).
- Attempted a Playwright screenshot of `_post.html` as an additional validation, but the browser run failed to open the local file (automated screenshot attempt failed due to file access/URL resolution).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699336e980d48329a1ad1e4ac8e5b47b)