### PR TITLE
Handle metadata overwrite keys case-insensitively

### DIFF
--- a/app/build/prepare/index.js
+++ b/app/build/prepare/index.js
@@ -203,11 +203,16 @@ function Prepare (entry, options = {}) {
 
   debug(entry.path, "Generating meta-overwrite");
 
-  for (var key in entry.metadata) {
-    const normalizedKey = key.toLowerCase();
+  const modelKeyByLower = Object.keys(Model).reduce((acc, modelKey) => {
+    acc[modelKey.toLowerCase()] = modelKey;
+    return acc;
+  }, {});
 
-    if (canOverwrite(normalizedKey) && type(entry.metadata[key], Model[normalizedKey]))
-      entry[normalizedKey] = entry.metadata[key];
+  for (var key in entry.metadata) {
+    const canonical = modelKeyByLower[key.toLowerCase()];
+
+    if (canOverwrite(canonical) && type(entry.metadata[key], Model[canonical]))
+      entry[canonical] = entry.metadata[key];
   }
 
   debug(entry.path, "Generated  meta-overwrite");

--- a/app/build/prepare/tests/index.js
+++ b/app/build/prepare/tests/index.js
@@ -78,6 +78,47 @@ describe("prepare", function () {
     expect(entry.permalink).toEqual("/mixed-case");
   });
 
+
+
+  it("overwrites titleTag from canonical metadata key", function () {
+    var entry = this.entry;
+
+    entry.html = "<h1>Generated title</h1><p>Body</p>";
+    entry.metadata = {
+      titleTag: "Metadata title tag"
+    };
+
+    prepare(entry);
+
+    expect(entry.titleTag).toEqual("Metadata title tag");
+  });
+
+  it("overwrites titleTag from mixed-case metadata key", function () {
+    var entry = this.entry;
+
+    entry.html = "<h1>Generated title</h1><p>Body</p>";
+    entry.metadata = {
+      TitleTag: "Mixed case metadata title tag"
+    };
+
+    prepare(entry);
+
+    expect(entry.titleTag).toEqual("Mixed case metadata title tag");
+  });
+
+  it("overwrites teaserBody from metadata", function () {
+    var entry = this.entry;
+
+    entry.html = "<p>Generated teaser body</p>";
+    entry.metadata = {
+      teaserBody: "Metadata teaser body"
+    };
+
+    prepare(entry);
+
+    expect(entry.teaserBody).toEqual("Metadata teaser body");
+  });
+
   it("generates an empty title when given an empty file", function () {
     var entry = this.entry;
 


### PR DESCRIPTION
### Motivation
- Metadata overwrites should match model keys case-insensitively but preserve the canonical model key casing when applying overrides.

### Description
- Build a lowercase-to-canonical map from `Object.keys(Model)` and resolve incoming metadata keys through that map before processing.
- Use the canonical model key for `canOverwrite(...)`, `type(...)` checks and assignment so overrides are written to `entry` with the canonical casing (e.g. `titleTag`).
- Add regression tests to cover canonical and mixed-case metadata keys: `titleTag`, `TitleTag`, and `teaserBody`.

### Testing
- Ran `NODE_PATH=app npx jasmine app/build/prepare/tests/index.js`, which executed the prepare tests and passed (`8 specs, 0 failures`).
- Attempted `npm test -- app/build/prepare/tests` but it could not complete in this environment because `docker` is unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996f522bd108329a2906c0039757a8e)