### PR TITLE
Refactor multi-tag pagination in fetchTaggedEntries

### DIFF
--- a/app/blog/render/retrieve/tagged.js
+++ b/app/blog/render/retrieve/tagged.js
@@ -166,25 +166,15 @@ function fetchTaggedEntries(blogID, slugs, options, callback) {
       return { entryIDs, prettyTags };
     })
     .then(({ entryIDs, prettyTags }) => {
-      if (pg.hasPagination) {
-        const sliced = entryIDs.slice(pg.offset, pg.offset + pg.limit);
-        return callback(
-          null,
-          buildTaggedResult({
-            entryIDs: sliced,
-            total: entryIDs.length,
-            prettyTags,
-            slugs: normalized,
-            pg,
-          })
-        );
-      }
-
+      const finalEntryIDs = pg.hasPagination
+        ? entryIDs.slice(pg.offset, pg.offset + pg.limit)
+        : entryIDs;
+      const finalTotal = pg.hasPagination ? entryIDs.length : undefined;
       return callback(
         null,
         buildTaggedResult({
-          entryIDs,
-          total: undefined,
+          entryIDs: finalEntryIDs,
+          total: finalTotal,
           prettyTags,
           slugs: normalized,
           pg,


### PR DESCRIPTION
### Motivation
- Simplify the multi-tag flow in `fetchTaggedEntries` to reduce branching and make pagination handling clearer while preserving current behavior.

### Description
- Removed the `if/else` pagination branch in the multi-tag `then` handler and unified the return path.
- Added `const finalEntryIDs = pg.hasPagination ? entryIDs.slice(pg.offset, pg.offset + pg.limit) : entryIDs` to compute the paged IDs.
- Added `const finalTotal = pg.hasPagination ? entryIDs.length : undefined` to set `total` only when pagination is enabled.
- Returned a single `callback(null, buildTaggedResult({...}))` with `entryIDs: finalEntryIDs` and `total: finalTotal` in `app/blog/render/retrieve/tagged.js`.

### Testing
- Ran `node -c app/blog/render/retrieve/tagged.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987817debc8329a66be409e54fba62)