### PR TITLE
Fix path-prefix date tie ordering to match Redis semantics

### DIFF
--- a/app/models/entries/index.js
+++ b/app/models/entries/index.js
@@ -527,7 +527,17 @@ module.exports = (function () {
         }
 
         scoredEntries.sort(function (a, b) {
-          return order === "asc" ? b.score - a.score : a.score - b.score;
+          var scoreDifference = order === "asc" ? b.score - a.score : a.score - b.score;
+
+          if (scoreDifference !== 0) return scoreDifference;
+
+          // Redis-compatible tie handling: equal scores are ordered by member
+          // lexicographically (reverse for ZREVRANGE semantics, forward for ZRANGE).
+          if (a.id === b.id) return 0;
+
+          if (order === "asc") return a.id < b.id ? 1 : -1;
+
+          return a.id < b.id ? -1 : 1;
         });
 
         totalEntries = scoredEntries.length;

--- a/app/models/entries/tests.js
+++ b/app/models/entries/tests.js
@@ -456,6 +456,73 @@ describe("entries", function () {
       );
     });
 
+
+
+    it("applies Redis-compatible tie ordering for equal date scores under pathPrefix", async function (done) {
+      const blogID = this.blog.id;
+      const entriesKey = `blog:${blogID}:entries`;
+      const lexKey = `blog:${blogID}:entries:lex`;
+      const tieScore = Date.now();
+      const tieIDs = ["/Blog/a.txt", "/Blog/m.txt", "/Blog/z.txt"];
+
+      await redis.zadd(
+        entriesKey,
+        tieScore,
+        tieIDs[0],
+        tieScore,
+        tieIDs[1],
+        tieScore,
+        tieIDs[2]
+      );
+
+      await redis
+        .multi()
+        .zadd(lexKey, 0, tieIDs[0])
+        .zadd(lexKey, 0, tieIDs[1])
+        .zadd(lexKey, 0, tieIDs[2])
+        .set(`blog:${blogID}:entries:lex:ready`, "1")
+        .exec();
+
+      const taggedSetKey = `blog:${blogID}:tags:sorted:redis-tie-check`;
+
+      await redis.del(taggedSetKey);
+      await redis.zadd(
+        taggedSetKey,
+        tieScore,
+        tieIDs[0],
+        tieScore,
+        tieIDs[1],
+        tieScore,
+        tieIDs[2]
+      );
+
+      redis.zrevrange(taggedSetKey, 0, -1, function (err, expectedAsc) {
+        if (err) return done.fail(err);
+
+        redis.zrange(taggedSetKey, 0, -1, function (err, expectedDesc) {
+          if (err) return done.fail(err);
+
+          Entries.getPage(
+            blogID,
+            { pageNumber: 1, pageSize: 10, sortBy: "date", order: "asc", pathPrefix: "/Blog/" },
+            function (error, ascEntries) {
+              expect(error).toBeNull();
+              expect(ascEntries.map((entry) => entry.id)).toEqual(expectedAsc);
+
+              Entries.getPage(
+                blogID,
+                { pageNumber: 1, pageSize: 10, sortBy: "date", order: "desc", pathPrefix: "/Blog/" },
+                function (error, descEntries) {
+                  expect(error).toBeNull();
+                  expect(descEntries.map((entry) => entry.id)).toEqual(expectedDesc);
+                  done();
+                }
+              );
+            }
+          );
+        });
+      });
+    });
     it("ignores empty or whitespace pathPrefix values", async function (done) {
       const blogID = this.blog.id;
       await seedPathPrefixEntries(blogID);


### PR DESCRIPTION
### Motivation

- Ensure deterministic ordering for entries with identical `dateStamp` when paginating with a `path_prefix` so behavior matches tagged retrieval which relies on Redis sorted-set tie semantics.
- Prevent nondeterministic client-side sort behavior by adding an explicit tie-breaker instead of relying on unstable sort outcomes.

### Description

- Update the comparator inside `getPrefixFilteredPage` (`app/models/entries/index.js`) to keep the existing primary score ordering and add an `id` lexicographic tie-break when `score` (equal `dateStamp`) is the same. 
- For `order === "asc"` the comparator uses reverse-lexicographic tie order, and for `order === "desc"` it uses lexicographic tie order, preserving current semantics for non-ties.
- Add an inline comment above the comparator documenting this is intentional Redis-compatible tie handling.
- Add a test in `app/models/entries/tests.js` that seeds multiple entries with the same `dateStamp` under the same `path_prefix` and asserts deterministic ordering for both `order: "asc"` and `order: "desc"` by comparing results against Redis `ZREVRANGE`/`ZRANGE` on an equivalent same-score set.

### Testing

- Attempted to run unit tests with `npm test -- app/models/entries/tests.js` but the repository test harness requires Docker and failed in this environment with `docker: command not found` so end-to-end tests could not be executed here.
- Loaded the modified module via `NODE_PATH=app node -e "require('./app/models/entries/index'); console.log('ok')"`, which succeeded in loading the module but emitted expected Redis connection errors because no Redis server was available locally.
- The new test was added to `app/models/entries/tests.js` and committed, but could not be executed in this environment due to the Docker/Redis constraints described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699891b3a404832997ce7ee04201fcf1)