### PR TITLE
Harden Disqus metadata lookup with lowercase metadata view

### DIFF
--- a/app/blog/entry.js
+++ b/app/blog/entry.js
@@ -34,6 +34,7 @@ module.exports = function (request, response, next) {
     // 1. Blog post metadata DOES have  'Comments: No'
     // 2. Page metadata DOES NOT have   'Comments: Yes'
     var metadataByLowercaseKey = metadataCaseInsensitive(entry.metadata);
+    entry.metadataLowercase = metadataByLowercaseKey;
 
     if (
       metadataByLowercaseKey.comments === "No" ||

--- a/app/build/plugins/disqus/entry.html
+++ b/app/build/plugins/disqus/entry.html
@@ -1,12 +1,12 @@
 <div id="disqus_thread"></div>
 <script type="text/javascript">
     var disqus_shortname = '{{plugins.disqus.options.shortname}}';
-    {{#entry.metadata.disqus}}
-    var disqus_identifier = '{{entry.metadata.disqus}}';
-    {{/entry.metadata.disqus}}
-    {{^entry.metadata.disqus}}
+    {{#entry.metadataLowercase.disqus}}
+    var disqus_identifier = '{{entry.metadataLowercase.disqus}}';
+    {{/entry.metadataLowercase.disqus}}
+    {{^entry.metadataLowercase.disqus}}
     var disqus_identifier = '{{entry.guid}}';
-    {{/entry.metadata.disqus}}
+    {{/entry.metadataLowercase.disqus}}
     var disqus_title = '{{entry.title}}';
 
     (function() {


### PR DESCRIPTION
### Motivation
- Prevent regressions where mixed-case metadata keys (e.g. `Disqus`) fail to resolve when plugin partials are rendered due to aliasing changes. 
- Provide a stable, case-insensitive metadata view that templates can reliably consume during render time.

### Description
- Derive a case-insensitive metadata view via `helper/metadataCaseInsensitive` and expose it as `entry.metadataLowercase` in the entry render path (`app/blog/entry.js`).
- Update the Disqus plugin partial to read `disqus_identifier` from `entry.metadataLowercase.disqus` in `app/build/plugins/disqus/entry.html`.
- Preserve the existing fallback to `entry.guid` when no Disqus metadata key is present, and make no other behavioral changes.

### Testing
- Attempted to run the plugin HTML test suite with `npm test -- app/blog/tests/pluginHTML.js`, but the test harness could not run here because `docker` is not available, so automated tests could not be executed in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996e46bb3b883298b459f5edd2ebdd3)