### PR TITLE
Add folder upload preview modal with overwrite controls

### DIFF
--- a/app/dashboard/site/folder/upload.js
+++ b/app/dashboard/site/folder/upload.js
@@ -97,6 +97,38 @@ const getMetadataLookups = (body = {}) => {
   return { byIndex, byField, byFieldIndex };
 };
 
+const parseBoolean = (value) => {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value === 1;
+  if (typeof value !== "string") return false;
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+};
+
+const getOverwriteSet = (body = {}) => {
+  const overwriteAll = parseBoolean(body.overwrite);
+  const payload =
+    body.overwritePaths ||
+    body.overwriteList ||
+    body.overwriteFiles ||
+    parseJSON(body.overwritePaths) ||
+    parseJSON(body.overwriteList) ||
+    parseJSON(body.overwriteFiles);
+
+  const overwriteSet = new Set();
+
+  if (Array.isArray(payload)) {
+    payload.forEach((item) => {
+      if (typeof item === "string" && item.trim()) {
+        overwriteSet.add(item.normalize("NFC").replace(/\\/g, "/").replace(/^\/+/, ""));
+      }
+    });
+  }
+
+  return { overwriteAll, overwriteSet };
+};
+
 const resolveRelativePath = (upload, globalIndex, lookups) => {
   const fromLookup =
     lookups.byFieldIndex.get(`${upload.field}:${upload.index}`) ||
@@ -144,6 +176,7 @@ const writeClientFile = (client, blogID, relativePath, contents) =>
 module.exports = async (req, res, next) => {
   const uploads = collectFiles(req.files);
   const lookups = getMetadataLookups(req.body || {});
+  const overwriteConfig = getOverwriteSet(req.body || {});
   const dryRun =
     req.body.dryRun === "1" ||
     req.body.dryRun === "true" ||
@@ -223,6 +256,21 @@ module.exports = async (req, res, next) => {
     const results = [];
 
     for (const entry of existingChecks) {
+      const canOverwrite =
+        !entry.exists ||
+        overwriteConfig.overwriteAll ||
+        overwriteConfig.overwriteSet.has(entry.relativePath);
+
+      if (!canOverwrite) {
+        results.push({
+          path: entry.relativePath,
+          overwritten: false,
+          skipped: true,
+          reason: "overwrite_not_allowed",
+        });
+        continue;
+      }
+
       let contents;
 
       try {

--- a/app/views/dashboard/folder/directory.html
+++ b/app/views/dashboard/folder/directory.html
@@ -77,10 +77,63 @@
           </tr>
           {{/contents}}
         </table>
+
+      <div class="upload-preview-modal" hidden>
+        <div class="upload-preview-modal-backdrop" data-upload-modal-close></div>
+        <div class="upload-preview-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="upload-preview-title">
+          <h2 id="upload-preview-title">Review upload</h2>
+          <p class="upload-preview-summary"></p>
+
+          <details class="upload-preview-section" open>
+            <summary>Incoming files (<span data-upload-count="incoming">0</span>)</summary>
+            <ul class="upload-preview-list" data-upload-list="incoming"></ul>
+          </details>
+
+          <details class="upload-preview-section" data-upload-section="overwrite" open>
+            <summary>Will overwrite (<span data-upload-count="overwrite">0</span>)</summary>
+            <ul class="upload-preview-list" data-upload-list="overwrite"></ul>
+          </details>
+
+          <details class="upload-preview-section" data-upload-section="rejected" open>
+            <summary>Skipped/rejected (<span data-upload-count="rejected">0</span>)</summary>
+            <ul class="upload-preview-list" data-upload-list="rejected"></ul>
+          </details>
+
+          <details class="upload-preview-section" data-upload-section="failures" open hidden>
+            <summary>Upload failures (<span data-upload-count="failures">0</span>)</summary>
+            <ul class="upload-preview-list" data-upload-list="failures"></ul>
+          </details>
+
+          <div class="buttons upload-preview-actions">
+            <button type="button" data-upload-action="cancel">Cancel</button>
+            <button type="button" data-upload-action="safe">Upload safe files only</button>
+            <button type="button" data-upload-action="overwrite">Upload and overwrite</button>
+          </div>
+        </div>
+      </div>
         <script>
           const table = document.querySelector('.directory-list');
           const folderBox = document.querySelector('.folder-box.directory');
           const dropTarget = document.querySelector('.folder-drop-target');
+          const uploadModal = document.querySelector('.upload-preview-modal');
+          const uploadModalSummary = uploadModal && uploadModal.querySelector('.upload-preview-summary');
+          const uploadModalLists = {
+            incoming: uploadModal && uploadModal.querySelector('[data-upload-list="incoming"]'),
+            overwrite: uploadModal && uploadModal.querySelector('[data-upload-list="overwrite"]'),
+            rejected: uploadModal && uploadModal.querySelector('[data-upload-list="rejected"]'),
+            failures: uploadModal && uploadModal.querySelector('[data-upload-list="failures"]')
+          };
+          const uploadModalCounts = {
+            incoming: uploadModal && uploadModal.querySelector('[data-upload-count="incoming"]'),
+            overwrite: uploadModal && uploadModal.querySelector('[data-upload-count="overwrite"]'),
+            rejected: uploadModal && uploadModal.querySelector('[data-upload-count="rejected"]'),
+            failures: uploadModal && uploadModal.querySelector('[data-upload-count="failures"]')
+          };
+          const uploadModalSections = {
+            overwrite: uploadModal && uploadModal.querySelector('[data-upload-section="overwrite"]'),
+            rejected: uploadModal && uploadModal.querySelector('[data-upload-section="rejected"]'),
+            failures: uploadModal && uploadModal.querySelector('[data-upload-section="failures"]')
+          };
           const csrfToken = '{{csrftoken}}';
           
           const state = {
@@ -276,9 +329,12 @@
             });
           }
 
-          function buildUploadFormData(collectedFiles, dryRun) {
+          function buildUploadFormData(collectedFiles, options) {
             var formData = new FormData();
             var relativePaths = [];
+            var overwritePaths = (options && options.overwritePaths) || [];
+            var overwriteAll = !!(options && options.overwriteAll);
+            var dryRun = !!(options && options.dryRun);
 
             collectedFiles.forEach(function (entry, index) {
               var field = 'upload-' + index;
@@ -292,10 +348,128 @@
             });
 
             formData.append('relativePaths', JSON.stringify(relativePaths));
+            formData.append('overwrite', overwriteAll ? 'true' : 'false');
+            formData.append('overwritePaths', JSON.stringify(overwritePaths));
             formData.append('dryRun', dryRun ? 'true' : 'false');
             formData.append('_csrf', csrfToken);
 
             return formData;
+          }
+
+          function clearList(list) {
+            if (list) list.innerHTML = '';
+          }
+
+          function renderList(list, items, mapFn) {
+            clearList(list);
+            if (!list || !items || !items.length) return;
+
+            items.forEach(function (item) {
+              var li = document.createElement('li');
+              li.textContent = mapFn ? mapFn(item) : item;
+              list.appendChild(li);
+            });
+          }
+
+          function updateCount(key, count) {
+            if (uploadModalCounts[key]) {
+              uploadModalCounts[key].textContent = String(count || 0);
+            }
+          }
+
+          function setSectionVisibility(section, visible) {
+            if (section) section.hidden = !visible;
+          }
+
+          function renderUploadPreview(collectedFiles, preview) {
+            var incomingPaths = collectedFiles.map(function (entry) { return entry.relativePath; });
+            var overwritePaths = (preview && preview.overwrite) || [];
+            var rejected = (preview && preview.rejected) || [];
+
+            renderList(uploadModalLists.incoming, incomingPaths);
+            renderList(uploadModalLists.overwrite, overwritePaths);
+            renderList(uploadModalLists.rejected, rejected, function (entry) {
+              var label = entry.relativePath || entry.filename || '(unknown file)';
+              return entry.reason ? label + ' — ' + entry.reason : label;
+            });
+            clearList(uploadModalLists.failures);
+
+            updateCount('incoming', incomingPaths.length);
+            updateCount('overwrite', overwritePaths.length);
+            updateCount('rejected', rejected.length);
+            updateCount('failures', 0);
+
+            setSectionVisibility(uploadModalSections.overwrite, overwritePaths.length > 0);
+            setSectionVisibility(uploadModalSections.rejected, rejected.length > 0);
+            setSectionVisibility(uploadModalSections.failures, false);
+
+            if (uploadModalSummary) {
+              uploadModalSummary.textContent = 'Create ' + ((preview && preview.create) || []).length + ', overwrite ' + overwritePaths.length + ', skipped/rejected ' + rejected.length + '.';
+            }
+          }
+
+          function openUploadModal() {
+            if (!uploadModal) return;
+            uploadModal.hidden = false;
+            document.body.classList.add('upload-modal-open');
+          }
+
+          function closeUploadModal() {
+            if (!uploadModal) return;
+            uploadModal.hidden = true;
+            document.body.classList.remove('upload-modal-open');
+          }
+
+          function collectFailures(result) {
+            var failures = [];
+
+            ((result && result.results) || []).forEach(function (entry) {
+              if (entry.skipped) {
+                failures.push(entry.path + ' — skipped (overwrite disabled)');
+              } else if (entry.local && entry.local.success === false) {
+                failures.push(entry.path + ' — local write failed: ' + (entry.local.error || 'Unknown error'));
+              } else if (entry.client && entry.client.success === false) {
+                failures.push(entry.path + ' — remote sync failed: ' + (entry.client.error || 'Unknown error'));
+              }
+            });
+
+            ((result && result.rejected) || []).forEach(function (entry) {
+              var label = entry.relativePath || entry.filename || '(unknown file)';
+              failures.push(label + ' — rejected: ' + (entry.reason || 'unknown'));
+            });
+
+            return failures;
+          }
+
+          function commitUpload(collectedFiles, options) {
+            return fetch('{{{base}}}/folder/upload', {
+              method: 'POST',
+              body: buildUploadFormData(collectedFiles, {
+                dryRun: false,
+                overwriteAll: !!(options && options.overwriteAll),
+                overwritePaths: (options && options.overwritePaths) || []
+              })
+            })
+              .then(function (response) {
+                if (!response.ok) throw new Error('Upload failed');
+                return response.json();
+              })
+              .then(function (result) {
+                var failures = collectFailures(result);
+
+                if (failures.length) {
+                  renderList(uploadModalLists.failures, failures);
+                  updateCount('failures', failures.length);
+                  setSectionVisibility(uploadModalSections.failures, true);
+                  if (uploadModalSummary) {
+                    uploadModalSummary.textContent = 'Upload finished with ' + failures.length + ' issue(s).';
+                  }
+                } else {
+                  closeUploadModal();
+                }
+
+                refreshFolderContents();
+              });
           }
 
           function uploadDroppedFiles(collectedFiles) {
@@ -303,38 +477,66 @@
 
             return fetch('{{{base}}}/folder/upload?dryRun=1', {
               method: 'POST',
-              body: buildUploadFormData(collectedFiles, true)
+              body: buildUploadFormData(collectedFiles, { dryRun: true })
             })
               .then(function (response) {
                 if (!response.ok) throw new Error('Upload dry-run failed');
                 return response.json();
               })
               .then(function (preview) {
-                var createCount = (preview.create || []).length;
-                var overwriteCount = (preview.overwrite || []).length;
-                var rejectedCount = (preview.rejected || []).length;
-                var shouldCommit = window.confirm(
-                  'Upload ' + collectedFiles.length + ' file(s)?\\n' +
-                  'Create: ' + createCount + '\\n' +
-                  'Overwrite: ' + overwriteCount + '\\n' +
-                  'Rejected: ' + rejectedCount
-                );
+                renderUploadPreview(collectedFiles, preview);
+                openUploadModal();
 
-                if (!shouldCommit) return null;
+                return new Promise(function (resolve, reject) {
+                  function cleanup() {
+                    if (uploadModal) uploadModal.removeEventListener('click', onClick);
+                  }
 
-                return fetch('{{{base}}}/folder/upload', {
-                  method: 'POST',
-                  body: buildUploadFormData(collectedFiles, false)
+                  function onClick(event) {
+                    var close = event.target.closest('[data-upload-modal-close]');
+                    if (close) {
+                      cleanup();
+                      closeUploadModal();
+                      resolve();
+                      return;
+                    }
+
+                    var button = event.target.closest('[data-upload-action]');
+                    if (!button) return;
+
+                    var action = button.getAttribute('data-upload-action');
+                    if (action === 'cancel') {
+                      cleanup();
+                      closeUploadModal();
+                      resolve();
+                      return;
+                    }
+
+                    if (action !== 'safe' && action !== 'overwrite') return;
+
+                    var overwritePaths = action === 'overwrite' ? ((preview && preview.overwrite) || []) : [];
+                    var overwriteAll = action === 'overwrite';
+                    button.disabled = true;
+
+                    commitUpload(collectedFiles, {
+                      overwriteAll: overwriteAll,
+                      overwritePaths: overwritePaths
+                    }).then(function () {
+                      button.disabled = false;
+                      if (uploadModal && uploadModal.hidden) cleanup();
+                      resolve();
+                    }).catch(function (err) {
+                      button.disabled = false;
+                      reject(err);
+                    });
+                  }
+
+                  if (uploadModal) {
+                    uploadModal.addEventListener('click', onClick);
+                  } else {
+                    resolve();
+                  }
                 });
-              })
-              .then(function (response) {
-                if (!response) return;
-                if (!response.ok) throw new Error('Upload failed');
-                return response.json();
-              })
-              .then(function (result) {
-                if (!result) return;
-                refreshFolderContents();
               });
           }
 

--- a/app/views/dashboard/folder/folder.css
+++ b/app/views/dashboard/folder/folder.css
@@ -277,3 +277,58 @@
 .directory-list th.sorted.reverse::after {
   background: url('data:image/svg+xml, <svg xmlns="http://www.w3.org/2000/svg" style="opacity:0.3" viewBox="0 0 12 12" width="12" height="12"><path d="M6 8.825c-.2 0-.4-.1-.5-.2l-3.3-3.3c-.3-.3-.3-.8 0-1.1.3-.3.8-.3 1.1 0l2.7 2.7 2.7-2.7c.3-.3.8-.3 1.1 0 .3.3.3.8 0 1.1l-3.2 3.2c-.2.2-.4.3-.6.3Z"></path></svg> ');
 }
+
+.upload-preview-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.upload-preview-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.28);
+}
+
+.upload-preview-modal-dialog {
+  position: relative;
+  width: min(680px, calc(100vw - 2rem));
+  max-height: calc(100vh - 4rem);
+  overflow: auto;
+  background: var(--background-color);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 1rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.upload-preview-summary {
+  color: var(--light-text-color);
+  margin: 0.25rem 0 1rem;
+}
+
+.upload-preview-section {
+  margin: 0.5rem 0;
+}
+
+.upload-preview-section summary {
+  cursor: pointer;
+}
+
+.upload-preview-list {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+  color: var(--light-text-color);
+  font-size: 0.95rem;
+}
+
+.upload-preview-actions {
+  margin-top: 1rem;
+}
+
+body.upload-modal-open {
+  overflow: hidden;
+}


### PR DESCRIPTION
### Motivation
- Give users a clear dry-run preview of files being uploaded so they can inspect which files will be created, overwritten, or rejected before committing. 
- Provide explicit overwrite controls so uploads can either skip existing files or explicitly overwrite a selected set or everything. 
- Surface per-file failures after a commit attempt so problems (local write or remote sync) are visible and actionable in the same UI.

### Description
- Add an upload preview modal in `app/views/dashboard/folder/directory.html` that renders dry-run results into distinct sections for `Incoming`, `Will overwrite`, `Skipped/rejected` and `Upload failures`, and replaces the previous `window.confirm` flow with modal-driven actions. 
- Wire modal actions to the upload flow so dry-run results are shown, and commit requests are sent with explicit overwrite intent using `overwrite` and `overwritePaths` form fields; client-side code now renders post-upload failures into the modal. 
- Extend server upload handler in `app/dashboard/site/folder/upload.js` to parse boolean/array overwrite inputs (`parseBoolean`, `getOverwriteSet`), honor `overwrite`/`overwritePaths`, and return structured `results` including skipped entries (reason: `overwrite_not_allowed`) for UI reporting. 
- Add minimal modal styles to `app/views/dashboard/folder/folder.css` to match existing dashboard visual language and reuse `details/summary` patterns for sections.

### Testing
- Ran `node --check app/dashboard/site/folder/upload.js` to validate the backend JS syntax and it succeeded. 
- Ran `git diff --check` (whitespace/patch checks) and it reported no issues. 
- Attempted an automated browser capture via Playwright to visually validate the modal, but the local app at `http://127.0.0.1:3000` was not reachable (`net::ERR_EMPTY_RESPONSE`), so end-to-end UI validation could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996e54368d8832998cffdd26d168aff)