### PR TITLE
Use shared pathPrefix helpers in tags list model

### DIFF
--- a/app/models/tags/list.js
+++ b/app/models/tags/list.js
@@ -1,17 +1,7 @@
 const client = require("models/client");
 const ensure = require("helper/ensure");
+const { normalizePathPrefix, filterEntryIDsByPathPrefix } = require("helper/pathPrefix");
 const key = require("./key");
-
-function normalizePathPrefix(pathPrefix) {
-  if (typeof pathPrefix !== "string") return null;
-
-  pathPrefix = pathPrefix.trim();
-  if (!pathPrefix) return null;
-
-  if (pathPrefix[0] !== "/") pathPrefix = "/" + pathPrefix;
-
-  return pathPrefix;
-}
 
 module.exports = async function getAll(blogID, options, callback) {
   try {
@@ -59,7 +49,7 @@ module.exports = async function getAll(blogID, options, callback) {
         const entries = await new Promise((resolve, reject) => {
           client.zrange(key.sortedTag(blogID, tag), 0, -1, (err, result) => {
             if (err) return reject(err);
-            resolve((result || []).filter((entryID) => entryID.startsWith(pathPrefix)));
+            resolve(filterEntryIDsByPathPrefix(result, pathPrefix));
           });
         });
 


### PR DESCRIPTION
### Motivation
- Centralize path prefix normalization and filtering by reusing the shared helpers to avoid duplicated logic and ensure consistent behavior across models.

### Description
- Import `normalizePathPrefix` and `filterEntryIDsByPathPrefix` from `helper/pathPrefix` and remove the local `normalizePathPrefix` implementation in `app/models/tags/list.js`.
- Replace the inline `.filter((entryID) => entryID.startsWith(pathPrefix))` logic with `filterEntryIDsByPathPrefix(result, pathPrefix)` when fetching tag entries.
- Keep the existing callback-based API and the returned tag structure unchanged, and do not modify `app/models/tags/tests/list.js` since its assertions remain valid.

### Testing
- Attempted to run `npm test -- app/models/tags/tests/list.js` but the test harness failed in this environment because `docker` is not available, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987c2992c08329878669879ca5a5b7)