### PR TITLE
Add LRU caching for posts retrieval with deterministic keys and tests

### DIFF
--- a/app/blog/render/retrieve/posts.js
+++ b/app/blog/render/retrieve/posts.js
@@ -1,6 +1,75 @@
 const Entry = require("models/entry");
-const { getPage } = require("models/entries");
+const entriesModel = require("models/entries");
+const LRUCache = require("lru-cache").LRUCache;
 const fetchTaggedEntries = require("./helpers/fetchTaggedEntries");
+
+const postsCache = new LRUCache({
+  max: 1000,
+});
+
+function cloneDeep(value) {
+  if (Array.isArray(value)) {
+    return value.map(cloneDeep);
+  }
+
+  if (value && typeof value === "object") {
+    const clone = {};
+
+    Object.keys(value).forEach((key) => {
+      clone[key] = cloneDeep(value[key]);
+    });
+
+    return clone;
+  }
+
+  return value;
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) {
+    return value;
+  }
+
+  Object.keys(value).forEach((key) => {
+    deepFreeze(value[key]);
+  });
+
+  return Object.freeze(value);
+}
+
+function normalizeTagKey(tags) {
+  if (Array.isArray(tags)) {
+    return tags.map((tag) => String(tag)).sort();
+  }
+
+  return tags === undefined ? undefined : String(tags);
+}
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = parseInt(value, 10);
+
+  if (!parsed || parsed < 1) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function createCacheKey(req, res, normalizedOptions) {
+  return JSON.stringify({
+    blogID: String(req?.blog?.id),
+    cacheID: String(req?.blog?.cacheID),
+    branch: String(normalizedOptions.branch),
+    tags: normalizeTagKey(normalizedOptions.tags),
+    sortBy: String(normalizedOptions.sortBy),
+    order: String(normalizedOptions.order),
+    pathPrefix: String(normalizedOptions.pathPrefix),
+    pageNumber: Number(normalizedOptions.pageNumber),
+    pageSize: Number(normalizedOptions.pageSize),
+    limit: Number(normalizedOptions.limit),
+    offset: Number(normalizedOptions.offset),
+  });
+}
 
 module.exports = function (req, res, callback) {
   const blogID = req?.blog?.id;
@@ -15,17 +84,46 @@ module.exports = function (req, res, callback) {
   };
 
   const tags = req?.query?.tag || req?.params?.tag || res?.locals?.tag;
+  const normalizedPageNumber = parsePositiveInteger(options.pageNumber, 1);
+  const normalizedPageSize = parsePositiveInteger(options.pageSize, 100);
+  const normalizedLimit = Math.max(1, Math.min(500, normalizedPageSize));
+  const normalizedOffset = (normalizedPageNumber - 1) * normalizedLimit;
+  const normalizedOptions = {
+    branch: tags ? "tagged" : "untagged",
+    tags,
+    sortBy: options.sortBy,
+    order: options.order,
+    pathPrefix: options.pathPrefix,
+    pageNumber: normalizedPageNumber,
+    pageSize: normalizedPageSize,
+    limit: normalizedLimit,
+    offset: normalizedOffset,
+  };
+
+  const key = createCacheKey(req, res, normalizedOptions);
+
+  if (postsCache.has(key)) {
+    const cachedPayload = cloneDeep(postsCache.get(key));
+    log("Retrieved posts from cache");
+    res.locals.pagination = cachedPayload.pagination;
+    return callback(null, cachedPayload.entries);
+  }
 
   if (!tags) {
     log("Loading page of entries");
-    return getPage(blogID, options, (err, entries, pagination) => {
+    return entriesModel.getPage(blogID, options, (err, entries, pagination) => {
       if (err) {
         return callback(err);
       }
 
-      res.locals.pagination = pagination;
+      const payload = { entries, pagination };
+      const immutableCopy = deepFreeze(cloneDeep(payload));
+      postsCache.set(key, immutableCopy);
+      const responsePayload = cloneDeep(immutableCopy);
 
-      callback(null, entries);
+      res.locals.pagination = responsePayload.pagination;
+
+      callback(null, responsePayload.entries);
     });
   }
 
@@ -50,9 +148,22 @@ module.exports = function (req, res, callback) {
 
       Entry.get(blogID, result.entryIDs || [], (entries) => {
         entries.sort((a, b) => b.dateStamp - a.dateStamp);
-        res.locals.pagination = result.pagination || {};
-        callback(null, entries);
+        const payload = {
+          entries,
+          pagination: result.pagination || {},
+        };
+        const immutableCopy = deepFreeze(cloneDeep(payload));
+        postsCache.set(key, immutableCopy);
+        const responsePayload = cloneDeep(immutableCopy);
+
+        res.locals.pagination = responsePayload.pagination;
+        callback(null, responsePayload.entries);
       });
     }
   );
+};
+
+module.exports._createCacheKey = createCacheKey;
+module.exports._clear = function () {
+  postsCache.clear();
 };

--- a/app/blog/render/retrieve/tests/posts.js
+++ b/app/blog/render/retrieve/tests/posts.js
@@ -160,3 +160,253 @@ describe("posts", function () {
     }
   });
 });
+
+describe("posts cache", function () {
+  const Entry = require("models/entry");
+  const entriesModel = require("models/entries");
+  const helperPath = require.resolve("../helpers/fetchTaggedEntries");
+  const postsPath = require.resolve("../posts");
+
+  function loadPostsWithTaggedStub(taggedStub) {
+    delete require.cache[postsPath];
+    delete require.cache[helperPath];
+    require.cache[helperPath] = {
+      id: helperPath,
+      filename: helperPath,
+      loaded: true,
+      exports: taggedStub,
+    };
+
+    return require("../posts");
+  }
+
+  afterEach(function () {
+    delete require.cache[postsPath];
+    delete require.cache[helperPath];
+  });
+
+  it("reuses cached untagged responses for identical inputs", function (done) {
+    const posts = loadPostsWithTaggedStub(function () {});
+    posts._clear();
+
+    spyOn(entriesModel, "getPage").and.callFake(function (blogID, options, callback) {
+      callback(null, [{ id: "1", title: "A" }], { page: 1, pages: 1 });
+    });
+
+    const req = {
+      blog: { id: "blog-1", cacheID: 100 },
+      query: {},
+      params: {},
+      template: { locals: { page_size: 5 } },
+      log: function () {},
+    };
+
+    posts(req, { locals: {} }, function () {
+      posts(req, { locals: {} }, function () {
+        expect(entriesModel.getPage).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+
+  it("reuses cached tagged responses for identical inputs", function (done) {
+    const taggedSpy = jasmine.createSpy("fetchTaggedEntries").and.callFake(function (
+      blogID,
+      tags,
+      options,
+      callback
+    ) {
+      callback(null, { entryIDs: ["1", "2"], pagination: { page: 1, pages: 1 } });
+    });
+
+    const posts = loadPostsWithTaggedStub(taggedSpy);
+    posts._clear();
+
+    spyOn(Entry, "get").and.callFake(function (blogID, entryIDs, callback) {
+      callback([
+        { id: "1", dateStamp: 1, title: "First" },
+        { id: "2", dateStamp: 2, title: "Second" },
+      ]);
+    });
+
+    const req = {
+      blog: { id: "blog-1", cacheID: 100 },
+      query: { tag: "foo" },
+      params: {},
+      template: { locals: { page_size: 2, path_prefix: "/blog/" } },
+      log: function () {},
+    };
+
+    posts(req, { locals: {} }, function () {
+      posts(req, { locals: {} }, function () {
+        expect(taggedSpy).toHaveBeenCalledTimes(1);
+        expect(Entry.get).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+
+  it("returns isolated copies so caller mutations do not taint cache", function (done) {
+    const posts = loadPostsWithTaggedStub(function () {});
+    posts._clear();
+
+    spyOn(entriesModel, "getPage").and.callFake(function (blogID, options, callback) {
+      callback(null, [{ title: "Original" }], { page: 1, pages: 3, nested: { total: 10 } });
+    });
+
+    const req = {
+      blog: { id: "blog-1", cacheID: 100 },
+      query: {},
+      params: {},
+      template: { locals: {} },
+      log: function () {},
+    };
+
+    const firstRes = { locals: {} };
+
+    posts(req, firstRes, function (err, firstEntries) {
+      expect(err).toBeNull();
+      firstEntries[0].title = "Mutated";
+      firstRes.locals.pagination.nested.total = -1;
+
+      const secondRes = { locals: {} };
+      posts(req, secondRes, function (secondErr, secondEntries) {
+        expect(secondErr).toBeNull();
+        expect(secondEntries[0].title).toBe("Original");
+        expect(secondRes.locals.pagination.nested.total).toBe(10);
+        expect(entriesModel.getPage).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+
+  it("varies cache keys across invalidation and query dimensions", function () {
+    const posts = loadPostsWithTaggedStub(function () {});
+
+    const makeKey = function ({ cacheID, tag, pageNumber, sortBy, order, pathPrefix }) {
+      return posts._createCacheKey(
+        { blog: { id: "blog-1", cacheID }, query: { tag }, params: {}, template: { locals: {} } },
+        { locals: {} },
+        {
+          branch: tag ? "tagged" : "untagged",
+          tags: tag,
+          sortBy,
+          order,
+          pathPrefix,
+          pageNumber,
+          pageSize: 10,
+          limit: 10,
+          offset: (pageNumber - 1) * 10,
+        }
+      );
+    };
+
+    const base = makeKey({
+      cacheID: "v1",
+      tag: "foo",
+      pageNumber: 1,
+      sortBy: "date",
+      order: "desc",
+      pathPrefix: "/blog/",
+    });
+
+    expect(base).not.toBe(
+      makeKey({
+        cacheID: "v2",
+        tag: "foo",
+        pageNumber: 1,
+        sortBy: "date",
+        order: "desc",
+        pathPrefix: "/blog/",
+      })
+    );
+    expect(base).not.toBe(
+      makeKey({
+        cacheID: "v1",
+        tag: "bar",
+        pageNumber: 1,
+        sortBy: "date",
+        order: "desc",
+        pathPrefix: "/blog/",
+      })
+    );
+    expect(base).not.toBe(
+      makeKey({
+        cacheID: "v1",
+        tag: "foo",
+        pageNumber: 2,
+        sortBy: "date",
+        order: "desc",
+        pathPrefix: "/blog/",
+      })
+    );
+    expect(base).not.toBe(
+      makeKey({
+        cacheID: "v1",
+        tag: "foo",
+        pageNumber: 1,
+        sortBy: "slug",
+        order: "desc",
+        pathPrefix: "/blog/",
+      })
+    );
+    expect(base).not.toBe(
+      makeKey({
+        cacheID: "v1",
+        tag: "foo",
+        pageNumber: 1,
+        sortBy: "date",
+        order: "asc",
+        pathPrefix: "/blog/",
+      })
+    );
+    expect(base).not.toBe(
+      makeKey({
+        cacheID: "v1",
+        tag: "foo",
+        pageNumber: 1,
+        sortBy: "date",
+        order: "desc",
+        pathPrefix: "/notes/",
+      })
+    );
+  });
+
+  it("does not collide tagged and untagged key spaces", function () {
+    const posts = loadPostsWithTaggedStub(function () {});
+
+    const tagged = posts._createCacheKey(
+      { blog: { id: "blog-1", cacheID: "v1" }, query: { tag: "foo" }, params: {}, template: { locals: {} } },
+      { locals: {} },
+      {
+        branch: "tagged",
+        tags: "foo",
+        sortBy: "date",
+        order: "desc",
+        pathPrefix: "/blog/",
+        pageNumber: 1,
+        pageSize: 10,
+        limit: 10,
+        offset: 0,
+      }
+    );
+
+    const untagged = posts._createCacheKey(
+      { blog: { id: "blog-1", cacheID: "v1" }, query: {}, params: {}, template: { locals: {} } },
+      { locals: {} },
+      {
+        branch: "untagged",
+        tags: "foo",
+        sortBy: "date",
+        order: "desc",
+        pathPrefix: "/blog/",
+        pageNumber: 1,
+        pageSize: 10,
+        limit: 10,
+        offset: 0,
+      }
+    );
+
+    expect(tagged).not.toBe(untagged);
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve performance of posts retrieval by caching rendered posts responses for repeated identical requests while ensuring cache invalidation when blog data or query parameters change. 
- Prevent caller-side mutation from tainting cache by storing immutable payloads and returning cloned copies. 
- Provide deterministic hooks for testing and verification of cache key behavior and isolation.

### Description
- Add an LRU cache (`LRUCache` from `lru-cache`) to `app/blog/render/retrieve/posts.js` and implement `cloneDeep`, `deepFreeze`, and `createCacheKey` helpers to store immutable `{ entries, pagination }` payloads and always return cloned copies. 
- Build cache keys from all output-affecting inputs including `blog.id` and `blog.cacheID`, normalized `tags` (canonical ordering for arrays), pagination (`pageNumber`, `pageSize`, `limit`, `offset`), sorting (`sortBy`, `order`), `pathPrefix`, and a `branch` discriminator (`tagged` vs `untagged`). 
- Preserve existing functional branches so untagged requests still call `entriesModel.getPage` and tagged requests still call `fetchTaggedEntries` -> `Entry.get` with date sorting, while wiring cache lookup before performing fetch and restoring `res.locals.pagination` on cache hits. 
- Expose test hooks `module.exports._createCacheKey` and `module.exports._clear` and extend `app/blog/render/retrieve/tests/posts.js` with cache-focused tests covering cache reuse, mutation isolation, key variance across `cacheID/tag/page/sort/order/path_prefix`, and separation of tagged vs untagged key spaces.

### Testing
- Ran syntax/checks with `node --check app/blog/render/retrieve/posts.js` and `node --check app/blog/render/retrieve/tests/posts.js`, both of which succeeded. 
- Added unit-style tests in `app/blog/render/retrieve/tests/posts.js` that exercise cache hits, tagged/untagged behavior, mutation isolation, and cache-key variation. 
- Attempted to run repository tests via `npm test -- app/blog/render/retrieve/tests/posts.js`, but the repo test harness requires Docker and this environment lacks Docker so the full test run could not be executed (Docker CLI error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a02de75f248329a86e3c10c4c3e813)