### PR TITLE
Harden test completion and CI timeout handling

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -283,6 +283,7 @@ jobs:
   test:
     needs: setup-tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix: ${{ fromJson(needs.setup-tests.outputs.matrix) }}
       fail-fast: false
@@ -304,6 +305,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log test suite and seed
+        run: echo "Running suite=${{ matrix.test_suite }} with seed=${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }}"
+
       - name: Run tests - ${{ matrix.test_suite }}
         env:
           BLOT_STRIPE_KEY: ${{ secrets.BLOT_STRIPE_KEY }}
@@ -321,4 +325,4 @@ jobs:
             -v ${{ github.workspace }}/scripts:/usr/src/app/scripts \
             -v ${{ github.workspace }}/config:/usr/src/app/config \
             $IMAGE_TAG \
-            sh -c "node scripts/tests ${{ matrix.test_suite }}"
+            sh -c "BLOT_TESTS_SEED=${{ github.run_id }}-${{ github.run_attempt }}-${{ strategy.job-index }} node scripts/tests ${{ matrix.test_suite }}"

--- a/scripts/tests/index.js
+++ b/scripts/tests/index.js
@@ -91,6 +91,17 @@ jasmine.addReporter({
   },
 });
 
+jasmine.addReporter({
+  jasmineDone: function (result) {
+    process.exitCode = result.overallStatus === "passed" ? 0 : 1;
+
+    // Make completion deterministic once reporters have finished flushing output.
+    setImmediate(function () {
+      process.exit(process.exitCode);
+    });
+  },
+});
+
 var startTimes = {};
 var durations = {};
 


### PR DESCRIPTION
### Motivation

- Make Jasmine test completion deterministic so CI jobs don't hang or leave unclear exit status when reporters are still flushing output.
- Preserve existing failure diagnostics (slow-spec reporting and debug rerun hints) while ensuring process termination is explicit.
- Fail long-running CI test jobs fast with a clear timeout and provide reproducible seeds for debugging timed-out runs.

### Description

- Add a final Jasmine reporter in `scripts/tests/index.js` that sets `process.exitCode` from `result.overallStatus` and calls `process.exit(...)` on `setImmediate` to ensure deterministic termination after reporters complete.
- Preserve existing slow-spec logging and debug rerun hint behavior so failure diagnostics remain available.
- Add `timeout-minutes: 30` to the GitHub Actions `test` job in `.github/workflows/node.yml` so hangs expire with clear logs.
- Emit a short CI log line before running tests that prints the matrix suite path and a deterministic seed, and pass that seed into the test runner via `BLOT_TESTS_SEED` for reproducible timed-out runs.

### Testing

- Ran `node --check scripts/tests/index.js` to validate the modified test bootstrap file, which succeeded.
- Validated the workflow YAML syntax by loading `.github/workflows/node.yml` with Ruby YAML, which succeeded and printed `workflow yaml ok`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e0e249988329bfd4d2a3852df7f9)