### PR TITLE
Remove includeTotal and make total exposure explicit in tagged retrieval

### DIFF
--- a/app/blog/render/retrieve/tagged.js
+++ b/app/blog/render/retrieve/tagged.js
@@ -48,7 +48,7 @@ function attachPagination(meta, pg) {
   return meta;
 }
 
-function buildTaggedResult({ entryIDs, total, prettyTags, slugs, pg, includeTotal }) {
+function buildTaggedResult({ entryIDs, total, prettyTags, slugs, pg }) {
   const metadata = buildTagMetadata(prettyTags);
   const result = {
     entryIDs,
@@ -58,7 +58,7 @@ function buildTaggedResult({ entryIDs, total, prettyTags, slugs, pg, includeTota
     slugs,
   };
 
-  if (includeTotal) {
+  if (total !== undefined) {
     result.total = total;
   }
 
@@ -112,11 +112,10 @@ function fetchTaggedEntries(blogID, slugs, options, callback) {
       null,
       buildTaggedResult({
         entryIDs: [],
-        total: 0,
+        total: options.limit !== undefined ? 0 : undefined,
         prettyTags: [],
         slugs: [],
         pg,
-        includeTotal: options.limit !== undefined,
       })
     );
   }
@@ -145,11 +144,10 @@ function fetchTaggedEntries(blogID, slugs, options, callback) {
           null,
           buildTaggedResult({
             entryIDs,
-            total: total || 0,
+            total: options.limit !== undefined ? total || 0 : undefined,
             prettyTags: [prettyTag],
             slugs: normalized,
             pg,
-            includeTotal: options.limit !== undefined,
           })
         );
       })
@@ -178,7 +176,6 @@ function fetchTaggedEntries(blogID, slugs, options, callback) {
             prettyTags,
             slugs: normalized,
             pg,
-            includeTotal: true,
           })
         );
       }
@@ -187,11 +184,10 @@ function fetchTaggedEntries(blogID, slugs, options, callback) {
         null,
         buildTaggedResult({
           entryIDs,
-          total: entryIDs.length,
+          total: undefined,
           prettyTags,
           slugs: normalized,
           pg,
-          includeTotal: false,
         })
       );
     })


### PR DESCRIPTION
### Motivation
- Simplify the API for tag-based retrieval by removing the redundant `includeTotal` boolean and make the presence of `total` explicit per call. 
- Prevent accidental parameter drift and ensure pagination logic reads `total` only when callers intend to expose it.

### Description
- Changed `buildTaggedResult` signature in `app/blog/render/retrieve/tagged.js` to remove the `includeTotal` parameter and only assign `result.total` when `total !== undefined`.
- Updated empty-tag, single-tag, and multi-tag call sites to pass `total` explicitly as either a concrete count (e.g. `0` or `entryIDs.length`) when totals should be exposed, or `undefined` when they should not be exposed.
- Kept `attachPagination` behavior unchanged so pagination continues to prefer an explicit `meta.total` and otherwise fall back to `meta.entryIDs.length`.
- Removed all former `includeTotal` usage to avoid the redundant boolean and make callers responsible for explicit total exposure.

### Testing
- Ran a syntax check with `node -c app/blog/render/retrieve/tagged.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998770e75b083299086a2283040ed56)