### PR TITLE
Use per-run Docker network in benchmark invoke script

### DIFF
--- a/scripts/benchmarks/invoke.sh
+++ b/scripts/benchmarks/invoke.sh
@@ -6,6 +6,7 @@ echo "Running benchmarks with args: $*"
 BLOT_BENCH_ID="${BLOT_BENCH_ID:-blot-bench-$$-${RANDOM}}"
 REDIS_CONTAINER="benchmark-redis-${BLOT_BENCH_ID}"
 BENCH_CONTAINER="benchmark-runner-${BLOT_BENCH_ID}"
+BENCH_NETWORK="benchmark-net-${BLOT_BENCH_ID}"
 
 REDIS_IMAGE="redis:alpine"
 BENCH_IMAGE="blot-bench"
@@ -18,16 +19,20 @@ ROOT_DIR=$(realpath "$SCRIPT_DIR/../..")
 
 cleanup() {
   docker rm -f "$BENCH_CONTAINER" >/dev/null 2>&1 || true
-  docker stop "$REDIS_CONTAINER" >/dev/null 2>&1 || true
   docker rm -f "$REDIS_CONTAINER" >/dev/null 2>&1 || true
+  docker network rm "$BENCH_NETWORK" >/dev/null 2>&1 || true
 }
 
 trap cleanup EXIT
 
 docker rm -f "$REDIS_CONTAINER" "$BENCH_CONTAINER" >/dev/null 2>&1 || true
+docker network rm "$BENCH_NETWORK" >/dev/null 2>&1 || true
+
+docker network create "$BENCH_NETWORK" >/dev/null
 
 docker run -d \
   --name "$REDIS_CONTAINER" \
+  --network "$BENCH_NETWORK" \
   --rm \
   "$REDIS_IMAGE" \
   sh -c "rm -f /data/dump.rdb && redis-server" >/dev/null
@@ -39,8 +44,8 @@ docker build \
 
 docker run --rm \
   --name "$BENCH_CONTAINER" \
-  --link "$REDIS_CONTAINER:redis" \
-  -e BLOT_REDIS_HOST="redis" \
+  --network "$BENCH_NETWORK" \
+  -e BLOT_REDIS_HOST="$REDIS_CONTAINER" \
   -e BLOT_HOST="localhost" \
   -e BLOT_PROTOCOL="https" \
   -e DEBUG="${DEBUG:-}" \


### PR DESCRIPTION
### Motivation
- Replace legacy Docker `--link` usage with a per-run network to make Redis connectivity more reliable and modern. 
- Isolate each benchmark run by creating a temporary Docker network named `benchmark-net-$BLOT_BENCH_ID` so parallel runs do not interfere. 
- Simplify and harden teardown so cleanup is idempotent and only removes containers and the temporary network.

### Description
- Add a `BENCH_NETWORK="benchmark-net-${BLOT_BENCH_ID}"` variable and create the network before launching containers with `docker network create`.
- Run Redis using `--network "$BENCH_NETWORK"` and start the benchmark container on the same network, and set `BLOT_REDIS_HOST` to the Redis container name instead of using `--link`.
- Remove the legacy `--link` flag and update the benchmark container environment to use the Redis container hostname via `BLOT_REDIS_HOST`.
- Simplify `cleanup()` to only use `docker rm -f` for containers and `docker network rm` for the temporary network, keeping `|| true` guards for idempotency.

### Testing
- Verified script syntax with `bash -n scripts/benchmarks/invoke.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da28cbc008329a5a094e0ccdf6447)