### PR TITLE
Normalize path_prefix and simplify tagged retrieval pagination/filtering

### DIFF
--- a/app/blog/render/retrieve/tagged.js
+++ b/app/blog/render/retrieve/tagged.js
@@ -1,6 +1,9 @@
 const Entry = require("models/entry");
 const Tags = require("models/tags");
-const { filterEntryIDsByPathPrefix } = require("helper/pathPrefix");
+const {
+  normalizePathPrefix,
+  filterEntryIDsByPathPrefix,
+} = require("helper/pathPrefix");
 
 function buildPagination(current, pageSize, totalEntries) {
   const total = pageSize > 0 ? Math.ceil(totalEntries / pageSize) : 0;
@@ -66,25 +69,12 @@ function buildTaggedResult({ entryIDs, total, prettyTags, slugs, pg }) {
 }
 
 function finalizeTaggedEntries({
-  entryIDs,
+  finalEntryIDs,
   prettyTags,
   slugs,
   pg,
-  pathPrefix,
-  total,
-  sliceLocally,
-  exposeTotalWhenPaginatedOnly,
+  finalTotal,
 }) {
-  const filteredEntryIDs = filterEntryIDsByPathPrefix(entryIDs || [], pathPrefix);
-  const finalEntryIDs = sliceLocally && pg.hasPagination
-    ? filteredEntryIDs.slice(pg.offset, pg.offset + pg.limit)
-    : filteredEntryIDs;
-
-  const shouldExposeTotal = exposeTotalWhenPaginatedOnly ? pg.hasPagination : true;
-  const finalTotal = shouldExposeTotal
-    ? (total !== undefined ? total : filteredEntryIDs.length)
-    : undefined;
-
   return buildTaggedResult({
     entryIDs: finalEntryIDs,
     total: finalTotal,
@@ -125,32 +115,38 @@ async function fetchTaggedEntriesInternal(blogID, slugs, options) {
 
   const pg = parsePaginationOptions(options);
   const normalized = normalizeSlugs(slugs);
+  const pathPrefix = normalizePathPrefix(options.pathPrefix);
 
   if (!normalized.length) {
     return finalizeTaggedEntries({
-      entryIDs: [],
+      finalEntryIDs: [],
+      finalTotal: pg.hasPagination ? 0 : undefined,
       prettyTags: [],
       slugs: [],
       pg,
-      exposeTotalWhenPaginatedOnly: true,
     });
   }
 
   if (normalized.length === 1) {
     const slug = normalized[0];
-    const pathPrefix = options.pathPrefix;
-    const tagOptions = pathPrefix ? undefined : options;
+    const tagOptions = !pathPrefix && pg.hasPagination
+      ? { limit: pg.limit, offset: pg.offset }
+      : undefined;
     const { entryIDs, prettyTag, total } = await getTag(blogID, slug, tagOptions);
+    const filteredEntryIDs = filterEntryIDsByPathPrefix(entryIDs || [], pathPrefix);
+    const finalEntryIDs = pathPrefix && pg.hasPagination
+      ? filteredEntryIDs.slice(pg.offset, pg.offset + pg.limit)
+      : filteredEntryIDs;
+    const finalTotal = total !== undefined
+      ? total
+      : filteredEntryIDs.length;
 
     return finalizeTaggedEntries({
-      entryIDs,
+      finalEntryIDs,
+      finalTotal,
       prettyTags: [prettyTag],
       slugs: normalized,
       pg,
-      pathPrefix,
-      total: pathPrefix ? undefined : total,
-      sliceLocally: pathPrefix,
-      exposeTotalWhenPaginatedOnly: false,
     });
   }
 
@@ -159,15 +155,18 @@ async function fetchTaggedEntriesInternal(blogID, slugs, options) {
   const lists = results.map((r) => r.entryIDs || []);
   const intersectedEntryIDs = intersectMany(lists);
   const prettyTags = results.map((r) => r.prettyTag);
+  const filteredEntryIDs = filterEntryIDsByPathPrefix(intersectedEntryIDs, pathPrefix);
+  const finalEntryIDs = pg.hasPagination
+    ? filteredEntryIDs.slice(pg.offset, pg.offset + pg.limit)
+    : filteredEntryIDs;
+  const finalTotal = pg.hasPagination ? filteredEntryIDs.length : undefined;
 
   return finalizeTaggedEntries({
-    entryIDs: intersectedEntryIDs,
+    finalEntryIDs,
+    finalTotal,
     prettyTags,
     slugs: normalized,
     pg,
-    pathPrefix: options.pathPrefix,
-    sliceLocally: true,
-    exposeTotalWhenPaginatedOnly: true,
   });
 }
 


### PR DESCRIPTION
### Motivation
- Ensure `path_prefix` is normalized once and used consistently to decide whether pagination options should be forwarded to `Tags.get` and whether local filtering/slicing is required.  
- Reduce complexity in the finalization step by moving boolean-driven logic out of `finalizeTaggedEntries` into explicit call-sites.  
- Preserve existing tagged result shape and pagination behavior while making the control flow clearer and less error-prone.  

### Description
- Import `normalizePathPrefix` from `helper/pathPrefix` and call it once at the start of `fetchTaggedEntriesInternal` as `pathPrefix`.  
- Single-tag flow now forwards pagination options to `Tags.get` only when there is no normalized `pathPrefix` and pagination is requested, and then applies `filterEntryIDsByPathPrefix` and local slicing at the call-site.  
- Multi-tag flow computes the intersection, applies `filterEntryIDsByPathPrefix`, and performs local slicing when paginated, computing `finalEntryIDs` and `finalTotal` explicitly.  
- Refactor `finalizeTaggedEntries` to accept precomputed `finalEntryIDs` and `finalTotal`, keeping `buildTaggedResult` and `attachPagination` behavior unchanged.  

### Testing
- Ran `node -c app/blog/render/retrieve/tagged.js` to validate syntax and it succeeded.  
- Attempted `npm test -- app/blog/render/retrieve/tests/tagged.js` but the project test harness requires Docker and the environment lacked `docker`, so the test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987ded75a08329825ca5681366bd99)