### PR TITLE
Define lifecycle contract for new Redis singleton client

### DIFF
--- a/app/models/client-new.js
+++ b/app/models/client-new.js
@@ -1,1 +1,19 @@
-module.exports = require("./redis-new")();
+/**
+ * Shared singleton Redis client for the "new" client path.
+ *
+ * Lifecycle contract:
+ * - This module owns the process-wide singleton connection.
+ * - Consumers should NOT call `quit()`/`disconnect()` on this client.
+ * - Use `redis-new` directly when you need a dedicated client with an
+ *   independent lifecycle that can be explicitly closed.
+ */
+const client = require("./redis-new")();
+
+client.connect().catch((err) => {
+  console.log("Redis connect error:");
+  console.log(err);
+  if (err.trace) console.log(err.trace);
+  if (err.stack) console.log(err.stack);
+});
+
+module.exports = client;

--- a/app/models/redis-new.js
+++ b/app/models/redis-new.js
@@ -14,5 +14,12 @@ module.exports = function () {
     },
   });
 
+  client.on("error", function (err) {
+    console.log("Redis Error:");
+    console.log(err);
+    if (err.trace) console.log(err.trace);
+    if (err.stack) console.log(err.stack);
+  });
+
   return client;
 };


### PR DESCRIPTION
### Motivation
- Provide a clear, process-wide singleton for the new Redis client path so consumers have a predictable lifecycle for shared connections.
- Surface connection and runtime errors from the new client path to match existing visibility in the legacy Redis client.
- Prevent accidental shutdown of the shared client by documenting whether consumers may call `quit()`/`disconnect()`.

### Description
- Turned `app/models/client-new.js` from a one-liner into a documented singleton module that requires `./redis-new`, calls `client.connect()` at module load, and exports the ready-to-use client.
- Added a module comment in `client-new.js` that defines the lifecycle contract and explicitly warns consumers not to call `quit()`/`disconnect()` on the singleton and to use `redis-new` for dedicated clients.
- Added an `error` event handler to `app/models/redis-new.js` that logs `Redis Error:` and prints `err`, `err.trace`, and `err.stack` when present to mirror legacy logging behavior.
- Kept `redis-new.js` as a factory for dedicated clients so callers can obtain independent clients that can be closed explicitly.

### Testing
- Ran `node --check app/models/client-new.js` which completed successfully.
- Ran `node --check app/models/redis-new.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b2cccb348329999f48c0da17414b)