### PR TITLE
Add backlink tests for unicode permalink URLs

### DIFF
--- a/app/models/entry/tests/backlinks.js
+++ b/app/models/entry/tests/backlinks.js
@@ -128,5 +128,49 @@ describe("entry.backlinks", function () {
     expect(entryAfterDrop.deleted).toEqual(true);
     expect(entryAfterRestore.backlinks).toEqual([]);
     done();
-  });  
+  });
+
+  it("tracks backlinks for unicode target URLs linked from ASCII linkers", async function (done) {
+    const pathTarget = "/unicode-target.txt";
+    const contentsTarget = "Permalink: grüße\n\nHey";
+
+    const pathLinker = "/ascii-linker.txt";
+    const contentsLinker = "Link: linker\n\n[grüße](/grüße)";
+
+    await this.set(pathTarget, contentsTarget);
+    await this.set(pathLinker, contentsLinker);
+
+    const entry = await this.get(pathTarget);
+
+    const updatedContentsLinker = "Link: linker\n\nNo internal link";
+    await this.set(pathLinker, updatedContentsLinker);
+
+    const entryAfterUpdate = await this.get(pathTarget);
+
+    expect(entry.backlinks).toEqual(["/linker"]);
+    expect(entryAfterUpdate.backlinks).toEqual([]);
+    done();
+  });
+
+  it("preserves unicode linker permalinks in backlinks", async function (done) {
+    const pathTarget = "/linked.txt";
+    const contentsTarget = "Link: linked\n\nHey";
+
+    const pathLinker = "/unicode-linker.txt";
+    const contentsLinker = "Permalink: über-uns\n\n[linked](/linked)";
+
+    await this.set(pathTarget, contentsTarget);
+    await this.set(pathLinker, contentsLinker);
+
+    const entry = await this.get(pathTarget);
+
+    const updatedContentsLinker = "Permalink: über-uns-neu\n\n[linked](/linked)";
+    await this.set(pathLinker, updatedContentsLinker);
+
+    const entryAfterUpdate = await this.get(pathTarget);
+
+    expect(entry.backlinks).toEqual(["/über-uns"]);
+    expect(entryAfterUpdate.backlinks).toEqual(["/über-uns-neu"]);
+    done();
+  });
 });


### PR DESCRIPTION
### Motivation
- Ensure backlink computation and updates handle unicode (umlaut) permalinks correctly and avoid mojibake or mis-encoding.
- Verify both cases where the target URL is unicode and where the linker’s permalink is unicode, including update/removal paths.

### Description
- Added two tests to `app/models/entry/tests/backlinks.js`: one that verifies an ASCII-named linker linking to a unicode target URL (`/grüße`) and one that verifies a unicode linker permalink (`/über-uns`) is preserved exactly in backlinks.
- Each test includes an update path: the first removes the internal link and asserts backlink removal, and the second renames the linker permalink to another unicode URL (`/über-uns-neu`) and asserts backlink replacement.
- Tests follow the existing `it(...)` style and use the same `this.set`/`this.get` helpers and assertion patterns as other `entry.backlinks` tests.

### Testing
- Ran `npx jasmine app/models/entry/tests/backlinks.js`, which failed in this environment due to module resolution error (`Cannot find module 'build'`) from the project test harness setup, so specs could not be executed here.
- Ran `./scripts/tests/invoke.sh app/models/entry/tests/backlinks.js`, which failed because `docker` is not available in the environment, so the containerized test runner could not be started.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c55ae60d0832992b1f120fe83b6b1)