### PR TITLE
docs(models): standardize redis client-new guidance

### DIFF
--- a/app/models/404/README
+++ b/app/models/404/README
@@ -99,7 +99,7 @@ An object with two functions for generating Redis key strings. Consumed internal
 
 ## Dependencies
 
-- **`models/client`** — the shared Redis client instance (`app/models/client.js`), which wraps `models/redis.js`.
+- **`models/client-new`** — the shared Redis singleton for model reads and writes (`app/models/client-new.js` → `app/models/redis-new.js`).
 - **`helper/ensure`** — runtime argument type validation. All public functions call `ensure` before touching Redis.
 - **`moment`** (`list.js` only) — converts stored timestamps to human-readable relative strings via `moment.utc(ts).fromNow()`.
 

--- a/app/models/README
+++ b/app/models/README
@@ -1,7 +1,7 @@
 Models
 ------
 
-Models are the data layer. They read and write to Redis. The Redis client is a singleton: require `models/client` (from `app/models/client.js`, which wraps `app/models/redis.js`).
+Models are the data layer. They read and write to Redis. New code should use the new Redis client modules: `models/client-new` for the shared singleton connection, or `models/redis-new` when a module needs a dedicated client instance with its own lifecycle.
 
 
 Redis conventions
@@ -14,6 +14,40 @@ Redis conventions
 - **Key names live in `key.js`.** Each model that uses Redis has a `key.js` (or equivalent) that centralises key names (e.g. `blog:${blogID}:info`, `user:${uid}:info`). Use these instead of building keys inline.
 
 - **Complex types: scheme + serial.** Models that store nested objects (e.g. blog) define a `scheme.js` and use a serial module to JSON.stringify/parse when writing/reading hashes. See blog’s `scheme.js`, `serial.js` and `get.js`/`set.js`.
+
+Choosing the Redis client module
+-------------------------------
+
+- **Use `models/client-new` by default.** It exports a process-wide singleton client and is the correct choice for almost all model reads and writes. Do not call `quit()`/`disconnect()` on this shared instance.
+
+- **Use `models/redis-new` only when you need isolation.** `require("models/redis-new")()` creates a dedicated client with an independent lifecycle. Use this for scripts, one-off migrations, worker-style jobs, or module flows that must explicitly connect and close without affecting the app-wide singleton.
+
+- **Rule of thumb:** if the code runs inside normal request/model flow, use `models/client-new`; if it needs explicit connect/teardown control, use a dedicated `models/redis-new` client.
+
+Legacy compatibility caveats
+----------------------------
+
+When migrating older `models/client`/`models/redis` usage, keep these compatibility differences in mind:
+
+- **Callbacks:** `models/client-new` follows modern promise-based redis APIs. Legacy callback-last patterns (e.g. `client.get(key, cb)`) are not automatically shimmed.
+
+- **Command naming:** the legacy adapter exposed both lowercase and uppercase aliases and normalized some argument shapes. With the new client path, use the current redis command API and argument forms directly.
+
+- **Pub/Sub cleanup:** dedicated pub/sub clients created via `models/redis-new` should be unsubscribed and closed when done. Avoid long-lived subscriptions on the shared singleton unless that lifecycle is intentional and app-wide.
+
+- **Connect lifecycle:** `models/client-new` connects once on module load and is shared process-wide. Dedicated `models/redis-new` clients must be connected and then explicitly closed by the owning module.
+
+Migration checklist (copy per module)
+-------------------------------------
+
+Use this checklist when updating a model:
+
+- [ ] Replace `require("models/client")` with `require("models/client-new")` unless the module needs an isolated client lifecycle.
+- [ ] If isolated lifecycle is required, switch to `const createRedisClient = require("models/redis-new")` and manage `connect()` + shutdown in that module.
+- [ ] Convert callback-last Redis calls to promise/`async`-`await` style where needed.
+- [ ] Re-validate Redis command names/arguments against the new client API (no dependence on legacy aliasing/shims).
+- [ ] Audit pub/sub code paths for explicit unsubscribe/cleanup on shutdown.
+- [ ] Verify tests cover connection lifecycle and module teardown behavior after the migration.
 
 
 Entities
@@ -41,5 +75,5 @@ Adding or changing a model
 --------------------------
 
 1. Add a folder under `app/models` (or a single file like `ignoredFiles.js`).
-2. Export an object of functions (or a single function). Models that use Redis should require `models/client` and use the key module pattern.
+2. Export an object of functions (or a single function). Models that use Redis should default to `models/client-new` and use the key module pattern.
 3. For new Redis keys, add them to the model’s `key.js` (or equivalent)

--- a/app/models/blog/README
+++ b/app/models/blog/README
@@ -255,7 +255,7 @@ The Redis key generator. Methods:
 
 | Dependency | Role |
 |---|---|
-| `models/client` | Shared Redis client (from `models/redis.js`) |
+| `models/client-new` | Shared Redis singleton (from `models/redis-new.js`) |
 | `models/user` | Used in `create` and `remove` to update the owner's blog list |
 | `helper/ensure` | Runtime type validation of all function arguments |
 | `helper/extend` | Merges objects; used in `create` to combine info and defaults |

--- a/app/models/entries/README
+++ b/app/models/entries/README
@@ -216,7 +216,7 @@ The lex index is only updated incrementally by `_assign.js` when the ready flag 
 
 | Module | Role |
 |--------|------|
-| `models/client` | Redis client singleton |
+| `models/client-new` | Redis client singleton (default model client) |
 | `models/entry` | Individual entry retrieval (`get`) and write (`set`) |
 | `models/blog` | Blog record lookup, used by `resave` |
 | `helper/ensure` | Runtime argument type validation |

--- a/app/models/question/README
+++ b/app/models/question/README
@@ -207,7 +207,7 @@ Currently a no-op. The function accepts no arguments and returns nothing.
 
 ## Internal Structure
 
-`create.js`, `update.js`, `list.js`, `search.js`, and `tags.js` all depend on `keys.js` for Redis key construction and on `models/client` for the Redis connection. `get.js` is also used as a dependency by `create.js` and `update.js` to return a freshly read object after write operations complete. `import.js` depends on `create.js` exclusively.
+`create.js`, `update.js`, `list.js`, `search.js`, and `tags.js` all depend on `keys.js` for Redis key construction and on `models/client-new` for the Redis connection. `get.js` is also used as a dependency by `create.js` and `update.js` to return a freshly read object after write operations complete. `import.js` depends on `create.js` exclusively.
 
 `export.js` and `import.js` are not exported from `index.js` and are not part of the standard public interface. They are utility functions for bulk data migration.
 
@@ -217,7 +217,7 @@ Currently a no-op. The function accepts no arguments and returns nothing.
 
 **Internal:**
 
-- `models/client` — the shared Redis client instance (`app/models/client.js` → `app/models/redis.js`).
+- `models/client-new` — the shared Redis singleton (`app/models/client-new.js` → `app/models/redis-new.js`).
 
 **External:**
 

--- a/app/models/redirects/README
+++ b/app/models/redirects/README
@@ -122,7 +122,7 @@ Exported for use by callers that need regex-awareness outside the standard CRUD 
 
 ## Dependencies
 
-- **`models/client`** — shared Redis client instance (`app/models/client.js` → `app/models/redis.js`).
+- **`models/client-new`** — shared Redis singleton (`app/models/client-new.js` → `app/models/redis-new.js`).
 - **`helper/ensure`** — runtime argument type validation used in every exported function.
 - **`lodash`** — used in `list.js` for `_.map` and `_.zip`.
 

--- a/app/models/tags/README
+++ b/app/models/tags/README
@@ -158,7 +158,7 @@ key.name(blogID, normalizedTag)        // → "blog:{blogID}:tags:name:{slug}"
 
 ## Dependencies
 
-- **`models/client`** — the shared Redis client instance. All reads and writes go through this client.
+- **`models/client-new`** — the shared Redis singleton. All reads and writes go through this client.
 - **`helper/ensure`** — runtime type validation. Used in `_get.js`, `set.js`, `list.js`, and `popular.js` to assert that arguments conform to expected types.
 - **`helper/type`** — type-checking predicate. Used in `_get.js` and `popular.js` to validate the `options` argument.
 - **`helper/makeSlug`** — the slug-generation function used by `normalize.js`.

--- a/app/models/template/README
+++ b/app/models/template/README
@@ -306,7 +306,7 @@ The CDN URL format is `{cdn.origin}/template/{h[0:2]}/{h[2:4]}/{h[4:]}/{basename
 
 | Module | Used for |
 |--------|----------|
-| `models/client` | Redis client (all reads and writes) |
+| `models/client-new` | Redis singleton (all reads and writes) |
 | `models/blog` | Bumping `cacheID`, reading blog configuration, resolving the active client |
 | `models/entry` | Fetching entry HTML for path-referenced partials in `getPartials` |
 | `helper/ensure` | Runtime type and schema validation |

--- a/app/models/user/README
+++ b/app/models/user/README
@@ -223,7 +223,7 @@ Validates and merges `updates` into `user`. Field types are checked against `mod
 
 ### Internal
 
-- `models/client` — Shared Redis client instance (`models/client.js`)
+- `models/client-new` — Shared Redis singleton (`models/client-new.js` → `models/redis-new.js`)
 - `models/blog/set` — Used by `disable` and `enable` to propagate account state to blogs
 - `helper/ensure` — Runtime type assertion, used throughout for argument and schema validation
 - `helper/email` — Sends transactional emails (`WELCOME`, `UPCOMING_EXPIRY`, `UPCOMING_RENEWAL`, `UPCOMING_MONTHLY_FIRST_RENEWAL`)


### PR DESCRIPTION
### Motivation

- Refresh internal model documentation so new work consistently targets the new Redis modules (`models/client-new` and `models/redis-new`) and reduce migration friction. 
- Clarify when to use the process-wide singleton vs a dedicated client, and surface legacy compatibility caveats that developers must consider when updating modules. 
- Provide a reusable, copy/paste migration checklist to make per-module updates consistent and safe.

### Description

- Updated `app/models/README` to prefer `models/client-new` by default, added a decision section describing when to use `models/client-new` (singleton) vs `models/redis-new` (dedicated factory), added a “legacy compatibility caveats” section, and added a copy/paste migration checklist. 
- Replaced module README references to the legacy `models/client`/`models/redis` with `models/client-new`/`models/redis-new` in the following docs: `app/models/404/README`, `app/models/redirects/README`, `app/models/user/README`, `app/models/entries/README`, `app/models/tags/README`, `app/models/blog/README`, `app/models/template/README`, and `app/models/question/README`. 
- Ensured the top-level guidance and the per-module dependency lists consistently direct developers to the new client modules and instruct on lifecycle and API differences to avoid accidental use of legacy callback or command-shim behaviors.

### Testing

- Ran `rg -n "models/redis|models/client" app/models --glob "**/README*"` to verify README files now reference the `*-new` modules, and the command returned the updated matches as expected. 
- Reviewed the resulting README diffs to confirm the new decision text, caveats, and checklist were inserted in the intended locations and that per-module dependency lines were updated accordingly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1b620d9488329b158215cde1e971a)