### PR TITLE
test: make top-level Jasmine suites unique for v6

### DIFF
--- a/app/blog/tests/archives.js
+++ b/app/blog/tests/archives.js
@@ -1,4 +1,4 @@
-describe("template engine", function () {
+describe("template engine - archives", function () {
   require("./util/setup")();
 
   it("renders the archives page", async function () {

--- a/app/blog/tests/template.js
+++ b/app/blog/tests/template.js
@@ -1,6 +1,6 @@
 const fs = require("fs-extra");
 
-describe("template engine", function () {
+describe("template engine - template", function () {
   require("./util/setup")();
 
   it("lists entries in reverse chronological", async function () {

--- a/app/build/prepare/tests/isHidden.js
+++ b/app/build/prepare/tests/isHidden.js
@@ -1,4 +1,4 @@
-describe("isHidden", function () {
+describe("isHidden - isHidden", function () {
   var assert = require("assert");
   var isHidden = require("../isHidden");
 

--- a/app/build/prepare/tests/tags.js
+++ b/app/build/prepare/tests/tags.js
@@ -1,4 +1,4 @@
-describe("isHidden", function () {
+describe("isHidden - tags", function () {
   var assert = require("assert");
   var extractTags = require("../tags");
 

--- a/app/clients/dropbox/tests/delta.js
+++ b/app/clients/dropbox/tests/delta.js
@@ -1,4 +1,4 @@
-describe("dropbox client", function () {
+describe("dropbox client - delta", function () {
   // In root means the user has set up their
   // entire Dropbox folder as their blog folder.
   // This typically only happens for 'App folders'

--- a/app/clients/dropbox/tests/index.js
+++ b/app/clients/dropbox/tests/index.js
@@ -1,4 +1,4 @@
-describe("dropbox client", function () {
+describe("dropbox client - index", function () {
   // Create test user and tmp directory
   require("./setup")();
 

--- a/app/clients/dropbox/tests/remove.js
+++ b/app/clients/dropbox/tests/remove.js
@@ -1,4 +1,4 @@
-describe("dropbox client", function () {
+describe("dropbox client - remove", function () {
   // Create test user and tmp directory
   require("./setup")();
 

--- a/app/clients/dropbox/tests/sync-root-directory.js
+++ b/app/clients/dropbox/tests/sync-root-directory.js
@@ -1,4 +1,4 @@
-describe("dropbox client", function () {
+describe("dropbox client - sync-root-directory", function () {
   // Create test user and tmp directory
   require("./setup")({ root: true });
 

--- a/app/clients/dropbox/tests/sync.js
+++ b/app/clients/dropbox/tests/sync.js
@@ -1,4 +1,4 @@
-describe("dropbox client", function () {
+describe("dropbox client - sync", function () {
   // Create test user and tmp directory
   require("./setup")();
 

--- a/app/clients/dropbox/tests/write.js
+++ b/app/clients/dropbox/tests/write.js
@@ -1,4 +1,4 @@
-describe("dropbox client", function () {
+describe("dropbox client - write", function () {
   // Create test user and tmp directory
   require("./setup")();
 

--- a/app/dashboard/tests/folder.js
+++ b/app/dashboard/tests/folder.js
@@ -1,4 +1,4 @@
-describe("folder", function () {
+describe("folder - folder", function () {
   global.test.site({ login: true });
 
   const testCases = [

--- a/app/dashboard/tests/title.js
+++ b/app/dashboard/tests/title.js
@@ -1,4 +1,4 @@
-describe("folder", function () {
+describe("folder - title", function () {
   global.test.site({ login: true });
 
   it("can update the site title", async function () {

--- a/app/helper/tests/formJSON.js
+++ b/app/helper/tests/formJSON.js
@@ -1,4 +1,4 @@
-describe("formJSON ", function () {
+describe("formJSON  - formJSON", function () {
   var formJSON = require("../formJSON");
 
   it("works", function () {

--- a/app/helper/tests/tempDir.js
+++ b/app/helper/tests/tempDir.js
@@ -1,4 +1,4 @@
-describe("formJSON ", function () {
+describe("formJSON  - tempDir", function () {
   var tempDir = require("../tempDir");
   var fs = require("fs-extra");
 

--- a/app/models/template/tests/clone.js
+++ b/app/models/template/tests/clone.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - clone", function () {
   require("./setup")();
 
   const getMetadata = require("../getMetadata");

--- a/app/models/template/tests/create.js
+++ b/app/models/template/tests/create.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - create", function () {
   require("./setup")();
 
   var create = require("models/template/index").create;

--- a/app/models/template/tests/createShareID.js
+++ b/app/models/template/tests/createShareID.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - createShareID", function () {
   require("./setup")({ createTemplate: true, createView: true });
 
   var createShareID = require("../index").createShareID;

--- a/app/models/template/tests/drop.js
+++ b/app/models/template/tests/drop.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - drop", function () {
   require("./setup")({ createTemplate: true });
 
   var drop = require("../index").drop;

--- a/app/models/template/tests/dropShareID.js
+++ b/app/models/template/tests/dropShareID.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - dropShareID", function () {
   require("./setup")({ createTemplate: true, createView: true });
 
   var createShareID = require("../index").createShareID;

--- a/app/models/template/tests/dropView.js
+++ b/app/models/template/tests/dropView.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - dropView", function () {
   require("./setup")({ createTemplate: true, createView: true });
 
   var dropView = require("../index").dropView;

--- a/app/models/template/tests/generateCdnUrl.js
+++ b/app/models/template/tests/generateCdnUrl.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - generateCdnUrl", function () {
   require("./setup")();
 
   const config = require("config");

--- a/app/models/template/tests/getAllViews.js
+++ b/app/models/template/tests/getAllViews.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - getAllViews", function () {
   require("./setup")({ createTemplate: true, createView: true });
 
   var getAllViews = require("../index").getAllViews;

--- a/app/models/template/tests/getByShareID.js
+++ b/app/models/template/tests/getByShareID.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - getByShareID", function () {
   require("./setup")({ createTemplate: true, createView: true });
 
   var createShareID = require("../index").createShareID;

--- a/app/models/template/tests/getFullView.js
+++ b/app/models/template/tests/getFullView.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - getFullView", function () {
   require("./setup")({ createTemplate: true });
 
   var async = require("async");

--- a/app/models/template/tests/getMetadata.js
+++ b/app/models/template/tests/getMetadata.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - getMetadata", function () {
   require("./setup")({ createTemplate: true });
 
   var getMetadata = require("../index").getMetadata;

--- a/app/models/template/tests/getPartials.js
+++ b/app/models/template/tests/getPartials.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - getPartials", function () {
   require("./setup")({ createTemplate: true, createView: true });
 
   var getPartials = require("../index").getPartials;

--- a/app/models/template/tests/getView.js
+++ b/app/models/template/tests/getView.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - getView", function () {
   require("./setup")({ createTemplate: true, createView: true });
 
   var getView = require("../index").getView;

--- a/app/models/template/tests/getViewByURL.js
+++ b/app/models/template/tests/getViewByURL.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - getViewByURL", function () {
   require("./setup")({ createTemplate: true });
 
   it("gets a view from a URL", async function () {

--- a/app/models/template/tests/index.js
+++ b/app/models/template/tests/index.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - index", function () {
   require("./setup")();
 
   it("loads the API without error", function () {

--- a/app/models/template/tests/isOwner.js
+++ b/app/models/template/tests/isOwner.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - isOwner", function () {
   require("./setup")({ createTemplate: true });
 
   var isOwner = require("../index").isOwner;

--- a/app/models/template/tests/makeID.js
+++ b/app/models/template/tests/makeID.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - makeID", function () {
   require("./setup")();
   var makeID = require("../index").makeID;
 

--- a/app/models/template/tests/metadataModel.js
+++ b/app/models/template/tests/metadataModel.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - metadataModel", function () {
   var metadataModel = require("../index").metadataModel;
 
   it("exposes a metadataModel property which defines the data structure of each template", function () {

--- a/app/models/template/tests/readFromFolder.js
+++ b/app/models/template/tests/readFromFolder.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - readFromFolder", function () {
   var fs = require("fs-extra");
   var get = require("../index").getView;
 

--- a/app/models/template/tests/removeFromFolder.js
+++ b/app/models/template/tests/removeFromFolder.js
@@ -1,5 +1,5 @@
 
-describe("template", function () {
+describe("template - removeFromFolder", function () {
   const { promisify } = require("util");
 
   const writeToFolder =  promisify(require("../index").writeToFolder);

--- a/app/models/template/tests/setMetadata.js
+++ b/app/models/template/tests/setMetadata.js
@@ -1,5 +1,5 @@
 const { promisify } = require("util");
-describe("template", function () {
+describe("template - setMetadata", function () {
   require("./setup")({ createTemplate: true });
 
   const setMetadata = promisify(require("../index").setMetadata);

--- a/app/models/template/tests/setView.js
+++ b/app/models/template/tests/setView.js
@@ -1,7 +1,7 @@
 const exp = require("constants");
 const { promisify } = require("util");
 
-describe("template", () => {
+describe("template - setView", () => {
 	require("./setup")({ createTemplate: true });
 
 	const setView = promisify(require("../index").setView);

--- a/app/models/template/tests/siteOwner.js
+++ b/app/models/template/tests/siteOwner.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - siteOwner", function () {
   var siteOwner = require("models/template/index").siteOwner;
 
   it("exposes a siteOwner property which returns the owner ID of Blot", function () {

--- a/app/models/template/tests/update.js
+++ b/app/models/template/tests/update.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - update", function () {
   require("./setup")({ createTemplate: true });
 
   var update = require("../index").update;

--- a/app/models/template/tests/viewModel.js
+++ b/app/models/template/tests/viewModel.js
@@ -1,4 +1,4 @@
-describe("template", function () {
+describe("template - viewModel", function () {
   var viewModel = require("../index").viewModel;
 
   it("exposes a viewModel property which defines the data structure of each view", function () {

--- a/app/models/template/tests/writeToFolder.js
+++ b/app/models/template/tests/writeToFolder.js
@@ -2,7 +2,7 @@ var fs = require("fs-extra");
 var join = require("path").join;
 var clients = require("clients");
 
-describe("template", function () {
+describe("template - writeToFolder", function () {
 var writeToFolder = require("../index").writeToFolder;
 var setView = require("../index").setView;
 var dropView = require("../index").dropView;

--- a/app/sync/tests/renames.js
+++ b/app/sync/tests/renames.js
@@ -1,4 +1,4 @@
-describe("update", function () {
+describe("update - renames", function () {
   var sync = require("../index");
   var fs = require("fs-extra");
   var async = require("async");

--- a/app/sync/tests/update.js
+++ b/app/sync/tests/update.js
@@ -1,4 +1,4 @@
-describe("update", function () {
+describe("update - update", function () {
   var sync = require("../index");
   var fs = require("fs-extra");
 


### PR DESCRIPTION
### Motivation
- Jasmine v6 treats duplicate top-level suite names as an error, and several test files used identical top-level `describe(...)` strings which caused test runs to fail. 
- The goal is to make each top-level suite name unique so the test runner accepts the suite structure without changing test behavior. 

### Description
- Updated top-level `describe` strings in 42 test files to include a file-specific suffix (for example `template engine - template`, `isHidden - isHidden`, `dropbox client - index`, `folder - folder`, `formJSON  - formJSON`, `template - index`, `update - update`).
- The changes are purely string updates to the suite names and do not modify test logic, assertions, or helper usage. 
- A search-and-replace approach was applied consistently across the affected folders (`app/blog`, `app/build/prepare`, `app/clients/dropbox`, `app/dashboard`, `app/helper`, `app/models/template`, `app/sync`). 

### Testing
- Ran a targeted search with `rg` to confirm the old duplicate top-level suite names no longer exist, and verified the new unique suite strings are present. 
- Attempted to run the full test suite with `npm test`, but the environment lacks `docker` so the test harness could not be executed and the full suite could not be validated here. 
- No runtime test logic was changed, so these edits are low-risk and intended to unblock Jasmine 6 test runs in CI where Docker is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995db236d2483298743033c34102715)