### PR TITLE
Refactor legacy pub/sub consumers to shared v4-compatible helper

### DIFF
--- a/app/helper/redisSubscriber.js
+++ b/app/helper/redisSubscriber.js
@@ -1,0 +1,54 @@
+const redis = require("models/redis");
+
+module.exports = function redisSubscriber({
+  channel,
+  onMessage,
+  onError,
+  logger = console,
+}) {
+  const client = new redis();
+  const messageHandler = typeof onMessage === "function" ? onMessage : function () {};
+  let cleanedUp = false;
+
+  function logRedisError(err) {
+    if (typeof onError === "function") {
+      return onError(err);
+    }
+
+    logger.log("Redis Error:", err);
+  }
+
+  client.on("error", logRedisError);
+
+  Promise.resolve(
+    client.subscribe(channel, function (message, subscribedChannel) {
+      try {
+        messageHandler(message, subscribedChannel || channel);
+      } catch (err) {
+        logRedisError(err);
+      }
+    })
+  ).catch(logRedisError);
+
+  async function cleanup() {
+    if (cleanedUp) return;
+    cleanedUp = true;
+
+    try {
+      await client.unsubscribe(channel);
+    } catch (err) {
+      logRedisError(err);
+    }
+
+    try {
+      await client.quit();
+    } catch (err) {
+      logRedisError(err);
+    }
+  }
+
+  return {
+    client,
+    cleanup,
+  };
+};

--- a/app/helper/sse.js
+++ b/app/helper/sse.js
@@ -1,9 +1,7 @@
-const redis = require("models/redis");
+const redisSubscriber = require("helper/redisSubscriber");
 
 module.exports = function ({ channel }) {
   return function (req, res) {
-    var client = new redis();
-
     req.socket.setTimeout(2147483647);
 
     res.writeHead(200, {
@@ -20,20 +18,20 @@ module.exports = function ({ channel }) {
 
     res.write("\n");
 
-    client.subscribe(channel(req), function (message) {
-      res.write("\n");
-      res.write("data: " + message + "\n\n");
-      res.flushHeaders();
-    });
-
-    // In case we encounter an error...print it out to the console
-    client.on("error", function (err) {
-      console.log("Redis Error: " + err);
+    const subscription = redisSubscriber({
+      channel: channel(req),
+      onMessage: function (message) {
+        res.write("\n");
+        res.write("data: " + message + "\n\n");
+        res.flushHeaders();
+      },
+      onError: function (err) {
+        console.log("Redis Error: " + err);
+      },
     });
 
     req.on("close", function () {
-      client.unsubscribe();
-      client.quit();
+      subscription.cleanup();
     });
   };
 };

--- a/app/templates/index.js
+++ b/app/templates/index.js
@@ -15,7 +15,7 @@ var urlNormalizer = require("helper/urlNormalizer");
 var TEMPLATES_DIRECTORY = require("path").resolve(__dirname + "/source");
 var TEMPLATES_OWNER = "SITE";
 
-const redis = require("models/redis");
+const redisSubscriber = require("helper/redisSubscriber");
 
 var HIGHLIGHTER_THEMES = require("blog/static/syntax-highlighter");
 
@@ -61,10 +61,11 @@ if (require.main === module) {
 
   // Rebuilds templates when we load new states
   // using scripts/state/info.js
-  let redis = require("models/redis");
-  let client = new redis();
-  client.subscribe("templates:rebuild", function () {
-    main({}, function () {});
+  redisSubscriber({
+    channel: "templates:rebuild",
+    onMessage: function () {
+      main({}, function () {});
+    },
   });
 }
 
@@ -82,10 +83,11 @@ function main(options, callback) {
 
         // Rebuilds templates when we load new states
         // using scripts/state/info.js
-        const templateClient = new redis();
-
-        templateClient.subscribe("templates:rebuild", function () {
-          main({}, function () {});
+        redisSubscriber({
+          channel: "templates:rebuild",
+          onMessage: function () {
+            main({}, function () {});
+          },
         });
 
         callback(null);


### PR DESCRIPTION
### Motivation
- Centralize Redis pub/sub plumbing to avoid duplicate migration mistakes and make consumers compatible with node-redis v4 patterns.
- Ensure SSE endpoints and background listeners correctly subscribe/unsubscribe and quit the client on cleanup to avoid connection leaks.
- Preserve existing message handler semantics and argument order to avoid subtle regressions across consumers.

### Description
- Add a shared helper `app/helper/redisSubscriber.js` that creates a Redis client, subscribes, forwards `(message, channel)` to handlers, logs errors, and exposes an idempotent `cleanup()` that `unsubscribe` + `quit` the client.
- Migrate `app/helper/sse.js` to use the new helper while keeping SSE payload formatting (`data: ...\n\n`) and calling `subscription.cleanup()` when the request closes.
- Replace `templates:rebuild` subscription wiring in `app/templates/index.js` (both direct-run bootstrap and watch-mode path) to use the helper and preserve the rebuild callback behavior.
- Ensure handler exceptions and Redis errors are logged via `onError`/logger and do not crash the process.

### Testing
- Syntax-checked the modified files with `node -c app/helper/redisSubscriber.js`, `node -c app/helper/sse.js`, and `node -c app/templates/index.js`, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b609f7688329adff2b47f4893345)