### PR TITLE
Add entries-route test for pagination.totalEntries

### DIFF
--- a/app/blog/tests/entries.js
+++ b/app/blog/tests/entries.js
@@ -138,4 +138,30 @@ describe("entries", function () {
             }
         }
     });
+
+    it("exposes totalEntries in pagination data", async function () {
+
+        const totalEntries = 5;
+        const page_size = 2;
+
+        for (let i = totalEntries; i > 0; i--) {
+            await this.write({path: `/${i}.txt`, content: `Hello, ${i}!`});
+        }
+
+        await this.template({ "entries.html": "{{pagination.current}}/{{pagination.total}}/{{pagination.pageSize}}/{{pagination.totalEntries}}" }, {
+            locals: {page_size}
+        });
+
+        const res = await this.get('/page/1');
+        const body = await res.text();
+
+        expect(res.status).toEqual(200);
+        expect(body).toContain('1/3/2/5');
+
+        const res2 = await this.get('/page/3');
+        const body2 = await res2.text();
+
+        expect(res2.status).toEqual(200);
+        expect(body2).toContain('3/3/2/5');
+    });
 });


### PR DESCRIPTION
### Motivation
- Ensure `pagination.totalEntries` is exposed on paginated entries routes and verify it separately from tagged-route tests.

### Description
- Add a new test `exposes totalEntries in pagination data` to `app/blog/tests/entries.js` that creates 5 entries with `page_size: 2`, renders `{{pagination.current}}/{{pagination.total}}/{{pagination.pageSize}}/{{pagination.totalEntries}}`, and asserts the expected values on `/page/1` and `/page/3`.

### Testing
- Ran `./node_modules/.bin/jasmine app/blog/tests/entries.js` (failed due to module resolution) and `NODE_PATH=app ./node_modules/.bin/jasmine app/blog/tests/entries.js` (progressed but failed because Redis at `127.0.0.1:6379` was unavailable), so tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ae36e6f883298850079fd40c693f)