### PR TITLE
Compute single-tag totals from filtered IDs when path_prefix is set

### DIFF
--- a/app/blog/render/retrieve/helpers/fetchTaggedEntries.js
+++ b/app/blog/render/retrieve/helpers/fetchTaggedEntries.js
@@ -144,7 +144,11 @@ async function fetchTaggedEntriesInternal(blogID, slugs, options) {
     const finalEntryIDs = pathPrefix && pg.hasPagination
       ? filteredEntryIDs.slice(pg.offset, pg.offset + pg.limit)
       : filteredEntryIDs;
-    const finalTotal = total !== undefined ? total : filteredEntryIDs.length;
+    const finalTotal = pathPrefix
+      ? filteredEntryIDs.length
+      : total !== undefined
+        ? total
+        : filteredEntryIDs.length;
 
     return buildSingleTagResult({
       entryIDs: finalEntryIDs,


### PR DESCRIPTION
### Motivation
- Ensure pagination metadata for single-tag queries reflects path-prefix filtering so totals and pagination are based on the filtered set when `path_prefix` is active.

### Description
- In `app/blog/render/retrieve/helpers/fetchTaggedEntries.js` inside `fetchTaggedEntriesInternal` single-tag branch, compute `finalTotal` as `filteredEntryIDs.length` when `pathPrefix` is active, otherwise use the `total` returned by `Tags.get` if provided and fall back to `filteredEntryIDs.length`, while preserving the existing behavior of passing `{ limit, offset }` to `Tags.get` only when `!pathPrefix && pg.hasPagination`.

### Testing
- Attempted to run `npm test -- app/blog/render/retrieve/tests/tagged.js` but the test harness requires Docker and failed with `docker: command not found`, and running `node tests app/blog/render/retrieve/tests/tagged.js` failed due to a missing local test entrypoint, so no automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69988ef6b31c8329828a4aeaa6e65990)