### PR TITLE
Add `pagination.page_size` while preserving `pagination.pageSize` compatibility

### DIFF
--- a/app/blog/README
+++ b/app/blog/README
@@ -170,7 +170,7 @@ Comments (Commento/Disqus plugins) are suppressed when entry metadata sets `Comm
 
 ### `entries.js`
 
-Calls `models/entries.getPage()` with options derived from `req.template.locals` (`sort_by`, `sort_order`, `page_size`, `path_prefix`) and from `req.params.page` or `req.query.page`. Sets `res.locals.entries` and `res.locals.pagination` (documented in templates with snake_case fields such as `total_entries`; camelCase aliases still resolve). Renders `entries.html`.
+Calls `models/entries.getPage()` with options derived from `req.template.locals` (`sort_by`, `sort_order`, `page_size`, `path_prefix`) and from `req.params.page` or `req.query.page`. Sets `res.locals.entries` and `res.locals.pagination` (documented in templates with snake_case fields such as `page_size` and `total_entries`; camelCase aliases still resolve for backwards compatibility). Renders `entries.html`.
 
 ### `view.js`
 

--- a/app/blog/render/retrieve/helpers/fetchTaggedEntries.js
+++ b/app/blog/render/retrieve/helpers/fetchTaggedEntries.js
@@ -11,6 +11,7 @@ function buildPagination(current, pageSize, totalEntries) {
   return {
     current,
     pageSize,
+    page_size: pageSize,
     total,
     totalEntries,
     // Prefer snake_case in public payloads; keep camelCase for legacy compatibility.

--- a/app/blog/tests/entries.js
+++ b/app/blog/tests/entries.js
@@ -148,7 +148,7 @@ describe("entries", function () {
             await this.write({path: `/${i}.txt`, content: `Hello, ${i}!`});
         }
 
-        await this.template({ "entries.html": "{{pagination.current}}/{{pagination.total}}/{{pagination.pageSize}}/{{pagination.totalEntries}}" }, {
+        await this.template({ "entries.html": "{{pagination.current}}/{{pagination.total}}/{{pagination.page_size}}/{{pagination.total_entries}}/{{pagination.pageSize}}" }, {
             locals: {page_size}
         });
 
@@ -156,12 +156,12 @@ describe("entries", function () {
         const body = await res.text();
 
         expect(res.status).toEqual(200);
-        expect(body).toContain('1/3/2/5');
+        expect(body).toContain('1/3/2/5/2');
 
         const res2 = await this.get('/page/3');
         const body2 = await res2.text();
 
         expect(res2.status).toEqual(200);
-        expect(body2).toContain('3/3/2/5');
+        expect(body2).toContain('3/3/2/5/2');
     });
 });

--- a/app/blog/tests/tagged.js
+++ b/app/blog/tests/tagged.js
@@ -358,7 +358,7 @@ describe("tags work on sites", function () {
       {
         "entries.html": "{{#entries}}{{title}}\n{{/entries}}",
         "tagged.html":
-          "pageSize={{pagination.pageSize}};current={{pagination.current}};entries={{#entries}}{{title}}|{{/entries}}",
+          "page_size={{pagination.page_size}};pageSize={{pagination.pageSize}};current={{pagination.current}};entries={{#entries}}{{title}}|{{/entries}}",
       },
       { locals: { page_size: 1, tagged_page_size: 2 } }
     );
@@ -374,7 +374,8 @@ describe("tags work on sites", function () {
     const res = await this.get(`/tagged/special`);
     expect(res.status).toBe(200);
     const body = await res.text();
-    const [pageSizePart, currentPart, entriesPart] = body.split(";");
+    const [pageSizeSnakePart, pageSizePart, currentPart, entriesPart] = body.split(";");
+    expect(pageSizeSnakePart).toBe("page_size=2");
     expect(pageSizePart).toBe("pageSize=2");
     expect(currentPart).toBe("current=1");
     const entries = entriesPart
@@ -388,8 +389,9 @@ describe("tags work on sites", function () {
     const resPage2 = await this.get(`/tagged/special/page/2`);
     expect(resPage2.status).toBe(200);
     const bodyPage2 = await resPage2.text();
-    const [pageSizePart2, currentPart2, entriesPart2] = bodyPage2.split(";");
+    const [pageSizeSnakePart2, pageSizePart2, currentPart2, entriesPart2] = bodyPage2.split(";");
 
+    expect(pageSizeSnakePart2).toBe("page_size=2");
     expect(pageSizePart2).toBe("pageSize=2");
     expect(currentPart2).toBe("current=2");
     const entriesPage2 = entriesPart2
@@ -422,7 +424,7 @@ describe("tags work on sites", function () {
     await this.template(
       {
         "tagged.html":
-          "pageSize={{pagination.pageSize}};current={{pagination.current}};entries={{#entries}}{{title}}|{{/entries}}",
+          "page_size={{pagination.page_size}};pageSize={{pagination.pageSize}};current={{pagination.current}};entries={{#entries}}{{title}}|{{/entries}}",
       },
       { locals: { page_size: 3 } }
     );
@@ -430,8 +432,9 @@ describe("tags work on sites", function () {
     const res = await this.get(`/tagged/alt`);
     expect(res.status).toBe(200);
     const body = await res.text();
-    const [pageSizePart, currentPart, entriesPart] = body.split(";");
+    const [pageSizeSnakePart, pageSizePart, currentPart, entriesPart] = body.split(";");
 
+    expect(pageSizeSnakePart).toBe("page_size=3");
     expect(pageSizePart).toBe("pageSize=3");
     expect(currentPart).toBe("current=1");
     const entries = entriesPart
@@ -449,7 +452,8 @@ describe("tags work on sites", function () {
     const resPage2 = await this.get(`/tagged/alt/page/2`);
     expect(resPage2.status).toBe(200);
     const bodyPage2 = await resPage2.text();
-    const [pageSizePart2, currentPart2, entriesPart2] = bodyPage2.split(";");
+    const [pageSizeSnakePart2, pageSizePart2, currentPart2, entriesPart2] = bodyPage2.split(";");
+    expect(pageSizeSnakePart2).toBe("page_size=3");
     expect(pageSizePart2).toBe("pageSize=3");
     expect(currentPart2).toBe("current=2");
     const entriesPage2 = entriesPart2
@@ -509,6 +513,7 @@ describe("tags work on sites", function () {
       jasmine.objectContaining({
         current: 1,
         pageSize: 1,
+        page_size: 1,
         total: 2,
         totalEntries: 2,
         previous: null,

--- a/app/models/entries/index.js
+++ b/app/models/entries/index.js
@@ -716,6 +716,7 @@ module.exports = (function () {
       pagination.total = Math.ceil(totalEntries / pageSize);
       pagination.current = pageNo;
       pagination.pageSize = pageSize;
+      pagination.page_size = pageSize;
       pagination.totalEntries = totalEntries;
       // Prefer snake_case in public payloads; keep camelCase for legacy compatibility.
       pagination.total_entries = totalEntries;

--- a/app/models/entries/tests.js
+++ b/app/models/entries/tests.js
@@ -286,6 +286,7 @@ describe("entries", function () {
           previous: 1,
           total: 3, // 6 entries / 2 per page
           pageSize: 2,
+          page_size: 2,
           totalEntries: 6,
         });
         expect(entries.at(-1).pagination).toEqual(pagination);
@@ -437,6 +438,7 @@ describe("entries", function () {
             next: 2,
             total: 2,
             pageSize: 2,
+            page_size: 2,
             totalEntries: 3,
           });
           expect(entries.at(-1).pagination).toEqual(pagination);

--- a/app/views/developers/reference.yml
+++ b/app/views/developers/reference.yml
@@ -392,7 +392,7 @@
         {{/all_entries}}
     - name: Pagination
       type: section
-      description: "Pagination is applied on tagged routes (`/tagged/:slug` and `/tagged/:slug/page/:page`) and on entry list routes that set `page_size`. Templates receive a `pagination` object with `current`, `previous`, `next`, `total`, `pageSize`, and `total_entries`. Defaults and limits: `page_size` uses a baseline of `5` with valid values `1-100`; tagged routes prefer `tagged_page_size` over `page_size`, and use an effective default of `100` when unset, invalid, or outside `1-500`."
+      description: "Pagination is applied on tagged routes (`/tagged/:slug` and `/tagged/:slug/page/:page`) and on entry list routes that set `page_size`. Templates receive a `pagination` object with `current`, `previous`, `next`, `total`, `page_size`, and `total_entries` (with legacy camelCase aliases like `pageSize` still available for compatibility). Defaults and limits: `page_size` uses a baseline of `5` with valid values `1-100`; tagged routes prefer `tagged_page_size` over `page_size`, and use an effective default of `100` when unset, invalid, or outside `1-500`."
       example: |
         {{#pagination.next}}
         <a href="/tagged/{{slug}}/page/{{pagination.next}}">Older</a>


### PR DESCRIPTION
### Motivation
- Make pagination output consistent with existing snake_case fields like `total_entries` by exposing `page_size` in pagination payloads while keeping the existing camelCase `pageSize` for backwards compatibility.

### Description
- Add `pagination.page_size = pageSize` where entries pagination is built in `app/models/entries/index.js` so templates can read `pagination.page_size` in addition to `pagination.pageSize`.
- Add `page_size` to the tagged pagination object in `app/blog/render/retrieve/helpers/fetchTaggedEntries.js` so tagged routes expose both `page_size` and `pageSize`.
- Update tests to assert the presence of `page_size` while preserving checks for `pageSize` in `app/blog/tests/entries.js`, `app/blog/tests/tagged.js`, and `app/models/entries/tests.js`.
- Update developer docs to prefer `page_size` and call out camelCase compatibility in `app/views/developers/reference.yml` and `app/blog/README`.

### Testing
- Ran syntax checks with `node --check` on `app/models/entries/index.js`, `app/blog/render/retrieve/helpers/fetchTaggedEntries.js`, `app/blog/tests/entries.js`, and `app/blog/tests/tagged.js`, which all passed.
- Attempted the project test command `npm test -- app/models/entries/tests.js` but the invocation requires Docker and failed in this environment due to `docker: command not found`, so the full test harness could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998bc2f04dc8329855f92af4d6cbc08)