### PR TITLE
docs: clarify snake_case pagination fields in public examples

### DIFF
--- a/app/blog/README
+++ b/app/blog/README
@@ -81,7 +81,7 @@ If `?debug=true` or `?json=true` is present in the query string, the rendered lo
 
 ### `render/retrieve/`
 
-Each file in this directory is a named retriever. The retrieve system (`render/retrieve/index.js`) accepts a map of local names that the view template declares it needs. It calls the matching retriever function for each name, passing `(req, res, callback)`. Retrievers are registered under both snake_case and camelCase aliases where applicable.
+Each file in this directory is a named retriever. The retrieve system (`render/retrieve/index.js`) accepts a map of local names that the view template declares it needs. It calls the matching retriever function for each name, passing `(req, res, callback)`. Retrievers are registered under both snake_case and camelCase aliases where applicable. Public template examples in this README use snake_case naming, while camelCase aliases continue to work for backward compatibility.
 
 | Local name(s) | Source file | What it provides |
 |---|---|---|
@@ -170,7 +170,7 @@ Comments (Commento/Disqus plugins) are suppressed when entry metadata sets `Comm
 
 ### `entries.js`
 
-Calls `models/entries.getPage()` with options derived from `req.template.locals` (`sort_by`, `sort_order`, `page_size`, `path_prefix`) and from `req.params.page` or `req.query.page`. Sets `res.locals.entries` and `res.locals.pagination`. Renders `entries.html`.
+Calls `models/entries.getPage()` with options derived from `req.template.locals` (`sort_by`, `sort_order`, `page_size`, `path_prefix`) and from `req.params.page` or `req.query.page`. Sets `res.locals.entries` and `res.locals.pagination` (documented in templates with snake_case fields such as `total_entries`; camelCase aliases still resolve). Renders `entries.html`.
 
 ### `view.js`
 

--- a/app/models/entries/README
+++ b/app/models/entries/README
@@ -65,13 +65,15 @@ Returns a single page of published entries from the `entries` list with full pag
   total: 3,      // total number of pages
   current: 2,    // current page number (1-based)
   pageSize: 5,   // entries per page
-  totalEntries: 15, // total number of entries across all pages
+  total_entries: 15, // total number of entries across all pages
   next: 3,       // present only when a next page exists
   previous: 1    // present only when a previous page exists
 }
 ```
 
 When there is only one page, `pagination` is set to `false` on the callback. The last entry in each page has the pagination object attached as `entry.pagination`.
+
+Use `total_entries` in public template examples. `totalEntries` remains available as a compatibility alias.
 
 Each entry in the result has an `index` property: a 1-based ordinal reflecting the entry's position in the total ordered set (the earliest published entry has index 1, the most recently published has index equal to total entry count).
 

--- a/app/views/developers/reference.yml
+++ b/app/views/developers/reference.yml
@@ -392,7 +392,7 @@
         {{/all_entries}}
     - name: Pagination
       type: section
-      description: "Pagination is applied on tagged routes (`/tagged/:slug` and `/tagged/:slug/page/:page`) and on entry list routes that set `page_size`. Templates receive a `pagination` object with `current`, `previous`, `next`, `total`, `pageSize`, and `totalEntries`. Defaults and limits: `page_size` uses a baseline of `5` with valid values `1-100`; tagged routes prefer `tagged_page_size` over `page_size`, and use an effective default of `100` when unset, invalid, or outside `1-500`."
+      description: "Pagination is applied on tagged routes (`/tagged/:slug` and `/tagged/:slug/page/:page`) and on entry list routes that set `page_size`. Templates receive a `pagination` object with `current`, `previous`, `next`, `total`, `pageSize`, and `total_entries`. Defaults and limits: `page_size` uses a baseline of `5` with valid values `1-100`; tagged routes prefer `tagged_page_size` over `page_size`, and use an effective default of `100` when unset, invalid, or outside `1-500`."
       example: |
         {{#pagination.next}}
         <a href="/tagged/{{slug}}/page/{{pagination.next}}">Older</a>


### PR DESCRIPTION
### Motivation
- Standardise public documentation to prefer snake_case for pagination fields used in templates while retaining camelCase as a compatibility alias.
- Make examples and developer docs consistent so template authors use `total_entries` in public examples and avoid confusion with `totalEntries`.

### Description
- Updated `app/views/developers/reference.yml` to list `total_entries` (instead of `totalEntries`) in the documented `pagination` object fields and examples.
- Updated `app/models/entries/README` pagination output example to use `total_entries` and added a short note that `totalEntries` remains available as a compatibility alias.
- Updated `app/blog/README` to clarify that public template examples use snake_case naming and that camelCase retriever aliases continue to work for backward compatibility, including a note in the `entries.js` documentation about `total_entries`.

### Testing
- Searched the modified files with `rg -n "totalEntries|total_entries|pagination|retriever|snake|camel"` to verify occurrences, and the results matched the intended changes (success).
- Reviewed diffs with `git diff -- app/views/developers/reference.yml app/models/entries/README app/blog/README` to confirm only the intended lines were changed (success).
- Verified repository status with `git status --short` and committed the changes with `git commit`, both completing successfully (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998bb34ff0c8329a01741bad5bcd023)