### PR TITLE
Add folder remove route tests and remove-modal UI tests

### DIFF
--- a/app/dashboard/tests/folder-remove-modal-listener.js
+++ b/app/dashboard/tests/folder-remove-modal-listener.js
@@ -1,0 +1,282 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function extractNamedFunction(source, functionName) {
+  const signature = `function ${functionName}(`;
+  const start = source.indexOf(signature);
+  if (start === -1) {
+    throw new Error(`Could not find ${functionName} in template`);
+  }
+
+  const braceStart = source.indexOf('{', start);
+  let depth = 0;
+  let end = braceStart;
+
+  for (; end < source.length; end += 1) {
+    const char = source[end];
+    if (char === '{') depth += 1;
+    if (char === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+
+  return source.slice(start, end);
+}
+
+function extractInlineFunction(source, signature) {
+  const start = source.indexOf(signature);
+  if (start === -1) {
+    throw new Error(`Could not find signature: ${signature}`);
+  }
+
+  const functionStart = source.indexOf('function', start);
+  const braceStart = source.indexOf('{', functionStart);
+  let depth = 0;
+  let end = braceStart;
+
+  for (; end < source.length; end += 1) {
+    const char = source[end];
+    if (char === '{') depth += 1;
+    if (char === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end += 1;
+        break;
+      }
+    }
+  }
+
+  return source.slice(functionStart, end);
+}
+
+describe('folder directory remove modal behavior', function () {
+  it('opens remove modal from menu, closes on cancel without fetch, submits remove and refreshes content', async function () {
+    const templatePath = path.join(__dirname, '../../views/dashboard/folder/directory.html');
+    const templateSource = fs.readFileSync(templatePath, 'utf8');
+
+    const resolveMenuRemovePathSource = extractNamedFunction(templateSource, 'resolveMenuRemovePath');
+    const openRemoveModalSource = extractNamedFunction(templateSource, 'openRemoveModal');
+    const closeRemoveModalSource = extractNamedFunction(templateSource, 'closeRemoveModal');
+    const resetRemoveModalButtonStateSource = extractNamedFunction(templateSource, 'resetRemoveModalButtonState');
+    const setRemoveModalButtonsDisabledSource = extractNamedFunction(templateSource, 'setRemoveModalButtonsDisabled');
+    const commitRemoveSource = extractNamedFunction(templateSource, 'commitRemove');
+    const handleRemoveMenuClickSource = extractNamedFunction(templateSource, 'handleRemoveMenuClick');
+    const handleRemoveModalClickSource = extractNamedFunction(templateSource, 'handleRemoveModalClick');
+
+    const modalButtons = [
+      { disabled: false, getAttribute: (name) => (name === 'data-remove-action' ? 'remove' : null) },
+      { disabled: false, getAttribute: (name) => (name === 'data-remove-action' ? 'cancel' : null) },
+    ];
+
+    const pathLabel = { textContent: '' };
+    const removeModal = {
+      hidden: true,
+      querySelector: (selector) => (selector === '[data-remove-path-label]' ? pathLabel : null),
+      querySelectorAll: (selector) => (selector === '[data-remove-action]' ? modalButtons : []),
+    };
+
+    const fetchCalls = [];
+    let refreshCount = 0;
+
+    const context = {
+      Promise,
+      removeModal,
+      removeTargetPath: null,
+      csrfToken: 'token',
+      fetch: (url, options) => {
+        fetchCalls.push({ url, options });
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+      },
+      refreshFolderContents: () => {
+        refreshCount += 1;
+      },
+      '{{{base}}}': '',
+    };
+
+    vm.runInNewContext(
+      `${resolveMenuRemovePathSource}
+${resetRemoveModalButtonStateSource}
+${setRemoveModalButtonsDisabledSource}
+${openRemoveModalSource}
+${closeRemoveModalSource}
+${commitRemoveSource}
+${handleRemoveMenuClickSource}
+${handleRemoveModalClickSource}
+this.handleRemoveMenuClick = handleRemoveMenuClick;
+this.handleRemoveModalClick = handleRemoveModalClick;`,
+      context
+    );
+
+    const preventDefault = jasmine.createSpy('preventDefault');
+    context.handleRemoveMenuClick({
+      preventDefault,
+      target: {
+        closest: (selector) => {
+          if (selector === '[data-menu-link="remove"]') {
+            return { getAttribute: () => 'action:remove-file:posts%2Fhello.md' };
+          }
+          return null;
+        },
+      },
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(removeModal.hidden).toBe(false);
+    expect(pathLabel.textContent).toBe('posts/hello.md');
+
+    context.handleRemoveModalClick({
+      target: {
+        closest: (selector) => {
+          if (selector === '[data-remove-modal-close]') return null;
+          if (selector === '[data-remove-action]') {
+            return { disabled: false, getAttribute: () => 'cancel' };
+          }
+          return null;
+        },
+      },
+    });
+
+    expect(removeModal.hidden).toBe(true);
+    expect(fetchCalls.length).toBe(0);
+
+    context.handleRemoveMenuClick({
+      preventDefault: () => {},
+      target: {
+        closest: (selector) => {
+          if (selector === '[data-menu-link="remove"]') {
+            return { getAttribute: () => 'action:remove-file:posts%2Fhello.md' };
+          }
+          return null;
+        },
+      },
+    });
+
+    context.handleRemoveModalClick({
+      target: {
+        closest: (selector) => {
+          if (selector === '[data-remove-modal-close]') return null;
+          if (selector === '[data-remove-action]') {
+            return { disabled: false, getAttribute: () => 'remove' };
+          }
+          return null;
+        },
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0].url).toBe('{{{base}}}/folder/remove/posts%2Fhello.md');
+    expect(refreshCount).toBe(1);
+    expect(removeModal.hidden).toBe(true);
+  });
+
+  it('locks remove modal buttons during in-flight request and unlocks on failure', async function () {
+    const flush = () => new Promise((resolve) => setImmediate(resolve));
+    const templatePath = path.join(__dirname, '../../views/dashboard/folder/directory.html');
+    const templateSource = fs.readFileSync(templatePath, 'utf8');
+
+    const setRemoveModalButtonsDisabledSource = extractNamedFunction(templateSource, 'setRemoveModalButtonsDisabled');
+    const resetRemoveModalButtonStateSource = extractNamedFunction(templateSource, 'resetRemoveModalButtonState');
+    const openRemoveModalSource = extractNamedFunction(templateSource, 'openRemoveModal');
+    const handleRemoveModalClickSource = extractNamedFunction(templateSource, 'handleRemoveModalClick');
+
+    const modalButtons = [
+      { disabled: false, getAttribute: (name) => (name === 'data-remove-action' ? 'remove' : null) },
+      { disabled: false, getAttribute: (name) => (name === 'data-remove-action' ? 'cancel' : null) },
+    ];
+
+    const removeModal = {
+      hidden: true,
+      querySelector: () => ({ textContent: '' }),
+      querySelectorAll: (selector) => (selector === '[data-remove-action]' ? modalButtons : []),
+    };
+
+    let rejectCommit;
+    const context = {
+      Promise,
+      removeModal,
+      removeTargetPath: null,
+      commitRemove: () =>
+        new Promise((resolve, reject) => {
+          rejectCommit = reject;
+        }),
+    };
+
+    vm.runInNewContext(
+      `${resetRemoveModalButtonStateSource}
+${setRemoveModalButtonsDisabledSource}
+${openRemoveModalSource}
+${handleRemoveModalClickSource}
+this.openRemoveModal = openRemoveModal;
+this.handleRemoveModalClick = handleRemoveModalClick;`,
+      context
+    );
+
+    context.openRemoveModal('drafts/a.md');
+    context.handleRemoveModalClick({
+      target: {
+        closest: (selector) => {
+          if (selector === '[data-remove-modal-close]') return null;
+          if (selector === '[data-remove-action]') {
+            return { disabled: false, getAttribute: () => 'remove' };
+          }
+          return null;
+        },
+      },
+    });
+
+    modalButtons.forEach((button) => {
+      expect(button.disabled).toBe(true);
+    });
+
+    rejectCommit(new Error('boom'));
+    await flush();
+
+    modalButtons.forEach((button) => {
+      expect(button.disabled).toBe(false);
+    });
+  });
+});
+
+describe('folder directory remove action state', function () {
+  it('keeps remove action disabled for entry rows', function () {
+    const templatePath = path.join(__dirname, '../../views/dashboard/folder/directory.html');
+    const templateSource = fs.readFileSync(templatePath, 'utf8');
+
+    const removeLinkResolverSource = extractInlineFunction(
+      templateSource,
+      "remove: function (dataset)"
+    );
+
+    const context = {};
+
+    vm.runInNewContext(
+      `var removeResolver = ${removeLinkResolverSource};\nthis.removeResolver = removeResolver;`,
+      context
+    );
+
+    const entryResult = context.removeResolver({
+      directory: 'false',
+      entry: 'true',
+      url: '/entry.md',
+    });
+
+    const fileResult = context.removeResolver({
+      directory: 'false',
+      entry: 'false',
+      url: '/plain.md',
+    });
+
+    expect(entryResult.disabled).toBe(true);
+    expect(fileResult.disabled).toBe(false);
+    expect(fileResult.href).toContain('action:remove-file:');
+  });
+});

--- a/app/dashboard/tests/folder-remove.js
+++ b/app/dashboard/tests/folder-remove.js
@@ -1,0 +1,225 @@
+const path = require('path');
+const Module = require('module');
+
+process.env.NODE_PATH = [path.join(__dirname, '../../'), process.env.NODE_PATH || '']
+  .filter(Boolean)
+  .join(path.delimiter);
+Module._initPaths();
+
+const removeRoutePath = require.resolve('../site/folder/remove');
+
+const resolveModulePath = (moduleName) => {
+  try {
+    return require.resolve(moduleName);
+  } catch (err) {
+    return require.resolve(path.join(__dirname, '../../', moduleName));
+  }
+};
+
+const setModuleMock = (moduleName, exportsValue, touched) => {
+  const resolved = resolveModulePath(moduleName);
+  touched.push({ resolved, previous: require.cache[resolved] });
+  require.cache[resolved] = {
+    id: resolved,
+    filename: resolved,
+    loaded: true,
+    exports: exportsValue,
+  };
+};
+
+const setResolvedModuleMock = (resolvedPath, exportsValue, touched) => {
+  touched.push({ resolved: resolvedPath, previous: require.cache[resolvedPath] });
+  require.cache[resolvedPath] = {
+    id: resolvedPath,
+    filename: resolvedPath,
+    loaded: true,
+    exports: exportsValue,
+  };
+};
+
+const restoreModuleMocks = (touched) => {
+  touched.reverse().forEach(({ resolved, previous }) => {
+    if (previous) {
+      require.cache[resolved] = previous;
+    } else {
+      delete require.cache[resolved];
+    }
+  });
+};
+
+const createRes = () => {
+  const res = {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return res;
+};
+
+describe('dashboard folder remove route', function () {
+  let touched;
+  let fs;
+  let establishSyncLock;
+  let folderUpdate;
+  let done;
+  let folderIndexMock;
+
+  beforeEach(function () {
+    touched = [];
+    folderUpdate = jasmine.createSpy('folder.update').and.returnValue(Promise.resolve());
+    done = jasmine.createSpy('done').and.returnValue(Promise.resolve());
+
+    fs = {
+      pathExists: jasmine.createSpy('pathExists').and.returnValue(Promise.resolve(true)),
+      remove: jasmine.createSpy('remove').and.returnValue(Promise.resolve()),
+    };
+
+    establishSyncLock = jasmine
+      .createSpy('establishSyncLock')
+      .and.returnValue(Promise.resolve({ folder: { update: folderUpdate }, done }));
+
+    folderIndexMock = {
+      invalidateCache: jasmine.createSpy('invalidateCache'),
+    };
+
+    setModuleMock('fs-extra', fs, touched);
+    setModuleMock('clients', {}, touched);
+    setModuleMock('sync/establishSyncLock', establishSyncLock, touched);
+    setModuleMock(
+      'helper/localPath',
+      (blogID, relPath) => path.join('/blogs', String(blogID), relPath.replace(/^\/+/, '')),
+      touched
+    );
+    setResolvedModuleMock(require.resolve('../site/folder/index'), folderIndexMock, touched);
+
+    delete require.cache[removeRoutePath];
+  });
+
+  afterEach(function () {
+    delete require.cache[removeRoutePath];
+    restoreModuleMocks(touched);
+  });
+
+  it('returns 400 when path is missing', async function () {
+    const handler = require('../site/folder/remove');
+    const req = { params: {}, body: {}, blog: { id: 'blog-1' } };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Missing path');
+    expect(establishSyncLock).not.toHaveBeenCalled();
+  });
+
+  it('rejects absolute and path traversal attempts with 400', async function () {
+    const handler = require('../site/folder/remove');
+
+    const absoluteRes = createRes();
+    await handler(
+      { params: { path: '/etc/passwd' }, body: {}, blog: { id: 'blog-1' } },
+      absoluteRes
+    );
+
+    expect(absoluteRes.statusCode).toBe(400);
+    expect(absoluteRes.body.error).toBe('Absolute paths are not allowed');
+
+    const traversalRes = createRes();
+    await handler(
+      { params: { path: '../../outside.txt' }, body: {}, blog: { id: 'blog-1' } },
+      traversalRes
+    );
+
+    expect(traversalRes.statusCode).toBe(400);
+    expect(traversalRes.body.error).toBe('Path escapes blog folder');
+    expect(establishSyncLock).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when path is not found', async function () {
+    fs.pathExists.and.returnValue(Promise.resolve(false));
+    const handler = require('../site/folder/remove');
+    const res = createRes();
+
+    await handler(
+      { params: { path: 'missing.txt' }, body: {}, blog: { id: 'blog-1' } },
+      res
+    );
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      ok: false,
+      removed: 'missing.txt',
+      error: 'Path not found',
+    });
+    expect(establishSyncLock).not.toHaveBeenCalled();
+  });
+
+  it('removes an existing local file and returns ok true', async function () {
+    const handler = require('../site/folder/remove');
+    const req = { params: { path: 'post.md' }, body: {}, blog: { id: 'blog-1', cacheID: 'c1' } };
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.removed).toBe('post.md');
+    expect(fs.remove).toHaveBeenCalledWith('/blogs/blog-1/post.md');
+    expect(folderUpdate).toHaveBeenCalledWith('/post.md');
+    expect(folderIndexMock.invalidateCache).toHaveBeenCalledWith(req.blog);
+    expect(done).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps client and entry errors to 403, 400, and 502 responses', async function () {
+    const clients = {
+      mockClient: {
+        remove: (blogID, relativePath, cb) => cb({ code: 'EACCES', message: 'denied' }),
+      },
+    };
+
+    setModuleMock('clients', clients, touched);
+    delete require.cache[removeRoutePath];
+    let handler = require('../site/folder/remove');
+
+    let res = createRes();
+    await handler(
+      { params: { path: 'locked.txt' }, body: {}, blog: { id: 'blog-1', client: 'mockClient' } },
+      res
+    );
+    expect(res.statusCode).toBe(403);
+
+    clients.mockClient.remove = (blogID, relativePath, cb) =>
+      cb({ name: 'ValidationError', message: 'bad target' });
+
+    delete require.cache[removeRoutePath];
+    handler = require('../site/folder/remove');
+
+    res = createRes();
+    await handler(
+      { params: { path: 'invalid.txt' }, body: {}, blog: { id: 'blog-1', client: 'mockClient' } },
+      res
+    );
+    expect(res.statusCode).toBe(400);
+
+    clients.mockClient.remove = (blogID, relativePath, cb) => cb(new Error('upstream failed'));
+
+    delete require.cache[removeRoutePath];
+    handler = require('../site/folder/remove');
+
+    res = createRes();
+    await handler(
+      { params: { path: 'broken.txt' }, body: {}, blog: { id: 'blog-1', client: 'mockClient' } },
+      res
+    );
+    expect(res.statusCode).toBe(502);
+    expect(done.calls.count()).toBe(3);
+  });
+});

--- a/app/views/dashboard/folder/directory.html
+++ b/app/views/dashboard/folder/directory.html
@@ -111,15 +111,29 @@
           </div>
         </div>
       </div>
+
+      <div class="remove-entry-modal" hidden>
+        <div class="remove-entry-modal-backdrop" data-remove-modal-close></div>
+        <div class="remove-entry-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="remove-entry-title">
+          <h2 id="remove-entry-title">Remove item</h2>
+          <p data-remove-path-label></p>
+          <div class="buttons">
+            <button type="button" data-remove-action="remove">Remove</button>
+            <button type="button" data-remove-action="cancel">Cancel</button>
+          </div>
+        </div>
+      </div>
         <script>
           const table = document.querySelector('.directory-list');
           const folderBox = document.querySelector('.folder-box.directory');
           const folderFileActionMenu = document.getElementById('folder-file-action-menu');
           const dropTarget = document.querySelector('.folder-drop-target');
           const uploadModal = document.querySelector('.upload-preview-modal');
+          const removeModal = document.querySelector('.remove-entry-modal');
           const uploadModalLists = {
             queued: uploadModal && uploadModal.querySelector('[data-upload-list="queued"]')
           };
+          var removeTargetPath = null;
           const csrfToken = '{{csrftoken}}';
           const currentFolderPrefix = normalizeCurrentFolderPrefix(window.location.pathname);
           
@@ -172,12 +186,12 @@
                   return '{{{base}}}/folder-download' + dataset.url;
                 },
                 remove: function (dataset) {
-                  if (!dataset || dataset.directory === 'true') {
+                  if (!dataset || dataset.directory === 'true' || !dataset.url) {
                     return null;
                   }
 
                   return {
-                    href: 'action:remove-file',
+                    href: 'action:remove-file:' + encodeURIComponent(dataset.url.replace(/^\/+/, '')),
                     disabled: dataset.entry === 'true'
                   };
                 }
@@ -185,13 +199,119 @@
             });
           }
 
-          if (folderFileActionMenu) {
-            folderFileActionMenu.addEventListener('click', function (event) {
-              var link = event.target.closest('[data-menu-link="remove"]');
-              if (!link) return;
-              if ((link.getAttribute('href') || '').indexOf('action:') !== 0) return;
-              event.preventDefault();
+          function resetRemoveModalButtonState() {
+            if (!removeModal || typeof removeModal.querySelectorAll !== 'function') return;
+            Array.from(removeModal.querySelectorAll('[data-remove-action]')).forEach(function (button) {
+              button.disabled = false;
             });
+          }
+
+          function setRemoveModalButtonsDisabled(disabled) {
+            if (!removeModal || typeof removeModal.querySelectorAll !== 'function') return;
+            Array.from(removeModal.querySelectorAll('[data-remove-action]')).forEach(function (button) {
+              button.disabled = disabled;
+            });
+          }
+
+          function openRemoveModal(targetPath) {
+            if (!removeModal || !targetPath) return;
+            removeTargetPath = targetPath;
+            var label = removeModal.querySelector('[data-remove-path-label]');
+            if (label) {
+              label.textContent = targetPath;
+            }
+            resetRemoveModalButtonState();
+            removeModal.hidden = false;
+          }
+
+          function closeRemoveModal() {
+            if (!removeModal) return;
+            removeModal.hidden = true;
+            removeTargetPath = null;
+            resetRemoveModalButtonState();
+          }
+
+          function commitRemove(targetPath) {
+            return fetch('{{{base}}}/folder/remove/' + encodeURIComponent(targetPath), {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify({
+                _csrf: csrfToken,
+                path: targetPath
+              })
+            }).then(function (response) {
+              if (!response.ok) throw new Error('Remove failed');
+              return response.json();
+            }).then(function (result) {
+              if (!result || result.ok !== true) {
+                throw new Error('Remove failed');
+              }
+
+              closeRemoveModal();
+              refreshFolderContents();
+            });
+          }
+
+          function resolveMenuRemovePath(link) {
+            if (!link) return null;
+            var href = (link.getAttribute('href') || '').trim();
+            var prefix = 'action:remove-file:';
+            if (href.indexOf(prefix) !== 0) return null;
+
+            var encodedPath = href.slice(prefix.length);
+            if (!encodedPath) return null;
+
+            try {
+              return decodeURIComponent(encodedPath);
+            } catch (err) {
+              return null;
+            }
+          }
+
+          function handleRemoveMenuClick(event) {
+            var link = event.target.closest('[data-menu-link="remove"]');
+            if (!link) return;
+
+            var targetPath = resolveMenuRemovePath(link);
+            if (!targetPath) return;
+
+            event.preventDefault();
+            openRemoveModal(targetPath);
+          }
+
+          function handleRemoveModalClick(event) {
+            var close = event.target.closest('[data-remove-modal-close]');
+            if (close) {
+              closeRemoveModal();
+              return;
+            }
+
+            var button = event.target.closest('[data-remove-action]');
+            if (!button || button.disabled) return;
+
+            var action = button.getAttribute('data-remove-action');
+            if (action === 'cancel') {
+              closeRemoveModal();
+              return;
+            }
+
+            if (action !== 'remove' || !removeTargetPath) return;
+
+            var pendingPath = removeTargetPath;
+            setRemoveModalButtonsDisabled(true);
+            commitRemove(pendingPath).catch(function () {
+              setRemoveModalButtonsDisabled(false);
+            });
+          }
+
+          if (folderFileActionMenu) {
+            folderFileActionMenu.addEventListener('click', handleRemoveMenuClick);
+          }
+
+          if (removeModal) {
+            removeModal.addEventListener('click', handleRemoveModalClick);
           }
           
            


### PR DESCRIPTION
### Motivation
- Provide route-level coverage for `app/dashboard/site/folder/remove.js` to verify validation, path-safety, not-found handling, successful removal, and mapping of client/entry errors to proper responses.  
- Add front-end behavioral tests for the directory remove modal to ensure the UI opens/closes correctly, protects entry rows, and correctly performs the remove request and refresh.  
- Surface and lock modal controls while requests are in-flight to exercise intended UX for successful and failed removals.

### Description
- Added route tests in `app/dashboard/tests/folder-remove.js` that mock `fs-extra`, `clients`, `sync/establishSyncLock`, and `helper/localPath`, covering missing path (400), absolute/traversal rejection (400), not found (404), success (200 + `{ ok: true }`), and client/validation/upstream error mapping (403/400/502).  
- Added front-end behavior tests in `app/dashboard/tests/folder-remove-modal-listener.js` (modeled on the upload modal tests) that extract modal helper functions from `app/views/dashboard/folder/directory.html` and assert menu click -> open modal, cancel -> close without fetch, remove -> calls expected endpoint and refreshes, and modal button locking/unlocking during in-flight/failure.  
- Updated `app/views/dashboard/folder/directory.html` to add the remove confirmation modal markup plus client-side helpers/listeners (`openRemoveModal`, `closeRemoveModal`, `commitRemove`, `handleRemoveMenuClick`, `handleRemoveModalClick`) and to emit encoded `action:remove-file:<encoded-path>` hrefs and disable remove for `data-entry=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69973a09ff788329b7056b985b134511)