### PR TITLE
Update entries pagination specs to include total_entries

### DIFF
--- a/app/models/entries/tests.js
+++ b/app/models/entries/tests.js
@@ -288,6 +288,7 @@ describe("entries", function () {
           pageSize: 2,
           page_size: 2,
           totalEntries: 6,
+          total_entries: 6,
         });
         expect(entries.at(-1).pagination).toEqual(pagination);
 
@@ -440,6 +441,7 @@ describe("entries", function () {
             pageSize: 2,
             page_size: 2,
             totalEntries: 3,
+            total_entries: 3,
           });
           expect(entries.at(-1).pagination).toEqual(pagination);
           done();


### PR DESCRIPTION
### Motivation
- The pagination objects returned by `Entries.getPage` include a snake_case `total_entries` alias and the tests were failing because they only expected `totalEntries`, so the specs were updated to match the actual output.

### Description
- Added `total_entries` to the pagination expectations in two tests in `app/models/entries/tests.js` (the date-sorted page and the path-prefix pagination test).

### Testing
- Attempted to run the targeted spec with `npx jasmine app/models/entries/tests.js`, which failed due to a module resolution error (`Cannot find module 'models/client'`), and attempted the project test harness with `./scripts/tests/invoke.sh`, which could not run because Docker is not available in this environment (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998bdf013cc83298b368b44ef32cebc)