### PR TITLE
Refactor blog tests to use `this.text` for body-only fetches

### DIFF
--- a/app/blog/render/replaceFolderLinks/tests/css.js
+++ b/app/blog/render/replaceFolderLinks/tests/css.js
@@ -16,8 +16,7 @@ describe("replaceCssUrls", function () {
       "style.css": `.test { background-image: url('/images/test.jpg'); }`,
     });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toMatch(cdnRegex("/images/test.jpg"));
   });
@@ -70,8 +69,7 @@ describe("replaceCssUrls", function () {
       "style.css": `.test { background: url(/images/test.jpg); }`,
     });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toMatch(cdnRegex("/images/test.jpg"));
   });
@@ -116,14 +114,12 @@ describe("replaceCssUrls", function () {
           }`,
     });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toMatch(cdnRegex("/img1.jpg"));
     expect(result).toMatch(cdnRegex("/img2.jpg"));
 
-    const res2 = await this.get("/style.css");
-    const result2 = await res2.text();
+    const result2 = await this.text("/style.css");
 
     expect(result2).toMatch(cdnRegex("/img1.jpg"));
     expect(result2).toMatch(cdnRegex("/img2.jpg"));
@@ -133,8 +129,7 @@ describe("replaceCssUrls", function () {
     const css = `.test{background:url(http://example.com/image.jpg);background-image:url(https://example.com/image.png)}`;
     await this.template({ "style.css": css });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toEqual(css);
   });
@@ -168,9 +163,7 @@ describe("replaceCssUrls", function () {
       content: "fake font data",
     });
 
-    const res = await this.get("/style.css");
-
-    const result = await res.text();
+    const result = await this.text("/style.css");
     expect(result).toMatch(
       cdnRegex("/Templates/Fonts/trio.grotesk/triogrotesk-regular.otf")
     );
@@ -178,8 +171,7 @@ describe("replaceCssUrls", function () {
       cdnRegex("/Templates/Fonts/trio.grotesk/triogrotesk-italic.otf")
     );
 
-    const res2 = await this.get("/style.css");
-    const result2 = await res2.text();
+    const result2 = await this.text("/style.css");
     expect(result2).toMatch(
       cdnRegex("/Templates/Fonts/trio.grotesk/triogrotesk-regular.otf")
     );
@@ -192,8 +184,7 @@ describe("replaceCssUrls", function () {
     const css = `.test{background:url(data:image/png;base64,abc123)}`;
     await this.template({ "style.css": css });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toEqual(css);
   });
@@ -202,8 +193,7 @@ describe("replaceCssUrls", function () {
     const css = `.test{background:url(/nonexistent.jpg)}`;
     await this.template({ "style.css": css });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toEqual(css);
   });
@@ -219,8 +209,7 @@ describe("replaceCssUrls", function () {
           }`,
     });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toMatch(/color:red/);
     expect(result).toMatch(/center\/cover;/);
@@ -234,8 +223,7 @@ describe("replaceCssUrls", function () {
       "style.css": `.test { background: url('/image.jpg?v=1'); }`,
     });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toMatch(cdnRegex("/image.jpg\\?v=1"));
   });
@@ -252,8 +240,7 @@ describe("replaceCssUrls", function () {
     fs.stat = jasmine.createSpy("stat").and.callFake(origStat);
 
     // First request
-    const res1 = await this.get("/style.css");
-    const result1 = await res1.text();
+    const result1 = await this.text("/style.css");
 
     expect(fs.stat).toHaveBeenCalledWith(filePath);
     expect(fs.stat.calls.count()).toBe(1);
@@ -261,8 +248,7 @@ describe("replaceCssUrls", function () {
     fs.stat.calls.reset();
 
     // Second request
-    const res2 = await this.get("/style.css");
-    const result2 = await res2.text();
+    const result2 = await this.text("/style.css");
 
     expect(result1).toEqual(result2);
     expect(fs.stat).not.toHaveBeenCalled();
@@ -280,8 +266,7 @@ describe("replaceCssUrls", function () {
           }`,
     });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     const matches = result.match(
       new RegExp(`${config.cdn.origin}/folder/v-[a-f0-9]{8}`, "g")
@@ -293,8 +278,7 @@ describe("replaceCssUrls", function () {
     const css = `.test{background:url(../../../../etc/passwd)}`;
     await this.template({ "style.css": css });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toEqual(css);
   });
@@ -309,8 +293,7 @@ describe("replaceCssUrls", function () {
     await this.template({ "style.css": css });
     await this.write({ path: "/test.jpg", content: "image" });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
     expect(result).toMatch(cdnRegex("/test.jpg"));
   });
 
@@ -333,8 +316,7 @@ describe("replaceCssUrls", function () {
             `,
     });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toMatch(cdnRegex("/a.jpg"));
     expect(result).toMatch(cdnRegex("/b.jpg"));
@@ -345,8 +327,7 @@ describe("replaceCssUrls", function () {
     await this.write({ path: "/test.jpg", content: "image 1" });
     await this.template({ "style.css": `.test {background: url(./test.jpg)}` });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toMatch(cdnRegex("/test.jpg"));
 
@@ -357,8 +338,7 @@ describe("replaceCssUrls", function () {
 
     await this.write({ path: "/test.jpg", content: "image 2" });
 
-    const res2 = await this.get("/style.css");
-    const result2 = await res2.text();
+    const result2 = await this.text("/style.css");
 
     expect(result2).toMatch(cdnRegex("/test.jpg"));
 
@@ -373,8 +353,7 @@ describe("replaceCssUrls", function () {
       "style.css": `@media (max-width:768px){.test{background-image:url(https://cdn.localhost/folder/v-e464a519/blog_2c245d7ded644f2380a75cdcf260a603/mobile.jpg)}}`,
     });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toMatch(cdnRegex("/mobile.jpg"));
     expect(result).toMatch(/@media \(max-width:768px\)/);
@@ -391,8 +370,7 @@ describe("replaceCssUrls", function () {
         }`,
     });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toMatch(cdnRegex("/image with spaces.jpg"));
     expect(result).toMatch(cdnRegex("/image.jpg"));
@@ -408,8 +386,7 @@ describe("replaceCssUrls", function () {
       }`;
     await this.template({ "style.css": css });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toEqual(css);
   });
@@ -427,8 +404,7 @@ describe("replaceCssUrls", function () {
         }`,
     });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toMatch(cdnRegex("/test.jpg"));
     expect(result).toMatch(/@media print/);
@@ -444,8 +420,7 @@ describe("replaceCssUrls", function () {
         }`,
     });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toMatch(cdnRegex("/test.jpg"));
     expect(result).toMatch(/linear-gradient\(red, blue\)/);
@@ -483,8 +458,7 @@ describe("replaceCssUrls", function () {
       "style.css": `.test { mask-image: url(/sprite.svg#icon-home); }`,
     });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     expect(result).toMatch(cdnRegex("/sprite.svg"));
   });
@@ -497,8 +471,7 @@ describe("replaceCssUrls", function () {
         .test { background: url(/test.jpg); }`,
     });
 
-    const res = await this.get("/style.css");
-    const result = await res.text();
+    const result = await this.text("/style.css");
 
     const matches = result.match(cdnRegex("/test.jpg"));
     expect(matches.length).toBe(1); // Should only replace the actual URL, not the one in comments

--- a/app/blog/render/replaceFolderLinks/tests/html.js
+++ b/app/blog/render/replaceFolderLinks/tests/html.js
@@ -14,8 +14,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<img src="/images/test.jpg">',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(
       new RegExp(
@@ -30,8 +29,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<video poster="/images/poster.jpg"></video>',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(
       new RegExp(
@@ -46,8 +44,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<img src="/iMaGeS/TeSt.jpg">',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(
       new RegExp(
@@ -60,8 +57,7 @@ describe("replaceFolderLinks", function () {
     await this.write({ path: "/test.jpg", content: "image 1" });
     await this.template({ "entries.html": '<img src="/test.jpg">' });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(cdnRegex("/test.jpg"));
 
@@ -72,8 +68,7 @@ describe("replaceFolderLinks", function () {
 
     await this.write({ path: "/test.jpg", content: "image 2" });
 
-    const res2 = await this.get("/");
-    const result2 = await res2.text();
+    const result2 = await this.text("/");
 
     expect(result2).toMatch(cdnRegex("/test.jpg"));
 
@@ -92,8 +87,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": "{{#entries}}{{{html}}}{{/entries}}",
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).not.toContain(config.cdn.origin);
     expect(result).toContain(
@@ -112,8 +106,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<img src="https://example.com/images/test.jpg">',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(
       new RegExp(
@@ -126,9 +119,9 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<img src="https://www.example.com/images/test.jpg">',
     });
 
-    const res2 = await this.get("/");
+    const result2 = await this.text("/");
 
-    expect(await res2.text()).toMatch(
+    expect(result2).toMatch(
       new RegExp(
         `<img src="${config.cdn.origin}/folder/v-[a-f0-9]{8}/[^"]+/images/test.jpg">`
       )
@@ -146,8 +139,7 @@ describe("replaceFolderLinks", function () {
         '/images/test.jpg">',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(
       new RegExp(
@@ -164,8 +156,7 @@ describe("replaceFolderLinks", function () {
         '/images/test.jpg">',
     });
 
-    const res2 = await this.get("/");
-    const result2 = await res2.text();
+    const result2 = await this.text("/");
 
     expect(result2).toMatch(
       new RegExp(
@@ -181,8 +172,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<a href="/docs/test.pdf">Download</a>',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(
       new RegExp(
@@ -196,8 +186,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<a href="/page.html">Link</a>',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toEqual('<a href="/page.html">Link</a>');
   });
@@ -209,8 +198,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<div><img src="/img1.jpg"><img src="/img2.jpg"></div>',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(
       new RegExp(`${config.cdn.origin}/folder/v-[a-f0-9]{8}`)
@@ -233,8 +221,7 @@ describe("replaceFolderLinks", function () {
               `.trim(),
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(/<!DOCTYPE html>/);
     expect(result).toMatch(/<html>/);
@@ -250,13 +237,11 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<img src="/nonexistent.jpg">',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toEqual('<img src="/nonexistent.jpg">');
 
-    const res2 = await this.get("/");
-    const result2 = await res2.text();
+    const result2 = await this.text("/");
 
     expect(result2).toEqual('<img src="/nonexistent.jpg">');
   });
@@ -269,8 +254,7 @@ describe("replaceFolderLinks", function () {
         '<img src="http://example.com/a.jpg"><a href="https://example.com/b.jpg">',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toEqual(
       '<img src="http://example.com/a.jpg"><a href="https://example.com/b.jpg">'
@@ -282,8 +266,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": `<img src="../../../../a.jpg"><a href="../../../../etc/passwd">`,
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toEqual(
       '<img src="../../../../a.jpg"><a href="../../../../etc/passwd">'
@@ -311,8 +294,7 @@ describe("replaceFolderLinks", function () {
       `.trim(),
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(cdnRegex("/images/picture.jpg"));
     expect(result).toMatch(cdnRegex("/media/video.mp4"));
@@ -327,8 +309,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<img srcset="/img-1.jpg 1x, /img-2.jpg 2x">',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(
       new RegExp(
@@ -347,8 +328,7 @@ describe("replaceFolderLinks", function () {
       `.trim(),
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(
       new RegExp(
@@ -363,8 +343,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": `<img srcset="https://${this.blog.handle}.${config.host}/images/abs.jpg 1x">`,
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(
       new RegExp(
@@ -378,8 +357,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<img srcset=", /img.jpg 1x">',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toEqual('<img srcset=", /img.jpg 1x">');
   });
@@ -389,8 +367,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<img src=""><a href="">',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toEqual('<img src=""><a href="">');
   });
@@ -404,8 +381,7 @@ describe("replaceFolderLinks", function () {
         '<img src="./a.jpg"><img src="b.jpg"><img src="../c.jpg">',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(cdnRegex("/a.jpg"));
     expect(result).toMatch(cdnRegex("/b.jpg"));
@@ -418,8 +394,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<img src="/image%20with%20space.jpg">',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(cdnRegex("/image with space.jpg"));
   });
@@ -430,8 +405,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<img src="/100% luck.jpg">',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(cdnRegex("/100% luck.jpg"));
   });
@@ -442,8 +416,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<img src="/image.jpg?cache=false">',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(cdnRegex("/image.jpg\\?cache=false"));
   });
@@ -460,8 +433,7 @@ describe("replaceFolderLinks", function () {
     fs.stat = jasmine.createSpy("stat").and.callFake(origStat);
 
     // First request should trigger a stat
-    const res1 = await this.get("/");
-    const result1 = await res1.text();
+    const result1 = await this.text("/");
 
     // Should have called stat once
     expect(fs.stat).toHaveBeenCalledWith(filePath);
@@ -471,8 +443,7 @@ describe("replaceFolderLinks", function () {
     fs.stat.calls.reset();
 
     // Second request should use cache
-    const res2 = await this.get("/");
-    const result2 = await res2.text();
+    const result2 = await this.text("/");
 
     // Verify responses match
     expect(result1).toEqual(result2);
@@ -497,8 +468,7 @@ describe("replaceFolderLinks", function () {
     fs.stat = jasmine.createSpy("stat").and.callFake(origStat);
 
     // First request should trigger a stat
-    const res1 = await this.get("/1.html");
-    const result1 = await res1.text();
+    const result1 = await this.text("/1.html");
 
     expect(result1).toMatch(cdnRegex("/cached.jpg"));
     // Should have called stat once
@@ -509,8 +479,7 @@ describe("replaceFolderLinks", function () {
     fs.stat.calls.reset();
 
     // Second request should use cache
-    const res2 = await this.get("/2.html");
-    const result2 = await res2.text();
+    const result2 = await this.text("/2.html");
 
     // Verify stat was not called again
     expect(fs.stat).not.toHaveBeenCalled();
@@ -526,8 +495,7 @@ describe("replaceFolderLinks", function () {
       "entries.html": '<img src="/test.jpg" data-src="/test.jpg">',
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     const matches = result.match(
       new RegExp(`${config.cdn.origin}/folder/v-[a-f0-9]{8}`, "g")
@@ -549,8 +517,7 @@ describe("replaceFolderLinks", function () {
               `.trim(),
     });
 
-    const res = await this.get("/");
-    const result = await res.text();
+    const result = await this.text("/");
 
     expect(result).toMatch(
       new RegExp(`${config.cdn.origin}/folder/v-[a-f0-9]{8}`)

--- a/app/blog/tests/assets.js
+++ b/app/blog/tests/assets.js
@@ -18,20 +18,20 @@ describe("asset middleware", function () {
 
   it("returns files with lower-case paths against upper-case URLs", async function () {
     await this.write({ path: "/pages/first.txt", content: "Foo" });
-    const res = await this.get(`/Pages/First.txt`);
-    expect(await res.text()).toEqual("Foo");
+    const body = await this.text(`/Pages/First.txt`);
+    expect(body).toEqual("Foo");
   });
 
   it("returns files with upper-case paths against lower-case URLs", async function () {
     await this.write({ path: "/Pages/First.txt", content: "Foo" });
-    const res = await this.get(`/pages/first.txt`);
-    expect(await res.text()).toEqual("Foo");
+    const body = await this.text(`/pages/first.txt`);
+    expect(body).toEqual("Foo");
   });
 
   it("returns files against URLs with incorrect case", async function () {
     await this.write({ path: "/Pages/First.xml", content: "123" });
-    const res = await this.get(`/pAgEs/FiRsT.xMl`);
-    expect(await res.text()).toEqual("123");
+    const body = await this.text(`/pAgEs/FiRsT.xMl`);
+    expect(body).toEqual("123");
   });
 
   it("returns the correct file if there are multiple with similar case", async function () {
@@ -271,8 +271,8 @@ describe("asset middleware", function () {
 
   it("respects query string parameters while ignoring them for file matching", async function () {
     await this.write({ path: "/query.txt", content: "Query test" });
-    const res = await this.get("/query.txt?param1=value1&param2=value2");
-    expect(await res.text()).toEqual("Query test");
+    const body = await this.text("/query.txt?param1=value1&param2=value2");
+    expect(body).toEqual("Query test");
   });
 
   it("handles files with multiple dots correctly", async function () {
@@ -321,8 +321,8 @@ describe("asset middleware", function () {
 
   it("handles paths with repeating slashes", async function () {
     await this.write({ path: "/folder/file.txt", content: "Content" });
-    const res = await this.get("/folder////file.txt");
-    expect(await res.text()).toEqual("Content");
+    const body = await this.text("/folder////file.txt");
+    expect(body).toEqual("Content");
   });
 
   // Alternative test that checks if the content is readable regardless of BOM
@@ -355,8 +355,8 @@ describe("asset middleware", function () {
     for (const variant of variants) {
       await this.write({ path: variant, content: "Index content" });
       const folderPath = variant.substring(0, variant.lastIndexOf("/") + 1);
-      const res = await this.get(folderPath);
-      expect(await res.text()).toEqual("Index content");
+      const body = await this.text(folderPath);
+      expect(body).toEqual("Index content");
     }
   });
 

--- a/app/blog/tests/pluginHTML.js
+++ b/app/blog/tests/pluginHTML.js
@@ -15,8 +15,7 @@ describe("pluginHTML", function () {
         await this.write({path: '/Drafts/test.txt', content: 'Hello, draft!'});        
 
         const areThereComments = async (path) => {
-            const res = await this.get(path);
-            const body = await res.text();
+            const body = await this.text(path);
             return body.includes('<script defer') && body.includes('src="https://cdn.commento.io/js/commento.js"');
         }
 
@@ -55,8 +54,7 @@ describe("pluginHTML", function () {
         await this.write({path: '/Drafts/test.txt', content: 'Hello, draft!'});
 
         const areThereComments = async (path) => {
-            const res = await this.get(path);
-            const body = await res.text();
+            const body = await this.text(path);
             return body.includes('<div id="disqus_thread"></div>') && body.includes('disqus.com/embed.js');
         }
 
@@ -100,8 +98,7 @@ describe("pluginHTML", function () {
         await this.write({path: '/Pages/page-whitespace-yes.txt', content: 'Link: /page-whitespace-yes\nComments:  yes \n\nHello, page!'});
 
         const areThereComments = async (path) => {
-            const res = await this.get(path);
-            const body = await res.text();
+            const body = await this.text(path);
             return body.includes('<script defer') && body.includes('src="https://cdn.commento.io/js/commento.js"');
         }
 

--- a/app/blog/tests/tagged.js
+++ b/app/blog/tests/tagged.js
@@ -13,9 +13,9 @@ describe("tags work on sites", function () {
       "tagged.html": "{{#entries}}{{title}} {{/entries}}",
     });
 
-    const res = await this.get(`/tagged/a`);
+    const body = await this.text(`/tagged/a`);
 
-    expect((await res.text()).trim().toLowerCase()).toEqual("second first");
+    expect(body.trim().toLowerCase()).toEqual("second first");
   });
 
   it("renders overlapping tag feeds independently", async function () {


### PR DESCRIPTION
### Motivation
- Reduce repetitive `this.get(...); await res.text()` boilerplate by using the helper that directly returns body text when only the response body is needed.
- Make tests clearer about when response metadata (status/headers) is required vs when only the body content matters.

### Description
- Replaced response-object-only body reads with `await this.text(...)` across high-density test suites including `replaceFolderLinks` HTML/CSS tests, and selected cases in `assets`, `pluginHTML`, and `tagged` tests.
- Left `this.get(...)` calls intact where the response object is used for non-body assertions (e.g., `res.status`, `res.headers`, redirect behavior, or multiple `.text()` reads).
- Updated helper closures in `pluginHTML` to use `this.text(path)` for body checks and simplified a tagged feed assertion in `tagged` to use `this.text(...)`.
- Changes touch the following files: `app/blog/render/replaceFolderLinks/tests/html.js`, `app/blog/render/replaceFolderLinks/tests/css.js`, `app/blog/tests/assets.js`, `app/blog/tests/pluginHTML.js`, and `app/blog/tests/tagged.js`.

### Testing
- Attempted to run the app/blog suite via `npm test -- app/blog`, but the project test harness requires Docker and the runner failed with `docker: command not found` so the full suite could not be executed here.
- Performed syntax validation with Node using `node --check` on the modified test files (`html.js`, `css.js`, `pluginHTML.js`, `tagged.js`, `assets.js`) and those checks succeeded.
- Ran targeted search/replace and verification scripts to ensure only body-only patterns were migrated and that places requiring `res` were retained, with no parser/runtime syntax errors detected by `node --check`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da0c432248329adc7c0dddc59f34a)