### PR TITLE
Refactor redisSearch main flow into collection and search phases

### DIFF
--- a/app/helper/redisSearch.js
+++ b/app/helper/redisSearch.js
@@ -4,39 +4,55 @@ var client = new redis();
 function main(string, callback) {
   var types = {};
   var result = [];
+  var allKeys = [];
 
   (async function () {
     await redisKeys("*", async function (keys) {
       for (const key of keys) {
+        allKeys.push(key);
+
         if (key.indexOf(string) > -1)
           result.push({ key: key, value: "KEY ITSELF", type: "KEY" });
-
-        const type = await client.type(key);
-
-        types[type] = types[type] || [];
-        types[type].push(key);
-      }
-
-      for (const type in types) {
-        const keysByType = types[type];
-
-        if (type === "string") {
-          await stringSearch(string, keysByType, result);
-        } else if (type === "hash") {
-          await hashSearch(string, keysByType, result);
-        } else if (type === "list") {
-          await listSearch(string, keysByType, result);
-        } else if (type === "set") {
-          await setSearch(string, keysByType, result);
-        } else if (type === "zset") {
-          await sortedSetSearch(string, keysByType, result);
-        } else {
-          throw new Error("No handlers for strings of type: " + type);
-        }
       }
     });
 
-    callback(null, result);
+    for (const key of allKeys) {
+      const type = await client.type(key);
+
+      types[type] = types[type] || [];
+      types[type].push(key);
+    }
+
+    for (const type in types) {
+      const keysByType = types[type];
+
+      if (type === "string") {
+        await stringSearch(string, keysByType, result);
+      } else if (type === "hash") {
+        await hashSearch(string, keysByType, result);
+      } else if (type === "list") {
+        await listSearch(string, keysByType, result);
+      } else if (type === "set") {
+        await setSearch(string, keysByType, result);
+      } else if (type === "zset") {
+        await sortedSetSearch(string, keysByType, result);
+      } else {
+        throw new Error("No handlers for strings of type: " + type);
+      }
+    }
+
+    const dedupedResult = [];
+    const seen = new Set();
+
+    for (const entry of result) {
+      const signature = `${entry.type}:${entry.key}:${entry.value}`;
+      if (seen.has(signature)) continue;
+
+      seen.add(signature);
+      dedupedResult.push(entry);
+    }
+
+    callback(null, dedupedResult);
   })().catch(callback);
 }
 


### PR DESCRIPTION
### Motivation
- Reduce repeated per-page type resolution during SCAN by separating key discovery from type-specific searching. 
- Preserve existing key-name hit detection (`KEY ITSELF`) while ensuring each type handler runs once per full bucket. 
- Return a single deduplicated result array and invoke the callback exactly once with the final aggregate.

### Description
- Added an `allKeys` accumulator and changed the SCAN page handler to only collect keys and record `KEY ITSELF` hits during collection. 
- After SCAN completes, classify every collected key by calling `client.type` once per key and bucket keys into the `types` map. 
- Run each type-specific search handler exactly once for its final bucket (`string`, `hash`, `list`, `set`, `zset`) and preserve the existing unknown-type error. 
- Deduplicate final `result` entries and call `callback(null, dedupedResult)` once with the aggregated results.

### Testing
- Ran `node --check app/helper/redisSearch.js` which succeeded. 
- Verified the diff and committed the change as part of the local validation steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ba6bce4c8329a32c17f08fa08804)