### PR TITLE
Expose total_entries alias in pagination payloads

### DIFF
--- a/app/blog/render/retrieve/helpers/fetchTaggedEntries.js
+++ b/app/blog/render/retrieve/helpers/fetchTaggedEntries.js
@@ -8,7 +8,16 @@ function buildPagination(current, pageSize, totalEntries) {
   const total = pageSize > 0 ? Math.ceil(totalEntries / pageSize) : 0;
   const previous = current > 1 ? current - 1 : null;
   const next = total > 0 && current < total ? current + 1 : null;
-  return { current, pageSize, total, totalEntries, previous, next };
+  return {
+    current,
+    pageSize,
+    total,
+    totalEntries,
+    // Prefer snake_case in public payloads; keep camelCase for legacy compatibility.
+    total_entries: totalEntries,
+    previous,
+    next,
+  };
 }
 
 function buildTagMetadata(prettyTags) {

--- a/app/models/entries/index.js
+++ b/app/models/entries/index.js
@@ -717,6 +717,8 @@ module.exports = (function () {
       pagination.current = pageNo;
       pagination.pageSize = pageSize;
       pagination.totalEntries = totalEntries;
+      // Prefer snake_case in public payloads; keep camelCase for legacy compatibility.
+      pagination.total_entries = totalEntries;
 
       // total entries is not 0 indexed, remove 1
       if (totalEntries - 1 > end) pagination.next = zeroIndexedPageNo + 2;


### PR DESCRIPTION
### Motivation
- Make pagination payloads available in both snake_case and camelCase so newer public templates can use `total_entries` while existing templates continue using `totalEntries`.

### Description
- Added `pagination.total_entries = totalEntries` immediately after `pagination.totalEntries` in `handlePaginationAndCallback(...)` in `app/models/entries/index.js` and included a brief inline comment clarifying snake_case is the preferred public style and camelCase is legacy compatibility.
- Updated `buildPagination(current, pageSize, totalEntries)` in `app/blog/render/retrieve/helpers/fetchTaggedEntries.js` to return both `totalEntries` and `total_entries` and added the same inline comment near the alias assignment.
- Kept all existing camelCase fields intact to avoid breaking existing templates.

### Testing
- Ran syntax checks with `node --check app/models/entries/index.js` and `node --check app/blog/render/retrieve/helpers/fetchTaggedEntries.js`, which completed successfully.
- Verified the modified functions (`handlePaginationAndCallback` and `buildPagination`) produce objects including both `totalEntries` and `total_entries` via local inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998bb1b73048329b3765b6e103cb489)