### PR TITLE
Migrate Redis HMSET usages to HSET and remove HMSET compatibility layer

### DIFF
--- a/app/clients/dropbox/database.js
+++ b/app/clients/dropbox/database.js
@@ -91,7 +91,7 @@ function set(blogID, changes, callback) {
 
     debug("Saving this account");
     multi.sadd(blogsKey(changes.account_id), blogID);
-    multi.hmset(accountKey(blogID), account);
+    multi.hset(accountKey(blogID), account);
     multi.exec(callback);
   });
 }

--- a/app/models/blog/set.js
+++ b/app/models/blog/set.js
@@ -172,7 +172,7 @@ module.exports = function (blogID, blog, callback) {
         return callback(null, changesList);
       }
 
-      multi.hmset(key.info(blogID), serial(latest));
+      multi.hset(key.info(blogID), serial(latest));
 
       multi.exec(async function (err) {
         // We didn't manage to apply any changes

--- a/app/models/question/create.js
+++ b/app/models/question/create.js
@@ -58,7 +58,7 @@ module.exports = async function ({
     multi.zadd(keys.by_number_of_replies, 0, id);
   }
 
-  multi.hmset(keys.item(id), item);
+  multi.hset(keys.item(id), item);
 
   // ensure the multi command fails if the ID
   // is already in use

--- a/app/models/question/tests/create.js
+++ b/app/models/question/tests/create.js
@@ -1,4 +1,4 @@
-const { hmset, setnx } = require("../../client");
+const { hset, setnx } = require("../../client");
 
 describe("questions.create", function () {
   require("./setup")();
@@ -62,7 +62,7 @@ describe("questions.create", function () {
       zadd: () => {},
       sadd: () => {},
       zincrby: () => {},
-      hmset: () => {},
+      hset: () => {},
       setnx: () => {},
       exec: (cb) => cb(new Error("Oh no!")),
     });

--- a/app/models/redis.js
+++ b/app/models/redis.js
@@ -243,38 +243,6 @@ module.exports = function () {
     return args;
   });
 
-  createLegacyCommand("hmset", "HSET", function normalizeHMSetArgs(args) {
-    const key = args[0];
-    const values = args[1];
-
-    if (args.length === 2 && values && typeof values === "object" && !Array.isArray(values)) {
-      const pairs = [];
-      Object.keys(values).forEach((field) => {
-        pairs.push(field, normalizeValue(values[field]));
-      });
-      return [key].concat(pairs);
-    }
-
-    if (args.length === 2 && Array.isArray(values)) {
-      return [
-        key,
-        ...values.map((value, index) =>
-          index % 2 === 1 ? normalizeValue(value) : value
-        ),
-      ];
-    }
-
-    if (args.length >= 3) {
-      const pairs = [];
-      for (let i = 1; i < args.length; i += 2) {
-        pairs.push(args[i], normalizeValue(args[i + 1]));
-      }
-      return [key].concat(pairs);
-    }
-
-    return args;
-  });
-
   createLegacyCommand("zadd", "ZADD", function normalizeZAddArgs(args) {
     // Preserve legacy varargs: zadd key score member [score member...]
     return args;
@@ -295,7 +263,6 @@ module.exports = function () {
         "hgetall",
         "hset",
         "hdel",
-        "hmset",
         "sadd",
         "srem",
         "smembers",
@@ -426,23 +393,6 @@ module.exports = function () {
           return multi;
         };
       }
-
-      multi.hmset = function hmsetCompat(key, values) {
-        if (
-          values &&
-          typeof values === "object" &&
-          !Array.isArray(values)
-        ) {
-          return multi.hset(key, values);
-        }
-
-        if (Array.isArray(values)) {
-          return multi.hset(key, ...values);
-        }
-
-        const args = Array.prototype.slice.call(arguments, 1);
-        return multi.hset(key, ...args);
-      };
 
       const nativeExec = multi.exec.bind(multi);
       multi.exec = function compatExec(callback) {

--- a/app/models/template/setMetadata.js
+++ b/app/models/template/setMetadata.js
@@ -49,7 +49,7 @@ module.exports = function setMetadata(id, updates, callback) {
     client.sadd(key.blogTemplates(metadata.owner), id, function (err) {
       if (err) return callback(err);
 
-      client.hmset(key.metadata(id), metadata, function (err) {
+      client.hset(key.metadata(id), metadata, function (err) {
         if (err) return callback(err);
 
         if (!changes) {

--- a/app/models/template/setView.js
+++ b/app/models/template/setView.js
@@ -277,7 +277,7 @@ module.exports = function setView(templateID, updates, callback) {
 
 						// Delete url and urlPatterns from Redis hash if they were removed
 						var multi = client.multi();
-						multi.hmset(viewKey, view);
+						multi.hset(viewKey, view);
 
 						if (shouldRemoveUrl) {
 							console.log("removing hdel", viewKey, "url");


### PR DESCRIPTION
### Motivation
- Replace legacy `hmset` usage with the modern `hset` API across the codebase and remove the now-unnecessary compatibility shims to simplify Redis command handling.

### Description
- Replaced call sites using `multi.hmset` / `client.hmset` with `multi.hset` / `client.hset` while preserving object payload semantics (`hset(key, { field: value })`) in `app/models/question/create.js`, `app/models/template/setMetadata.js`, `app/models/template/setView.js`, `app/models/blog/set.js`, and `app/clients/dropbox/database.js`.
- Updated the question test double in `app/models/question/tests/create.js` to reflect `hset` instead of `hmset` so mocks match runtime calls.
- Removed the `hmset` legacy handling from `app/models/redis.js` by deleting the `createLegacyCommand("hmset", "HSET", ...)` block, removing `"hmset"` from the multi command compatibility list, and removing the `multi.hmset` shim.

### Testing
- Ran `node --check` on the modified files and it completed successfully with no syntax errors.
- Attempted to run the question spec via Jasmine (`node ./node_modules/jasmine/bin/jasmine.js app/models/question/tests/create.js`), but the test run failed in this environment due to a missing runtime dependency (`config` module) required by the Redis bootstrap, so full test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a34bca4083298a124133f46fee1d)