### PR TITLE
Canonicalize internal links before backlink extraction

### DIFF
--- a/app/build/prepare/internalLinks.js
+++ b/app/build/prepare/internalLinks.js
@@ -8,10 +8,15 @@ function internalLinks($) {
 
 	$("[href]").each(function () {
 		let value = $(this).attr("href");
+		let normalizedValue = value;
 
-		if (value.indexOf("/") !== 0 || result.indexOf(value) > -1) return;
+		if (value.indexOf("/") !== 0) return;
 
-		result.push(value);
+		normalizedValue = normalizedValue.split("#")[0].split("?")[0];
+
+		if (!normalizedValue || result.indexOf(normalizedValue) > -1) return;
+
+		result.push(normalizedValue);
 	});
 
 	debug(result);

--- a/app/build/prepare/tests/internalLinks.js
+++ b/app/build/prepare/tests/internalLinks.js
@@ -17,7 +17,27 @@ describe("internalLinks", function () {
     };
   });
 
-  it("works", function () {
+  it("keeps canonical internal links", function () {
     expect(this.internalLinks('<a href="/hey">Hey</a>')).toEqual(["/hey"]);
+  });
+
+  it("ignores external links", function () {
+    expect(this.internalLinks('<a href="https://example.com/hey">Hey</a>')).toEqual([]);
+  });
+
+  it("normalizes fragments and query strings to the base path", function () {
+    expect(
+      this.internalLinks(
+        '<a href="/target#section">Section</a><a href="/target?x=1">Query</a><a href="/target?x=1#section">Both</a>'
+      )
+    ).toEqual(["/target"]);
+  });
+
+  it("deduplicates across canonical and variant internal links", function () {
+    expect(
+      this.internalLinks(
+        '<a href="/target">Base</a><a href="/target#x">Fragment</a><a href="/target?y=1">Query</a>'
+      )
+    ).toEqual(["/target"]);
   });
 });


### PR DESCRIPTION
### Motivation
- Backlinks should reference canonical site paths so variants with fragments or query strings do not create duplicate or mismatched backlink targets.
- The extractor should continue to only consider site-local links (those starting with `/`) while ensuring stored targets are comparable.

### Description
- Updated `internalLinks($)` in `app/build/prepare/internalLinks.js` to strip fragments and query strings from candidate `href` values before storing them by splitting on `#` and `?` and using the base path.
- Kept the existing local-only filter (`href` begins with `/`) and moved deduplication to operate on the normalized value.
- Skip empty normalized results to avoid inserting empty targets into the result list.
- Extended `app/build/prepare/tests/internalLinks.js` with tests that assert canonical internal links are preserved, external links are ignored, fragment/query variants normalize to the base path, and variants deduplicate to a single entry.

### Testing
- Ran `npx jasmine app/build/prepare/tests/internalLinks.js` and the suite passed with `4 specs, 0 failures`.
- The new/updated unit tests verify normalization and deduplication behavior for internal links.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c8ba3d79c8329a78487473346a903)