### PR TITLE
Fix entries path-prefix pagination spec to include previous:null

### DIFF
--- a/app/models/entries/tests.js
+++ b/app/models/entries/tests.js
@@ -470,6 +470,7 @@ describe("entries", function () {
           expect(pagination).toEqual({
             current: 1,
             next: 2,
+            previous: null,
             total: 2,
             pageSize: 2,
             page_size: 2,


### PR DESCRIPTION
### Motivation
- The pagination test for path-prefix filtering expected a payload missing the `previous` key while the implementation includes `previous` (null on the first page), causing a mismatch and a failing spec.

### Description
- Update `app/models/entries/tests.js` to include `previous: null` in the expected pagination object for the path-prefix pagination spec so the test matches the current `Entries.getPage` contract.

### Testing
- Ran `npx jasmine app/models/entries/tests.js`, which failed in this environment due to a missing module alias (`Cannot find module 'models/client'`).
- Ran `npm test -- app/models/entries/tests.js`, which failed because the repository test harness requires Docker and `docker` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998d1825f18832986a99714633e567e)