### PR TITLE
Add timeout guard for blog test template setup

### DIFF
--- a/app/blog/tests/util/setup.js
+++ b/app/blog/tests/util/setup.js
@@ -26,8 +26,28 @@ module.exports = function () {
 
   // Build the templates
   beforeAll(function (done) {
-    templates({ watch: false }, done);
-  }, 10 * 1000); // longer timeout
+    const timeoutMs = 30 * 1000;
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      done.fail(
+        new Error(
+          `templates({ watch: false }) did not finish within ${timeoutMs}ms`
+        )
+      );
+    }, timeoutMs);
+
+    templates({ watch: false }, (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+
+      if (err) return done.fail(err);
+      done();
+    });
+  }, 35 * 1000);
 
   beforeEach(function () {
     this.write = async ({ path, content }) => {


### PR DESCRIPTION
### Motivation
- The `app/blog` test suite could stall indefinitely at startup because `beforeAll` calls `templates({ watch: false }, done)` and the callback may never fire, leaving Jasmine stuck at `Started` with no clear failure.

### Description
- Add a guarded timeout around the template build in `app/blog/tests/util/setup.js` that fails the hook with a clear error if `templates({ watch: false })` does not invoke its callback within `30 * 1000` ms and increase the Jasmine hook timeout to `35 * 1000` ms to accommodate slow-but-correct environments.

### Testing
- Attempted to run the `app/blog` test suite via `npm test -- app/blog`, but the run could not start in this environment because Docker is unavailable (`docker: command not found`), so the change could not be exercised by the full test runner here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995ebbb45108329bf033bb1c8a410b8)