### PR TITLE
Refactor fetchTaggedEntries to async internal flow

### DIFF
--- a/app/blog/render/retrieve/tagged.js
+++ b/app/blog/render/retrieve/tagged.js
@@ -120,79 +120,65 @@ function getTag(blogID, slug, opts) {
   });
 }
 
-function fetchTaggedEntries(blogID, slugs, options, callback) {
-  if (typeof options === "function") {
-    callback = options;
-    options = {};
-  }
+async function fetchTaggedEntriesInternal(blogID, slugs, options) {
   options = options || {};
 
   const pg = parsePaginationOptions(options);
-
-  let normalized;
-  try {
-    normalized = normalizeSlugs(slugs);
-  } catch (e) {
-    return callback(e);
-  }
+  const normalized = normalizeSlugs(slugs);
 
   if (!normalized.length) {
-    return callback(
-      null,
-      finalizeTaggedEntries({
-        entryIDs: [],
-        prettyTags: [],
-        slugs: [],
-        pg,
-        exposeTotalWhenPaginatedOnly: true,
-      })
-    );
+    return finalizeTaggedEntries({
+      entryIDs: [],
+      prettyTags: [],
+      slugs: [],
+      pg,
+      exposeTotalWhenPaginatedOnly: true,
+    });
   }
 
   if (normalized.length === 1) {
     const slug = normalized[0];
     const pathPrefix = options.pathPrefix;
     const tagOptions = pathPrefix ? undefined : options;
+    const { entryIDs, prettyTag, total } = await getTag(blogID, slug, tagOptions);
 
-    return getTag(blogID, slug, tagOptions)
-      .then(({ entryIDs, prettyTag, total }) => {
-        return callback(
-          null,
-          finalizeTaggedEntries({
-            entryIDs,
-            prettyTags: [prettyTag],
-            slugs: normalized,
-            pg,
-            pathPrefix,
-            total: pathPrefix ? undefined : total,
-            sliceLocally: pathPrefix,
-            exposeTotalWhenPaginatedOnly: false,
-          })
-        );
-      })
-      .catch(callback);
+    return finalizeTaggedEntries({
+      entryIDs,
+      prettyTags: [prettyTag],
+      slugs: normalized,
+      pg,
+      pathPrefix,
+      total: pathPrefix ? undefined : total,
+      sliceLocally: pathPrefix,
+      exposeTotalWhenPaginatedOnly: false,
+    });
   }
 
   // Multiple tags: fetch without pagination options, then intersect and slice locally
-  Promise.all(normalized.map((slug) => getTag(blogID, slug)))
-    .then((results) => {
-      const lists = results.map((r) => r.entryIDs || []);
-      const intersectedEntryIDs = intersectMany(lists);
-      const prettyTags = results.map((r) => r.prettyTag);
+  const results = await Promise.all(normalized.map((slug) => getTag(blogID, slug)));
+  const lists = results.map((r) => r.entryIDs || []);
+  const intersectedEntryIDs = intersectMany(lists);
+  const prettyTags = results.map((r) => r.prettyTag);
 
-      return callback(
-        null,
-        finalizeTaggedEntries({
-          entryIDs: intersectedEntryIDs,
-          prettyTags,
-          slugs: normalized,
-          pg,
-          pathPrefix: options.pathPrefix,
-          sliceLocally: true,
-          exposeTotalWhenPaginatedOnly: true,
-        })
-      );
-    })
+  return finalizeTaggedEntries({
+    entryIDs: intersectedEntryIDs,
+    prettyTags,
+    slugs: normalized,
+    pg,
+    pathPrefix: options.pathPrefix,
+    sliceLocally: true,
+    exposeTotalWhenPaginatedOnly: true,
+  });
+}
+
+function fetchTaggedEntries(blogID, slugs, options, callback) {
+  if (typeof options === "function") {
+    callback = options;
+    options = {};
+  }
+
+  return fetchTaggedEntriesInternal(blogID, slugs, options)
+    .then((result) => callback(null, result))
     .catch(callback);
 }
 


### PR DESCRIPTION
### Motivation
- Convert internal control flow of tagged-entry retrieval to `async/await` to simplify logic and ensure there is exactly one callback invocation point in `fetchTaggedEntries`.
- Preserve existing behavior for invalid slug types, single-tag queries, empty slug lists, and multi-tag intersections while making the implementation easier to reason about.

### Description
- Added `async function fetchTaggedEntriesInternal(blogID, slugs, options)` in `app/blog/render/retrieve/tagged.js` and moved the previous Promise/`.then` logic into it using `await` and `Promise.all` for multi-tag resolution.
- Kept `fetchTaggedEntries(blogID, slugs, options, callback)` as a thin wrapper that normalizes `(options, callback)` and forwards results via `fetchTaggedEntriesInternal(...).then(result => callback(null, result)).catch(callback)` so the callback is invoked exactly once.
- Preserved slug normalization semantics and empty-array handling by reusing `normalizeSlugs(slugs)` and returning the same finalized empty result from the internal function.
- Removed internal `.then(...)` branches that invoked the callback directly and retained existing output shape produced by `finalizeTaggedEntries`.

### Testing
- Ran `npm test -- --runInBand`, which failed in this environment because the test runner depends on Docker and `docker` was not found (tests did not run to completion).
- Executed `node -e "require('./app/blog/render/retrieve/tagged')"`, which failed here because project-specific module aliases like `models/entry` are not resolvable without the application runtime/bootstrap, so the module could not be fully loaded for runtime validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987b047a048329ac204e721f91eb5b)