### PR TITLE
Fix render metadata object guard in augment

### DIFF
--- a/app/blog/render/load/augment.js
+++ b/app/blog/render/load/augment.js
@@ -142,7 +142,7 @@ module.exports = function (req, res, entry, callback) {
 };
 
 function createRenderMetadata(sourceMetadata) {
-  if (!sourceMetadata || type(sourceMetadata, "object") !== "object") {
+  if (!sourceMetadata || !type(sourceMetadata, "object")) {
     return sourceMetadata;
   }
 


### PR DESCRIPTION
### Motivation
- Fix a broken object-ness check in `createRenderMetadata` so non-object metadata is returned unchanged and lowercase aliasing only runs for real objects.

### Description
- Replace the guard with `if (!sourceMetadata || !type(sourceMetadata, "object")) return sourceMetadata;` while preserving lowercase-key precedence and the non-mutating copy via `Object.assign({}, sourceMetadata)`.

### Testing
- Attempted to run `./scripts/tests/invoke.sh app/blog/render/tests/augment.js` (failed: `docker: command not found`) and `node scripts/tests app/blog/render/tests/augment.js` (failed: `Cannot find module 'models/client'`), so automated tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996e45d74808329bb25d7d16ce45af5)