### PR TITLE
Update entries-path-index fix tests for auto-pipelined Redis client

### DIFF
--- a/app/sync/fix/tests/entries-path-index.js
+++ b/app/sync/fix/tests/entries-path-index.js
@@ -4,46 +4,26 @@ describe("sync/fix/entries-path-index", function () {
   var fixEntriesPathIndex = require("../entries-path-index");
 
   it("does nothing when entry count and path index count match", function (done) {
-    var exec = jasmine.createSpy("exec").and.callFake(function (callback) {
-      callback(null, ["2", "2"]);
-    });
-
-    var batch = {
-      zcard: jasmine.createSpy("zcard").and.returnValue(this),
-      exec: exec,
-    };
-
-    batch.zcard.and.callFake(function () {
-      return batch;
-    });
-
-    spyOn(client, "batch").and.returnValue(batch);
+    var zcard = spyOn(client, "zcard").and.returnValues(
+      Promise.resolve("2"),
+      Promise.resolve("2")
+    );
     spyOn(pathIndex, "backfillIndex");
 
     fixEntriesPathIndex({ id: "blog-id" }, function (err, changes) {
       expect(err).toBeNull();
       expect(changes).toEqual([]);
-      expect(batch.zcard.calls.count()).toBe(2);
+      expect(zcard.calls.count()).toBe(2);
       expect(pathIndex.backfillIndex).not.toHaveBeenCalled();
       done();
     });
   });
 
   it("backfills the index when counts do not match", function (done) {
-    var exec = jasmine.createSpy("exec").and.callFake(function (callback) {
-      callback(null, ["5", "3"]);
-    });
-
-    var batch = {
-      zcard: jasmine.createSpy("zcard").and.returnValue(this),
-      exec: exec,
-    };
-
-    batch.zcard.and.callFake(function () {
-      return batch;
-    });
-
-    spyOn(client, "batch").and.returnValue(batch);
+    spyOn(client, "zcard").and.returnValues(
+      Promise.resolve("5"),
+      Promise.resolve("3")
+    );
     spyOn(pathIndex, "backfillIndex").and.callFake(function (blogID, callback) {
       expect(blogID).toBe("blog-id");
       callback(null, 5);
@@ -63,18 +43,10 @@ describe("sync/fix/entries-path-index", function () {
   it("returns errors from the initial redis query", function (done) {
     var redisError = new Error("redis exploded");
 
-    var batch = {
-      zcard: jasmine.createSpy("zcard").and.returnValue(this),
-      exec: jasmine.createSpy("exec").and.callFake(function (callback) {
-        callback(redisError);
-      }),
-    };
-
-    batch.zcard.and.callFake(function () {
-      return batch;
-    });
-
-    spyOn(client, "batch").and.returnValue(batch);
+    spyOn(client, "zcard").and.returnValues(
+      Promise.reject(redisError),
+      Promise.resolve("2")
+    );
     spyOn(pathIndex, "backfillIndex");
 
     fixEntriesPathIndex({ id: "blog-id" }, function (err, changes) {


### PR DESCRIPTION
### Motivation
- The Redis client now uses promise-based calls and auto-pipelining, so tests that stubbed `client.batch()` needed to be updated to reflect direct promise `client.zcard()` usage.

### Description
- Replaced stubs of `client.batch()` with `spyOn(client, "zcard").and.returnValues(...)` that return `Promise.resolve(...)` or `Promise.reject(...)` in `app/sync/fix/tests/entries-path-index.js`.
- Updated assertions to check `zcard` call counts instead of the old `batch` object and preserved existing expectations for matching counts, mismatch/backfill behavior, and error propagation.
- Only test code was modified; no production code changes were made.

### Testing
- Ran `npx jasmine app/sync/fix/tests/entries-path-index.js` which failed due to module resolution for `models/client` in this environment (no `NODE_PATH` set). 
- Ran `NODE_PATH=app npx jasmine app/sync/fix/tests/entries-path-index.js` which failed because Redis is not available in this environment and the model initialization expects a live Redis client (connection refused / `client.connect` errors). 
- The tests are updated to run against the promise-based client and should pass in the normal project test environment where `NODE_PATH=app` is set and a Redis instance is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19f48d6a8832999d31015ceadc2ac)