### PR TITLE
Unify dashboard row action menus across template and folder lists

### DIFF
--- a/app/views/dashboard/css/row-action-menu.css
+++ b/app/views/dashboard/css/row-action-menu.css
@@ -1,0 +1,105 @@
+:root {
+  --row-action-menu-trigger-padding: 0.125em 0.1875em;
+  --row-action-menu-trigger-margin: 0 0.25em;
+  --row-action-menu-trigger-border-radius: 4px;
+  --row-action-menu-trigger-color: #7f8799;
+  --row-action-menu-trigger-font-size: 16px;
+  --row-action-menu-trigger-opacity: 0;
+  --row-action-menu-trigger-opacity-active: 1;
+
+  --row-action-menu-right: -120px;
+  --row-action-menu-margin-top: 28px;
+  --row-action-menu-width: 180px;
+  --row-action-menu-border-radius: 8px;
+  --row-action-menu-bg: #fff;
+  --row-action-menu-shadow: 0px 18px 40px rgba(24, 34, 67, 0.12), 0px 2px 6px rgba(24, 34, 67, 0.08);
+  --row-action-menu-link-padding: 0.219em 0.5625em;
+  --row-action-menu-link-gap: 0.3125em;
+  --row-action-menu-link-font-size: 13px;
+  --row-action-menu-link-color: #434a5d;
+  --row-action-menu-link-hover-bg: #f2f4fb;
+}
+
+.row-action-menu__trigger {
+  appearance: none;
+  padding: var(--row-action-menu-trigger-padding);
+  margin: var(--row-action-menu-trigger-margin);
+  border: none;
+  border-radius: var(--row-action-menu-trigger-border-radius);
+  background: none;
+  color: var(--row-action-menu-trigger-color);
+  font-size: var(--row-action-menu-trigger-font-size);
+  line-height: 1;
+  cursor: pointer;
+  opacity: var(--row-action-menu-trigger-opacity);
+  transition: opacity 0.15s ease, background-color 0.15s ease;
+}
+
+.row-action-menu-row:hover .row-action-menu__trigger,
+.row-action-menu-row.menu-open .row-action-menu__trigger,
+.row-action-menu__trigger:focus-visible {
+  opacity: var(--row-action-menu-trigger-opacity-active);
+}
+
+.row-action-menu {
+  position: absolute;
+  right: var(--row-action-menu-right);
+  z-index: 20;
+  min-width: var(--row-action-menu-width);
+  margin-top: var(--row-action-menu-margin-top);
+  border-radius: var(--row-action-menu-border-radius);
+  background: var(--row-action-menu-bg);
+  box-shadow: var(--row-action-menu-shadow);
+  opacity: 0;
+  transform: translateY(-6px);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  pointer-events: none;
+}
+
+.row-action-menu.is-open {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.row-action-menu ul {
+  margin: 0;
+  padding: 0.25em 0;
+  list-style: none;
+}
+
+.row-action-menu li {
+  margin: 0;
+}
+
+.row-action-menu a {
+  display: flex;
+  align-items: center;
+  padding: var(--row-action-menu-link-padding);
+  gap: var(--row-action-menu-link-gap);
+  font-size: var(--row-action-menu-link-font-size);
+  color: var(--row-action-menu-link-color);
+  text-decoration: none;
+}
+
+.row-action-menu a:hover,
+.row-action-menu a:focus-visible {
+  background: var(--row-action-menu-link-hover-bg);
+  color: var(--accent-color);
+  outline: none;
+}
+
+.row-action-menu a.is-disabled,
+.row-action-menu a.is-disabled:hover,
+.row-action-menu a.is-disabled:focus-visible {
+  color: var(--light-text-color);
+}
+
+.row-action-menu a.is-disabled {
+  cursor: default;
+}
+
+.row-action-menu a.is-disabled:hover,
+.row-action-menu a.is-disabled:focus-visible {
+  background: transparent;
+}

--- a/app/views/dashboard/folder/directory.html
+++ b/app/views/dashboard/folder/directory.html
@@ -55,7 +55,7 @@
           {{/contents.length}}
       
           {{#contents}}
-          <tr class="directory-row" data-directory-row="true">
+          <tr class="directory-row row-action-menu-row" data-directory-row="true">
             <td>
               <div class="directory-row__name-cell">
                 <a href="{{{base}}}/folder{{{url}}}" class="directory-row__link {{#directory}}directory{{/directory}} {{#entry}}entry{{/entry}}">
@@ -74,7 +74,7 @@
                 <span class="truncate">{{name}}</span>
                 </a>
                 <button
-                  class="directory-row__menu-trigger"
+                  class="directory-row__menu-trigger row-action-menu__trigger"
                   type="button"
                   aria-haspopup="true"
                   aria-expanded="false"
@@ -93,7 +93,7 @@
           {{/contents}}
         </table>
 
-        <div id="folder-file-action-menu" class="template-action-menu folder-action-menu" aria-hidden="true">
+        <div id="folder-file-action-menu" class="template-action-menu row-action-menu" aria-hidden="true">
           <ul>
             <li><a data-menu-link="download" href="#">Download</a></li>
             <li><a data-menu-link="remove" href="#">Remove</a></li>
@@ -170,7 +170,7 @@
           sortTable();
 
           if (folderBox) {
-            Array.from(folderBox.querySelectorAll('.directory-row__menu-trigger')).forEach(function (trigger) {
+            Array.from(folderBox.querySelectorAll('.row-action-menu__trigger')).forEach(function (trigger) {
               var rowUrl = trigger.getAttribute('data-url') || '';
               trigger.setAttribute('data-encoded-url', encodeURIComponent(rowUrl));
             });
@@ -181,7 +181,7 @@
               container: folderBox,
               menuElement: folderFileActionMenu,
               rowSelector: '.directory-row',
-              triggerSelector: '.directory-row__menu-trigger',
+              triggerSelector: '.row-action-menu__trigger',
               linkMap: {
                 download: function (dataset) {
                   if (!dataset || !dataset.url) return null;

--- a/app/views/dashboard/folder/folder.css
+++ b/app/views/dashboard/folder/folder.css
@@ -354,18 +354,20 @@ body.upload-modal-open {
   flex: 1;
 }
 
+.folder-box.directory {
+  --row-action-menu-right: 12px;
+  --row-action-menu-margin-top: 28px;
+  --row-action-menu-trigger-opacity: 1;
+  --row-action-menu-trigger-color: var(--light-text-color);
+}
+
 .directory-row__menu-trigger {
   flex-shrink: 0;
   width: 26px;
   height: 26px;
-  border: none;
-  background: transparent;
-  color: var(--light-text-color);
-  border-radius: 6px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
 }
 
 .directory-row__menu-trigger:hover,
@@ -373,57 +375,4 @@ body.upload-modal-open {
 .directory-row.menu-open .directory-row__menu-trigger {
   background: var(--light-background-color);
   color: var(--text-color);
-}
-
-.folder-action-menu {
-  position: absolute;
-  right: 12px;
-  min-width: 180px;
-  margin-top: 28px;
-  border-radius: 8px;
-  background: #fff;
-  box-shadow: 0px 18px 40px rgba(24, 34, 67, 0.12), 0px 2px 6px rgba(24, 34, 67, 0.08);
-  border: 1px solid rgba(24, 34, 67, 0.08);
-  z-index: 20;
-  display: none;
-}
-
-.folder-action-menu.is-open {
-  display: block;
-}
-
-.folder-action-menu ul {
-  list-style: none;
-  margin: 0;
-  padding: 6px;
-}
-
-.folder-action-menu li {
-  margin: 0;
-}
-
-.folder-action-menu a {
-  display: flex;
-  align-items: center;
-  padding: 6px 10px;
-  gap: 6px;
-  font-size: 13px;
-  color: #434a5d;
-  border-radius: 6px;
-  text-decoration: none;
-}
-
-.folder-action-menu a:hover,
-.folder-action-menu a:focus-visible {
-  background: #f2f4fb;
-}
-
-.folder-action-menu a.is-disabled {
-  color: #9aa0ad;
-  cursor: default;
-}
-
-.folder-action-menu a.is-disabled:hover,
-.folder-action-menu a.is-disabled:focus-visible {
-  background: transparent;
 }

--- a/app/views/dashboard/template/css/template-editor.css
+++ b/app/views/dashboard/template/css/template-editor.css
@@ -10,19 +10,6 @@
   --template-row-gap: 0.25rem;
   --template-row-link-font-size: 14px;
   --template-row-link-padding: 0.219em 0 0.219em 0.25em;
-  --template-row-menu-trigger-opacity: 0;
-  --template-row-menu-trigger-opacity-active: 1;
-  --template-action-menu-right: -120px;
-  --template-action-menu-margin-top: 28px;
-  --template-action-menu-width: 180px;
-  --template-action-menu-bg: #fff;
-  --template-action-menu-border-radius: 8px;
-  --template-action-menu-shadow: 0px 18px 40px rgba(24, 34, 67, 0.12), 0px 2px 6px rgba(24, 34, 67, 0.08);
-  --template-action-menu-link-color: #434a5d;
-  --template-action-menu-link-padding: 0.219em 0.5625em;
-  --template-action-menu-link-gap: 0.3125em;
-  --template-action-menu-link-font-size: 13px;
-  --template-action-menu-link-hover-bg: #f2f4fb;
   --template-preview-height: 16px;
   --template-preview-width: 20px;
   --template-preview-margin: 0.6875em;
@@ -283,84 +270,9 @@ form.upload-control:last-of-type {
   font-weight: 600;
 }
 
-.template-row__menu-trigger {
-  appearance: none;
-  padding: 0.125em 0.1875em;
-  margin: 0 0.25em;
-  border: none;
-  border-radius: 4px;
-  background: none;
-  color: #7f8799;
-  font-size: 16px;
-  line-height: 1;
-  cursor: pointer;
-  opacity: var(--template-row-menu-trigger-opacity);
-  transition: opacity 0.15s ease, background-color 0.15s ease;
-}
-
-.template-row:hover .template-row__menu-trigger,
-.template-row.menu-open .template-row__menu-trigger,
-.template-row__menu-trigger:focus-visible {
-  opacity: var(--template-row-menu-trigger-opacity-active);
-}
-
-.template-action-menu {
-  position: absolute;
-  right: var(--template-action-menu-right);
-  z-index: 20;
-  min-width: var(--template-action-menu-width);
-  margin-top: var(--template-action-menu-margin-top);
-  border-radius: var(--template-action-menu-border-radius);
-  background: var(--template-action-menu-bg);
-  box-shadow: var(--template-action-menu-shadow);
-  opacity: 0;
-  transform: translateY(-6px);
-  transition: opacity 0.15s ease, transform 0.15s ease;
-  pointer-events: none;
-}
-
-.template-action-menu.is-open {
-  opacity: 1;
-  transform: translateY(0);
-  pointer-events: auto;
-}
-
-.template-action-menu ul {
-  margin: 0;
-  padding: 0.25em 0;
-  list-style: none;
-}
-
-.template-action-menu li {
-  margin: 0;
-}
-
-.template-action-menu a {
-  display: flex;
-  align-items: center;
-  padding: var(--template-action-menu-link-padding);
-  gap: var(--template-action-menu-link-gap);
-  font-size: var(--template-action-menu-link-font-size);
-  color: var(--template-action-menu-link-color);
-  text-decoration: none;
-}
-
-.template-action-menu a:hover,
-.template-action-menu a:focus-visible {
-  background: var(--template-action-menu-link-hover-bg);
-  color: var(--accent-color);
-  outline: none;
-}
-
-.template-action-menu a.is-disabled {
-  cursor: default;
-  color: var(--light-text-color);
-}
-
-.template-action-menu a.is-disabled:hover,
-.template-action-menu a.is-disabled:focus-visible {
-  background: transparent;
-  color: var(--light-text-color);
+.template-sidebar {
+  --row-action-menu-right: -120px;
+  --row-action-menu-margin-top: 28px;
 }
 
 .template-row .preview {

--- a/app/views/dashboard/template/js/sidebar-action-menu.js
+++ b/app/views/dashboard/template/js/sidebar-action-menu.js
@@ -6,7 +6,7 @@ function initSidebarActionMenu(options) {
   var container = options.container;
   var menuElement = options.menuElement;
   var rowSelector = options.rowSelector || ".template-row";
-  var triggerSelector = options.triggerSelector || ".template-row__menu-trigger";
+  var triggerSelector = options.triggerSelector || ".row-action-menu__trigger";
   var linkMap = options.linkMap || {};
   var initialFocusKey = options.initialFocusKey;
 

--- a/app/views/dashboard/template/js/source-code-editor.js
+++ b/app/views/dashboard/template/js/source-code-editor.js
@@ -199,7 +199,7 @@ function initializeSourceSidebarMenu() {
     container: list,
     menuElement: menu,
     rowSelector: ".template-row",
-    triggerSelector: ".template-row__menu-trigger",
+    triggerSelector: ".row-action-menu__trigger",
     initialFocusKey: "edit",
     linkMap: {
       edit: function (dataset) {

--- a/app/views/dashboard/template/js/template-editor.js
+++ b/app/views/dashboard/template/js/template-editor.js
@@ -28,7 +28,7 @@ if (template_list) {
       container: template_list,
       menuElement: templateActionMenu,
       rowSelector: ".template-row",
-      triggerSelector: ".template-row__menu-trigger",
+      triggerSelector: ".row-action-menu__trigger",
       initialFocusKey: "settings",
       linkMap: {
         settings: function (dataset) {

--- a/app/views/dashboard/template/layout.html
+++ b/app/views/dashboard/template/layout.html
@@ -13,7 +13,7 @@
                 {{> template-navbar-list}}
             </div>			
 
-<div id="template-action-menu" class="template-action-menu" aria-hidden="true">
+<div id="template-action-menu" class="template-action-menu row-action-menu" aria-hidden="true">
   <ul>
     <li><a data-menu-link="settings" href="#">Settings</a></li>
     <li><a data-menu-link="use" href="#">Use template</a></li>

--- a/app/views/dashboard/template/source-code/source-code-sidebar.html
+++ b/app/views/dashboard/template/source-code/source-code-sidebar.html
@@ -14,7 +14,7 @@
 
 
         {{#views}}
-        <div class="template-row {{selected}}">
+        <div class="template-row row-action-menu-row {{selected}}">
           <a class="template-row__link {{selected}}" href="{{{base}}}/source-code/{{name}}/edit">
             {{#extension.css}}
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path fill="var(--accent-color)" d="m10.3 23.3.8-4H8.6v-2.1h3l.5-2.5H9.5v-2.1h3.1l.8-3.9h2.8l-.8 3.9h2.8l.8-3.9h2.8l-.8 3.9h2.5v2.1h-2.9l-.6 2.5h2.6v2.1h-3l-.8 4H16l.8-4H14l-.8 4h-2.9zm6.9-6.1.5-2.5h-2.8l-.5 2.5h2.8z"/></svg>
@@ -40,7 +40,7 @@
              {{name}}
           </a>
           <button
-            class="template-row__menu-trigger"
+            class="template-row__menu-trigger row-action-menu__trigger"
             type="button"
             aria-haspopup="true"
             aria-expanded="false"
@@ -72,7 +72,7 @@
      </div>
     {{/template.localEditing}}
 
-        <div id="source-file-action-menu" class="template-action-menu" aria-hidden="true">
+        <div id="source-file-action-menu" class="template-action-menu row-action-menu" aria-hidden="true">
           <ul>
             <li><a data-menu-link="edit" href="#">Edit</a></li>
             <li><a data-menu-link="rename" href="#">Rename</a></li>

--- a/app/views/dashboard/template/template-row.html
+++ b/app/views/dashboard/template/template-row.html
@@ -1,5 +1,5 @@
 <div
-  class="template-row {{#selected}}selected{{/selected}}"
+  class="template-row row-action-menu-row {{#selected}}selected{{/selected}}"
   data-template-slug="{{slug}}"
   data-template-name="{{#localEditing}}{{slug}}{{/localEditing}}{{^localEditing}}{{name}}{{/localEditing}}"
 >
@@ -47,7 +47,7 @@
     {{/checked}}
   </a>
   <button
-    class="template-row__menu-trigger"
+    class="template-row__menu-trigger row-action-menu__trigger"
     type="button"
     data-editurl="{{{editURL}}}"
     data-previewurl="{{{previewMenuURL}}}"


### PR DESCRIPTION
### Motivation
- Provide a single, shared presentation and contract for row action menus so template source lists and folder directory rows render and behave identically.
- Preserve the existing JS behavior primitive (`initSidebarActionMenu`) while centralizing styling and small per-context layout overrides.

### Description
- Added a shared stylesheet `app/views/dashboard/css/row-action-menu.css` that exposes CSS tokens and base styles for the menu trigger and flyout (`.row-action-menu__trigger`, `.row-action-menu`, `.row-action-menu-row`) and disabled/hover states.
- Removed duplicated template-specific menu presentation rules from `app/views/dashboard/template/css/template-editor.css` and left only template-specific offset variables on `.template-sidebar` to control menu placement.
- Replaced folder-only menu visuals (`.folder-action-menu*`) with the shared classes and tokens and preserved folder-specific placement and always-visible trigger behavior via a small set of variable overrides in `app/views/dashboard/folder/folder.css` (e.g. `--row-action-menu-right`, `--row-action-menu-trigger-opacity`).
- Standardized markup and JS contract so both template and folder rows use the same trigger class and icon markup (`.row-action-menu__trigger` with `<span class="icon-dots"></span>`) and rows opt into hover/open behavior with `.row-action-menu-row`.
- Kept `initSidebarActionMenu` as the shared JS primitive and updated its default trigger selector and all callers to the new shared selector `'.row-action-menu__trigger'` (template list, source-code sidebar, and folder directory initialization).

### Testing
- Ran repository-wide pattern checks with `rg` to verify the new selector and classes are used (`rg -n "row-action-menu__trigger|row-action-menu" app/views/dashboard/template app/views/dashboard/folder app/views/dashboard/css/row-action-menu.css`) and these searches succeeded.
- Verified there are no remaining `folder-action-menu` references via `rg` searches and validated that template and folder action-menu containers include the shared `.row-action-menu` class, which succeeded.
- Attempted an automated Playwright screenshot to validate UI rendering, but the local app server was not reachable at `http://127.0.0.1:3000` so the Playwright run failed with `ERR_EMPTY_RESPONSE` and UI-level rendering could not be captured.
- No other automated test failures were introduced by these changes (no unit test suite was executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699744ab5d7c832987aefc5a8990dcb8)