### PR TITLE
Use documented jasmine timeout global in test helper

### DIFF
--- a/scripts/tests/index.js
+++ b/scripts/tests/index.js
@@ -152,18 +152,28 @@ global.test = {
   templates: require("./util/templates"),
 
   timeout: function (ms) {
-    // Store original value
-    let originalTimeout;
+    var originalTimeout;
+    var hasOriginalTimeout = false;
 
     beforeAll(function () {
-      // In your setup, jasmine.DEFAULT_TIMEOUT_INTERVAL isn't available
-      // We need to access the timeout through the Jasmine instance
-      originalTimeout = jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL;
-      jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL = ms;
+      if (
+        !globalThis.jasmine ||
+        typeof globalThis.jasmine.DEFAULT_TIMEOUT_INTERVAL !== "number"
+      ) {
+        throw new Error(
+          "test.timeout(ms) requires jasmine.DEFAULT_TIMEOUT_INTERVAL to be available."
+        );
+      }
+
+      originalTimeout = globalThis.jasmine.DEFAULT_TIMEOUT_INTERVAL;
+      hasOriginalTimeout = true;
+      globalThis.jasmine.DEFAULT_TIMEOUT_INTERVAL = ms;
     });
 
     afterAll(function () {
-      jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout || 5000;
+      if (hasOriginalTimeout && globalThis.jasmine) {
+        globalThis.jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+      }
     });
   },
 


### PR DESCRIPTION
### Motivation
- Ensure the test helper uses the documented Jasmine API instead of an internal path and avoid silently no-oping when the timeout API is unavailable.
- Preserve and exactly restore the prior timeout value to avoid unexpected fallback behavior.

### Description
- Read and write the timeout using `globalThis.jasmine.DEFAULT_TIMEOUT_INTERVAL` rather than `jasmine.jasmine.DEFAULT_TIMEOUT_INTERVAL`.
- Add a `beforeAll` guard that throws a clear error when `jasmine.DEFAULT_TIMEOUT_INTERVAL` is not available to prevent silent failures.
- Capture the original timeout in `originalTimeout` and restore that exact value in `afterAll` instead of using a hardcoded fallback.
- Remove/update helper comments that referenced the old internal Jasmine path.

### Testing
- Ran `node --check scripts/tests/index.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e8ed92648329aecd1f51ce0303bc)