### PR TITLE
Add backlinks edge case specs for self-links, dedupe, fragments, and external URLs

### DIFF
--- a/app/blog/tests/backlinks.js
+++ b/app/blog/tests/backlinks.js
@@ -101,3 +101,79 @@ describe("backlinks", function () {
     expect(body).toContain("Linker");
   });
 });
+
+describe("backlinks edge cases", function () {
+  require("./util/setup")();
+
+  const backlinksTemplate = {
+    "entry.html":
+      "{{#entry}}{{#backlinks.length}}Backlinks: {{#backlinks}}{{title}}{{/backlinks}}{{/backlinks.length}}{{/entry}}",
+  };
+
+  it("does not create a backlink for self-links", async function () {
+    await this.write({
+      path: "/self.txt",
+      content: "Title: Self\n\n[self](/self)",
+    });
+    await this.template(backlinksTemplate);
+
+    const res = await this.get("/self");
+    const body = await res.text();
+
+    expect(res.status).toEqual(200);
+    expect(body).not.toContain("Backlinks:");
+  });
+
+  it("deduplicates multiple links from the same source post", async function () {
+    await this.write({ path: "/target.txt", content: "Title: Target" });
+    await this.write({
+      path: "/linker.txt",
+      content: "Title: Linker\n\n[first](/target) and [second](/target)",
+    });
+    await this.template(backlinksTemplate);
+
+    const res = await this.get("/target");
+    const body = await res.text();
+
+    expect(res.status).toEqual(200);
+    expect(body).toContain("Backlinks:");
+    expect((body.match(/Linker/g) || []).length).toEqual(1);
+  });
+
+  it("resolves backlinks when the link includes a fragment or query", async function () {
+    await this.write({ path: "/target.txt", content: "Title: Target" });
+    await this.write({
+      path: "/linker-fragment.txt",
+      content: "Title: Linker Fragment\n\n[target](/target#section)",
+    });
+    await this.write({
+      path: "/linker-query.txt",
+      content: "Title: Linker Query\n\n[target](/target?x=1)",
+    });
+    await this.template(backlinksTemplate);
+
+    const res = await this.get("/target");
+    const body = await res.text();
+
+    expect(res.status).toEqual(200);
+    expect(body).toContain("Backlinks:");
+    expect(body).toContain("Linker Fragment");
+    expect(body).toContain("Linker Query");
+  });
+
+  it("ignores external URLs when building backlinks", async function () {
+    await this.write({ path: "/target.txt", content: "Title: Target" });
+    await this.write({
+      path: "/linker-external.txt",
+      content:
+        "Title: Linker External\n\n[external](https://example.com/target)",
+    });
+    await this.template(backlinksTemplate);
+
+    const res = await this.get("/target");
+    const body = await res.text();
+
+    expect(res.status).toEqual(200);
+    expect(body).not.toContain("Backlinks:");
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve backlink feature coverage by validating edge cases that previously had no tests: self-links, duplicate links from the same source, links containing fragments/queries, and external URLs.
- Ensure the backlink-building logic treats internally-resolved URLs consistently and avoids false positives or duplicates.

### Description
- Added a new `describe("backlinks edge cases")` block to `app/blog/tests/backlinks.js` that uses the existing `setup`, `this.write`, `this.template(backlinksTemplate)`, and `this.get` pattern for isolated specs.
- Added a spec that verifies a self-link (post linking to itself) does not produce a backlink entry and that the page response is `200`.
- Added a spec that creates multiple links from the same source post to the same target and asserts the backlink entry for that source is deduplicated using a match-count assertion.
- Added a spec that verifies links containing a fragment (`#section`) or query (`?x=1`) still resolve to the target’s backlinks, and a spec that external full-URL links (e.g. `https://example.com/target`) are not treated as internal backlinks.

### Testing
- Ran the project test command targeting the file with `npm test -- app/blog/tests/backlinks.js` but automated test execution failed in this environment because the test runner requires Docker; the invocation failed with `docker: command not found` from `scripts/tests/invoke.sh`.
- No other automated test runs were possible here due to the environment constraint described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c528baa1483298982177588a6e90a)