### PR TITLE
Normalize comment-toggle metadata parsing

### DIFF
--- a/app/blog/entry.js
+++ b/app/blog/entry.js
@@ -4,6 +4,11 @@ var plugins = require("build/plugins");
 var Entries = require("models/entries");
 var metadataCaseInsensitive = require("helper/metadataCaseInsensitive");
 
+var normalizeMetadataToggle = function (value) {
+  if (typeof value === "undefined" || value === null) return "";
+  return String(value).trim().toLowerCase();
+};
+
 module.exports = function (request, response, next) {
   
   request.log("Loading entry");
@@ -35,10 +40,11 @@ module.exports = function (request, response, next) {
     // 2. Page metadata DOES NOT have   'Comments: Yes'
     var metadataByLowercaseKey = metadataCaseInsensitive(entry.metadata);
     entry.metadataLowercase = metadataByLowercaseKey;
+    var commentsToggle = normalizeMetadataToggle(metadataByLowercaseKey.comments);
 
     if (
-      metadataByLowercaseKey.comments === "No" ||
-      (metadataByLowercaseKey.comments !== "Yes" && entry.page)
+      commentsToggle === "no" ||
+      (commentsToggle !== "yes" && entry.page)
     ) {
       delete blog.plugins.commento;
       delete blog.plugins.disqus;

--- a/app/blog/tests/pluginHTML.js
+++ b/app/blog/tests/pluginHTML.js
@@ -88,6 +88,29 @@ describe("pluginHTML", function () {
         expect(await areThereComments('/foo')).toBe(false, 'comments should not appear on posts with comments disabled');
     });
 
+    it("normalizes comment metadata toggles", async function () {
+
+        const plugins = {...this.blog.plugins, commento: {enabled: true, options: {}}};
+        await this.blog.update({plugins})
+
+        await this.template({ "entry.html": "{{{entry.html}}} {{> pluginHTML}}" });
+        await this.write({path: '/post-no.txt', content: 'Link: /post-no\nComments: no\n\nHello, world!'});
+        await this.write({path: '/post-mixed-no.txt', content: 'Link: /post-mixed-no\ncOmMeNtS: nO\n\nHello, world!'});
+        await this.write({path: '/Pages/page-mixed-yes.txt', content: 'Link: /page-mixed-yes\ncOmMeNtS: YeS\n\nHello, page!'});
+        await this.write({path: '/Pages/page-whitespace-yes.txt', content: 'Link: /page-whitespace-yes\nComments:  yes \n\nHello, page!'});
+
+        const areThereComments = async (path) => {
+            const res = await this.get(path);
+            const body = await res.text();
+            return body.includes('<script defer') && body.includes('src="https://cdn.commento.io/js/commento.js"');
+        }
+
+        expect(await areThereComments('/post-no')).toBe(false, 'comments should not appear on posts with lowercase no');
+        expect(await areThereComments('/post-mixed-no')).toBe(false, 'comments should not appear on posts with mixed case no');
+        expect(await areThereComments('/page-mixed-yes')).toBe(true, 'comments should appear on pages with mixed case yes');
+        expect(await areThereComments('/page-whitespace-yes')).toBe(true, 'comments should appear on pages with whitespace around yes');
+    });
+
     it("injects google analytics into appJS", async function () {
 
         const plugins = {...this.blog.plugins, analytics: {enabled: true, options: {provider: {Google: true}, trackingID: 'UA-12345678-9'}}};


### PR DESCRIPTION
### Motivation
- Ensure `Comments` metadata is interpreted consistently across case and whitespace so values like `yes`, `no`, `Yes`, `No`, and `  yes ` behave predictably and pages still require an explicit `yes` to enable comments.

### Description
- Add a local helper `normalizeMetadataToggle` in `app/blog/entry.js` that safely coerces metadata values via `String(value).trim().toLowerCase()` and handles `undefined`/`null`.
- Replace direct string comparisons with normalized checks so `commentsToggle === "no"` disables comments and `commentsToggle === "yes"` enables them, while preserving the existing page default semantics.
- Extend `app/blog/tests/pluginHTML.js` with a new spec covering lowercase `Comments: no`, mixed-case `cOmMeNtS: YeS`/`nO`, and a whitespace case `Comments:  yes ` alongside existing fixtures.

### Testing
- Added automated test cases in `app/blog/tests/pluginHTML.js` to cover normalization scenarios and existing `Comments: Yes`/`Comments: No` fixtures.
- Attempted to run `npm test -- app/blog/tests/pluginHTML.js`, but the test harness failed in this environment because `docker` is not available, so the new tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996fdb5d4a48329b8a922b02ae12297)