### PR TITLE
Guard posts retrieval logging when req.log is undefined

### DIFF
--- a/app/blog/render/retrieve/posts.js
+++ b/app/blog/render/retrieve/posts.js
@@ -4,6 +4,7 @@ const fetchTaggedEntries = require("./helpers/fetchTaggedEntries");
 
 module.exports = function (req, res, callback) {
   const blogID = req?.blog?.id;
+  const log = typeof req?.log === "function" ? req.log.bind(req) : () => {};
 
   const options = {
     sortBy: req?.template?.locals?.sort_by,
@@ -16,7 +17,7 @@ module.exports = function (req, res, callback) {
   const tags = req?.query?.tag || req?.params?.tag || res?.locals?.tag;
 
   if (!tags) {
-    req.log("Loading page of entries");
+    log("Loading page of entries");
     return getPage(blogID, options, (err, entries, pagination) => {
       if (err) {
         return callback(err);
@@ -37,7 +38,7 @@ module.exports = function (req, res, callback) {
 
   const offset = (page - 1) * limit;
 
-  req.log("Loading tagged page of entries");
+  log("Loading tagged page of entries");
   fetchTaggedEntries(
     blogID,
     tags,


### PR DESCRIPTION
### Motivation
- Prevent runtime exceptions when `req.log` is not provided by adding a safe local logger in the posts retrieval code.

### Description
- Add `const log = typeof req?.log === "function" ? req.log.bind(req) : () => {};` to `app/blog/render/retrieve/posts.js` and replace direct `req.log(...)` calls with `log(...)` in both the untagged and tagged retrieval paths to preserve behavior while avoiding throws.

### Testing
- Ran `./scripts/tests/invoke.sh app/blog/render/retrieve/tests/posts.js` which failed to start the docker test harness because `docker` is not available in this environment, so the test could not run. 
- Ran `node tests app/blog/render/retrieve/tests/posts.js` as a fallback which failed because the repository's docker-based test runner entrypoint (`/workspace/blot/tests`) is not present, so no tests passed or were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69988f0cc6408329995e43abe0442826)