### PR TITLE
Guard upload modal actions against double submission

### DIFF
--- a/app/dashboard/tests/folder-upload-modal-listener.js
+++ b/app/dashboard/tests/folder-upload-modal-listener.js
@@ -47,6 +47,13 @@ function createModalEvent(action) {
   };
 }
 
+function createModalActionButtons(actions) {
+  return actions.map((action) => ({
+    disabled: false,
+    getAttribute: (name) => (name === 'data-upload-action' ? action : null),
+  }));
+}
+
 describe('folder directory upload modal listener lifecycle', function () {
   it('does not keep stale action listeners across upload attempts after partial failure', async function () {
     const flush = () => new Promise((resolve) => setImmediate(resolve));
@@ -121,5 +128,89 @@ describe('folder directory upload modal listener lifecycle', function () {
 
     expect(commitCount).toBe(2);
     expect(clickListeners.size).toBe(0);
+  });
+
+  it('allows only one submit across rapid multi-clicks on different action buttons', async function () {
+    const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+    const templatePath = path.join(
+      __dirname,
+      '../../views/dashboard/folder/directory.html'
+    );
+    const templateSource = fs.readFileSync(templatePath, 'utf8');
+    const uploadDroppedFilesSource = extractNamedFunction(
+      templateSource,
+      'uploadDroppedFiles'
+    );
+
+    const clickListeners = new Set();
+    const modalActionButtons = createModalActionButtons(['cancel', 'safe', 'overwrite']);
+    const uploadModal = {
+      hidden: false,
+      querySelectorAll: (selector) => {
+        if (selector === '[data-upload-action]') return modalActionButtons;
+        return [];
+      },
+      addEventListener: (event, handler) => {
+        if (event === 'click') clickListeners.add(handler);
+      },
+      removeEventListener: (event, handler) => {
+        if (event === 'click') clickListeners.delete(handler);
+      },
+    };
+
+    let commitCount = 0;
+    let resolveCommit;
+
+    const context = {
+      Promise,
+      fetch: () =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ overwrite: ['existing.txt'] }),
+        }),
+      buildUploadFormData: () => ({}),
+      renderUploadPreview: () => {},
+      openUploadModal: () => {
+        uploadModal.hidden = false;
+      },
+      closeUploadModal: () => {
+        uploadModal.hidden = true;
+      },
+      uploadModal,
+      commitUpload: () => {
+        commitCount += 1;
+        return new Promise((resolve) => {
+          resolveCommit = resolve;
+        });
+      },
+      '{{{base}}}': '',
+    };
+
+    vm.runInNewContext(
+      `${uploadDroppedFilesSource}\nthis.uploadDroppedFiles = uploadDroppedFiles;`,
+      context
+    );
+
+    const collectedFiles = [{ file: { name: 'example.txt' }, relativePath: 'example.txt' }];
+    const attempt = context.uploadDroppedFiles(collectedFiles);
+
+    await flush();
+
+    const listeners = Array.from(clickListeners);
+    listeners.forEach((handler) => handler(createModalEvent('safe')));
+    listeners.forEach((handler) => handler(createModalEvent('overwrite')));
+
+    expect(commitCount).toBe(1);
+    modalActionButtons.forEach((button) => {
+      expect(button.disabled).toBe(true);
+    });
+
+    resolveCommit();
+    await attempt;
+
+    modalActionButtons.forEach((button) => {
+      expect(button.disabled).toBe(false);
+    });
   });
 });

--- a/app/views/dashboard/folder/directory.html
+++ b/app/views/dashboard/folder/directory.html
@@ -489,6 +489,15 @@
 
                 return new Promise(function (resolve, reject) {
                   var finished = false;
+                  var isSubmitting = false;
+
+                  function setModalActionButtonsDisabled(disabled) {
+                    if (!uploadModal || typeof uploadModal.querySelectorAll !== 'function') return;
+
+                    Array.from(uploadModal.querySelectorAll('[data-upload-action]')).forEach(function (actionButton) {
+                      actionButton.disabled = disabled;
+                    });
+                  }
 
                   function cleanup() {
                     if (uploadModal) uploadModal.removeEventListener('click', onClick);
@@ -502,6 +511,8 @@
                   }
 
                   function onClick(event) {
+                    if (isSubmitting) return;
+
                     var close = event.target.closest('[data-upload-modal-close]');
                     if (close) {
                       closeUploadModal();
@@ -523,16 +534,19 @@
 
                     var overwritePaths = action === 'overwrite' ? ((preview && preview.overwrite) || []) : [];
                     var overwriteAll = action === 'overwrite';
-                    button.disabled = true;
+                    isSubmitting = true;
+                    setModalActionButtonsDisabled(true);
 
                     commitUpload(collectedFiles, {
                       overwriteAll: overwriteAll,
                       overwritePaths: overwritePaths
                     }).then(function () {
-                      button.disabled = false;
+                      isSubmitting = false;
+                      setModalActionButtonsDisabled(false);
                       finish(resolve);
                     }).catch(function (err) {
-                      button.disabled = false;
+                      isSubmitting = false;
+                      setModalActionButtonsDisabled(false);
                       finish(reject, err);
                     });
                   }


### PR DESCRIPTION
### Motivation
- Prevent duplicate `commitUpload` calls caused by rapid multi-clicks in the upload confirmation modal during a single modal attempt.
- Ensure consistent UX by disabling all modal action buttons while an upload request is in flight.
- Preserve existing listener cleanup and `finish` lifecycle so retries and re-openings remain leak-free.

### Description
- Added an in-scope flag `isSubmitting` inside `uploadDroppedFiles()` to short-circuit click handling while a submit is active in `app/views/dashboard/folder/directory.html`.
- Added `setModalActionButtonsDisabled(disabled)` and use it to disable all `[data-upload-action]` buttons before calling `commitUpload` for `safe`/`overwrite` actions and to re-enable them in both the success and error paths before calling `finish(...)`.
- Kept the original `cleanup()`/`finish()` logic intact and ensured `isSubmitting` is reset prior to resolving or rejecting so the modal lifecycle remains leak-free.
- Extended the focused unit test file `app/dashboard/tests/folder-upload-modal-listener.js` with a new spec that simulates rapid multi-clicks across different action buttons and asserts a single `commitUpload` invocation per modal attempt and correct button disabled/enabled behavior.

### Testing
- Ran the focused spec with `npx jasmine app/dashboard/tests/folder-upload-modal-listener.js`, which executed the new and existing specs: 2 specs, 0 failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996ff2478588329a7fdddeb2f60a436)