### PR TITLE
Migrate simple Redis consumers to new node-redis v4 clients

### DIFF
--- a/app/scheduler/daily/newsletter-subscribers.js
+++ b/app/scheduler/daily/newsletter-subscribers.js
@@ -1,6 +1,5 @@
 async function main(callback) {
-  var redis = require("models/redis");
-  var client = new redis();
+  var client = require("models/client-new");
 
   try {
     const subscribers = await client.smembers("newsletter:list");

--- a/app/server.js
+++ b/app/server.js
@@ -27,22 +27,24 @@ console.log(
 server.set("trust proxy", true);
 
 // Check if the database is healthy
-server.get("/redis-health", function (req, res) {
-  let redis = require("models/redis");
-  let client = redis();
+server.get("/redis-health", async function (req, res) {
+  const createRedisClient = require("models/redis-new");
+  const client = createRedisClient();
 
   // do not cache response
   res.set("Cache-Control", "no-store");
 
-  client.ping(function (err, reply) {
-    if (err) {
-      res.status(400).send("Failed to ping redis");
-    } else {
-      res.send("OK");
+  try {
+    await client.connect();
+    await client.ping();
+    res.send("OK");
+  } catch (err) {
+    res.status(400).send("Failed to ping redis");
+  } finally {
+    if (client.isOpen) {
+      await client.quit();
     }
-
-    client.quit();
-  });
+  }
 });
 
 // Prevent <iframes> embedding pages served by Blot while allowing


### PR DESCRIPTION
### Motivation
- Validate the new node-redis v4 stack by converting the lowest-risk Redis consumers first to minimize behavioral impact.
- Move healthcheck and a simple scheduler consumer to the new client paths and promise-based APIs to align with the upgraded client semantics.

### Description
- Rewrote `/redis-health` in `app/server.js` to use async/await and the per-request factory `models/redis-new`, including `await client.connect()` and `await client.ping()` while preserving `Cache-Control: no-store` and HTTP success/error responses.
- Ensured the healthcheck explicitly cleans up the dedicated client under v4 semantics by guarding `await client.quit()` behind `client.isOpen` in a `finally` block.
- Updated `app/scheduler/daily/newsletter-subscribers.js` to use the singleton `models/client-new` client instead of constructing the legacy `models/redis` instance and preserved the callback contract `callback(err, { newsletter_subscribers: ... })`.
- Kept behavioral outputs identical on success/failure for both updated paths.

### Testing
- Ran `node --check app/server.js` which completed successfully.
- Ran `node --check app/scheduler/daily/newsletter-subscribers.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b60225708329b8804681a2d72cce)