### PR TITLE
Fix single-tag pagination to avoid double slicing

### DIFF
--- a/app/blog/render/retrieve/tagged.js
+++ b/app/blog/render/retrieve/tagged.js
@@ -127,28 +127,29 @@ function fetchTaggedEntries(blogID, slugs, options, callback) {
     const slug = normalized[0];
     const pathPrefix = options.pathPrefix;
     const tagOptions = pathPrefix ? undefined : options;
+    const shouldSliceLocally = pathPrefix && pg.hasPagination;
 
     return getTag(blogID, slug, tagOptions)
       .then(({ entryIDs, prettyTag, total }) => {
         const filteredEntryIDs = applyPathPrefix(entryIDs, pathPrefix);
+        const pagedEntryIDs = shouldSliceLocally
+          ? filteredEntryIDs.slice(pg.offset, pg.offset + pg.limit)
+          : filteredEntryIDs;
 
         return {
           prettyTag,
-          entryIDs: filteredEntryIDs,
+          entryIDs: pagedEntryIDs,
           total: pathPrefix ? filteredEntryIDs.length : total,
         };
       })
       .then(({ entryIDs, prettyTag, total }) => {
         const meta = buildTagMetadata([prettyTag]);
-        const pagedEntryIDs = pg.hasPagination
-          ? entryIDs.slice(pg.offset, pg.offset + pg.limit)
-          : entryIDs;
 
         return callback(
           null,
           attachPagination(
             {
-              entryIDs: pagedEntryIDs,
+              entryIDs,
               total: options.limit !== undefined ? total || 0 : undefined,
               tag: meta.tag,
               tagged: meta.tagged,


### PR DESCRIPTION
### Motivation
- Prevent double-pagination for single-tag queries by ensuring `Tags.get` handles pagination when possible and local slicing only occurs when `pathPrefix` necessitates post-filtering.
- Preserve accurate `total` and `pagination` metadata based on the full matching set (or the filtered set when a `pathPrefix` is applied).

### Description
- In `app/blog/render/retrieve/tagged.js` added `shouldSliceLocally = pathPrefix && pg.hasPagination` to decide when to apply local slicing for single-tag queries.
- When `pathPrefix` is not present, continue passing `options` into `getTag` so backend pagination is used and return `entryIDs` directly from `Tags.get` without an additional local slice.
- When `pathPrefix` is present, apply the prefix filter and then locally slice the filtered results; `total` is computed from the full filtered set (not the page length).
- Removed the redundant second `slice` for single-tag flow so pagination is applied exactly once.

### Testing
- Ran `node app/blog/tests/tagged.js` which failed in this environment with `Error: Cannot find module 'models/entries'` due to module-resolution/test harness constraints, so the test suite could not be executed directly here.
- Ran `npm test -- app/blog/tests/tagged.js` which could not run because the project test runner requires Docker and `docker` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998705a67d48329a1358a5ce5044ad2)