### PR TITLE
Add regression tests for getByUrl single-decode behavior

### DIFF
--- a/app/blog/tests/backlinks.js
+++ b/app/blog/tests/backlinks.js
@@ -76,6 +76,27 @@ describe("backlinks", function () {
     expect(body).not.toContain("Backlinks:");
   });
 
+
+  it("resolves backlinks from double-encoded href values", async function () {
+    await this.write({
+      path: "/target.txt",
+      content: "Title: Target\nLink: /a%2520b\n\nContent.",
+    });
+    await this.write({
+      path: "/linker.txt",
+      content:
+        'Title: Linker\n\n<p><a href="/a%2520b">Link to target</a></p>',
+    });
+    await this.template(backlinksTemplate);
+
+    const res = await this.get("/a%2520b");
+    const body = await res.text();
+
+    expect(res.status).toEqual(200);
+    expect(body).toContain("Backlinks:");
+    expect(body).toContain("Linker");
+  });
+
   it("renders backlinks when the linked page has umlauts (ä, ü, ö) in its URL", async function () {
     // Page with umlaut in URL (explicit Link so the URL is /grüße)
     await this.write({

--- a/app/blog/tests/entry.js
+++ b/app/blog/tests/entry.js
@@ -110,6 +110,17 @@ describe("entry", function () {
         expect(res.status).toEqual(400);
     });
 
+    it("resolves a permalink with a literal percent-encoded token after one decode", async function () {
+
+        await this.write({ path: '/encoded.txt', content: 'Link: /a%2520b\nHello, encoded!' });
+
+        const res = await this.get('/a%2520b', { redirect: 'manual' });
+        const body = await res.text();
+
+        expect(res.status).toEqual(200);
+        expect(body).toContain('Hello, encoded!');
+    });
+
     it("adds dependency when URL is deduplicated during rename", async function () {
 
         await this.write({path: '/a.txt', content: 'Link: a\nHello, A!'});

--- a/app/models/entry/tests/getByUrl.js
+++ b/app/models/entry/tests/getByUrl.js
@@ -1,0 +1,115 @@
+describe("entry.getByUrl", function () {
+  function withMocks(redisImpl, getImpl, run) {
+    const modulePath = require.resolve("../getByUrl");
+    const redisPath = require.resolve("models/client");
+    const getPath = require.resolve("../get");
+
+    const oldGetByUrl = require.cache[modulePath];
+    const oldRedis = require.cache[redisPath];
+    const oldGet = require.cache[getPath];
+
+    require.cache[redisPath] = {
+      id: redisPath,
+      filename: redisPath,
+      loaded: true,
+      exports: redisImpl,
+    };
+
+    require.cache[getPath] = {
+      id: getPath,
+      filename: getPath,
+      loaded: true,
+      exports: getImpl,
+    };
+
+    delete require.cache[modulePath];
+
+    try {
+      const getByUrl = require("../getByUrl");
+      run(getByUrl);
+    } finally {
+      delete require.cache[modulePath];
+
+      if (oldRedis) require.cache[redisPath] = oldRedis;
+      else delete require.cache[redisPath];
+
+      if (oldGet) require.cache[getPath] = oldGet;
+      else delete require.cache[getPath];
+
+      if (oldGetByUrl) require.cache[modulePath] = oldGetByUrl;
+      else delete require.cache[modulePath];
+    }
+  }
+
+  it("decodes encoded unicode input and resolves the decoded key", function (done) {
+    const calls = [];
+
+    withMocks(
+      {
+        get: (key, callback) => {
+          calls.push(key);
+          callback(null, "/entry.txt");
+        },
+      },
+      (blogID, entryID, callback) => {
+        expect(blogID).toEqual("blog-id");
+        expect(entryID).toEqual("/entry.txt");
+        callback({ id: entryID, title: "ok" });
+      },
+      getByUrl => {
+        getByUrl("blog-id", "/gr%C3%BC%C3%9Fe", entry => {
+          expect(calls.length).toEqual(1);
+          expect(calls[0]).toContain("/grüße");
+          expect(entry.title).toEqual("ok");
+          done();
+        });
+      }
+    );
+  });
+
+  it("does not throw on malformed percent input and falls back to raw key", function (done) {
+    const calls = [];
+
+    withMocks(
+      {
+        get: (key, callback) => {
+          calls.push(key);
+          callback(null, "/entry.txt");
+        },
+      },
+      (_blogID, _entryID, callback) => callback({ id: "/entry.txt" }),
+      getByUrl => {
+        expect(function () {
+          getByUrl("blog-id", "/bad%2", entry => {
+            expect(calls.length).toEqual(1);
+            expect(calls[0]).toContain("/bad%2");
+            expect(entry.id).toEqual("/entry.txt");
+            done();
+          });
+        }).not.toThrow();
+      }
+    );
+  });
+
+  it("keeps already-decoded input stable", function (done) {
+    const calls = [];
+
+    withMocks(
+      {
+        get: (key, callback) => {
+          calls.push(key);
+          callback(null, "/entry.txt");
+        },
+      },
+      (_blogID, _entryID, callback) => callback({ id: "/entry.txt" }),
+      getByUrl => {
+        getByUrl("blog-id", "/already-decoded", entry => {
+          expect(calls.length).toEqual(1);
+          expect(calls[0]).toContain("/already-decoded");
+          expect(entry.id).toEqual("/entry.txt");
+          done();
+        });
+      }
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent regressions where `getByUrl` is decoded more than once (or not at the intended time) which can cause 404s for permalinks that include percent-encoded tokens.
- Ensure backlink extraction and resolution is robust when source HTML contains percent-encoded or double-encoded href values.
- Provide a focused unit test for `getByUrl` to exercise decoding, malformed input handling, and idempotence of already-decoded input.

### Description
- Add an integration test in `app/blog/tests/entry.js` that creates an entry with `Link: /a%2520b` and requests `/a%2520b`, asserting the entry renders with HTTP `200` to verify no double-decode 404. (`app/blog/tests/entry.js`)
- Add a backlinks integration test in `app/blog/tests/backlinks.js` that writes a linker using a double-encoded HTML `href="/a%2520b"` and asserts backlinks still render for the target. (`app/blog/tests/backlinks.js`)
- Add a focused unit test file `app/models/entry/tests/getByUrl.js` that mocks the Redis client and `get` helper and verifies: encoded Unicode input is decoded and resolved, malformed `%` sequences do not throw and fallback to the raw key, and already-decoded input is left unchanged; the test harness uses `require.cache` injection to mock dependencies. (`app/models/entry/tests/getByUrl.js`)

### Testing
- Ran `node --check app/blog/tests/entry.js` and the file passed a syntax check. (succeeded)
- Ran `node --check app/blog/tests/backlinks.js` and `node --check app/models/entry/tests/getByUrl.js` and both passed syntax checks. (succeeded)
- Attempted `npm test -- app/blog/tests/entry.js` but the project test harness requires `docker` and the environment does not have `docker` available so the full test run could not be executed here. (failed to run due to environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c526dd23083298f07fca69cba553c)