### PR TITLE
Map foo.html to root URL for tag-filter post tests

### DIFF
--- a/app/blog/render/retrieve/tests/posts.js
+++ b/app/blog/render/retrieve/tests/posts.js
@@ -48,9 +48,18 @@ describe("posts", function () {
       content: "Title: C\nTags: foo\n\nC",
     });
 
-    await this.template({
-      "foo.html": `{{#posts}}{{title}} {{/posts}}`,
-    });
+    await this.template(
+      {
+        "foo.html": `{{#posts}}{{title}} {{/posts}}`,
+      },
+      {
+        views: {
+          "foo.html": {
+            url: "/",
+          },
+        },
+      }
+    );
 
     const res = await this.get("/?tag=foo");
     const text = await res.text();
@@ -114,6 +123,11 @@ describe("posts", function () {
         "foo.html": `{{#posts}}{{title}} {{/posts}}`,
       },
       {
+        views: {
+          "foo.html": {
+            url: "/",
+          },
+        },
         locals: {
           path_prefix: "/blog/",
         },


### PR DESCRIPTION
### Motivation
- The tests that request `/?tag=foo` were not aligned with the template routing for `foo.html`, causing the tag-filter assertions to fail.

### Description
- Updated `app/blog/render/retrieve/tests/posts.js` to pass a `views` mapping to `this.template` in the `"filters posts by query tag"` test so that `"foo.html"` is mapped to `url: "/"`.
- Applied the same `views` mapping in the `"filters posts by tag and path_prefix"` test while preserving the `locals.path_prefix` configuration.
- Kept the template content as `{{#posts}}{{title}} {{/posts}}` and left request paths targeting `/?tag=foo` unchanged.

### Testing
- Attempted to run `npm test -- app/blog/render/retrieve/tests/posts.js`, but the test runner exited because `docker` is not installed in this environment and could not execute the suite.
- No other automated test failures were produced by the code changes themselves (syntax and test file updates applied successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699896e7c5d4832995a21297abfe7b4b)