### PR TITLE
Add lowercase render-time metadata aliases for entry templates

### DIFF
--- a/app/blog/render/load/augment.js
+++ b/app/blog/render/load/augment.js
@@ -10,6 +10,8 @@ require("moment-timezone");
 module.exports = function (req, res, entry, callback) {
   var blog = req.blog;
 
+  entry.metadata = createRenderMetadata(entry.metadata);
+
   // Can be either inherited from the properties of the blog
   // or from the template, or from the view
   var hideDate = res.locals.hide_dates || false;
@@ -138,6 +140,28 @@ module.exports = function (req, res, entry, callback) {
     }
   );
 };
+
+function createRenderMetadata(sourceMetadata) {
+  if (!sourceMetadata || type(sourceMetadata, "object") !== "object") {
+    return sourceMetadata;
+  }
+
+  var renderMetadata = Object.assign({}, sourceMetadata);
+  var keys = Object.keys(sourceMetadata);
+
+  for (var i = 0; i < keys.length; i++) {
+    var key = keys[i];
+    var lowerKey = key.toLowerCase();
+
+    if (lowerKey === key || Object.prototype.hasOwnProperty.call(renderMetadata, lowerKey)) {
+      continue;
+    }
+
+    renderMetadata[lowerKey] = sourceMetadata[key];
+  }
+
+  return renderMetadata;
+}
 
 function FormatDate(dateStamp, zone) {
   return function () {

--- a/app/blog/render/tests/augment.js
+++ b/app/blog/render/tests/augment.js
@@ -54,6 +54,42 @@ describe("augment", function () {
         expect(body.trim()).toEqual('Second');
     });
 
+
+    it("creates lowercase metadata aliases for rendering", async function () {
+
+        await this.write({
+            path: "/mixed-case-metadata.txt",
+            content: "Apple: Honeycrisp\n\nBody"
+        });
+
+        await this.template({
+            'entry.html': '{{entry.metadata.apple}}'
+        });
+
+        const res = await this.get('/mixed-case-metadata');
+        const body = await res.text();
+
+        expect(res.status).toEqual(200);
+        expect(body.trim()).toEqual('Honeycrisp');
+    });
+
+    it("preserves explicit lowercase metadata values", async function () {
+
+        await this.write({
+            path: "/metadata-precedence.txt",
+            content: "Apple: Honeycrisp\napple: Gala\n\nBody"
+        });
+
+        await this.template({
+            'entry.html': '{{entry.metadata.apple}}'
+        });
+
+        const res = await this.get('/metadata-precedence');
+        const body = await res.text();
+
+        expect(res.status).toEqual(200);
+        expect(body.trim()).toEqual('Gala');
+    });
     it("encodes tag slugs when augmenting entry tags", async function () {
 
         await this.write({

--- a/app/blog/tests/pluginHTML.js
+++ b/app/blog/tests/pluginHTML.js
@@ -50,7 +50,7 @@ describe("pluginHTML", function () {
         await this.blog.update({plugins})
 
         await this.template({ "entry.html": "{{{entry.html}}} {{> pluginHTML}}" });
-        await this.write({path: '/a.txt', content: 'Link: /foo\n\nHello, world!'});        
+        await this.write({path: '/a.txt', content: 'Link: /foo\nDisqus: mixed-case-disqus-id\n\nHello, world!'});        
         await this.write({path: '/Pages/about.txt', content: 'Link: /about\n\nHello, world!'});        
         await this.write({path: '/Drafts/test.txt', content: 'Hello, draft!'});
 
@@ -61,6 +61,13 @@ describe("pluginHTML", function () {
         }
 
         expect(await areThereComments('/foo')).toBe(true, 'comments should appear on posts');
+
+        const fooRes = await this.get('/foo');
+        const fooBody = await fooRes.text();
+
+        expect(fooRes.status).toEqual(200);
+        expect(fooBody).toContain("var disqus_identifier = 'mixed-case-disqus-id';");
+
         expect(await areThereComments('/about')).toBe(false, 'comments should not appear on pages');
         expect(await areThereComments('/draft/view/Drafts/test.txt')).toBe(false, 'comments should not appear on drafts');  
 


### PR DESCRIPTION
### Motivation

- Templates expect lowercase metadata keys (e.g. `entry.metadata.disqus` or `entry.metadata.apple`) to work even when source metadata uses mixed case, without changing persisted entry state.
- Create a render-only metadata view that exposes lowercase aliases while preserving source key precedence and avoiding mutations that could leak into cached/persisted state.

### Description

- Replace `entry.metadata` with a render-only clone created by `createRenderMetadata(entry.metadata)` inside `app/blog/render/load/augment.js` so templates see a safe copy only for rendering. 
- Implement `createRenderMetadata` which clones the source metadata with `Object.assign` and adds lowercase aliases for keys whose lowercase form differs and is not already present, while leaving existing lowercase keys untouched. 
- The function is careful not to mutate the original `sourceMetadata` and returns non-object metadata unchanged. 
- Add/extend tests: add two render tests in `app/blog/render/tests/augment.js` proving that mixed-case `Apple` is available as `{{entry.metadata.apple}}` and that an explicit lowercase `apple` key keeps precedence, and extend `app/blog/tests/pluginHTML.js` to include a Disqus integration check using a mixed-case `Disqus` source key.

### Testing

- Ran the project test runner for the new/modified tests via `npm test app/blog/render/tests/augment.js`, but the automated test invocation failed in this environment because the test harness requires Docker and `docker` was not found. (failed)
- Ran `npm test app/blog/tests/pluginHTML.js` which also failed in this environment for the same missing `docker` dependency. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996d8fd1ca48329a016683caf73fdcf)