### PR TITLE
Adjust test runner exit behavior and add hang diagnostics

### DIFF
--- a/scripts/tests/index.js
+++ b/scripts/tests/index.js
@@ -5,7 +5,7 @@ var client = require("models/client");
 var clfdate = require("helper/clfdate");
 var seedrandom = require("seedrandom");
 var async = require("async");
-const { before } = require("lodash");
+const asyncHooks = require("async_hooks");
 var seed;
 var config = {
   spec_dir: "",
@@ -95,10 +95,86 @@ jasmine.addReporter({
   jasmineDone: function (result) {
     process.exitCode = result.overallStatus === "passed" ? 0 : 1;
 
-    // Make completion deterministic once reporters have finished flushing output.
-    setImmediate(function () {
-      process.exit(process.exitCode);
+    client.quit(function (err) {
+      if (err) {
+        console.warn(
+          clfdate(),
+          colors.yellow("[tests] Failed to quit redis client"),
+          err.message || err
+        );
+      }
     });
+
+    const diagnosticGraceMs = Number(
+      process.env.BLOT_TESTS_EXIT_GRACE_TIMEOUT_MS || 0
+    );
+
+    if (!Number.isFinite(diagnosticGraceMs) || diagnosticGraceMs <= 0) {
+      return;
+    }
+
+    const sourceByResource = new WeakMap();
+    const hook = asyncHooks.createHook({
+      init: function (_asyncId, type, _triggerAsyncId, resource) {
+        if (!resource || sourceByResource.has(resource)) return;
+        const source = new Error().stack
+          .split("\n")
+          .slice(2)
+          .map((line) => line.trim())
+          .filter((line) => !line.includes("scripts/tests/index.js"))
+          .slice(0, 8)
+          .join("\n");
+
+        sourceByResource.set(resource, { type, source });
+      },
+    });
+
+    hook.enable();
+
+    const gracefulExitTimer = setTimeout(function () {
+      hook.disable();
+
+      const handles = process._getActiveHandles();
+      if (!handles.length) return;
+
+      console.log();
+      console.warn(
+        clfdate(),
+        colors.yellow(
+          `[tests] Process did not exit within ${diagnosticGraceMs}ms. Active handles:`
+        )
+      );
+
+      handles.forEach(function (handle, index) {
+        const details = sourceByResource.get(handle);
+        const type =
+          (details && details.type) ||
+          (handle && handle.constructor && handle.constructor.name) ||
+          typeof handle;
+
+        console.warn(
+          colors.yellow(`  [${index + 1}] ${type}`),
+          handle && handle.constructor && handle.constructor.name
+            ? colors.dim(`(${handle.constructor.name})`)
+            : ""
+        );
+
+        if (index === 0 && details && details.source) {
+          console.warn(colors.yellow("    First still-open handle source:"));
+          console.warn(colors.dim(details.source));
+        }
+      });
+
+      const requests = process._getActiveRequests();
+      if (requests.length) {
+        console.warn(
+          colors.yellow(`  Active requests: ${requests.length}`)
+        );
+      }
+    }, diagnosticGraceMs);
+
+    gracefulExitTimer.unref();
+
   },
 });
 

--- a/scripts/tests/util/server.js
+++ b/scripts/tests/util/server.js
@@ -77,7 +77,8 @@ module.exports = function (router) {
     this.checkBrokenLinks = (url = this.origin, options = {}) => checkBrokenLinks(this.fetch, url, options);
   });
 
-  afterAll(function () {
-    server.close();
+  afterAll(function (done) {
+    if (!server) return done();
+    server.close(done);
   });
 };

--- a/scripts/tests/util/site.js
+++ b/scripts/tests/util/site.js
@@ -199,8 +199,9 @@ module.exports = function (options = {}) {
     };
   });
 
-  afterAll(function () {
-    server.close();
+  afterAll(function (done) {
+    if (!server) return done();
+    server.close(done);
   });
 
   if (options.login) {


### PR DESCRIPTION
### Motivation

- Ensure the test runner allows Node to exit naturally after reporters and hooks complete instead of forcing `process.exit(...)`, making teardown more reliable.
- Improve ability to diagnose hanging test shards by printing active handle information and the originating stack when tests fail to terminate within a configurable grace period.
- Make common long-lived test resources (HTTP servers, Redis client) be explicitly closed in helpers so natural exit is reliable.

### Description

- Removed the forced `process.exit(...)` call from `jasmineDone` and preserved `process.exitCode` so Node will exit naturally once hooks and reporters finish. 
- Added an explicit `client.quit(...)` call for the shared Redis client to help close that long-lived connection.
- Added optional hang diagnostics in `scripts/tests/index.js` gated by the `BLOT_TESTS_EXIT_GRACE_TIMEOUT_MS` environment variable; when set and the process is still alive after the grace timeout the reporter will log `process._getActiveHandles()`/`process._getActiveRequests()` and, using `async_hooks`, capture and print the source stack for the first still-open handle. 
- Updated test helpers to reliably close HTTP servers by switching to `server.close(done)` and guarding against missing server instances in `scripts/tests/util/server.js` and `scripts/tests/util/site.js` so teardowns call back when the server has fully closed.
- Files changed: `scripts/tests/index.js`, `scripts/tests/util/server.js`, `scripts/tests/util/site.js`.

### Testing

- Ran syntax checks with `node --check scripts/tests/index.js`, `node --check scripts/tests/util/server.js`, and `node --check scripts/tests/util/site.js`, all of which succeeded. 
- Attempted to re-run the problematic shard with `BLOT_TESTS_EXIT_GRACE_TIMEOUT_MS=3000 npm test -- app/templates` to capture a live hang, but execution was blocked in this environment because `docker` is not available so the container-based test run could not be executed. 
- Note: the new diagnostics are silent unless `BLOT_TESTS_EXIT_GRACE_TIMEOUT_MS` is set and the process has not exited within the configured grace period.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e8efc16083299056755f1d126297)