### PR TITLE
Harden metadataCaseInsensitive against invalid inputs

### DIFF
--- a/app/helper/metadataCaseInsensitive.js
+++ b/app/helper/metadataCaseInsensitive.js
@@ -1,4 +1,8 @@
 module.exports = function metadataCaseInsensitive (metadata) {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return {};
+  }
+
   const view = {};
 
   Object.keys(metadata)

--- a/app/helper/tests/metadataCaseInsensitive.js
+++ b/app/helper/tests/metadataCaseInsensitive.js
@@ -17,6 +17,18 @@ describe("metadataCaseInsensitive", function () {
     });
   });
 
+
+  it("returns empty object for undefined", function () {
+    expect(metadataCaseInsensitive(undefined)).toEqual({});
+  });
+
+  it("returns empty object for null", function () {
+    expect(metadataCaseInsensitive(null)).toEqual({});
+  });
+
+  it("returns empty object for arrays", function () {
+    expect(metadataCaseInsensitive([])).toEqual({});
+  });
   it("uses first key in deterministic order for collisions", function () {
     const metadata = {
       permalink: "/lower",


### PR DESCRIPTION
### Motivation

- Prevent runtime errors when `metadataCaseInsensitive` is called with unexpected inputs (falsy values, non-objects, or arrays) by making behavior explicit and safe.

### Description

- Add an early guard in `app/helper/metadataCaseInsensitive.js` to return `{}` when `metadata` is falsy, not an object, or an array.
- Preserve the existing behavior for valid object inputs (lowercase key view and deterministic collision handling based on sorted keys).
- Extend `app/helper/tests/metadataCaseInsensitive.js` with tests for `undefined`, `null`, and array inputs while keeping the existing collision-order test.

### Testing

- Ran `npx jasmine app/helper/tests/metadataCaseInsensitive.js` which executed 5 specs with 0 failures.
- Attempted `npm test -- app/helper/tests/metadataCaseInsensitive.js` but the repo test harness requires Docker and the environment lacked `docker`, so that command could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996fdb4dda88329953effefd940a36d)