### PR TITLE
Fix tagged totals for path_prefix-filtered single-tag results

### DIFF
--- a/app/blog/render/retrieve/helpers/fetchTaggedEntries.js
+++ b/app/blog/render/retrieve/helpers/fetchTaggedEntries.js
@@ -141,10 +141,13 @@ async function fetchTaggedEntriesInternal(blogID, slugs, options) {
       : undefined;
     const { entryIDs, prettyTag, total } = await getTag(blogID, slug, tagOptions);
     const filteredEntryIDs = applyPathPrefixFiltering(entryIDs, pathPrefix);
+    const filteredTotal = filteredEntryIDs.length;
     const finalEntryIDs = pathPrefix && pg.hasPagination
       ? filteredEntryIDs.slice(pg.offset, pg.offset + pg.limit)
       : filteredEntryIDs;
-    const finalTotal = total !== undefined ? total : filteredEntryIDs.length;
+    const finalTotal = pathPrefix
+      ? filteredTotal
+      : (total !== undefined ? total : filteredTotal);
 
     return buildSingleTagResult({
       entryIDs: finalEntryIDs,


### PR DESCRIPTION
### Motivation

- Ensure `total` reflects the same filtered dataset as `entryIDs` when `pathPrefix` filtering is applied, because `Tags.get` may report a `total` that includes IDs later discarded by path/type checks.

### Description

- Compute `filteredTotal` from the derived `filteredEntryIDs` array and use it as the `total` whenever `pathPrefix` is active.
- Preserve the previous behavior for non-`pathPrefix` queries by still using `Tags.get`’s `total` when available, with a fallback to the filtered length.
- Keep `entryIDs` as the filtered/sliced IDs and ensure `pagination.totalEntries` is consistent with `result.total` for single-tag and paginated responses.

### Testing

- Ran `npm test -- app/blog/render/retrieve/tests/tagged.js`, which failed in this environment because Docker is not installed and the test harness requires containerization (so tests could not execute).
- Ran `node tests app/blog/render/retrieve/tests/tagged.js`, which failed due to the repository expecting a containerized test entrypoint (`MODULE_NOT_FOUND: /workspace/blot/tests`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69988eff0238832997f486be45697caf)