### PR TITLE
Add metadataCaseInsensitive helper and use across entry pipeline

### DIFF
--- a/app/blog/entry.js
+++ b/app/blog/entry.js
@@ -2,6 +2,7 @@ var Entry = require("models/entry");
 var normalize = require("helper/urlNormalizer");
 var plugins = require("build/plugins");
 var Entries = require("models/entries");
+var metadataCaseInsensitive = require("helper/metadataCaseInsensitive");
 
 module.exports = function (request, response, next) {
   
@@ -32,9 +33,11 @@ module.exports = function (request, response, next) {
     // Disable comments in cases:
     // 1. Blog post metadata DOES have  'Comments: No'
     // 2. Page metadata DOES NOT have   'Comments: Yes'
+    var metadataByLowercaseKey = metadataCaseInsensitive(entry.metadata);
+
     if (
-      entry.metadata.comments === "No" ||
-      (entry.metadata.comments !== "Yes" && entry.page)
+      metadataByLowercaseKey.comments === "No" ||
+      (metadataByLowercaseKey.comments !== "Yes" && entry.page)
     ) {
       delete blog.plugins.commento;
       delete blog.plugins.disqus;

--- a/app/build/dependencies/index.js
+++ b/app/build/dependencies/index.js
@@ -3,6 +3,7 @@ var cheerio = require("cheerio");
 var is_url = require("./is_url");
 var debug = require("debug")("blot:build:dependencies");
 var is_path = require("./is_path");
+var metadataCaseInsensitive = require("helper/metadataCaseInsensitive");
 
 // The purpose of this module is to take the HTML for
 // a given blog post and work out if it references any
@@ -19,6 +20,7 @@ function dependencies (path, html, metadata) {
   var $ = cheerio.load(html, { decodeEntities: false }, false);
   var dependencies = [];
   var attribute, value, resolved_value;
+  var metadataByLowercaseKey = metadataCaseInsensitive(metadata);
 
   // We have to be slightly stricter for
   Object.keys(metadata).forEach(function (attribute) {
@@ -47,7 +49,11 @@ function dependencies (path, html, metadata) {
 
     // Try and resolve the thumbnail path
     // Likewise if it's e.g. ./image.png
-    if (attribute.toLowerCase() === "thumbnail" || value.indexOf("./") === 0) {
+    var isThumbnail =
+      attribute.toLowerCase() === "thumbnail" &&
+      value === metadataByLowercaseKey.thumbnail;
+
+    if (isThumbnail || value.indexOf("./") === 0) {
       dependencies.push(resolved_value);
       metadata[attribute] = resolved_value;
       debug(path, attribute, resolved_value, "was added to dependencies");

--- a/app/build/dependencies/tests/index.js
+++ b/app/build/dependencies/tests/index.js
@@ -158,6 +158,19 @@ describe("dependencies", function () {
     },
   });
 
+
+  // Should resolve thumbnail metadata with mixed-case key
+  should_get_dependencies({
+    html: "Hello",
+    path: "/foo/post.txt",
+    metadata: { ThUmBnAiL: "image.jpg" },
+    result: {
+      html: "Hello",
+      metadata: { ThUmBnAiL: "/foo/image.jpg" },
+      dependencies: ["/foo/image.jpg"],
+    },
+  });
+
   // Should ignore thumbnail metadata which is a URL
   should_get_dependencies({
     html: "x",

--- a/app/build/prepare/dateStamp/index.js
+++ b/app/build/prepare/dateStamp/index.js
@@ -7,15 +7,16 @@ const type = require("helper/type");
 const moment = require("moment");
 require("moment-timezone");
 
+const metadataCaseInsensitive = require("helper/metadataCaseInsensitive");
+
 module.exports = function (blog, path, metadata) {
   const { id, dateFormat, timeZone } = blog;
   let dateStamp;
 
   debug("Blog:", id, "dateFormat:", dateFormat, "timeZone", timeZone, path);
 
-  const metadataDate = metadata.date !== undefined
-    ? metadata.date
-    : metadata[Object.keys(metadata).find(key => key.toLowerCase() === "date")];
+  const metadataByLowercaseKey = metadataCaseInsensitive(metadata);
+  const metadataDate = metadataByLowercaseKey.date;
 
   // If the user specified a date
   // field in the entry's metadata,

--- a/app/build/prepare/dateStamp/tests/index.js
+++ b/app/build/prepare/dateStamp/tests/index.js
@@ -1,0 +1,10 @@
+const dateStamp = require("..");
+
+describe("dateStamp", function () {
+  it("reads Date metadata with mixed-case key", function () {
+    const blog = { id: "test", dateFormat: "M/D/YYYY", timeZone: "Etc/UTC" };
+    const metadata = { Date: "2019-04-03 12:33:15" };
+
+    expect(dateStamp(blog, "/post.txt", metadata)).toEqual(1554294795000);
+  });
+});

--- a/app/build/prepare/index.js
+++ b/app/build/prepare/index.js
@@ -10,6 +10,7 @@ var pathNormalizer = require("helper/pathNormalizer");
 var type = require("helper/type");
 
 var makeSlug = require("helper/makeSlug");
+var metadataCaseInsensitive = require("helper/metadataCaseInsensitive");
 var ensure = require("helper/ensure");
 var Model = require("models/entry").model;
 
@@ -49,15 +50,7 @@ function Prepare (entry, options = {}) {
     .and(entry.draft, "boolean")
     .and(entry.metadata, "object");
 
-  const metadataKeys = Object.keys(entry.metadata);
-  const metadataByLowercaseKey = {};
-
-  metadataKeys.forEach(metaKey => {
-    const lowercaseKey = String(metaKey).toLowerCase();
-    if (!(lowercaseKey in metadataByLowercaseKey)) {
-      metadataByLowercaseKey[lowercaseKey] = entry.metadata[metaKey];
-    }
-  });
+  const metadataByLowercaseKey = metadataCaseInsensitive(entry.metadata);
 
   function metadataValue (key) {
     if (entry.metadata[key] !== undefined) return entry.metadata[key];

--- a/app/build/prepare/tests/index.js
+++ b/app/build/prepare/tests/index.js
@@ -58,6 +58,26 @@ describe("prepare", function () {
     expect(entry.body).toEqual(entry.html);
   });
 
+
+  it("uses mixed-case metadata keys for page, menu and permalink", function () {
+    var entry = this.entry;
+
+    entry.path = "/post.txt";
+    entry.html = "<p>Hello there</p>";
+    entry.draft = false;
+    entry.metadata = {
+      Page: "yes",
+      MENU: "no",
+      Permalink: "/mixed-case"
+    };
+
+    prepare(entry);
+
+    expect(entry.page).toEqual(true);
+    expect(entry.menu).toEqual(false);
+    expect(entry.permalink).toEqual("/mixed-case");
+  });
+
   it("generates an empty title when given an empty file", function () {
     var entry = this.entry;
 

--- a/app/build/thumbnail/candidates.js
+++ b/app/build/thumbnail/candidates.js
@@ -1,6 +1,8 @@
 const cheerio = require("cheerio");
 const URL = require("url");
 
+const metadataCaseInsensitive = require("helper/metadataCaseInsensitive");
+
 const YOUTUBE_HOSTS = [
   "www.youtube.com",
   "youtube.com",
@@ -12,12 +14,13 @@ const YOUTUBE_HOSTS = [
 
 module.exports = function (metadata, html) {
   const candidates = [];
+  const metadataByLowercaseKey = metadataCaseInsensitive(metadata);
 
   // Would be nice to resolve this relative to
   // the location of the entry so we could
   // use a relative path in the thumbnail metadata
-  if (metadata.thumbnail) {
-    candidates.push(metadata.thumbnail);
+  if (metadataByLowercaseKey.thumbnail) {
+    candidates.push(metadataByLowercaseKey.thumbnail);
   }
 
   const $ = cheerio.load(html, { decodeEntities: false }, false);

--- a/app/build/thumbnail/tests/candidates.js
+++ b/app/build/thumbnail/tests/candidates.js
@@ -19,6 +19,15 @@ describe("candidates", function () {
     ]);
   });
 
+
+  it("uses mixed-case thumbnail metadata", function () {
+    var metadata = { ThUmBnAiL: "http://example.com/mixed.jpg" };
+
+    expect(candidates(metadata, "<p>Hello</p>")).toEqual([
+      "http://example.com/mixed.jpg"
+    ]);
+  });
+
   it("does not find a thumbnail candidate", function () {
     var metadata = {};
     var html = "<p>Hello, World!</p>";

--- a/app/helper/metadataCaseInsensitive.js
+++ b/app/helper/metadataCaseInsensitive.js
@@ -1,0 +1,15 @@
+module.exports = function metadataCaseInsensitive (metadata) {
+  const view = {};
+
+  Object.keys(metadata)
+    .sort((a, b) => a.localeCompare(b))
+    .forEach(key => {
+      const lowered = String(key).toLowerCase();
+
+      if (!(lowered in view)) {
+        view[lowered] = metadata[key];
+      }
+    });
+
+  return view;
+};

--- a/app/helper/tests/metadataCaseInsensitive.js
+++ b/app/helper/tests/metadataCaseInsensitive.js
@@ -1,0 +1,30 @@
+const metadataCaseInsensitive = require("../metadataCaseInsensitive");
+
+describe("metadataCaseInsensitive", function () {
+  it("returns lowercase-key metadata values", function () {
+    const metadata = {
+      Page: "yes",
+      MENU: "no",
+      ThUmBnAiL: "cover.jpg",
+      Permalink: "/hello"
+    };
+
+    expect(metadataCaseInsensitive(metadata)).toEqual({
+      page: "yes",
+      menu: "no",
+      thumbnail: "cover.jpg",
+      permalink: "/hello"
+    });
+  });
+
+  it("uses first key in deterministic order for collisions", function () {
+    const metadata = {
+      permalink: "/lower",
+      Permalink: "/upper"
+    };
+
+    const view = metadataCaseInsensitive(metadata);
+
+    expect(view.permalink).toEqual(metadata[Object.keys(metadata).sort((a, b) => a.localeCompare(b))[0]]);
+  });
+});

--- a/app/models/entry/_setUrl.js
+++ b/app/models/entry/_setUrl.js
@@ -4,6 +4,7 @@ var _ = require("lodash");
 var urlNormalizer = require("helper/urlNormalizer");
 var UID = require("helper/makeUid");
 var makeSlug = require("helper/makeSlug");
+var metadataCaseInsensitive = require("helper/metadataCaseInsensitive");
 var withoutExtension = require("helper/withoutExtension");
 var redis = require("models/client");
 var Permalink = require("build/prepare/permalink");
@@ -51,15 +52,16 @@ var UID_PERMUTATIONS = 500;
 
 function Candidates(blog, entry) {
   var candidates = [];
+  var metadataByLowercaseKey = metadataCaseInsensitive(entry.metadata);
 
   var format = blog.permalink.isCustom ? blog.permalink.custom : blog.permalink.format;
   
   // Don't use the permalink format for pages
   // or posts with user specified permalinks.
   if (
-    !entry.metadata.permalink &&
-    !entry.metadata.link &&
-    !entry.metadata.url &&
+    !metadataByLowercaseKey.permalink &&
+    !metadataByLowercaseKey.link &&
+    !metadataByLowercaseKey.url &&
     !entry.page
   ) {
     entry.permalink = Permalink(blog.timeZone, format, entry);

--- a/app/models/entry/search.js
+++ b/app/models/entry/search.js
@@ -11,6 +11,7 @@ const zscan = promisify(client.zscan).bind(client);
 const TIMEOUT = 8000;
 const MAX_RESULTS = 25;
 const CHUNK_SIZE = 200;
+const metadataCaseInsensitive = require("helper/metadataCaseInsensitive");
 
 function buildSearchText(entry) {
   return [
@@ -24,9 +25,11 @@ function buildSearchText(entry) {
 }
 
 function isSearchable(entry) {
+  const metadataByLowercaseKey = metadataCaseInsensitive(entry.metadata);
+
   if (entry.deleted || entry.draft) return false;
-  if (entry.page && (!entry.metadata.search || isFalsy(entry.metadata.search))) return false;
-  if (entry.metadata.search && isFalsy(entry.metadata.search)) return false;
+  if (entry.page && (!metadataByLowercaseKey.search || isFalsy(metadataByLowercaseKey.search))) return false;
+  if (metadataByLowercaseKey.search && isFalsy(metadataByLowercaseKey.search)) return false;
   return true;
 }
 

--- a/app/models/entry/tests/search.js
+++ b/app/models/entry/tests/search.js
@@ -147,6 +147,19 @@ describe("entry.search", function () {
     done();
   });
 
+
+  it("ignores entries with mixed-case Search metadata set to no", async function (done) {
+    const path = "/post-mixed-search.txt";
+    const contents = `SeArCh: no
+    Hello, world!`;
+
+    await this.set(path, contents);
+
+    expect((await this.search("Hello")).length).toEqual(0);
+
+    done();
+  });
+
   it("includes pages with Search: yes metadata", async function (done) {
     const path = "/Pages/About.txt";
     const contents = `Search: yes

--- a/app/models/entry/tests/urlDeduplication.js
+++ b/app/models/entry/tests/urlDeduplication.js
@@ -31,6 +31,16 @@ describe("entry.urlDeduplication", function () {
     expect(result.conflictingEntryPath).toEqual("/original.txt");
   });
 
+
+  it("uses mixed-case permalink metadata as first url candidate", async function () {
+    const entry = await this.set(
+      "/mixed-permalink.txt",
+      "Permalink: Mixed-Case-Path\nHello, mixed!"
+    );
+
+    expect(entry.url).toEqual("/mixed-case-path");
+  });
+
   it("adds dependency when URL is deduplicated", async function () {
     await this.set("/dep-a.txt", "Link: dedup\nHello, dep A!");
     const deduplicated = await this.set(


### PR DESCRIPTION
### Motivation

- Ensure metadata lookups are case-insensitive and deterministic so mixed-case keys like `Page`, `MENU`, `ThUmBnAiL`, and `Permalink` behave the same as lowercase keys.
- Avoid repeated scans for lowercase metadata by computing a single lowercase-key view per function invocation.

### Description

- Added `app/helper/metadataCaseInsensitive.js` which returns a read-only lowercase-key view of a metadata object by iterating keys in deterministic sorted order and keeping the first match on collisions.
- Refactored modules to use the helper and compute the lowercase view once per invocation: `app/build/prepare/index.js`, `app/build/prepare/dateStamp/index.js`, `app/build/thumbnail/candidates.js`, `app/build/dependencies/index.js` (thumbnail-specific handling), `app/models/entry/_setUrl.js`, `app/models/entry/search.js`, and `app/blog/entry.js`.
- Kept existing semantics (truthy/falsy checks, permalink candidate priority, comments logic, dependency resolution, etc.) — only changed key resolution to consult the lowercase view instead of repeated direct `entry.metadata` casing reads.
- Added focused tests covering mixed-case metadata keys and helper behavior in: `app/helper/tests/metadataCaseInsensitive.js`, `app/build/prepare/tests/index.js`, `app/build/prepare/dateStamp/tests/index.js`, `app/build/thumbnail/tests/candidates.js`, `app/build/dependencies/tests/index.js`, `app/models/entry/tests/search.js`, and `app/models/entry/tests/urlDeduplication.js`.

### Testing

- Ran unit specs with Jasmine via: `NODE_PATH=app npx jasmine app/helper/tests/metadataCaseInsensitive.js app/build/prepare/tests/index.js app/build/prepare/dateStamp/tests/index.js app/build/thumbnail/tests/candidates.js app/build/dependencies/tests/index.js` which completed successfully (Jasmine output: 27 specs, 0 failures, with a Redis connection warning in this environment).
- Attempted the project test harness (`npm test -- app/build/prepare/tests/index.js`) but it cannot run in this environment because the repository test script uses Docker; the command failed due to Docker being unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996d8dec8c8832984e5fed90f75baac)