### PR TITLE
Fix folder viewer action menu remove/download flows

### DIFF
--- a/app/views/dashboard/folder/directory.html
+++ b/app/views/dashboard/folder/directory.html
@@ -102,6 +102,18 @@
           </ul>
         </div>
 
+      <div class="download-entry-modal" hidden>
+        <div class="download-entry-modal-backdrop" data-download-modal-close></div>
+        <div class="download-entry-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="download-entry-title">
+          <h2 id="download-entry-title">Download file</h2>
+          <p data-download-path-label></p>
+          <div class="buttons">
+            <button type="button" data-download-action="download">Download</button>
+            <button type="button" data-download-action="cancel">Cancel</button>
+          </div>
+        </div>
+      </div>
+
       <div class="upload-preview-modal" hidden>
         <div class="upload-preview-modal-backdrop" data-upload-modal-close></div>
         <div class="upload-preview-modal-dialog" role="dialog" aria-modal="true" aria-labelledby="upload-preview-title">
@@ -133,11 +145,13 @@
           const dropTarget = document.querySelector('.folder-drop-target');
           const uploadModal = document.querySelector('.upload-preview-modal');
           const removeModal = document.querySelector('.remove-entry-modal');
+          const downloadModal = document.querySelector('.download-entry-modal');
           const uploadModalLists = {
             queued: uploadModal && uploadModal.querySelector('[data-upload-list="queued"]')
           };
           var removeTargetPath = null;
           var removeTargetFile = null;
+          var downloadTargetFile = null;
           const csrfToken = '{{csrftoken}}';
           const currentFolderPrefix = normalizeCurrentFolderPrefix(window.location.pathname);
           
@@ -186,8 +200,23 @@
               triggerSelector: '.row-action-menu__trigger',
               linkMap: {
                 download: function (dataset) {
-                  if (!dataset || !dataset.url) return null;
-                  return '{{{base}}}/folder-download' + dataset.url;
+                  var downloadLink = folderFileActionMenu && folderFileActionMenu.querySelector('[data-menu-link="download"]');
+                  if (downloadLink) {
+                    downloadLink.dataset.url = (dataset && dataset.url) || '';
+                    downloadLink.dataset.name = (dataset && dataset.name) || '';
+                  }
+
+                  if (!dataset || !dataset.url || dataset.directory === 'true') {
+                    return {
+                      href: null,
+                      disabled: true
+                    };
+                  }
+
+                  return {
+                    href: 'action:download-file:' + encodePathSegments(dataset.url.replace(/^\/+/, '')),
+                    disabled: false
+                  };
                 },
                 remove: function (dataset) {
                   var removeLink = folderFileActionMenu && folderFileActionMenu.querySelector('[data-menu-link="remove"]');
@@ -310,6 +339,44 @@
             }
           }
 
+          function resolveMenuDownloadPath(link) {
+            if (!link) return null;
+            var href = (link.getAttribute('href') || '').trim();
+            var prefix = 'action:download-file:';
+            if (href.indexOf(prefix) !== 0) return null;
+
+            var encodedPath = href.slice(prefix.length);
+            if (!encodedPath) return null;
+
+            try {
+              return decodePathSegments(encodedPath);
+            } catch (err) {
+              return null;
+            }
+          }
+
+          function openDownloadModal(targetFile) {
+            if (!downloadModal || !targetFile || !targetFile.path) return;
+            downloadTargetFile = targetFile;
+            var label = downloadModal.querySelector('[data-download-path-label]');
+            if (label) {
+              label.textContent = 'Download ' + (targetFile.name || targetFile.path) + '?';
+            }
+            downloadModal.hidden = false;
+          }
+
+          function closeDownloadModal() {
+            if (!downloadModal) return;
+            downloadModal.hidden = true;
+            downloadTargetFile = null;
+          }
+
+          function triggerDownload(relativeUrl) {
+            var encodedPath = encodePathSegments(relativeUrl);
+            if (!encodedPath) return;
+            window.location.href = '{{{base}}}/folder-download/' + encodedPath;
+          }
+
           function handleRemoveMenuClick(event) {
             var link = event.target.closest('[data-menu-link="remove"]');
             if (!link) return;
@@ -318,7 +385,7 @@
             if (!targetPath) return;
 
             event.preventDefault();
-            if (link.classList.contains('is-disabled') || link.dataset.entry === 'true') {
+            if (link.classList.contains('is-disabled')) {
               return;
             }
 
@@ -327,6 +394,24 @@
               name: (link.dataset && link.dataset.name) || targetPath.split('/').pop() || targetPath
             };
             openRemoveModal(removeTargetFile);
+          }
+
+          function handleDownloadMenuClick(event) {
+            var link = event.target.closest('[data-menu-link="download"]');
+            if (!link) return;
+
+            var targetPath = resolveMenuDownloadPath(link);
+            if (!targetPath) return;
+
+            event.preventDefault();
+            if (link.classList.contains('is-disabled')) {
+              return;
+            }
+
+            openDownloadModal({
+              path: targetPath,
+              name: (link.dataset && link.dataset.name) || targetPath.split('/').pop() || targetPath
+            });
           }
 
           function handleRemoveModalClick(event) {
@@ -354,12 +439,40 @@
             });
           }
 
+          function handleDownloadModalClick(event) {
+            var close = event.target.closest('[data-download-modal-close]');
+            if (close) {
+              closeDownloadModal();
+              return;
+            }
+
+            var button = event.target.closest('[data-download-action]');
+            if (!button || button.disabled) return;
+
+            var action = button.getAttribute('data-download-action');
+            if (action === 'cancel') {
+              closeDownloadModal();
+              return;
+            }
+
+            if (action !== 'download' || !downloadTargetFile || !downloadTargetFile.path) return;
+
+            var pendingPath = downloadTargetFile.path;
+            closeDownloadModal();
+            triggerDownload(pendingPath);
+          }
+
           if (folderFileActionMenu) {
+            folderFileActionMenu.addEventListener('click', handleDownloadMenuClick);
             folderFileActionMenu.addEventListener('click', handleRemoveMenuClick);
           }
 
           if (removeModal) {
             removeModal.addEventListener('click', handleRemoveModalClick);
+          }
+
+          if (downloadModal) {
+            downloadModal.addEventListener('click', handleDownloadModalClick);
           }
           
            

--- a/app/views/dashboard/folder/folder.css
+++ b/app/views/dashboard/folder/folder.css
@@ -343,6 +343,42 @@ body.upload-modal-open {
 }
 
 
+.remove-entry-modal,
+.download-entry-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.remove-entry-modal[hidden],
+.download-entry-modal[hidden] {
+  display: none !important;
+}
+
+.remove-entry-modal-backdrop,
+.download-entry-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.28);
+}
+
+.remove-entry-modal-dialog,
+.download-entry-modal-dialog {
+  position: relative;
+  width: min(480px, calc(100vw - 2rem));
+  max-height: calc(100vh - 4rem);
+  overflow: auto;
+  background: var(--background-color);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 1rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+
 .directory-row__name-cell {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- fixed the folder viewer row action menu so **Remove** opens the remove confirmation modal for files instead of silently closing
- added a new **Download confirmation modal** that appears when clicking Download from the row action menu
- updated the download action to be **disabled for directories/folders** and only enabled for files
- added modal styles for the remove/download confirmation dialogs in folder CSS

## Details
- `app/views/dashboard/folder/directory.html`
  - Added `download-entry-modal` markup with confirm/cancel actions.
  - Updated `linkMap.download` to return a disabled state for directories and a custom action href for files.
  - Added helpers to resolve encoded download action paths and open/close the download modal.
  - Wired menu click handling for download to open confirmation modal and only start download after explicit confirm.
  - Removed the extra guard that prevented remove modal opening for entry files.
  - Hooked modal click handlers for both remove and download flows.
- `app/views/dashboard/folder/folder.css`
  - Added shared overlay/dialog styles for `.remove-entry-modal` and `.download-entry-modal`.

## Validation
- Static inspection only (no test execution requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987c1a7b048329b0455abcdfba5c26)