### PR TITLE
Refactor benchmarks to share invoke.sh entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "download-folder": "./scripts/development/download-folder.sh",
     "test": "./scripts/tests/invoke.sh",
     "benchmark": "./scripts/benchmarks/invoke.sh",
-    "benchmark:ci": "NODE_PATH=app node scripts/benchmarks --ci",
+    "benchmark:ci": "./scripts/benchmarks/invoke.sh --ci",
     "start": "./scripts/development/start.sh",
     "debug": "DEBUG=blot* ./scripts/development/start.sh",
     "deploy-node": "node scripts/deploy",

--- a/scripts/benchmarks/invoke.sh
+++ b/scripts/benchmarks/invoke.sh
@@ -17,6 +17,13 @@ SCRIPTS_DIR=$(realpath "$SCRIPT_DIR/../../scripts")
 CONFIG_DIR=$(realpath "$SCRIPT_DIR/../../config")
 ROOT_DIR=$(realpath "$SCRIPT_DIR/../..")
 
+BENCH_ENV=(
+  -e BLOT_REDIS_HOST="$REDIS_CONTAINER"
+  -e BLOT_HOST="localhost"
+  -e BLOT_PROTOCOL="https"
+  -e NODE_PATH="app"
+)
+
 cleanup() {
   docker rm -f "$BENCH_CONTAINER" >/dev/null 2>&1 || true
   docker rm -f "$REDIS_CONTAINER" >/dev/null 2>&1 || true
@@ -45,9 +52,7 @@ docker build \
 docker run --rm \
   --name "$BENCH_CONTAINER" \
   --network "$BENCH_NETWORK" \
-  -e BLOT_REDIS_HOST="$REDIS_CONTAINER" \
-  -e BLOT_HOST="localhost" \
-  -e BLOT_PROTOCOL="https" \
+  "${BENCH_ENV[@]}" \
   -e DEBUG="${DEBUG:-}" \
   -v "$APP_DIR:/usr/src/app/app" \
   -v "$SCRIPTS_DIR:/usr/src/app/scripts" \


### PR DESCRIPTION
### Motivation
- Unify CI and local benchmark runs behind a single wrapper so both modes differ only by flags and required environment is defined in one place.

### Description
- Introduced a `BENCH_ENV` array in `scripts/benchmarks/invoke.sh` that sets `BLOT_REDIS_HOST`, `BLOT_HOST`, `BLOT_PROTOCOL`, and `NODE_PATH` and reused it in the `docker run` invocation.
- Preserved CLI pass-through to the benchmark runner via `"$@"` so extra flags like `--output` and `--baseline-file` continue to work.
- Updated `package.json` so `benchmark` is `./scripts/benchmarks/invoke.sh` and `benchmark:ci` is `./scripts/benchmarks/invoke.sh --ci` so both modes use the same entrypoint.

### Testing
- Verified script syntax with `bash -n scripts/benchmarks/invoke.sh`, which succeeded.
- Verified the `package.json` script entries with `node -e 'const p=require("./package.json"); console.log(p.scripts.benchmark); console.log(p.scripts["benchmark:ci"]);'`, which printed the updated wrapper commands successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da393b9008329857a0dc0f770b620)