### PR TITLE
Centralize tagged result construction and pagination

### DIFF
--- a/app/blog/render/retrieve/tagged.js
+++ b/app/blog/render/retrieve/tagged.js
@@ -48,6 +48,23 @@ function attachPagination(meta, pg) {
   return meta;
 }
 
+function buildTaggedResult({ entryIDs, total, prettyTags, slugs, pg, includeTotal }) {
+  const metadata = buildTagMetadata(prettyTags);
+  const result = {
+    entryIDs,
+    tag: metadata.tag,
+    tagged: metadata.tagged,
+    prettyTags,
+    slugs,
+  };
+
+  if (includeTotal) {
+    result.total = total;
+  }
+
+  return attachPagination(result, pg);
+}
+
 function intersectMany(arrays) {
   if (!arrays.length) return [];
   let set = new Set(arrays[0]);
@@ -93,17 +110,14 @@ function fetchTaggedEntries(blogID, slugs, options, callback) {
   if (!normalized.length) {
     return callback(
       null,
-      attachPagination(
-        {
-          entryIDs: [],
-          total: options.limit !== undefined ? 0 : undefined,
-          tag: "",
-          tagged: {},
-          prettyTags: [],
-          slugs: [],
-        },
-        pg
-      )
+      buildTaggedResult({
+        entryIDs: [],
+        total: 0,
+        prettyTags: [],
+        slugs: [],
+        pg,
+        includeTotal: options.limit !== undefined,
+      })
     );
   }
 
@@ -127,21 +141,16 @@ function fetchTaggedEntries(blogID, slugs, options, callback) {
         };
       })
       .then(({ entryIDs, prettyTag, total }) => {
-        const meta = buildTagMetadata([prettyTag]);
-
         return callback(
           null,
-          attachPagination(
-            {
-              entryIDs,
-              total: options.limit !== undefined ? total || 0 : undefined,
-              tag: meta.tag,
-              tagged: meta.tagged,
-              prettyTags: [prettyTag],
-              slugs: normalized,
-            },
-            pg
-          )
+          buildTaggedResult({
+            entryIDs,
+            total: total || 0,
+            prettyTags: [prettyTag],
+            slugs: normalized,
+            pg,
+            includeTotal: options.limit !== undefined,
+          })
         );
       })
       .catch(callback);
@@ -153,39 +162,38 @@ function fetchTaggedEntries(blogID, slugs, options, callback) {
       const lists = results.map((r) => r.entryIDs || []);
       const intersectedEntryIDs = intersectMany(lists);
       const prettyTags = results.map((r) => r.prettyTag);
-      const meta = buildTagMetadata(prettyTags);
 
       const entryIDs = filterEntryIDsByPathPrefix(intersectedEntryIDs, options.pathPrefix);
 
-      return { entryIDs, prettyTags, meta };
+      return { entryIDs, prettyTags };
     })
-    .then(({ entryIDs, prettyTags, meta }) => {
+    .then(({ entryIDs, prettyTags }) => {
       if (pg.hasPagination) {
         const sliced = entryIDs.slice(pg.offset, pg.offset + pg.limit);
         return callback(
           null,
-          attachPagination(
-            {
-              entryIDs: sliced,
-              total: entryIDs.length,
-              tag: meta.tag,
-              tagged: meta.tagged,
-              prettyTags,
-              slugs: normalized,
-            },
-            pg
-          )
+          buildTaggedResult({
+            entryIDs: sliced,
+            total: entryIDs.length,
+            prettyTags,
+            slugs: normalized,
+            pg,
+            includeTotal: true,
+          })
         );
       }
 
-      return callback(null, {
-        entryIDs,
-        total: undefined,
-        tag: meta.tag,
-        tagged: meta.tagged,
-        prettyTags,
-        slugs: normalized,
-      });
+      return callback(
+        null,
+        buildTaggedResult({
+          entryIDs,
+          total: entryIDs.length,
+          prettyTags,
+          slugs: normalized,
+          pg,
+          includeTotal: false,
+        })
+      );
     })
     .catch(callback);
 }


### PR DESCRIPTION
### Motivation

- Reduce duplicated object construction and ensure consistent tag metadata and pagination attachment when returning tagged entry results.

### Description

- Add a helper `buildTaggedResult({ entryIDs, total, prettyTags, slugs, pg, includeTotal })` that calls `buildTagMetadata(prettyTags)`, conditionally includes `total`, and applies `attachPagination`.
- Route empty-tag, single-tag, and multi-tag return paths through `buildTaggedResult` so the response shape is built in one place and pagination is attached consistently.
- Preserve existing behavior for `total` semantics when `options.limit` is undefined, single-tag `total` selection when `pathPrefix` is used, and paginated vs non-paginated results by controlling the `includeTotal` flag.
- Modified file: `app/blog/render/retrieve/tagged.js` to centralize the logic and replace inline result object literals with calls to the new helper.

### Testing

- Ran `npm test -- app/blog/render/retrieve/tests/tagged.js`, which could not execute in this environment because the test harness requires Docker and the run failed with `docker: command not found`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998760554b48329aa069f2203ac632f)