### PR TITLE
Refactor tests to remove mixed async(done) patterns and use async/await

### DIFF
--- a/app/build/tests/index.js
+++ b/app/build/tests/index.js
@@ -301,25 +301,23 @@ describe("build", function () {
     });
   });
 
-  it("will generate a list of internal links", async function (done) {
+  it("will generate a list of internal links", async function () {
     const path = "/post.txt";
     const contents = "[linker](/linked)";
     const entry = await this.build(path, contents);
 
     expect(entry.internalLinks).toEqual(["/linked"]);
-    done();
   });
 
-  it("will generate an empty list of internal links", async function (done) {
+  it("will generate an empty list of internal links", async function () {
     const path = "/post.txt";
     const contents = "Hey no link here.";
     const entry = await this.build(path, contents);
 
     expect(entry.internalLinks).toEqual([]);
-    done();
   });
 
-  it("will preserve nested YAML metadata arrays and objects", async function (done) {
+  it("will preserve nested YAML metadata arrays and objects", async function () {
     const path = "/post.txt";
     const contents = `---\narray:\n  - one\n  - two\nobject:\n  key: value\n---\n\n# Hello`;
     const entry = await this.build(path, contents);
@@ -329,10 +327,9 @@ describe("build", function () {
       object: { key: "value" },
     });
 
-    done();
   });
 
-  it("will tolerate empty YAML front matter", async function (done) {
+  it("will tolerate empty YAML front matter", async function () {
     const path = "/post.txt";
     const contents = `---\n---\n\n# Hello`;
     const entry = await this.build(path, contents);
@@ -340,10 +337,9 @@ describe("build", function () {
     expect(entry.metadata).toEqual({});
     expect(entry.html.trim()).toEqual('<h1 id="hello">Hello</h1>');
 
-    done();
   });
 
-  it("will extract tags in nested YAML metadata arrays", async function (done) {
+  it("will extract tags in nested YAML metadata arrays", async function () {
     const path = "/post.txt";
     const contents = `---\ntags:\n  - one\n  - two\nobject:\n  key: value\n---\n\n# Hello`;
     const entry = await this.build(path, contents);
@@ -355,51 +351,45 @@ describe("build", function () {
 
     expect(entry.tags).toEqual(["one", "two"]);
 
-    done();
   });
 
-  it("will build without error if date is a YAML array (i.e. not a string)", async function (done) {
+  it("will build without error if date is a YAML array (i.e. not a string)", async function () {
     const path = "/post.txt";
     const contents = `---\ndate:\n  - 2020\n  - 12\n  - 25\n---\n\n# Hello`;
     const entry = await this.build(path, contents);
 
     expect(entry.path).toEqual(path);
-    done();
   });
 
-  it("will build without error if page is a YAML array (i.e. not a string)", async function (done) {
+  it("will build without error if page is a YAML array (i.e. not a string)", async function () {
     const path = "/post.txt";
     const contents = `---\npage:\n  - 2020\n  - 12\n  - 25\n---\n\n# Hello`;
     const entry = await this.build(path, contents);
 
     expect(entry.path).toEqual(path);
-    done();
   });
 
-  it("will build without error if draft is a YAML array (i.e. not a bool)", async function (done) {
+  it("will build without error if draft is a YAML array (i.e. not a bool)", async function () {
     const path = "/post.txt";
     const contents = `---\ndraft:\n  - 2020\n  - 12\n  - 25\n---\n\n# Hello`;
     const entry = await this.build(path, contents);
 
     expect(entry.path).toEqual(path);
-    done();
   });
 
-  it("will build without error if menu is a YAML array (i.e. not a bool)", async function (done) {
+  it("will build without error if menu is a YAML array (i.e. not a bool)", async function () {
     const path = "/post.txt";
     const contents = `---\nmenu:\n  - 2020\n  - 12\n  - 25\n---\n\n# Hello`;
     const entry = await this.build(path, contents);
 
     expect(entry.path).toEqual(path);
-    done();
   });
 
-  it("will build without error if thumbnail is a YAML array (i.e. not a string)", async function (done) {
+  it("will build without error if thumbnail is a YAML array (i.e. not a string)", async function () {
     const path = "/post.txt";
     const contents = `---\nthumbnail:\n  - 2020\n  - 12\n  - 25\n---\n\n# Hello`;
     const entry = await this.build(path, contents);
 
     expect(entry.path).toEqual(path);
-    done();
   });
 });

--- a/app/build/tests/plugins/wikilinks.js
+++ b/app/build/tests/plugins/wikilinks.js
@@ -180,7 +180,7 @@ Heading Here
     this.syncAndCheck(files, entry, done);
   });
 
-  it("will support media embedding", async function (done) {
+  it("will support media embedding", async function () {
     await this.blog.write({
       path: "/_Image.png",
       content: await global.test.fake.pngBuffer()
@@ -201,10 +201,9 @@ Heading Here
     expect(entry.html).toContain('title="wikilink"');
     expect(entry.html).toContain('alt="An example image"');
 
-    done();
   });
 
-  it("will support media embedding with spaces in filenames", async function (done) {
+  it("will support media embedding with spaces in filenames", async function () {
     await this.blog.write({
       path: "/Pasted image 2024-01-01.png",
       content: await global.test.fake.pngBuffer()
@@ -225,10 +224,9 @@ Heading Here
     expect(entry.html).toContain('/_image_cache/');
     expect(entry.html).toContain('alt="Pasted image 2024-01-01.png"');
 
-    done();
   });
 
-  it("will support media embedding from nested folders", async function (done) {
+  it("will support media embedding from nested folders", async function () {
     await this.blog.write({
       path: "/Assets/image.png",
       content: await global.test.fake.pngBuffer()
@@ -249,10 +247,9 @@ Heading Here
     expect(entry.html).toContain('alt="Assets/image.png"');
     expect(entry.html).toContain('/_image_cache/');
 
-    done();
   });
 
-  it("will process embedded media through the image cache", async function (done) {
+  it("will process embedded media through the image cache", async function () {
     await this.blog.write({
       path: "/Assets/photo.png",
       content: await global.test.fake.pngBuffer()
@@ -270,10 +267,9 @@ Heading Here
     expect(entry.html).toContain('<img');
     expect(entry.html).toContain('/_image_cache/');
 
-    done();
   });
 
-  it("will support video embedding with piped alt text", async function (done) {
+  it("will support video embedding with piped alt text", async function () {
     await this.blog.write({
       path: "/Assets/video.mp4",
       content: Buffer.from("fake video content")
@@ -293,10 +289,9 @@ Heading Here
     expect(entry.html).toContain('title="wikilink"');
     expect(entry.html).toContain('Demo video');
 
-    done();
   });
 
-  it("will support audio embedding via wikilinks", async function (done) {
+  it("will support audio embedding via wikilinks", async function () {
     await this.blog.write({
       path: "/Assets/audio.mp3",
       content: Buffer.from("fake audio content")
@@ -316,10 +311,9 @@ Heading Here
     expect(entry.html).toContain('title="wikilink"');
     expect(entry.html).toContain('Sample audio');
 
-    done();
   });
 
-  it("will support document embedding via wikilinks", async function (done) {
+  it("will support document embedding via wikilinks", async function () {
     await this.blog.write({
       path: "/Assets/document.pdf",
       content: Buffer.from("%PDF-1.4 fake pdf content")
@@ -337,7 +331,6 @@ Heading Here
     expect(entry.html).toContain('<embed src="/Assets/document.pdf"');
     expect(entry.html).toContain('title="wikilink"');
 
-    done();
   });
 
   it("will support wikilinks by URL", function (done) {

--- a/app/clients/google-drive/database/tests/folder.js
+++ b/app/clients/google-drive/database/tests/folder.js
@@ -321,76 +321,72 @@ describe("folder module", function () {
     expect(await folder.get(fileId)).toBe("/baz/bar/file1.txt");
   });
   
-  it("throws an error when trying to set a mapping with an empty ID or path", async function (done) {
+  it("throws an error when trying to set a mapping with an empty ID or path", async function () {
     const metadata = { size: 1024, lastModified: "2025-02-21" };
   
     try {
       await folder.set("", "/file1.txt", metadata);
-      done.fail("Expected an error for empty ID");
+      fail("Expected an error for empty ID");
     } catch (err) {
       expect(err.message).toBe("ID and path must be non-empty strings");
     }
   
     try {
       await folder.set("file_1", "", metadata);
-      done.fail("Expected an error for empty path");
+      fail("Expected an error for empty path");
     } catch (err) {
       expect(err.message).toBe("ID and path must be non-empty strings");
     }
   
     try {
       await folder.set(null, null, metadata);
-      done.fail("Expected an error for null ID and path");
+      fail("Expected an error for null ID and path");
     } catch (err) {
       expect(err.message).toBe("ID and path must be non-empty strings");
     }
   
-    done();
   });
 
-  it("throws an error when trying to move a nonexistent file or folder", async function (done) {
+  it("throws an error when trying to move a nonexistent file or folder", async function () {
     const nonExistentId = "nonexistent_file";
     const newPath = "/new/path/file.txt";
   
     try {
       await folder.move(nonExistentId, newPath);
-      done.fail("Expected an error for nonexistent ID");
+      fail("Expected an error for nonexistent ID");
     } catch (err) {
       expect(err.message).toBe(`No file or folder found for ID: ${nonExistentId}`);
     }
   
-    done();
   });
   
-  it("throws an error when trying to remove a nonexistent file or folder", async function (done) {
+  it("throws an error when trying to remove a nonexistent file or folder", async function () {
     const nonExistentId = "nonexistent_file";
   
     const removedPaths = await folder.remove(nonExistentId);
     expect(removedPaths).toEqual([]); // Should simply return an empty array
   
-    done();
   });
 
-  it("throws an error when metadata is not a valid object", async function (done) {
+  it("throws an error when metadata is not a valid object", async function () {
     const id = "file_1";
     const path = "/folder/file1.txt";
   
     try {
       await folder.set(id, path, "invalid_metadata");
-      done.fail("Expected an error for invalid metadata");
+      fail("Expected an error for invalid metadata");
     } catch (err) {
       expect(err.message).toBe("Metadata must be a valid object");
     }
   
     try {
       await folder.set(id, path, null); // Null metadata should still succeed
-      done();
     } catch (err) {
-      done.fail("Did not expect an error for null metadata");
+      fail("Did not expect an error for null metadata");
     }
   });
 
-  it("handles errors when metadata is corrupted or invalid", async function (done) {
+  it("handles errors when metadata is corrupted or invalid", async function () {
     const id = "file_1";
     const path = "/folder/file1.txt";
   
@@ -399,15 +395,14 @@ describe("folder module", function () {
   
     try {
       await folder.getMetadata(id);
-      done.fail("Expected a SyntaxError for corrupted metadata");
+      fail("Expected a SyntaxError for corrupted metadata");
     } catch (err) {
       expect(err instanceof SyntaxError).toBe(true);
     }
   
-    done();
   });
 
-  it("handles path collisions gracefully during move operations", async function (done) {
+  it("handles path collisions gracefully during move operations", async function () {
     const folderId1 = "folder_1";
     const folderId2 = "folder_2";
   
@@ -416,12 +411,11 @@ describe("folder module", function () {
   
     try {
       await folder.move(folderId1, "/bar"); // Attempt to move /foo to /bar
-      done.fail("Expected an error due to path collision");
+      fail("Expected an error due to path collision");
     } catch (err) {
       expect(err.message).toBe("Target path already exists: /bar");
     }
   
-    done();
   });
 
   it("replaces the path when the same ID is reused", async function () {
@@ -472,7 +466,7 @@ describe("folder module", function () {
     expect(retrievedPath).toBe(path); // Path should remain unchanged
   });
 
-  it("throws an error when trying to move to an existing path", async function (done) {
+  it("throws an error when trying to move to an existing path", async function () {
     const folderId = "folder_1";
     const existingFolderId = "folder_2";
     const oldFolderPath = "/foo";
@@ -483,12 +477,11 @@ describe("folder module", function () {
   
     try {
       await folder.move(folderId, newFolderPath); // This should throw an error
-      done.fail("Expected an error when moving to an existing path");
+      fail("Expected an error when moving to an existing path");
     } catch (err) {
       expect(err.message).toBe("Target path already exists: /bar");
     }
   
-    done();
   });
 
   it("treats paths as case-sensitive", async function () {
@@ -547,7 +540,7 @@ describe("folder module", function () {
     expect(metadata).toBeNull();
   });
 
-  it("throws an error when trying to move a folder to a subfolder of itself", async function (done) {
+  it("throws an error when trying to move a folder to a subfolder of itself", async function () {
     const folderId = "folder_1";
     const oldFolderPath = "/foo";
     const newFolderPath = "/foo/bar";
@@ -556,12 +549,11 @@ describe("folder module", function () {
   
     try {
       await folder.move(folderId, newFolderPath);
-      done.fail("Expected an error when moving to a subfolder of itself");
+      fail("Expected an error when moving to a subfolder of itself");
     } catch (err) {
       expect(err.message).toBe("Cannot move a folder to a subfolder of itself");
     }
   
-    done();
   });
 
   it("returns entries sorted alphabetically by path", async function () {
@@ -672,22 +664,21 @@ describe("folder module", function () {
     );
   });
 
-  it("throws an error for invalid directory paths", async function (done) {
+  it("throws an error for invalid directory paths", async function () {
     try {
       await folder.readdir("");
-      done.fail("Expected an error for an empty directory path");
+      fail("Expected an error for an empty directory path");
     } catch (err) {
       expect(err.message).toBe("Directory path must be a non-empty string");
     }
 
     try {
       await folder.readdir(null);
-      done.fail("Expected an error for a null directory path");
+      fail("Expected an error for a null directory path");
     } catch (err) {
       expect(err.message).toBe("Directory path must be a non-empty string");
     }
 
-    done();
   });
 
   it("does not include entries outside the given directory", async function () {

--- a/app/helper/tests/flushCache.js
+++ b/app/helper/tests/flushCache.js
@@ -117,17 +117,16 @@ describe("flushCache", function () {
     expect(timestamps.at(-1) - timestamps[0]).toBeGreaterThanOrEqual(3000);
   });
 
-  it("handles failed requests appropriately", async function (done) {
+  it("handles failed requests appropriately", async function () {
     await this.setup({
       onPurge: (req, res) => res.status(500).send("error"),
     });
 
     try {
       await this.flush("example.com");
-      done.fail("Should have thrown an error");
+      fail("Should have thrown an error");
     } catch (error) {
       expect(error instanceof Error).toBe(true);
-      done();
     }
   });
 
@@ -170,22 +169,21 @@ describe("flushCache", function () {
     server2.close();
   });
 
-  it("validates input parameters", async function (done) {
+  it("validates input parameters", async function () {
     await this.setup({
       onPurge: (req, res) => res.send("ok"),
     });
 
     try {
       await this.flush({ invalid: "input" });
-      done.fail("Should have thrown an error");
+      fail("Should have thrown an error");
     } catch (error) {
       expect(error instanceof Error).toBe(true);
-      done();
     }
   });
 
   // Re-implement when we have a timeout mechanism
-  xit("handles network errors gracefully", async function (done) {
+  xit("handles network errors gracefully", async function () {
     const flush = flushCache({
       reverse_proxies: ["http://invalid-domain-name:12345"],
       requestsPerSecond: 10,
@@ -193,10 +191,9 @@ describe("flushCache", function () {
 
     try {
       await flush("example.com");
-      done.fail("Should have thrown an error");
+      fail("Should have thrown an error");
     } catch (error) {
       expect(error instanceof Error).toBe(true);
-      done();
     }
   });
 });

--- a/app/models/entries/tests.js
+++ b/app/models/entries/tests.js
@@ -151,16 +151,23 @@ describe("entries", function () {
     });
   });
 
-  it("getTotal should return the total number of entries for a blog", async function (done) {
+  it("getTotal should return the total number of entries for a blog", async function () {
     const key = `blog:${this.blog.id}:entries`;
 
     // Add mock entries in Redis
     await redis.zadd(key, 1, "entry1", 2, "entry2", 3, "entry3");
 
-    Entries.getTotal(this.blog.id, function (err, total) {
-      expect(err).toBeNull();
-      expect(total).toBe(3);
-      done();
+    await new Promise((resolve, reject) => {
+      Entries.getTotal(this.blog.id, function (err, total) {
+        if (err) return reject(err);
+
+        try {
+          expect(total).toBe(3);
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
     });
   });
 
@@ -172,16 +179,23 @@ describe("entries", function () {
     });
   });
 
-  it("getAllIDs should return all entry IDs for a blog", async function (done) {
+  it("getAllIDs should return all entry IDs for a blog", async function () {
     const key = `blog:${this.blog.id}:all`;
 
     // Add mock entries in Redis
     await redis.zadd(key, 1, "id1", 2, "id2", 3, "id3");
 
-    Entries.getAllIDs(this.blog.id, function (err, ids) {
-      expect(err).toBeNull();
-      expect(ids).toEqual(["id3", "id2", "id1"]); // Returned in descending order
-      done();
+    await new Promise((resolve, reject) => {
+      Entries.getAllIDs(this.blog.id, function (err, ids) {
+        if (err) return reject(err);
+
+        try {
+          expect(ids).toEqual(["id3", "id2", "id1"]); // Returned in descending order
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
     });
   });
 
@@ -232,7 +246,7 @@ describe("entries", function () {
     });
   });
 
-  it("getPage should return a page of entries sorted by date", async function (done) {
+  it("getPage should return a page of entries sorted by date", async function () {
     const key = `blog:${this.blog.id}:entries`;
     const now = Date.now();
     // Add 6 mock entries in Redis
@@ -270,54 +284,64 @@ describe("entries", function () {
     const blogID = this.blog.id;
 
     // get the second page of entries, 2 per page, sorted by date with newest first
-    Entries.getPage(
-      blogID,
-      {
-        pageNumber: pageNo,
-        pageSize,
-        sortBy: "date",
-      },
-      function (error, entries, pagination) {
-        expect(error).toBeNull();
-        expect(entries.map((entry) => entry.id)).toEqual(["/d.txt", "/c.txt"]);
-        expect(pagination).toEqual({
-          current: 2,
-          next: 3,
-          previous: 1,
-          total: 3, // 6 entries / 2 per page
-          pageSize: 2,
-        });
+    await new Promise((resolve, reject) => {
+      Entries.getPage(
+        blogID,
+        {
+          pageNumber: pageNo,
+          pageSize,
+          sortBy: "date",
+        },
+        function (error, entries, pagination) {
+          if (error) return reject(error);
 
-        // get the first page of entries, 2 per page, sorted reverse alphabetically
-        Entries.getPage(
-          blogID,
-          { pageNumber: 1, pageSize, sortBy: "id", order: "desc" },
-          function (error, entries, pagination) {
-            expect(error).toBeNull();
-            expect(entries.map((entry) => entry.id)).toEqual([
-              "/f.txt",
-              "/e.txt",
-            ]);
-            // get the first page of entries, 2 per page, sorted alphabetically
-            Entries.getPage(
-              blogID,
-          { pageNumber: 1, pageSize, sortBy: "id", order: "asc" },
-              function (error, entries, pagination) {
-                expect(error).toBeNull();
-                expect(entries.map((entry) => entry.id)).toEqual([
-                  "/a.txt",
-                  "/b.txt",
-                ]);
-                done();
-              }
-            );
+          try {
+            expect(entries.map((entry) => entry.id)).toEqual(["/d.txt", "/c.txt"]);
+            expect(pagination).toEqual({
+              current: 2,
+              next: 3,
+              previous: 1,
+              total: 3,
+              pageSize: 2,
+            });
+          } catch (e) {
+            return reject(e);
           }
-        );
-      }
-    );
+
+          Entries.getPage(
+            blogID,
+            { pageNumber: 1, pageSize, sortBy: "id", order: "desc" },
+            function (error, entries) {
+              if (error) return reject(error);
+
+              try {
+                expect(entries.map((entry) => entry.id)).toEqual(["/f.txt", "/e.txt"]);
+              } catch (e) {
+                return reject(e);
+              }
+
+              Entries.getPage(
+                blogID,
+                { pageNumber: 1, pageSize, sortBy: "id", order: "asc" },
+                function (error, entries) {
+                  if (error) return reject(error);
+
+                  try {
+                    expect(entries.map((entry) => entry.id)).toEqual(["/a.txt", "/b.txt"]);
+                    resolve();
+                  } catch (e) {
+                    reject(e);
+                  }
+                }
+              );
+            }
+          );
+        }
+      );
+    });
   });
 
-  it("getRecent should return the most recent entries with their indices", async function (done) {
+  it("getRecent should return the most recent entries with their indices", async function () {
     const key = `blog:${this.blog.id}:entries`;
 
     // Add mock entries in Redis
@@ -332,13 +356,14 @@ describe("entries", function () {
       callback(entries);
     });
 
-    Entries.getRecent(this.blog.id, function (entries) {
-      expect(entries.map((entry) => entry.id)).toEqual(["id3", "id2", "id1"]);
-      expect(entries[0].index).toBe(3);
-      expect(entries[1].index).toBe(2);
-      expect(entries[2].index).toBe(1);
-      done();
+    const entries = await new Promise((resolve) => {
+      Entries.getRecent(this.blog.id, resolve);
     });
+
+    expect(entries.map((entry) => entry.id)).toEqual(["id3", "id2", "id1"]);
+    expect(entries[0].index).toBe(3);
+    expect(entries[1].index).toBe(2);
+    expect(entries[2].index).toBe(1);
   });
 
   it("getRecent should return an empty array if there are no entries", function (done) {
@@ -394,7 +419,7 @@ describe("entries", function () {
       });
     });
 
-    it("filters posts by path prefix and paginates by id", async function (done) {
+    it("filters posts by path prefix and paginates by id", async function () {
       const blogID = this.blog.id;
       const entriesKey = `blog:${blogID}:entries`;
       const now = Date.now();
@@ -420,21 +445,27 @@ describe("entries", function () {
         .set(`blog:${blogID}:entries:lex:ready`, "1")
         .exec();
 
-      Entries.getPage(
-        blogID,
-        { pageNumber: 1, pageSize: 2, sortBy: "id", order: "asc", pathPrefix: "/Blog/" },
-        function (error, entries, pagination) {
-          expect(error).toBeNull();
-          expect(entries.map((entry) => entry.id)).toEqual(["/Blog/a.txt", "/Blog/b.txt"]);
-          expect(pagination).toEqual({
-            current: 1,
-            next: 2,
-            total: 2,
-            pageSize: 2,
-          });
-          done();
-        }
-      );
+      await new Promise((resolve, reject) => {
+        Entries.getPage(
+          blogID,
+          { pageNumber: 1, pageSize: 2, sortBy: "id", order: "asc", pathPrefix: "/Blog/" },
+          function (error, entries, pagination) {
+            if (error) return reject(error);
+            try {
+              expect(entries.map((entry) => entry.id)).toEqual(["/Blog/a.txt", "/Blog/b.txt"]);
+              expect(pagination).toEqual({
+                current: 1,
+                next: 2,
+                total: 2,
+                pageSize: 2,
+              });
+              resolve();
+            } catch (e) {
+              reject(e);
+            }
+          }
+        );
+      });
     });
   });
   describe("adjacentTo", function () {
@@ -445,46 +476,55 @@ describe("entries", function () {
       });
     });
 
-    it("should return adjacent entries correctly", async function (done) {
+    it("should return adjacent entries correctly", async function () {
       const key = `blog:${this.blog.id}:entries`;
 
       // Add mock entries in Redis
       await redis.zadd(key, 1, "id1", 2, "id2", 3, "id3");
 
-      Entries.adjacentTo(this.blog.id, "id2", function (next, previous, rank) {
+      const { next, previous, rank } = await new Promise((resolve) => {
+        Entries.adjacentTo(this.blog.id, "id2", function (next, previous, rank) {
+          resolve({ next, previous, rank });
+        });
+      });
+
         expect(previous).toEqual({ id: "id1" });
         expect(next).toEqual({ id: "id3" });
         expect(rank).toBe(2);
-        done();
-      });
     });
 
-    it("should return undefined if the entry is at the start of the list", async function (done) {
+    it("should return undefined if the entry is at the start of the list", async function () {
       const key = `blog:${this.blog.id}:entries`;
 
       // Add mock entries in Redis
       await redis.zadd(key, 1, "id1", 2, "id2", 3, "id3");
 
-      Entries.adjacentTo(this.blog.id, "id1", function (next, previous, rank) {
+      const { next, previous, rank } = await new Promise((resolve) => {
+        Entries.adjacentTo(this.blog.id, "id1", function (next, previous, rank) {
+          resolve({ next, previous, rank });
+        });
+      });
+
         expect(previous).toBeUndefined();
         expect(next).toEqual({ id: "id2" });
         expect(rank).toBe(1);
-        done();
-      });
     });
 
-    it("should return undefined if the entry is at the end of the list", async function (done) {
+    it("should return undefined if the entry is at the end of the list", async function () {
       const key = `blog:${this.blog.id}:entries`;
 
       // Add mock entries in Redis
       await redis.zadd(key, 1, "id1", 2, "id2", 3, "id3");
 
-      Entries.adjacentTo(this.blog.id, "id3", function (next, previous, rank) {
+      const { next, previous, rank } = await new Promise((resolve) => {
+        Entries.adjacentTo(this.blog.id, "id3", function (next, previous, rank) {
+          resolve({ next, previous, rank });
+        });
+      });
+
         expect(previous).toEqual({ id: "id2" });
         expect(next).toBeUndefined();
         expect(rank).toBe(3);
-        done();
-      });
     });
   });
 
@@ -570,7 +610,7 @@ describe("entries", function () {
   });
 
   describe("resave", function () {
-    it("should update entries with new dateStamps", async function (done) {
+    it("should update entries with new dateStamps", async function () {
       const blog = { id: this.blog.id, permalink: true };
       const entries = [
         { path: "entry1", metadata: {}, id: "id1", metadata: {} },
@@ -598,10 +638,16 @@ describe("entries", function () {
         callback();
       });
 
-      Entries.resave(this.blog.id, function (err) {
-        expect(err).toBeNull();
-        expect(Entry.set).toHaveBeenCalledTimes(2); // Once per entry
-        done();
+      await new Promise((resolve, reject) => {
+        Entries.resave(this.blog.id, function (err) {
+          if (err) return reject(err);
+          try {
+            expect(Entry.set).toHaveBeenCalledTimes(2);
+            resolve();
+          } catch (error) {
+            reject(error);
+          }
+        });
       });
     });
 

--- a/app/models/entry/tests/backlinks.js
+++ b/app/models/entry/tests/backlinks.js
@@ -1,7 +1,7 @@
 describe("entry.backlinks", function () {
   require("./setup")();
 
-  it("works", async function (done) {
+  it("works", async function () {
     const path = "/post.txt";
     const contents = "Link: linker\n\n[linker](/linked)";
 
@@ -14,10 +14,9 @@ describe("entry.backlinks", function () {
     const entry = await this.get(pathLinked);
 
     expect(entry.backlinks).toEqual(["/linker"]);
-    done();
   });
 
-  it("will not contain deleted internal links", async function (done) {
+  it("will not contain deleted internal links", async function () {
     const path = "/post.txt";
     const contents = "Link: linker\n\n[linker](/linked)";
 
@@ -36,10 +35,9 @@ describe("entry.backlinks", function () {
 
     expect(entry.backlinks).toEqual(["/linker"]);
     expect(entryAfterUpdate.backlinks).toEqual([]);
-    done();
   });
 
-  it("works with multiple files", async function (done) {
+  it("works with multiple files", async function () {
     const pathFirst = "/post-1.txt";
     const contentsFirst = "Link: linker-1\n\n[linker](/linked)";
 
@@ -56,10 +54,9 @@ describe("entry.backlinks", function () {
     const entry = await this.get(pathLinked);
 
     expect(entry.backlinks.sort()).toEqual(["/linker-1", "/linker-2"]);
-    done();
   });
 
-  it("won't contain internal links from deleted posts", async function (done) {
+  it("won't contain internal links from deleted posts", async function () {
     const path = "/post.txt";
     const contents = "Link: linker\n\n[linker](/linked)";
 
@@ -77,10 +74,9 @@ describe("entry.backlinks", function () {
 
     expect(entry.backlinks).toEqual(["/linker"]);
     expect(entryAfterDrop.backlinks).toEqual([]);
-    done();
   });
 
-  it("updates the backlink when the linker's URL changes", async function (done) {
+  it("updates the backlink when the linker's URL changes", async function () {
     const path = "/post.txt";
     const contents = "Link: linker\n\n[linker](/linked)";
 
@@ -99,10 +95,9 @@ describe("entry.backlinks", function () {
 
     expect(entry.backlinks).toEqual(["/linker"]);
     expect(entryAfterUpdate.backlinks).toEqual(["/new-linker"]);
-    done();
   });
 
-  it("updates the backlinks property of deleted posts", async function (done) {
+  it("updates the backlinks property of deleted posts", async function () {
     const path = "/post.txt";
     const contents = "Link: linker\n\n[linker](/linked)";
 
@@ -127,6 +122,5 @@ describe("entry.backlinks", function () {
     expect(entry.backlinks).toEqual(["/linker"]);
     expect(entryAfterDrop.deleted).toEqual(true);
     expect(entryAfterRestore.backlinks).toEqual([]);
-    done();
   });  
 });

--- a/app/models/entry/tests/search.js
+++ b/app/models/entry/tests/search.js
@@ -4,7 +4,7 @@ describe("entry.search", function () {
   // Some of these tests take a while to run, so we need to increase the timeout
   global.test.timeout(60 * 1000);
 
-  it("works with a single entry", async function (done) {
+  it("works with a single entry", async function () {
     const path = "/post.txt";
     const contents = `Custom: Metadata hello!
     Tags: apple, pear, orange
@@ -39,10 +39,9 @@ describe("entry.search", function () {
     // Tags
     check(await this.search("apple"));
 
-    done();
   });
 
-  it("works with two entries", async function (done) {
+  it("works with two entries", async function () {
     const path1 = "/post.txt";
     const contents1 = `Custom: Metadata hello!
     Tags: apple, pear, orange
@@ -73,10 +72,9 @@ describe("entry.search", function () {
     // Lowercase
     check(await this.search("hello"));
 
-    done();
   });
 
-  it("supports non-latin characters", async function (done) {
+  it("supports non-latin characters", async function () {
     const path = "/post.txt";
     const contents = `Custom: Metadata hello!
     Tags: apple, pear, orange
@@ -96,10 +94,9 @@ describe("entry.search", function () {
     // Lowercase
     check(await this.search("你好"));
 
-    done();
   });
 
-  it("ignores deleted entries", async function (done) {
+  it("ignores deleted entries", async function () {
     const path = "/post.txt";
     const contents = `Hello, world!`;
 
@@ -111,10 +108,9 @@ describe("entry.search", function () {
 
     expect((await this.search("Hello")).length).toEqual(0);
 
-    done();
   });
 
-  it("ignores draft entries", async function (done) {
+  it("ignores draft entries", async function () {
     const path = "/post.txt";
     const contents = `Draft: true
 
@@ -124,10 +120,9 @@ describe("entry.search", function () {
 
     expect((await this.search("Hello")).length).toEqual(0);
 
-    done();
   });
 
-  it("ignores entries with Search: no metadata", async function (done) {
+  it("ignores entries with Search: no metadata", async function () {
     const path = "/post.txt";
     const contents = `Search: no
     Custom: Metadata hello!
@@ -144,10 +139,9 @@ describe("entry.search", function () {
     // Exact match
     check(await this.search("Hello"));
 
-    done();
   });
 
-  it("includes pages with Search: yes metadata", async function (done) {
+  it("includes pages with Search: yes metadata", async function () {
     const path = "/Pages/About.txt";
     const contents = `Search: yes
     Custom: Metadata hello!
@@ -165,10 +159,9 @@ describe("entry.search", function () {
     // Exact match
     check(await this.search("Hello"));
 
-    done();
   });
 
-  it("includes pages with Search: true metadata", async function (done) {
+  it("includes pages with Search: true metadata", async function () {
     const path = "/Pages/About.txt";
     const contents = `Search: true
     Custom: Metadata hello!
@@ -186,30 +179,27 @@ describe("entry.search", function () {
     // Exact match
     check(await this.search("Hello"));
 
-    done();
   });
 
-  it("requires boths terms to be present in multi-term search", async function (done) {
+  it("requires boths terms to be present in multi-term search", async function () {
     await this.set("/post.txt", `Hello, world!`);
 
     await this.set("/second.txt", `Hello, goodbye!`);
 
     expect((await this.search("Hello world")).length).toEqual(1);
 
-    done();
   });
 
-  it("returns a maximum of 25 results", async function (done) {
+  it("returns a maximum of 25 results", async function () {
     for (let i = 0; i < 100; i++) {
       await this.set(`/post${i}.txt`, `Hello, world ${i}!`);
     }
 
     expect((await this.search("Hello")).length).toEqual(25);
 
-    done();
   });
 
-  it("returns results within timeout even with large dataset", async function (done) {
+  it("returns results within timeout even with large dataset", async function () {
     for (let i = 0; i < 1000; i++) {
       await this.set(`/post${i}.txt`, `Hello, world ${i}! Some more content to search through.`);
     }
@@ -221,10 +211,9 @@ describe("entry.search", function () {
     expect(duration).toBeLessThanOrEqual(4100);
     expect(results.length).toEqual(25);
   
-    done();
   });
   
-  it("handles timeout with extremely large text content", async function (done) {
+  it("handles timeout with extremely large text content", async function () {
     let largeContent = "Start ";
     for (let i = 0; i < 100000; i++) {
       largeContent += `word${i} `;
@@ -240,10 +229,9 @@ describe("entry.search", function () {
     expect(duration).toBeLessThanOrEqual(4100);
     expect(results.length).toBeLessThan(2);
   
-    done();
   });
   
-  it("maintains performance with complex multi-term searches", async function (done) {
+  it("maintains performance with complex multi-term searches", async function () {
     for (let i = 0; i < 100; i++) {
       await this.set(`/complex${i}.txt`, `
         Title: Complex Post ${i}
@@ -263,10 +251,9 @@ describe("entry.search", function () {
     expect(duration).toBeLessThanOrEqual(4100);
     expect(results.length).toEqual(1);
   
-    done();
   });
   
-  it("returns partial results if timeout occurs mid-search", async function (done) {
+  it("returns partial results if timeout occurs mid-search", async function () {
     for (let i = 0; i < 500; i++) {
       await this.set(`/slow${i}.txt`, `
         Title: Slow Search Test ${i}
@@ -285,10 +272,9 @@ describe("entry.search", function () {
     expect(results.length).toBeLessThanOrEqual(50);
     expect(results.length).toBeGreaterThan(0);
   
-    done();
   });
   
-  it("performs well with concurrent searches", async function (done) {
+  it("performs well with concurrent searches", async function () {
     for (let i = 0; i < 200; i++) {
       await this.set(`/concurrent${i}.txt`, `Post ${i} with some searchable content`);
     }
@@ -310,6 +296,5 @@ describe("entry.search", function () {
       expect(result.length).toBeLessThanOrEqual(50);
     });
   
-    done();
   });
 });

--- a/app/models/question/tests/export.js
+++ b/app/models/question/tests/export.js
@@ -7,7 +7,7 @@ describe("exportQuestions", function () {
     const exportQuestions = require('../export'); // Adjust the path as needed
     const create = require("../create"); // Function to create questions/replies
     
-    it("exports questions correctly from Redis", async function (done) {
+    it("exports questions correctly from Redis", async function () {
       // Insert mock data into Redis using create function
       const question1 = await create({ title: 'How?', body: 'Yes' });
       const question2 = await create({ title: 'What?', body: 'No' });
@@ -50,28 +50,30 @@ describe("exportQuestions", function () {
       ];
   
       expect(exportedData).toEqual(expectedData);
-      done();
     });
   
-    it("handles empty questions gracefully", async function (done) {
-        client.keys("blot:questions:*", async function (err, keys) {
-            if (err) return done(err);
-            if (keys.length > 0) {
-              client.del(keys, async function (err, response) {
-                if (err) return done(err);
-                const exportedData = await exportQuestions();
-                expect(exportedData).toEqual([]);
-                done();
-            });
-            } else {
-                const exportedData = await exportQuestions();
-                expect(exportedData).toEqual([]);
-                done();
-                    }
+    it("handles empty questions gracefully", async function () {
+      const keys = await new Promise((resolve, reject) => {
+        client.keys("blot:questions:*", function (err, result) {
+          if (err) return reject(err);
+          resolve(result);
+        });
+      });
+
+      if (keys.length > 0) {
+        await new Promise((resolve, reject) => {
+          client.del(keys, function (err) {
+            if (err) return reject(err);
+            resolve();
           });
+        });
+      }
+
+      const exportedData = await exportQuestions();
+      expect(exportedData).toEqual([]);
     });
   
-    it("handles questions without replies", async function (done) {
+    it("handles questions without replies", async function () {
       const question = await create({ title: 'How?', body: 'Yes' });
   
       const exportedData = await exportQuestions();
@@ -90,10 +92,9 @@ describe("exportQuestions", function () {
       ];
   
       expect(exportedData).toEqual(expectedData);
-      done();
     });
   
-    it("handles replies without comments", async function (done) {
+    it("handles replies without comments", async function () {
       const question = await create({ title: 'How?', body: 'Yes' });
       const reply = await create({ body: 'Reply to How?', parent: question.id });
   
@@ -124,10 +125,9 @@ describe("exportQuestions", function () {
       ];
   
       expect(exportedData).toEqual(expectedData);
-      done();
     });
 
-    it("handles replies with comments", async function (done) {
+    it("handles replies with comments", async function () {
       const question = await create({ title: 'How?', body: 'Yes' });
       const reply = await create({ body: 'Reply to How?', parent: question.id });
       const comment = await create({ body: 'Comment to Reply', parent: reply.id });
@@ -169,11 +169,10 @@ describe("exportQuestions", function () {
       ];
   
       expect(exportedData).toEqual(expectedData);
-      done();
     });
 
 
-    it("handles questions with tags", async function (done) {
+    it("handles questions with tags", async function () {
         const question = await create({ title: 'How?', body: 'Yes', tags: ['tag1', 'tag2'] });
       
         const exportedData = await exportQuestions();
@@ -192,10 +191,9 @@ describe("exportQuestions", function () {
         ];
       
         expect(exportedData).toEqual(expectedData);
-        done();
       });
 
-      it("handles questions with author information", async function (done) {
+      it("handles questions with author information", async function () {
         const question = await create({ title: 'How?', body: 'Yes', author: 'User1' });
       
         const exportedData = await exportQuestions();
@@ -214,10 +212,9 @@ describe("exportQuestions", function () {
         ];
       
         expect(exportedData).toEqual(expectedData);
-        done();
       });
 
-      it("handles replies with author information", async function (done) {
+      it("handles replies with author information", async function () {
         const question = await create({ title: 'How?', body: 'Yes' });
         const reply = await create({ body: 'Reply to How?', parent: question.id, author: 'User2' });
       
@@ -248,7 +245,6 @@ describe("exportQuestions", function () {
         ];
       
         expect(exportedData).toEqual(expectedData);
-        done();
       });
 
       it("will throw an error if you trigger an issue with redis smembers", async function () {

--- a/app/models/question/tests/import.js
+++ b/app/models/question/tests/import.js
@@ -6,7 +6,7 @@ describe("importQuestions", function () {
     const exportQuestions = require('../export'); // We'll use this to verify the import
   
   
-    it("imports questions correctly into Redis", async function (done) {
+    it("imports questions correctly into Redis", async function () {
       const allQuestions = [
         {
           id: '1',
@@ -47,28 +47,26 @@ describe("importQuestions", function () {
   
       expect(exportedData.length).toBe(2);
       expect(exportedData).toEqual(jasmine.arrayContaining(allQuestions));
-      done();
     });
   
-    it("handles empty input gracefully", async function (done) {
+    it("handles empty input gracefully", async function () {
       await importQuestions([]);
   
       const exportedData = await exportQuestions();
   
       expect(exportedData).toEqual([]);
-      done();
     });
   
-    it("throws an error for invalid input", async function (done) {
+    it("throws an error for invalid input", async function () {
       try {
         await importQuestions({});
+        fail('Should have thrown');
       } catch (err) {
         expect(err.message).toBe('Input must be an array');
-        done();
       }
     });
   
-    it("imports questions without replies", async function (done) {
+    it("imports questions without replies", async function () {
       const allQuestions = [
         {
           id: '1',
@@ -88,10 +86,9 @@ describe("importQuestions", function () {
   
       expect(exportedData.length).toBe(1);
       expect(exportedData).toEqual(jasmine.arrayContaining(allQuestions));
-      done();
     });
   
-    it("imports replies without comments", async function (done) {
+    it("imports replies without comments", async function () {
       const allQuestions = [
         {
           id: '1',
@@ -122,7 +119,6 @@ describe("importQuestions", function () {
   
       expect(exportedData.length).toBe(1);
       expect(exportedData).toEqual(jasmine.arrayContaining(allQuestions));
-      done();
     });
   
 });

--- a/app/sync/tests/build.js
+++ b/app/sync/tests/build.js
@@ -145,7 +145,7 @@ describe("build", function () {
     this.syncAndCheck(file, entry, done);
   });
 
-  it("rebuilds dependent entries", async function (done) {
+  it("rebuilds dependent entries", async function () {
     var path = "/post.txt";
     var content = "![](/image.png)";
 
@@ -163,6 +163,11 @@ describe("build", function () {
         result.indexOf("cdn.") > -1 && result.indexOf(this.blog.id) > -1
     };
 
-    this.syncAndCheck(files, entry, done);
+    await new Promise((resolve, reject) => {
+      this.syncAndCheck(files, entry, (err) => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
   });
 });

--- a/app/sync/tests/rebuild.js
+++ b/app/sync/tests/rebuild.js
@@ -2,7 +2,7 @@ describe("rebuild", function () {
   // Set up a test blog before each test
   global.test.blog();
 
-  it("will rebuild entries on blog", async function (done) {
+  it("will rebuild entries on blog", async function () {
     const path = "/Hello.txt";
 
     await this.blog.write({ path, content: "Title: Hello" });
@@ -13,10 +13,9 @@ describe("rebuild", function () {
     await this.blog.rebuild();
     await this.blog.check({ path, title: "Bye" });
 
-    done();
   });
 
-  it("will rebuild cached images on blog", async function (done) {
+  it("will rebuild cached images on blog", async function () {
     const path = "/Hello.txt";
 
     await this.blog.write({ path, content: "![](_image.png)" });
@@ -37,10 +36,9 @@ describe("rebuild", function () {
     expect(rebuiltEntry.html).not.toEqual(entry.html);
     expect(entry.thumbnail).toEqual(rebuiltEntry.thumbnail);
 
-    done();
   });
 
-  it("will rebuild entries with dependent files", async function (done) {
+  it("will rebuild entries with dependent files", async function () {
     const path = "/Posts/Hello.txt";
 
     await this.blog.write({ path, content: "![Image](/Public/image.png)" });
@@ -58,10 +56,9 @@ describe("rebuild", function () {
     await this.blog.rebuild();
     await this.blog.check({ path });
 
-    done();
   });
 
-  it("will rebuild thumbnails on blog", async function (done) {
+  it("will rebuild thumbnails on blog", async function () {
     const path = "/Hello.txt";
 
     await this.blog.write({ path, content: "![](_image.png)" });
@@ -82,6 +79,5 @@ describe("rebuild", function () {
     expect(rebuiltEntry.html).toEqual(entry.html);
     expect(entry.thumbnail).not.toEqual(rebuiltEntry.thumbnail);
 
-    done();
   });
 });

--- a/scripts/tests/util/site.js
+++ b/scripts/tests/util/site.js
@@ -204,7 +204,7 @@ module.exports = function (options = {}) {
   });
 
   if (options.login) {
-    beforeEach(async function (done) {
+    beforeEach(async function () {
       // first fetch the login page to get the csrf token
       const loginPage = await this.fetch("/sites/log-in", {
         redirect: "manual",
@@ -223,7 +223,7 @@ module.exports = function (options = {}) {
       );
 
       if (!csrfTokenMatch) {
-        return done(new Error("CSRF token not found in login page"));
+        throw new Error("CSRF token not found in login page");
       }
 
       const email = this.user.email;
@@ -255,8 +255,8 @@ module.exports = function (options = {}) {
       expect(res.status).toEqual(302);
 
       if (res.status !== 302) {
-        return done(
-          new Error(`Failed to log in: expected status 302, got ${res.status}`)
+        throw new Error(
+          `Failed to log in: expected status 302, got ${res.status}`
         );
       }
 
@@ -279,7 +279,6 @@ module.exports = function (options = {}) {
 
       expect(dashboardText).toMatch(email);
 
-      done();
     });
   }
 };


### PR DESCRIPTION
### Motivation
- Stabilize test completion semantics by removing tests that mix `async function (done)` with `await` or callbacks, which can swallow failures or cause timeouts.
- Prioritize high-volume suites that most affect CI turnaround (`app/build/tests`, `app/models/entries/tests`, `app/models/question/tests`).
- Preserve existing assertions and side effects while making completion and failure propagation deterministic via promises or explicit callback-wrapping.

### Description
- Converted tests that used `async function (done)` with `await` to plain `async function ()` so promise resolution/rejection controls completion, removing `done` calls where appropriate.
- Wrapped callback-only APIs used in async tests (for example `Entries.getTotal`, `Entries.getAllIDs`, `Entries.getPage`, `Entries.getRecent`, `Entries.adjacentTo`, `Entries.resave`, `client.keys`, `client.del`) in `new Promise((resolve, reject) => { ... })` and `await`ed them so errors reject the promise immediately.
- Replaced `done.fail(...)`/`return done(new Error(...))` with `fail(...)` or thrown `Error` instances inside async tests to ensure assertion failures surface without relying on callback signaling.
- Changes touch the prioritized and related suites including `app/models/entries/tests.js`, `app/build/tests/index.js`, `app/build/tests/plugins/wikilinks.js`, `app/models/question/tests/export.js`, `app/models/question/tests/import.js`, and additional files (`app/models/entry/tests/*`, `app/sync/tests/*`, `app/helper/tests/flushCache.js`, `app/clients/google-drive/database/tests/folder.js`, `scripts/tests/util/site.js`) to ensure consistent async completion handling.

### Testing
- Ran syntax checks with `node --check` across all modified files, which completed without errors.
- Verified there are no remaining patterns matching `async function (done)` via a repository search (`rg`), and validated specific callback-to-promise conversions in the high-volume suites.
- Attempted to run the test harness with `npm test ...` but the environment’s test runner requires Docker and failed in this environment (`docker: command not found`); local/CI test execution should be performed where Docker is available to exercise the full suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e0ea267483299ba4d4d5b7347e96)