### PR TITLE
Add RESP3 Redis client modules for migration groundwork

### DIFF
--- a/app/models/client-new.js
+++ b/app/models/client-new.js
@@ -1,0 +1,1 @@
+module.exports = require("./redis-new")();

--- a/app/models/redis-new.js
+++ b/app/models/redis-new.js
@@ -1,0 +1,18 @@
+const config = require("config");
+const redis = require("redis");
+
+const url = `redis://${config.redis.host}:${config.redis.port}`;
+
+module.exports = function () {
+  const client = redis.createClient({
+    url,
+    RESP: 3,
+    clientSideCache: {
+      ttl: 0,
+      maxEntries: 10000,
+      evictPolicy: "LRU",
+    },
+  });
+
+  return client;
+};


### PR DESCRIPTION
## Summary
- add `app/models/redis-new.js` to construct a Redis client configured for RESP3 and client-side cache
- add `app/models/client-new.js` as a convenience module exporting an initialized instance
- leave existing `app/models/redis.js` / `app/models/client.js` unchanged so migration can proceed incrementally

## Why
This introduces a parallel Redis client path so individual call sites can be migrated safely in phases rather than forcing a big-bang switch.

## Follow-up migration tasks
1. Inventory all imports of `app/models/client.js` and group by command patterns used (callbacks, `multi`, scans, hash/set/zset/list usage).
2. Migrate promise-based consumers first to `app/models/client-new.js` and add targeted verification around returned reply shapes.
3. Add compatibility wrappers (or localized adapters) for callback and `multi.exec(callback)` call sites before moving those modules.
4. After all call sites are moved, remove legacy compatibility code and retire the old client modules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b0ef9e988329a80e0da6ed5753c5)