### PR TITLE
Centralize entry route URL decoding in Entry.getByUrl

### DIFF
--- a/app/blog/tests/entry.js
+++ b/app/blog/tests/entry.js
@@ -92,6 +92,30 @@ describe("entry", function () {
         }
     });
 
+
+    it("redirects encoded unicode URLs to canonical unicode paths", async function () {
+
+        await this.write({path: '/grüße.txt', content: 'Link: /grüße\nHello, Grüße!'});
+
+        const res = await this.get('/gr%C3%BC%C3%9Fe', {redirect: 'manual'});
+        const body = await res.text();
+
+        expect(res.status).toEqual(301);
+        expect(res.headers.get('location')).toEqual('/gr%C3%BC%C3%9Fe');
+        expect(body).toContain('Redirecting to /gr%C3%BC%C3%9Fe');
+    });
+
+    it("renders canonical unicode URLs without redirect", async function () {
+
+        await this.write({path: '/grüße.txt', content: 'Link: /grüße\nHello, Grüße!'});
+
+        const res = await this.get('/grüße', {redirect: 'manual'});
+        const body = await res.text();
+
+        expect(res.status).toEqual(200);
+        expect(body).toContain('Hello, Grüße!');
+    });
+
     it("does not crash when the URL contains malformed percent-encoding", async function () {
 
         await this.write({ path: '/malformed.txt', content: 'Hello!' });


### PR DESCRIPTION
### Motivation
- Ensure URL decoding is handled in one place (`app/models/entry/getByUrl.js`) so lookups consistently resolve encoded and unicode paths.
- Keep local path-shaping behavior (trim trailing slash, ensure leading slash, lowercase) in the route handler so routing normalization remains localized.

### Description
- Removed the `decodeURIComponent` step from `app/blog/entry.js` and added a comment indicating decoding is centralized in `app/models/entry/getByUrl.js`.
- Continue to perform local path shaping in `app/blog/entry.js` (strip trailing slash, ensure leading slash, lowercase) and pass the normalized-but-not-decoded path into `Entry.getByUrl`.
- Introduced `comparableUrl` in `app/blog/entry.js` which attempts `decodeURI()` only for canonical/index-page comparison and redirect logic so encoded and decoded request variants canonicalize correctly without moving decode responsibility out of `getByUrl`.
- Added two regression tests in `app/blog/tests/entry.js` that verify encoded-unicode requests redirect to canonical paths and that plain-unicode requests render without redirect.

### Testing
- Ran syntax checks with `node --check app/blog/entry.js` and `node --check app/blog/tests/entry.js`, both succeeded.
- Attempted to run the test suite via `./scripts/tests/invoke.sh app/blog/tests/entry.js`, but the environment lacks Docker so the run failed (`docker: command not found`).
- Attempted to run `NODE_PATH=app node scripts/tests/index.js app/blog/tests/entry.js`, but the runner failed due to Redis being unavailable (`ECONNREFUSED 127.0.0.1:6379`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c527046048329bab3da02f3d0e05b)