### PR TITLE
Pass template locals via metadata in allTags test

### DIFF
--- a/app/blog/render/retrieve/tests/allTags.js
+++ b/app/blog/render/retrieve/tests/allTags.js
@@ -52,9 +52,11 @@ describe("all tags", function () {
       await this.write({path: '/blog/b.txt', content: 'Tags: abc, def\n\nB'});
       await this.write({path: '/notes/c.txt', content: 'Tags: def\n\nC'});
 
+      // this.template reads locals from package metadata (second argument).
       await this.template({
-          'entries.html': `<ul>{{#all_tags}}<li>{{tag}} {{total}} {{entries.length}}</li>{{/all_tags}}</ul>`,
-          'locals.json': JSON.stringify({ path_prefix: '/blog/' })
+          'entries.html': `<ul>{{#all_tags}}<li>{{tag}} {{total}} {{entries.length}}</li>{{/all_tags}}</ul>`
+      }, {
+          locals: { path_prefix: '/blog/' }
       });
 
       const res = await this.get('/');


### PR DESCRIPTION
### Motivation
- Ensure template locals are provided to `this.template` via package metadata (second argument) rather than as a `locals.json` pseudo-file while keeping the template file in the first argument.

### Description
- Updated `app/blog/render/retrieve/tests/allTags.js` to remove the `'locals.json'` pseudo-file and call `this.template({ 'entries.html': ... }, { locals: { path_prefix: '/blog/' } })`, and added a short comment explaining that `this.template` reads locals from package metadata.

### Testing
- Attempted a focused test run with `npm test -- app/blog/render/retrieve/tests/allTags.js` but the test harness requires Docker and `docker` was not found, so the test could not be executed here; the test assertions remain unchanged and expect `abc 2 2` and `def 1 1`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699875ad338c8329adbbc61474e1ba1e)