### PR TITLE
Extract shared path-prefix helper and reuse in tagged retrieval and entries model

### DIFF
--- a/app/blog/render/retrieve/tagged.js
+++ b/app/blog/render/retrieve/tagged.js
@@ -1,5 +1,6 @@
 const Entry = require("models/entry");
 const Tags = require("models/tags");
+const { filterEntryIDsByPathPrefix } = require("helper/pathPrefix");
 
 function buildPagination(current, pageSize, totalEntries) {
   const total = pageSize > 0 ? Math.ceil(totalEntries / pageSize) : 0;
@@ -73,23 +74,6 @@ function getTag(blogID, slug, opts) {
   });
 }
 
-function normalizePathPrefix(prefix) {
-  if (typeof prefix !== "string") return null;
-
-  const trimmed = prefix.trim();
-  if (!trimmed) return null;
-
-  return trimmed[0] === "/" ? trimmed : `/${trimmed}`;
-}
-
-function applyPathPrefix(entryIDs, pathPrefix) {
-  const normalizedPrefix = normalizePathPrefix(pathPrefix);
-  if (!normalizedPrefix) return entryIDs || [];
-
-  return (entryIDs || []).filter((entryID) =>
-    typeof entryID === "string" && entryID.startsWith(normalizedPrefix)
-  );
-}
 function fetchTaggedEntries(blogID, slugs, options, callback) {
   if (typeof options === "function") {
     callback = options;
@@ -131,7 +115,7 @@ function fetchTaggedEntries(blogID, slugs, options, callback) {
 
     return getTag(blogID, slug, tagOptions)
       .then(({ entryIDs, prettyTag, total }) => {
-        const filteredEntryIDs = applyPathPrefix(entryIDs, pathPrefix);
+        const filteredEntryIDs = filterEntryIDsByPathPrefix(entryIDs, pathPrefix);
         const pagedEntryIDs = shouldSliceLocally
           ? filteredEntryIDs.slice(pg.offset, pg.offset + pg.limit)
           : filteredEntryIDs;
@@ -171,7 +155,7 @@ function fetchTaggedEntries(blogID, slugs, options, callback) {
       const prettyTags = results.map((r) => r.prettyTag);
       const meta = buildTagMetadata(prettyTags);
 
-      const entryIDs = applyPathPrefix(intersectedEntryIDs, options.pathPrefix);
+      const entryIDs = filterEntryIDsByPathPrefix(intersectedEntryIDs, options.pathPrefix);
 
       return { entryIDs, prettyTags, meta };
     })

--- a/app/blog/render/retrieve/tests/tagged.js
+++ b/app/blog/render/retrieve/tests/tagged.js
@@ -122,6 +122,125 @@ describe("tagged block", function () {
     expect(body.trim()).toEqual("<ul><li>Three</li><li>One</li></ul>");
   });
 
+
+
+  it("treats empty and whitespace path_prefix as disabled filtering", async function () {
+    await this.write({
+      path: "/blog/one.txt",
+      content: "Title: One\nTags: foo\n\nOne body",
+    });
+    await this.write({
+      path: "/notes/two.txt",
+      content: "Title: Two\nTags: foo\n\nTwo body",
+    });
+
+    await this.template(
+      {
+        "tagged.html": `<ul>{{#tagged}}{{#entries}}<li>{{title}}</li>{{/entries}}{{/tagged}}</ul>`,
+      },
+      {
+        locals: {
+          path_prefix: "   ",
+        },
+      }
+    );
+
+    const res = await this.get("/tagged/foo");
+    const body = await res.text();
+
+    expect(res.status).toEqual(200);
+    expect(body.trim()).toEqual("<ul><li>Two</li><li>One</li></ul>");
+  });
+
+  it("normalizes path_prefix values that are missing a leading slash", async function () {
+    await this.write({
+      path: "/blog/one.txt",
+      content: "Title: One\nTags: foo\n\nOne body",
+    });
+    await this.write({
+      path: "/notes/two.txt",
+      content: "Title: Two\nTags: foo\n\nTwo body",
+    });
+
+    await this.template(
+      {
+        "tagged.html": `<ul>{{#tagged}}{{#entries}}<li>{{title}}</li>{{/entries}}{{/tagged}}</ul>`,
+      },
+      {
+        locals: {
+          path_prefix: "blog/",
+        },
+      }
+    );
+
+    const res = await this.get("/tagged/foo");
+    const body = await res.text();
+
+    expect(res.status).toEqual(200);
+    expect(body.trim()).toEqual("<ul><li>One</li></ul>");
+  });
+
+  it("respects trailing slash path_prefix boundaries", async function () {
+    await this.write({
+      path: "/blog/one.txt",
+      content: "Title: One\nTags: foo\n\nOne body",
+    });
+    await this.write({
+      path: "/blog-two.txt",
+      content: "Title: Two\nTags: foo\n\nTwo body",
+    });
+
+    await this.template(
+      {
+        "tagged.html": `<ul>{{#tagged}}{{#entries}}<li>{{title}}</li>{{/entries}}{{/tagged}}</ul>`,
+      },
+      {
+        locals: {
+          path_prefix: "/blog/",
+        },
+      }
+    );
+
+    const res = await this.get("/tagged/foo");
+    const body = await res.text();
+
+    expect(res.status).toEqual(200);
+    expect(body.trim()).toEqual("<ul><li>One</li></ul>");
+  });
+
+  it("ignores non-string entry IDs when filtering by path_prefix", function (done) {
+    const tagged = require("blog/render/retrieve/tagged");
+    const Tags = require("models/tags");
+    const Entry = require("models/entry");
+
+    spyOn(Tags, "get").and.callFake(function (blogID, slug, callback) {
+      callback(null, ["/blog/one.txt", 7, null, "/notes/two.txt"], "foo", 4);
+    });
+
+    spyOn(Entry, "get").and.callFake(function (blogID, entryIDs, callback) {
+      expect(entryIDs).toEqual(["/blog/one.txt"]);
+      callback([{ id: "/blog/one.txt", title: "One", dateStamp: 1 }]);
+    });
+
+    const req = {
+      blog: { id: this.blog.id },
+      query: { tag: "foo" },
+      params: {},
+      template: { locals: {} },
+    };
+
+    const res = {
+      locals: { path_prefix: "/blog/" },
+    };
+
+    tagged(req, res, function (err, result) {
+      expect(err).toBeNull();
+      expect(result.entryIDs).toEqual(["/blog/one.txt"]);
+      expect(result.total).toBe(1);
+      done();
+    });
+  });
+
   it("paginates tagged entries using filtered totals when path_prefix is set", async function () {
     await this.write({
       path: "/blog/one.txt",

--- a/app/helper/pathPrefix.js
+++ b/app/helper/pathPrefix.js
@@ -1,0 +1,24 @@
+function normalizePathPrefix(prefix) {
+  if (typeof prefix !== "string") return null;
+
+  var trimmed = prefix.trim();
+  if (!trimmed) return null;
+
+  return trimmed[0] === "/" ? trimmed : "/" + trimmed;
+}
+
+function filterEntryIDsByPathPrefix(entryIDs, pathPrefix) {
+  var normalizedPrefix = normalizePathPrefix(pathPrefix);
+  var ids = Array.isArray(entryIDs) ? entryIDs : [];
+
+  if (!normalizedPrefix) return ids;
+
+  return ids.filter(function (entryID) {
+    return typeof entryID === "string" && entryID.startsWith(normalizedPrefix);
+  });
+}
+
+module.exports = {
+  normalizePathPrefix,
+  filterEntryIDsByPathPrefix,
+};

--- a/app/helper/tests/pathPrefix.js
+++ b/app/helper/tests/pathPrefix.js
@@ -1,0 +1,21 @@
+const {
+  normalizePathPrefix,
+  filterEntryIDsByPathPrefix,
+} = require("helper/pathPrefix");
+
+describe("pathPrefix helper", function () {
+  it("normalizes prefixes with missing slash and trims whitespace", function () {
+    expect(normalizePathPrefix(" blog/")).toBe("/blog/");
+  });
+
+  it("returns null for empty or whitespace-only prefixes", function () {
+    expect(normalizePathPrefix("")).toBeNull();
+    expect(normalizePathPrefix("   ")).toBeNull();
+  });
+
+  it("filters IDs by normalized prefix and ignores non-string IDs", function () {
+    expect(
+      filterEntryIDsByPathPrefix(["/blog/a.txt", 3, null, "/notes/b.txt"], "blog/")
+    ).toEqual(["/blog/a.txt"]);
+  });
+});

--- a/app/models/entries/index.js
+++ b/app/models/entries/index.js
@@ -5,6 +5,7 @@ var Entry = require("../entry");
 var DateStamp = require("../../build/prepare/dateStamp");
 var Blog = require("../blog");
 var pathIndex = require("./pathIndex");
+var normalizePathPrefix = require("helper/pathPrefix").normalizePathPrefix;
 
 var MAX_RANDOM_ATTEMPTS = 10;
 
@@ -435,17 +436,6 @@ module.exports = (function () {
   }
 
 
-
-  function normalizePathPrefix(pathPrefix) {
-    if (typeof pathPrefix !== "string") return null;
-
-    pathPrefix = pathPrefix.trim();
-    if (!pathPrefix) return null;
-
-    if (pathPrefix[0] !== "/") pathPrefix = "/" + pathPrefix;
-
-    return pathPrefix;
-  }
 
   function fetchEntryScores(blogID, entryIDs, callback) {
     if (!entryIDs.length) return callback(null, []);

--- a/app/models/entries/tests.js
+++ b/app/models/entries/tests.js
@@ -394,8 +394,7 @@ describe("entries", function () {
       });
     });
 
-    it("filters posts by path prefix and paginates by id", async function (done) {
-      const blogID = this.blog.id;
+    async function seedPathPrefixEntries(blogID) {
       const entriesKey = `blog:${blogID}:entries`;
       const now = Date.now();
 
@@ -419,6 +418,11 @@ describe("entries", function () {
         .zadd(`blog:${blogID}:entries:lex`, 0, "/Notes/d.txt")
         .set(`blog:${blogID}:entries:lex:ready`, "1")
         .exec();
+    }
+
+    it("filters posts by path prefix and paginates by id", async function (done) {
+      const blogID = this.blog.id;
+      await seedPathPrefixEntries(blogID);
 
       Entries.getPage(
         blogID,
@@ -432,6 +436,41 @@ describe("entries", function () {
             total: 2,
             pageSize: 2,
           });
+          done();
+        }
+      );
+    });
+
+    it("normalizes pathPrefix values missing a leading slash", async function (done) {
+      const blogID = this.blog.id;
+      await seedPathPrefixEntries(blogID);
+
+      Entries.getPage(
+        blogID,
+        { pageNumber: 1, pageSize: 2, sortBy: "id", order: "asc", pathPrefix: "Blog/" },
+        function (error, entries) {
+          expect(error).toBeNull();
+          expect(entries.map((entry) => entry.id)).toEqual(["/Blog/a.txt", "/Blog/b.txt"]);
+          done();
+        }
+      );
+    });
+
+    it("ignores empty or whitespace pathPrefix values", async function (done) {
+      const blogID = this.blog.id;
+      await seedPathPrefixEntries(blogID);
+
+      Entries.getPage(
+        blogID,
+        { pageNumber: 1, pageSize: 4, sortBy: "id", order: "asc", pathPrefix: "   " },
+        function (error, entries) {
+          expect(error).toBeNull();
+          expect(entries.map((entry) => entry.id)).toEqual([
+            "/Blog/a.txt",
+            "/Blog/b.txt",
+            "/Blog/c.txt",
+            "/Notes/d.txt",
+          ]);
           done();
         }
       );


### PR DESCRIPTION
### Motivation
- Consolidate duplicate path-prefix normalization and filtering logic into a single helper to avoid divergence and enable reuse across tagged retrieval and the entries model.

### Description
- Add `app/helper/pathPrefix.js` exporting `normalizePathPrefix(prefix)` and `filterEntryIDsByPathPrefix(entryIDs, pathPrefix)`.
- Update `app/blog/render/retrieve/tagged.js` to import and use `filterEntryIDsByPathPrefix` and remove its local normalize/filter implementations.
- Update `app/models/entries/index.js` to import `normalizePathPrefix` and remove the duplicated normalization function.
- Add tests and extend existing tests: `app/helper/tests/pathPrefix.js`, additional cases in `app/blog/render/retrieve/tests/tagged.js`, and additional path-prefix cases in `app/models/entries/tests.js` covering whitespace/empty prefixes, missing leading slash normalization, trailing-slash boundaries, and ignoring non-string IDs.

### Testing
- Ran `NODE_PATH=app npx jasmine app/helper/tests/pathPrefix.js` which passed (3 specs, 0 failures).
- Performed syntax checks via `node -c` on modified files (`app/blog/render/retrieve/tagged.js`, `app/models/entries/index.js`, the updated tests and helper`) which completed without errors.
- Attempted `npm test -- app/helper/tests/pathPrefix.js` but the repository test harness requires Docker and that invocation failed in this environment due to missing Docker.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987499ee288329b489aeeca445713a)