### PR TITLE
Migrate app/models/404 to models/client-new with async Redis API and add tests

### DIFF
--- a/app/models/404/ignore.js
+++ b/app/models/404/ignore.js
@@ -1,4 +1,4 @@
-var client = require("models/client");
+var client = require("models/client-new");
 var ensure = require("helper/ensure");
 var key = require("./key");
 
@@ -9,5 +9,12 @@ module.exports = function (blogID, url, callback) {
 
   ensure(ignoreKey, "string");
 
-  return client.SADD(ignoreKey, url, callback);
+  (async function () {
+    try {
+      var result = await client.sAdd(ignoreKey, url);
+      return callback(null, result);
+    } catch (err) {
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/404/list.js
+++ b/app/models/404/list.js
@@ -1,4 +1,4 @@
-var client = require("models/client");
+var client = require("models/client-new");
 var ensure = require("helper/ensure");
 var key = require("./key");
 var moment = require("moment");
@@ -11,34 +11,30 @@ module.exports = function (blogID, callback) {
 
   ensure(everythingKey, "string").and(ignoreKey, "string");
 
-  client.SMEMBERS(ignoreKey, function (err, ignoreThese) {
-    if (err) throw err;
+  (async function () {
+    try {
+      var data = await Promise.all([
+        client.sMembers(ignoreKey),
+        client.zRangeWithScores(everythingKey, 0, -1, { REV: true }),
+      ]);
 
-    ensure(ignoreThese, "array");
+      var ignoreThese = data[0];
+      var response = data[1];
 
-    client.ZREVRANGE(everythingKey, 0, -1, "WITHSCORES", function (
-      err,
-      response
-    ) {
-      if (err) throw err;
-
-      ensure(response, "array");
+      ensure(ignoreThese, "array").and(response, "array");
 
       var list = [];
       var ignored = [];
 
-      for (var i in response) {
-        if (i % 2) continue;
-
-        var url = response[i];
-        var timeStamp = parseInt(response[++i]);
+      for (var itemIndex in response) {
+        var entry = response[itemIndex];
 
         var item = {
-          url: url,
-          time: moment.utc(timeStamp).fromNow(),
+          url: entry.value,
+          time: moment.utc(entry.score).fromNow(),
         };
 
-        if (ignoreThese.indexOf(url) > -1) {
+        if (ignoreThese.indexOf(entry.value) > -1) {
           ignored.push(item);
         } else {
           list.push(item);
@@ -46,6 +42,8 @@ module.exports = function (blogID, callback) {
       }
 
       return callback(null, list, ignored);
-    });
-  });
+    } catch (err) {
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/404/set.js
+++ b/app/models/404/set.js
@@ -1,4 +1,4 @@
-var client = require("models/client");
+var client = require("models/client-new");
 var ensure = require("helper/ensure");
 var Key = require("./key");
 
@@ -12,21 +12,29 @@ module.exports = function (blogID, url, callback) {
   var key = Key.everything(blogID);
   var now = Date.now();
   var thirtyDaysAgo = now - 1000 * 60 * 60 * 24 * 30;
-  var multi = client.multi();
 
-  // Add the new 404
-  multi.ZADD(key, now, url);
+  (async function () {
+    try {
+      var multi = client.multi();
 
-  // Remove any entries which are older than 30 days
-  // -inf is to avoid looking up the lowest score in the sorted set.
-  multi.ZREMRANGEBYSCORE(key, "-inf", thirtyDaysAgo);
+      // Add the new 404
+      multi.zAdd(key, {
+        score: now,
+        value: url,
+      });
 
-  // Trim the list of 404s
-  multi.ZREMRANGEBYRANK(key, 0, -MAX_404s);
+      // Remove any entries which are older than 30 days
+      // -inf is to avoid looking up the lowest score in the sorted set.
+      multi.zRemRangeByScore(key, "-inf", thirtyDaysAgo);
 
-  multi.exec(function (err) {
-    if (err) throw err;
+      // Trim the list of 404s
+      multi.zRemRangeByRank(key, 0, -MAX_404s);
 
-    callback();
-  });
+      await multi.exec();
+
+      return callback();
+    } catch (err) {
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/404/tests/index.js
+++ b/app/models/404/tests/index.js
@@ -1,0 +1,216 @@
+describe("models/404 migration", function () {
+  function withMockedClient(clientImpl, run) {
+    var listPath = require.resolve("../list");
+    var setPath = require.resolve("../set");
+    var ignorePath = require.resolve("../ignore");
+    var unignorePath = require.resolve("../unignore");
+    var clientPath = require.resolve("models/client-new");
+
+    var oldList = require.cache[listPath];
+    var oldSet = require.cache[setPath];
+    var oldIgnore = require.cache[ignorePath];
+    var oldUnignore = require.cache[unignorePath];
+    var oldClient = require.cache[clientPath];
+
+    require.cache[clientPath] = {
+      id: clientPath,
+      filename: clientPath,
+      loaded: true,
+      exports: clientImpl,
+    };
+
+    delete require.cache[listPath];
+    delete require.cache[setPath];
+    delete require.cache[ignorePath];
+    delete require.cache[unignorePath];
+
+    try {
+      run({
+        list: require("../list"),
+        set: require("../set"),
+        ignore: require("../ignore"),
+        unignore: require("../unignore"),
+      });
+    } finally {
+      delete require.cache[listPath];
+      delete require.cache[setPath];
+      delete require.cache[ignorePath];
+      delete require.cache[unignorePath];
+
+      if (oldClient) require.cache[clientPath] = oldClient;
+      else delete require.cache[clientPath];
+
+      if (oldList) require.cache[listPath] = oldList;
+      if (oldSet) require.cache[setPath] = oldSet;
+      if (oldIgnore) require.cache[ignorePath] = oldIgnore;
+      if (oldUnignore) require.cache[unignorePath] = oldUnignore;
+    }
+  }
+
+  it("set records a URL and prunes/trims in a single multi exec", function (done) {
+    var calls = [];
+
+    withMockedClient(
+      {
+        multi: function () {
+          return {
+            zAdd: function (key, payload) {
+              calls.push(["zAdd", key, payload]);
+              return this;
+            },
+            zRemRangeByScore: function (key, min, max) {
+              calls.push(["zRemRangeByScore", key, min, max]);
+              return this;
+            },
+            zRemRangeByRank: function (key, start, stop) {
+              calls.push(["zRemRangeByRank", key, start, stop]);
+              return this;
+            },
+            exec: async function () {
+              calls.push(["exec"]);
+              return [1, 0, 0];
+            },
+          };
+        },
+      },
+      function (models404) {
+        models404.set("blog-1", "/missing", function (err) {
+          expect(err).toBeUndefined();
+
+          expect(calls.length).toBe(4);
+          expect(calls[0][0]).toBe("zAdd");
+          expect(calls[0][1]).toBe("blog:blog-1:404:everything");
+          expect(calls[0][2].value).toBe("/missing");
+          expect(typeof calls[0][2].score).toBe("number");
+
+          expect(calls[1][0]).toBe("zRemRangeByScore");
+          expect(calls[1][1]).toBe("blog:blog-1:404:everything");
+          expect(calls[1][2]).toBe("-inf");
+          expect(typeof calls[1][3]).toBe("number");
+          expect(calls[2]).toEqual([
+            "zRemRangeByRank",
+            "blog:blog-1:404:everything",
+            0,
+            -500,
+          ]);
+          expect(calls[3]).toEqual(["exec"]);
+
+          done();
+        });
+      }
+    );
+  });
+
+  it("list returns active and ignored entries based on ignore-set membership", function (done) {
+    withMockedClient(
+      {
+        sMembers: async function () {
+          return ["/favicon.ico"];
+        },
+        zRangeWithScores: async function () {
+          return [
+            { value: "/missing", score: Date.now() },
+            { value: "/favicon.ico", score: Date.now() - 1000 },
+          ];
+        },
+      },
+      function (models404) {
+        models404.list("blog-1", function (err, list, ignored) {
+          expect(err).toBeNull();
+          expect(list.length).toBe(1);
+          expect(ignored.length).toBe(1);
+          expect(list[0].url).toBe("/missing");
+          expect(ignored[0].url).toBe("/favicon.ico");
+          expect(typeof list[0].time).toBe("string");
+          done();
+        });
+      }
+    );
+  });
+
+  it("ignore and unignore toggle set membership with callback results", function (done) {
+    var ignored = new Set();
+
+    withMockedClient(
+      {
+        sAdd: async function (_key, value) {
+          var before = ignored.size;
+          ignored.add(value);
+          return ignored.size > before ? 1 : 0;
+        },
+        sRem: async function (_key, value) {
+          var existed = ignored.has(value);
+          ignored.delete(value);
+          return existed ? 1 : 0;
+        },
+      },
+      function (models404) {
+        models404.ignore("blog-1", "/foo", function (err, added) {
+          expect(err).toBeNull();
+          expect(added).toBe(1);
+          expect(ignored.has("/foo")).toBe(true);
+
+          models404.unignore("blog-1", "/foo", function (unignoreErr, removed) {
+            expect(unignoreErr).toBeNull();
+            expect(removed).toBe(1);
+            expect(ignored.has("/foo")).toBe(false);
+            done();
+          });
+        });
+      }
+    );
+  });
+
+  it("passes Redis errors through callbacks with client-new method names", function (done) {
+    withMockedClient(
+      {
+        multi: function () {
+          return {
+            zAdd: function () {
+              return this;
+            },
+            zRemRangeByScore: function () {
+              return this;
+            },
+            zRemRangeByRank: function () {
+              return this;
+            },
+            exec: async function () {
+              throw new Error("exec failed");
+            },
+          };
+        },
+        sMembers: async function () {
+          throw new Error("sMembers failed");
+        },
+        zRangeWithScores: async function () {
+          return [];
+        },
+        sAdd: async function () {
+          throw new Error("sAdd failed");
+        },
+        sRem: async function () {
+          throw new Error("sRem failed");
+        },
+      },
+      function (models404) {
+        models404.set("blog-1", "/foo", function (setErr) {
+          expect(setErr.message).toBe("exec failed");
+
+          models404.list("blog-1", function (listErr) {
+            expect(listErr.message).toBe("sMembers failed");
+
+            models404.ignore("blog-1", "/foo", function (ignoreErr) {
+              expect(ignoreErr.message).toBe("sAdd failed");
+
+              models404.unignore("blog-1", "/foo", function (unignoreErr) {
+                expect(unignoreErr.message).toBe("sRem failed");
+                done();
+              });
+            });
+          });
+        });
+      }
+    );
+  });
+});

--- a/app/models/404/unignore.js
+++ b/app/models/404/unignore.js
@@ -1,4 +1,4 @@
-var client = require("models/client");
+var client = require("models/client-new");
 var ensure = require("helper/ensure");
 var key = require("./key");
 
@@ -9,5 +9,12 @@ module.exports = function (blogID, url, callback) {
 
   ensure(ignoreKey, "string");
 
-  return client.SREM(ignoreKey, url, callback);
+  (async function () {
+    try {
+      var result = await client.sRem(ignoreKey, url);
+      return callback(null, result);
+    } catch (err) {
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/README
+++ b/app/models/README
@@ -49,6 +49,16 @@ Use this checklist when updating a model:
 - [ ] Audit pub/sub code paths for explicit unsubscribe/cleanup on shutdown.
 - [ ] Verify tests cover connection lifecycle and module teardown behavior after the migration.
 
+404 migration notes (template for similar folders)
+------------------------------------------------
+
+- **Keep public callbacks stable while adopting async internals.** Wrap migrated logic in an internal async IIFE (or helper), `await` Redis calls from `models/client-new`, and translate outcomes back to the existing callback contract (`callback(null, result...)` on success, `callback(err)` on failure).
+
+- **Use `multi()` for atomic write paths only.** For write flows like 404 event recording (add + prune + trim), keep commands in one `client.multi() ... .exec()` transaction to preserve ordering and atomicity under concurrent requests.
+
+- **Use modern command names and argument shapes explicitly.** Prefer methods like `sMembers`, `zRangeWithScores(..., { REV: true })`, `zAdd(key, { score, value })`, `zRemRangeByScore`, and `zRemRangeByRank`; do not rely on legacy uppercase aliases (e.g. `SMEMBERS`) or callback shims.
+
+- **Update test spies/mocks to `models/client-new` + modern methods.** When migrating tests, re-point module mocks from `models/client` to `models/client-new`, and spy on promise-returning methods (`sAdd`, `sRem`, `zRangeWithScores`, `multi().exec`, etc.) so error-path assertions still reflect production code.
 
 Entities
 --------


### PR DESCRIPTION
### Motivation

- Replace legacy `models/client` callback-style Redis usage with the modern promise-based `models/client-new` singleton and modern Redis command names. 
- Preserve existing public callback contracts while converting internals to `async`/`await` to reduce legacy callback complexity and enable safer concurrent reads/writes. 
- Add tests and migration notes to ensure correct behavior and to serve as a template for future model migrations.

### Description

- Replaced `require("models/client")` with `require("models/client-new")` in `app/models/404/list.js`, `set.js`, `ignore.js`, and `unignore.js`. 
- Converted `list.js` to use `Promise.all` with `client.sMembers(ignoreKey)` and `client.zRangeWithScores(everythingKey, 0, -1, { REV: true })`, translated returned `{ value, score }` pairs into the existing `(err, list, ignored)` callback shape. 
- Converted `set.js` to keep atomic write semantics using `client.multi()` and modern commands (`zAdd`, `zRemRangeByScore`, `zRemRangeByRank`) and `await multi.exec()`, returning results through the existing callback. 
- Converted `ignore.js` and `unignore.js` to `async` calls to `client.sAdd` and `client.sRem` respectively, bridging results/errors back to the original callback signature. 
- Added `app/models/404/tests/index.js` with mocked `models/client-new` spies that validate: `set` write/prune/trim sequence, `list` active vs ignored bucketing, `ignore`/`unignore` membership toggles, and error propagation for `multi().exec`, `sMembers`, `sAdd`, and `sRem`. 
- Appended a reusable “404 migration notes” subsection to `app/models/README` documenting callback-to-async adaptation, `multi` usage guidance, command-name/argument gotchas, and test-spy updates.

### Testing

- Ran static checks with `node --check` on the modified model files and the new test file, which completed without syntax errors. 
- Executed the new 404 test suite directly with Jasmine via `NODE_PATH=app node` (Jasmine runner targeting `app/models/404/tests/index.js`), which ran 4 specs with `0` failures. 
- Attempted `npm test -- app/models/404/tests/index.js` but this invocation failed in the current environment because Docker is unavailable (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1bc89f844832982899c72b29d31a8)