### PR TITLE
Modernize redisSearch to use modern Redis APIs and handle RESP3 scan replies

### DIFF
--- a/app/helper/redisSearch.js
+++ b/app/helper/redisSearch.js
@@ -53,7 +53,7 @@ async function stringSearch(string, keys, result) {
 
 async function listSearch(string, keys, result) {
   for (const key of keys) {
-    const items = await client.lrange(key, 0, -1);
+    const items = await client.lRange(key, 0, -1);
     if (!items) continue;
 
     items.forEach(function (item) {
@@ -65,7 +65,7 @@ async function listSearch(string, keys, result) {
 
 async function hashSearch(string, keys, result) {
   for (const key of keys) {
-    const res = await client.hgetall(key);
+    const res = await client.hGetAll(key);
     if (!res) continue;
 
     for (var property in res)
@@ -80,7 +80,7 @@ async function hashSearch(string, keys, result) {
 
 async function setSearch(string, keys, result) {
   for (const key of keys) {
-    const members = await client.smembers(key);
+    const members = await client.sMembers(key);
     if (!members) continue;
 
     members.forEach(function (member) {
@@ -92,7 +92,7 @@ async function setSearch(string, keys, result) {
 
 async function sortedSetSearch(string, keys, result) {
   for (const key of keys) {
-    const members = await client.zrange(key, 0, -1);
+    const members = await client.zRange(key, 0, -1);
     if (!members) continue;
 
     members.forEach(function (member) {
@@ -107,13 +107,42 @@ async function redisKeys(pattern, fn) {
   var cursor = "0";
 
   while (!complete) {
-    const res = await client.scan(cursor, "match", pattern, "count", 1000);
+    const scanReply = await client.scan(cursor, {
+      MATCH: pattern,
+      COUNT: 1000,
+    });
+    const normalizedScanReply = normalizeScanReply(scanReply);
 
-    cursor = res[0];
-    await fn(res[1]);
+    cursor = normalizedScanReply.cursor;
+    await fn(normalizedScanReply.keys);
 
     complete = cursor === "0";
   }
+}
+
+function normalizeScanReply(reply) {
+  if (Array.isArray(reply)) {
+    return {
+      cursor: String(reply[0] || "0"),
+      keys: Array.isArray(reply[1]) ? reply[1] : [],
+    };
+  }
+
+  if (reply && typeof reply === "object") {
+    const cursor = Object.prototype.hasOwnProperty.call(reply, "cursor")
+      ? String(reply.cursor)
+      : "0";
+
+    const keys = Array.isArray(reply.keys)
+      ? reply.keys
+      : Array.isArray(reply.results)
+      ? reply.results
+      : [];
+
+    return { cursor, keys };
+  }
+
+  return { cursor: "0", keys: [] };
 }
 
 module.exports = main;

--- a/app/helper/tests/redisSearch.js
+++ b/app/helper/tests/redisSearch.js
@@ -1,0 +1,116 @@
+const redisSearchPath = require.resolve("helper/redisSearch");
+const redisModelPath = require.resolve("models/redis");
+
+function loadWithClient(mockClient) {
+  delete require.cache[redisSearchPath];
+
+  require.cache[redisModelPath] = {
+    id: redisModelPath,
+    filename: redisModelPath,
+    loaded: true,
+    exports: function MockRedisClient() {
+      return mockClient;
+    },
+  };
+
+  return require(redisSearchPath);
+}
+
+function runSearch(main, term) {
+  return new Promise((resolve, reject) => {
+    main(term, function (err, result) {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+}
+
+describe("redisSearch helper", function () {
+  afterEach(function () {
+    delete require.cache[redisSearchPath];
+    delete require.cache[redisModelPath];
+  });
+
+  it("searches string/hash/list/set/zset values and key names", async function () {
+    const keyTypes = {
+      "string:key": "string",
+      "hash:key": "hash",
+      "list:key": "list",
+      "set:key": "set",
+      "zset:key": "zset",
+      "needle:key": "string",
+    };
+
+    const mockClient = {
+      scan: jasmine
+        .createSpy("scan")
+        .and.returnValues(
+          Promise.resolve({ cursor: 1, keys: ["string:key", "hash:key"] }),
+          Promise.resolve({ cursor: 0, keys: ["list:key", "set:key", "zset:key", "needle:key"] })
+        ),
+      type: jasmine.createSpy("type").and.callFake((key) => Promise.resolve(keyTypes[key])),
+      get: jasmine
+        .createSpy("get")
+        .and.callFake((key) => Promise.resolve(key === "string:key" ? "prefix-needle-suffix" : "other")),
+      hGetAll: jasmine
+        .createSpy("hGetAll")
+        .and.returnValue(Promise.resolve({ field: "contains needle", needleField: "nope" })),
+      lRange: jasmine
+        .createSpy("lRange")
+        .and.returnValue(Promise.resolve(["x", "list-needle"])),
+      sMembers: jasmine
+        .createSpy("sMembers")
+        .and.returnValue(Promise.resolve(["set-needle", "y"])),
+      zRange: jasmine
+        .createSpy("zRange")
+        .and.returnValue(Promise.resolve(["zset-needle", "z"])),
+    };
+
+    const main = loadWithClient(mockClient);
+    const result = await runSearch(main, "needle");
+
+    expect(mockClient.scan).toHaveBeenCalledWith("0", {
+      MATCH: "*",
+      COUNT: 1000,
+    });
+    expect(mockClient.hGetAll).toHaveBeenCalledWith("hash:key");
+    expect(mockClient.lRange).toHaveBeenCalledWith("list:key", 0, -1);
+    expect(mockClient.sMembers).toHaveBeenCalledWith("set:key");
+    expect(mockClient.zRange).toHaveBeenCalledWith("zset:key", 0, -1);
+
+    expect(result).toEqual([
+      { key: "needle:key", value: "KEY ITSELF", type: "KEY" },
+      { key: "string:key", type: "STRING", value: "prefix-needle-suffix" },
+      { key: "hash:key", type: "HASH", value: "field contains needle" },
+      { key: "hash:key", type: "HASH", value: "needleField nope" },
+      { key: "list:key", type: "LIST", value: "list-needle" },
+      { key: "set:key", type: "SET", value: "set-needle" },
+      { key: "zset:key", type: "ZSET", value: "zset-needle" },
+    ]);
+  });
+
+  it("handles RESP3 scan replies that return results arrays", async function () {
+    const mockClient = {
+      scan: jasmine
+        .createSpy("scan")
+        .and.returnValues(
+          Promise.resolve({ cursor: "1", results: ["k1"] }),
+          Promise.resolve({ cursor: "0", results: ["k2"] })
+        ),
+      type: jasmine.createSpy("type").and.returnValue(Promise.resolve("string")),
+      get: jasmine.createSpy("get").and.returnValue(Promise.resolve("no match")),
+      hGetAll: jasmine.createSpy("hGetAll"),
+      lRange: jasmine.createSpy("lRange"),
+      sMembers: jasmine.createSpy("sMembers"),
+      zRange: jasmine.createSpy("zRange"),
+    };
+
+    const main = loadWithClient(mockClient);
+    const result = await runSearch(main, "needle");
+
+    expect(mockClient.type.calls.count()).toBe(2);
+    expect(mockClient.type.calls.argsFor(0)[0]).toBe("k1");
+    expect(mockClient.type.calls.argsFor(1)[0]).toBe("k2");
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Remove reliance on legacy-mode Redis command aliases and reply shapes to future-proof search logic. 
- Make key scanning robust to both legacy tuple replies and RESP3 object replies that return `results` arrays. 
- Preserve the external entrypoint signature `main(string, callback)` to avoid downstream changes. 
- Add focused unit coverage for common data types to guard regressions.

### Description
- Replaced legacy-style read calls with explicit modern Redis client methods: `hGetAll`, `lRange`, `sMembers`, and `zRange` in `app/helper/redisSearch.js`.
- Reworked `redisKeys()` to call `scan(cursor, { MATCH, COUNT })` and added `normalizeScanReply()` to normalize tuple-style and RESP3 object-style replies into a `{ cursor, keys }` shape.
- Kept `main(string, callback)` unchanged so existing callers are unaffected.
- Added focused unit tests at `app/helper/tests/redisSearch.js` that mock a Redis client and cover string/hash/list/set/zset search paths and RESP3-style `scan` replies returning `results` arrays.

### Testing
- Added unit tests file `app/helper/tests/redisSearch.js` (not executed in Docker here but present for CI).
- Ran syntax checks with `node --check app/helper/redisSearch.js` and `node --check app/helper/tests/redisSearch.js`, which succeeded.
- Attempted to run the Docker-backed test runner `./scripts/tests/invoke.sh app/helper/tests/redisSearch.js`, which failed in this environment because `docker` is not available.
- Attempted to run the local Jasmine binary (`NODE_PATH=app ./node_modules/.bin/jasmine ...`), which failed here because the local `node_modules` test runner is not present; tests should run in CI or a developer environment with Docker/Jasmine available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b617c5f08329b5cdd367f3621439)