### PR TITLE
Remove deprecated Redis batch compatibility alias

### DIFF
--- a/app/models/redis.js
+++ b/app/models/redis.js
@@ -468,10 +468,6 @@ module.exports = function () {
     };
   }
 
-  if (typeof client.batch !== "function") {
-    client.batch = client.multi.bind(client);
-  }
-
   if (typeof client.quit === "function") {
     const nativeQuit = client.quit.bind(client);
     client.quit = function compatQuit(callback) {


### PR DESCRIPTION
## Summary
- removed the Redis compatibility alias in `app/models/redis.js` that exposed `client.batch` via `client.multi.bind(client)`
- left no `batch` API exposed on the Redis client

## Notes
- searched for `.batch(` usage in `app/` and found only documentation references, with no runtime call sites to migrate
- because there were no call sites, the temporary throwing guard was not added

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19e834964832986c8621e96d5bea1)