### PR TITLE
Deterministic cleanup for upload modal listeners in directory view

### DIFF
--- a/app/dashboard/tests/folder-upload-modal-listener.js
+++ b/app/dashboard/tests/folder-upload-modal-listener.js
@@ -1,0 +1,125 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function extractNamedFunction(source, functionName) {
+  const signature = `function ${functionName}(`;
+  const start = source.indexOf(signature);
+
+  if (start === -1) {
+    throw new Error(`Could not find ${functionName} in template`);
+  }
+
+  const braceStart = source.indexOf('{', start);
+
+  let depth = 0;
+  let end = braceStart;
+
+  for (; end < source.length; end += 1) {
+    const char = source[end];
+    if (char === '{') depth += 1;
+    if (char === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+
+  return source.slice(start, end);
+}
+
+function createModalEvent(action) {
+  const button = {
+    disabled: false,
+    getAttribute: (name) => (name === 'data-upload-action' ? action : null),
+  };
+
+  return {
+    target: {
+      closest: (selector) => {
+        if (selector === '[data-upload-modal-close]') return null;
+        if (selector === '[data-upload-action]') return button;
+        return null;
+      },
+    },
+  };
+}
+
+describe('folder directory upload modal listener lifecycle', function () {
+  it('does not keep stale action listeners across upload attempts after partial failure', async function () {
+    const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+    const templatePath = path.join(
+      __dirname,
+      '../../views/dashboard/folder/directory.html'
+    );
+    const templateSource = fs.readFileSync(templatePath, 'utf8');
+    const uploadDroppedFilesSource = extractNamedFunction(
+      templateSource,
+      'uploadDroppedFiles'
+    );
+
+    const clickListeners = new Set();
+    const uploadModal = {
+      hidden: false,
+      addEventListener: (event, handler) => {
+        if (event === 'click') clickListeners.add(handler);
+      },
+      removeEventListener: (event, handler) => {
+        if (event === 'click') clickListeners.delete(handler);
+      },
+    };
+
+    let commitCount = 0;
+
+    const context = {
+      Promise,
+      fetch: () =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ overwrite: ['existing.txt'] }),
+        }),
+      buildUploadFormData: () => ({}),
+      renderUploadPreview: () => {},
+      openUploadModal: () => {
+        uploadModal.hidden = false;
+      },
+      closeUploadModal: () => {
+        uploadModal.hidden = true;
+      },
+      uploadModal,
+      commitUpload: () => {
+        commitCount += 1;
+        // Simulate partial-failure UX where modal remains visible.
+        uploadModal.hidden = false;
+        return Promise.resolve();
+      },
+      '{{{base}}}': '',
+    };
+
+    vm.runInNewContext(
+      `${uploadDroppedFilesSource}\nthis.uploadDroppedFiles = uploadDroppedFiles;`,
+      context
+    );
+
+    const collectedFiles = [{ file: { name: 'example.txt' }, relativePath: 'example.txt' }];
+
+    const firstAttempt = context.uploadDroppedFiles(collectedFiles);
+    await flush();
+    clickListeners.forEach((handler) => handler(createModalEvent('safe')));
+    await firstAttempt;
+
+    expect(commitCount).toBe(1);
+    expect(clickListeners.size).toBe(0);
+
+    const secondAttempt = context.uploadDroppedFiles(collectedFiles);
+    await flush();
+    clickListeners.forEach((handler) => handler(createModalEvent('safe')));
+    await secondAttempt;
+
+    expect(commitCount).toBe(2);
+    expect(clickListeners.size).toBe(0);
+  });
+});

--- a/app/views/dashboard/folder/directory.html
+++ b/app/views/dashboard/folder/directory.html
@@ -488,16 +488,24 @@
                 openUploadModal();
 
                 return new Promise(function (resolve, reject) {
+                  var finished = false;
+
                   function cleanup() {
                     if (uploadModal) uploadModal.removeEventListener('click', onClick);
+                  }
+
+                  function finish(done, value) {
+                    if (finished) return;
+                    finished = true;
+                    cleanup();
+                    done(value);
                   }
 
                   function onClick(event) {
                     var close = event.target.closest('[data-upload-modal-close]');
                     if (close) {
-                      cleanup();
                       closeUploadModal();
-                      resolve();
+                      finish(resolve);
                       return;
                     }
 
@@ -506,9 +514,8 @@
 
                     var action = button.getAttribute('data-upload-action');
                     if (action === 'cancel') {
-                      cleanup();
                       closeUploadModal();
-                      resolve();
+                      finish(resolve);
                       return;
                     }
 
@@ -523,18 +530,17 @@
                       overwritePaths: overwritePaths
                     }).then(function () {
                       button.disabled = false;
-                      if (uploadModal && uploadModal.hidden) cleanup();
-                      resolve();
+                      finish(resolve);
                     }).catch(function (err) {
                       button.disabled = false;
-                      reject(err);
+                      finish(reject, err);
                     });
                   }
 
                   if (uploadModal) {
                     uploadModal.addEventListener('click', onClick);
                   } else {
-                    resolve();
+                    finish(resolve);
                   }
                 });
               });


### PR DESCRIPTION
### Motivation

- The upload preview modal installed click listeners per invocation but teardown was not guaranteed on every resolve/reject path, allowing stale handlers to persist across attempts. 
- This caused duplicated handler invocations when a prior upload left the modal visible (partial-failure UX). 
- The goal is to ensure ownership of the listener is per-invocation and cleanup is always deterministic while preserving the existing modal UX.

### Description

- Refactor `uploadDroppedFiles` in `app/views/dashboard/folder/directory.html` to introduce a `finished` flag and a single `finish(done, value)` helper that always calls `cleanup()` before resolving or rejecting the Promise. 
- Move listener lifecycle to a single ownership pattern by adding the `click` listener once per `uploadDroppedFiles` invocation and removing it via `cleanup()` when that invocation finishes. 
- Preserve the UX where the modal can remain visible after `commitUpload` returns failures, while ensuring the invocation's handler is detached so no stale handlers are reused. 
- Add a regression test `app/dashboard/tests/folder-upload-modal-listener.js` that extracts and executes the `uploadDroppedFiles` function, simulates a partial-failure first attempt, runs a second attempt, and verifies only the intended handler fires on the second attempt.

### Testing

- Ran the new regression test with `npx jasmine app/dashboard/tests/folder-upload-modal-listener.js`, which passed. 
- Ran `npx jasmine app/dashboard/tests/folder-upload.js` which fails in this environment due to a test-runtime mismatch (existing tests use Jasmine helpers like `and.resolveTo` / `and.rejectWith` not available in the installed Jasmine version), so unrelated upstream test adjustments are required to run that suite here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996f97aa9d48329b8341b67b244b919)