### PR TITLE
Migrate question model Redis usage to client-new APIs

### DIFF
--- a/app/models/README
+++ b/app/models/README
@@ -49,16 +49,18 @@ Use this checklist when updating a model:
 - [ ] Audit pub/sub code paths for explicit unsubscribe/cleanup on shutdown.
 - [ ] Verify tests cover connection lifecycle and module teardown behavior after the migration.
 
-404 migration notes (template for similar folders)
-------------------------------------------------
+Model migration guidance (reusable)
+-----------------------------------
 
-- **Keep public callbacks stable while adopting async internals.** Wrap migrated logic in an internal async IIFE (or helper), `await` Redis calls from `models/client-new`, and translate outcomes back to the existing callback contract (`callback(null, result...)` on success, `callback(err)` on failure).
+- **Preserve public API contracts while modernizing internals.** Keep existing return shapes/callback signatures stable, but move Redis internals to `async`/`await` with promise-based `models/client-new` commands.
 
-- **Use `multi()` for atomic write paths only.** For write flows like 404 event recording (add + prune + trim), keep commands in one `client.multi() ... .exec()` transaction to preserve ordering and atomicity under concurrent requests.
+- **Reserve `multi()` for true atomic write paths.** For create/update flows that must commit several writes together, keep them inside `client.multi() ... await multi.exec()`. Use direct awaited calls for non-atomic reads.
 
-- **Use modern command names and argument shapes explicitly.** Prefer methods like `sMembers`, `zRangeWithScores(..., { REV: true })`, `zAdd(key, { score, value })`, `zRemRangeByScore`, and `zRemRangeByRank`; do not rely on legacy uppercase aliases (e.g. `SMEMBERS`) or callback shims.
+- **Use modern command names and argument shapes explicitly.** Prefer methods like `sMembers`, `hGetAll`, `zRange(..., { REV: true })`, `zAdd(key, { score, value })`, and `sScan`; avoid legacy lowercase/callback alias assumptions.
 
-- **Update test spies/mocks to `models/client-new` + modern methods.** When migrating tests, re-point module mocks from `models/client` to `models/client-new`, and spy on promise-returning methods (`sAdd`, `sRem`, `zRangeWithScores`, `multi().exec`, etc.) so error-path assertions still reflect production code.
+- **Keep migration patterns model-agnostic.** Apply the same approach whether you are migrating `question`, `redirects`, `404`, or any other model folder.
+
+- **Apply-per-model checklist note:** when command names or call styles change, update test doubles/spies to match the new methods (including `multi().exec()` promise rejection assertions) before finalizing the migration.
 
 Entities
 --------

--- a/app/models/question/README
+++ b/app/models/question/README
@@ -205,6 +205,14 @@ Currently a no-op. The function accepts no arguments and returns nothing.
 
 ---
 
+## Migration note
+
+This model now uses `models/client-new` for shared Redis access, with promise-based command calls (`hGetAll`, `sMembers`, `zRange`, `sScan`) and `multi().exec()` reserved for atomic writes in `create.js` and `update.js`.
+
+When extending or migrating nearby modules, keep the exported function contracts stable and update tests to spy on the same modern command names used in production code.
+
+---
+
 ## Internal Structure
 
 `create.js`, `update.js`, `list.js`, `search.js`, and `tags.js` all depend on `keys.js` for Redis key construction and on `models/client-new` for the Redis connection. `get.js` is also used as a dependency by `create.js` and `update.js` to return a freshly read object after write operations complete. `import.js` depends on `create.js` exclusively.

--- a/app/models/question/create.js
+++ b/app/models/question/create.js
@@ -1,4 +1,4 @@
-const client = require("models/client");
+const client = require("models/client-new");
 const keys = require("./keys");
 const get = require("./get");
 
@@ -40,52 +40,39 @@ module.exports = async function ({
 
   // Handle replies
   if (parent) {
-    multi.zadd(keys.children(parent), parseInt(created_at), id);
-    multi.zadd(keys.by_last_reply, parseInt(created_at), parent);
-    multi.zincrby(keys.by_number_of_replies, 1, parent);
+    multi.zAdd(keys.children(parent), { score: parseInt(created_at, 10), value: id });
+    multi.zAdd(keys.by_last_reply, { score: parseInt(created_at, 10), value: parent });
+    multi.zIncrBy(keys.by_number_of_replies, 1, parent);
 
     // Handle questions
   } else {
-
     tags.forEach((tag) => {
-      multi.sadd(keys.all_tags, tag);
-      multi.zadd(keys.by_tag(tag),  parseInt(created_at), id);
+      multi.sAdd(keys.all_tags, tag);
+      multi.zAdd(keys.by_tag(tag), { score: parseInt(created_at, 10), value: id });
     });
 
-    multi.sadd(keys.all_questions, id);
-    multi.zadd(keys.by_last_reply,  parseInt(created_at), id);
-    multi.zadd(keys.by_created,  parseInt(created_at), id);
-    multi.zadd(keys.by_number_of_replies, 0, id);
+    multi.sAdd(keys.all_questions, id);
+    multi.zAdd(keys.by_last_reply, { score: parseInt(created_at, 10), value: id });
+    multi.zAdd(keys.by_created, { score: parseInt(created_at, 10), value: id });
+    multi.zAdd(keys.by_number_of_replies, { score: 0, value: id });
   }
 
-  multi.hset(keys.item(id), item);
+  multi.hSet(keys.item(id), item);
 
   // ensure the multi command fails if the ID
   // is already in use
-  multi.setnx(keys.item(id), id);
+  multi.setNX(keys.item(id), id);
 
-  return new Promise((resolve, reject) => {
-    multi.exec((err) => {
-      if (err) return reject(err);
-      get(id).then(resolve).catch(reject);
-    });
-  });
+  await multi.exec();
+
+  return get(id);
 };
 
-function checkIDisUnique(id) {
-  return new Promise((resolve, reject) => {
-    client.exists(keys.item(id), (err, exists) => {
-      if (err) return reject(err);
-      resolve(!exists);
-    });
-  });
+async function checkIDisUnique(id) {
+  return !(await client.exists(keys.item(id)));
 }
 
-function generateID() {
-  return new Promise((resolve, reject) => {
-    client.incr(keys.next_id, (err, id) => {
-      if (err) return reject(err);
-      resolve(id.toString());
-    });
-  });
+async function generateID() {
+  const id = await client.incr(keys.next_id);
+  return id.toString();
 }

--- a/app/models/question/export.js
+++ b/app/models/question/export.js
@@ -1,55 +1,26 @@
-const client = require("models/client");
+const client = require("models/client-new");
 const keys = require("./keys");
-const fs = require('fs-extra');
-
-function smembersAsync(key) {
-  return new Promise((resolve, reject) => {
-    client.smembers(key, (err, result) => {
-      if (err) return reject(err);
-      resolve(result);
-    });
-  });
-}
-
-function hgetallAsync(key) {
-  return new Promise((resolve, reject) => {
-    client.hgetall(key, (err, result) => {
-      if (err) return reject(err);
-      resolve(result);
-    });
-  });
-}
-
-function zrangeAsync(key, start, stop) {
-  return new Promise((resolve, reject) => {
-    client.zrange(key, start, stop, (err, result) => {
-      if (err) return reject(err);
-      resolve(result);
-    });
-  });
-}
 
 async function exportQuestions() {
-  const allQuestionIds = await smembersAsync(keys.all_questions);
+  const allQuestionIds = await client.sMembers(keys.all_questions);
   const allQuestions = [];
 
   for (const id of allQuestionIds) {
-    const question = await hgetallAsync(keys.item(id));
+    const question = await client.hGetAll(keys.item(id));
 
     // map tags to an array
     question.tags = JSON.parse(question.tags);
 
-
-    const replies = await zrangeAsync(keys.children(id), 0, -1);
+    const replies = await client.zRange(keys.children(id), 0, -1);
 
     question.replies = [];
     for (const replyId of replies) {
-      const reply = await hgetallAsync(keys.item(replyId));
-      const comments = await zrangeAsync(keys.children(replyId), 0, -1);
+      const reply = await client.hGetAll(keys.item(replyId));
+      const comments = await client.zRange(keys.children(replyId), 0, -1);
 
       reply.comments = [];
       for (const commentId of comments) {
-        const comment = await hgetallAsync(keys.item(commentId));
+        const comment = await client.hGetAll(keys.item(commentId));
         // map tags to an array
         comment.tags = JSON.parse(comment.tags);
         reply.comments.push(comment);

--- a/app/models/question/get.js
+++ b/app/models/question/get.js
@@ -1,54 +1,50 @@
-const client = require("models/client");
+const client = require("models/client-new");
 const keys = require("./keys");
 const moment = require("moment");
 
-module.exports = id => {
-  return new Promise((resolve, reject) => {
-    (async () => {
-      const [reply_ids, question, last_reply_created_at] = await Promise.all([
-        client.zrange(keys.children(id), 0, -1),
-        client.hgetall(keys.item(id)),
-        client.zscore(keys.by_last_reply, id),
-      ]);
+module.exports = async (id) => {
+  const [reply_ids, question, last_reply_created_at] = await Promise.all([
+    client.zRange(keys.children(id), 0, -1),
+    client.hGetAll(keys.item(id)),
+    client.zScore(keys.by_last_reply, id),
+  ]);
 
-      if (!question) return resolve(null);
+  if (!question || !Object.keys(question).length) return null;
 
-      const replies = await Promise.all(
-        reply_ids.map((reply_id) => {
-          return client.hgetall(keys.item(reply_id));
-        })
-      );
+  const replies = await Promise.all(
+    reply_ids.map((reply_id) => {
+      return client.hGetAll(keys.item(reply_id));
+    })
+  );
 
-      try {
-        question.tags = JSON.parse(question.tags);
-      } catch (e) {
-        question.tags = [];
-      }
+  try {
+    question.tags = JSON.parse(question.tags);
+  } catch (e) {
+    question.tags = [];
+  }
 
-      question.replies = replies.map((reply) => {
-        const date = new Date(parseInt(reply.created_at, 10));
-        reply.time = moment(date).fromNow();
-        return reply;
-      });
-
-      const createdDate = new Date(parseInt(question.created_at, 10));
-      const createdTime = moment(createdDate).fromNow();
-
-      const hasLastReplyTimestamp =
-        last_reply_created_at !== null &&
-        !Number.isNaN(parseInt(last_reply_created_at, 10));
-      const lastReplyTimestamp = hasLastReplyTimestamp
-        ? last_reply_created_at
-        : question.created_at;
-      const lastReplyDate = new Date(parseInt(lastReplyTimestamp, 10));
-
-      question.number_of_replies = replies.length;
-      question.last_reply_created_at = lastReplyTimestamp;
-      question.last_reply_time = moment(lastReplyDate).fromNow();
-      question.created_time = createdTime;
-      question.time = createdTime;
-
-      resolve(question);
-    })().catch(reject);
+  question.replies = replies.map((reply) => {
+    const date = new Date(parseInt(reply.created_at, 10));
+    reply.time = moment(date).fromNow();
+    return reply;
   });
+
+  const createdDate = new Date(parseInt(question.created_at, 10));
+  const createdTime = moment(createdDate).fromNow();
+
+  const hasLastReplyTimestamp =
+    last_reply_created_at !== null &&
+    !Number.isNaN(parseInt(last_reply_created_at, 10));
+  const lastReplyTimestamp = hasLastReplyTimestamp
+    ? last_reply_created_at
+    : question.created_at;
+  const lastReplyDate = new Date(parseInt(lastReplyTimestamp, 10));
+
+  question.number_of_replies = replies.length;
+  question.last_reply_created_at = lastReplyTimestamp;
+  question.last_reply_time = moment(lastReplyDate).fromNow();
+  question.created_time = createdTime;
+  question.time = createdTime;
+
+  return question;
 };

--- a/app/models/question/list.js
+++ b/app/models/question/list.js
@@ -1,94 +1,89 @@
 const PAGE_SIZE = 10;
-const client = require("models/client");
+const client = require("models/client-new");
 const keys = require("./keys");
 const moment = require("moment");
 
-module.exports = ({
+module.exports = async ({
   page = 1,
   tag = "",
   page_size = PAGE_SIZE,
-  sort = 'by_last_reply'
+  sort = "by_last_reply",
 } = {}) => {
-  return new Promise((resolve, reject) => {
-    const startIndex = (page - 1) * page_size;
-    const endIndex = startIndex + page_size - 1;
+  const startIndex = (page - 1) * page_size;
+  const endIndex = startIndex + page_size - 1;
 
-    const key = tag
-      ? keys.by_tag(tag)
-      : sort === 'by_created'
-      ? keys.by_created
-      : sort === 'by_number_of_replies' 
-      ? keys.by_number_of_replies :
-      keys.by_last_reply;
-      
+  const key = tag
+    ? keys.by_tag(tag)
+    : sort === "by_created"
+    ? keys.by_created
+    : sort === "by_number_of_replies"
+    ? keys.by_number_of_replies
+    : keys.by_last_reply;
 
-    (async () => {
-      const [total, question_ids] = await Promise.all([
-        client.zcard(key),
-        client.zrevrange(key, startIndex, endIndex),
-      ]);
+  const [total, question_ids] = await Promise.all([
+    client.zCard(key),
+    client.zRange(key, startIndex, endIndex, { REV: true }),
+  ]);
 
-      if (!question_ids.length) {
-        return resolve({ questions: [], stats: { total, page_size, page } });
+  if (!question_ids.length) {
+    return { questions: [], stats: { total, page_size, page } };
+  }
+
+  const results = (
+    await Promise.all(
+      question_ids.map(async (id) => {
+        return Promise.all([
+          client.hGetAll(keys.item(id)),
+          client.zScore(keys.by_last_reply, id),
+          client.zScore(keys.by_number_of_replies, id),
+        ]);
+      })
+    )
+  ).flat();
+
+  const questions = results
+    .filter((_, index) => index % 3 === 0)
+    .map((question, index) => {
+      const last_reply_created_at = results[index * 3 + 1];
+      const number_of_replies = results[index * 3 + 2];
+
+      const createdTimestamp = parseInt(question.created_at, 10);
+      const hasValidCreatedTimestamp = !Number.isNaN(createdTimestamp);
+      const createdDate = hasValidCreatedTimestamp
+        ? new Date(createdTimestamp)
+        : new Date();
+      const createdTime = moment(createdDate).fromNow();
+
+      const hasLastReplyTimestamp =
+        last_reply_created_at !== null &&
+        !Number.isNaN(parseInt(last_reply_created_at, 10));
+      const lastReplyTimestamp = hasLastReplyTimestamp
+        ? last_reply_created_at
+        : question.created_at;
+      const lastReplyTimestampInt = parseInt(lastReplyTimestamp, 10);
+      const lastReplyDate = Number.isNaN(lastReplyTimestampInt)
+        ? createdDate
+        : new Date(lastReplyTimestampInt);
+
+      question.last_reply_created_at = lastReplyTimestamp;
+      question.last_reply_time = moment(lastReplyDate).fromNow();
+      question.created_time = createdTime;
+      question.time = createdTime;
+
+      const parsedNumberOfReplies = parseInt(number_of_replies, 10);
+      question.number_of_replies = Number.isNaN(parsedNumberOfReplies)
+        ? 0
+        : parsedNumberOfReplies;
+
+      try {
+        question.tags = JSON.parse(question.tags);
+      } catch (err) {
+        question.tags = [];
       }
 
-      const results = (
-        await Promise.all(
-          question_ids.map(async (id) => {
-            return Promise.all([
-              client.hgetall(keys.item(id)),
-              client.zscore(keys.by_last_reply, id),
-              client.zscore(keys.by_number_of_replies, id),
-            ]);
-          })
-        )
-      ).flat();
+      return question;
+    })
+    .filter((question) => question.title && !!question.title.trim());
 
-      const questions = results
-            .filter((_, index) => index % 3 === 0)
-            .map((question, index) => {
-              const last_reply_created_at = results[index * 3 + 1];
-              const number_of_replies = results[index * 3 + 2];
-
-              const createdTimestamp = parseInt(question.created_at, 10);
-              const hasValidCreatedTimestamp = !Number.isNaN(createdTimestamp);
-              const createdDate = hasValidCreatedTimestamp
-                ? new Date(createdTimestamp)
-                : new Date();
-              const createdTime = moment(createdDate).fromNow();
-
-              const hasLastReplyTimestamp =
-                last_reply_created_at !== null &&
-                !Number.isNaN(parseInt(last_reply_created_at, 10));
-              const lastReplyTimestamp = hasLastReplyTimestamp
-                ? last_reply_created_at
-                : question.created_at;
-              const lastReplyTimestampInt = parseInt(lastReplyTimestamp, 10);
-              const lastReplyDate = Number.isNaN(lastReplyTimestampInt)
-                ? createdDate
-                : new Date(lastReplyTimestampInt);
-
-              question.last_reply_created_at = lastReplyTimestamp;
-              question.last_reply_time = moment(lastReplyDate).fromNow();
-              question.created_time = createdTime;
-              question.time = createdTime;
-
-              const parsedNumberOfReplies = parseInt(number_of_replies, 10);
-              question.number_of_replies = Number.isNaN(parsedNumberOfReplies)
-                ? 0
-                : parsedNumberOfReplies;
-
-              try {
-                question.tags = JSON.parse(question.tags);
-              } catch (err) {
-                question.tags = [];
-              }
-
-              return question;
-            })
-            .filter(question => question.title && !!question.title.trim());
-
-      resolve({ questions, stats: { total, page_size, page } });
-    })().catch(reject);
-  });
+  return { questions, stats: { total, page_size, page } };
 };

--- a/app/models/question/search.js
+++ b/app/models/question/search.js
@@ -1,4 +1,4 @@
-const client = require("models/client");
+const client = require("models/client-new");
 const keys = require("./keys");
 const PAGE_SIZE = 20;
 
@@ -58,90 +58,68 @@ const hasNonEmptyBody = (body) =>
 const hasNonEmptyTitle = (title) =>
   typeof title === "string" && title.trim().length > 0;
 
-const load = (ids) => {
-  return new Promise((resolve, reject) => {
-    (async () => {
-      const childIDs = await Promise.all(
-        ids.map((id) => {
-          return client.zrange(keys.children(id), 0, -1);
-        })
-      );
+const load = async (ids) => {
+  const childIDs = await Promise.all(
+    ids.map((id) => {
+      return client.zRange(keys.children(id), 0, -1);
+    })
+  );
 
-      const results = await Promise.all([
-        ...ids.map((id) => client.hgetall(keys.item(id))),
-        ...childIDs.flat().map((id) => client.hgetall(keys.item(id))),
-      ]);
+  const results = await Promise.all([
+    ...ids.map((id) => client.hGetAll(keys.item(id))),
+    ...childIDs.flat().map((id) => client.hGetAll(keys.item(id))),
+  ]);
 
-      const questions = results
+  const questions = results
+    .filter(
+      (result) =>
+        result &&
+        !result.parent &&
+        hasNonEmptyBody(result.body) &&
+        hasNonEmptyTitle(result.title)
+    )
+    .map((result) => {
+      result.replies = results
         .filter(
-          (result) =>
-            result &&
-            !result.parent &&
-            hasNonEmptyBody(result.body) &&
-            hasNonEmptyTitle(result.title)
+          (reply) => reply && reply.parent === result.id && hasNonEmptyBody(reply.body)
         )
-        .map((result) => {
-          result.replies = results
-            .filter(
-              (reply) =>
-                reply &&
-                reply.parent === result.id &&
-                hasNonEmptyBody(reply.body)
-            )
-            .map((reply) => {
-              return { body: reply.body };
-            });
-
-          return {
-            id: result.id,
-            title: result.title,
-            body: result.body,
-            replies: result.replies,
-          };
+        .map((reply) => {
+          return { body: reply.body };
         });
 
-      resolve(questions);
-    })().catch(reject);
-  });
+      return {
+        id: result.id,
+        title: result.title,
+        body: result.body,
+        replies: result.replies,
+      };
+    });
+
+  return questions;
 };
 
-module.exports = ({ query, page = 1, page_size = PAGE_SIZE } = {}) => {
-  return new Promise((resolve, reject) => {
-    const key = keys.all_questions;
-    const questions = [];
-    const cursor = 0;
+module.exports = async ({ query, page = 1, page_size = PAGE_SIZE } = {}) => {
+  const key = keys.all_questions;
+  const questions = [];
+  let cursor = "0";
 
-    const iterate = async (err, [cursor, ids]) => {
-      if (err) {
-        return reject(err);
+  do {
+    const result = await client.sScan(key, cursor);
+    cursor = result.cursor;
+
+    const candidates = await load(result.members);
+
+    candidates.forEach((entry) => {
+      const score = Score(query, entry);
+      if (score > 0) {
+        questions.push({
+          title: entry.title,
+          id: entry.id,
+          score,
+        });
       }
+    });
+  } while (questions.length < page_size * page && cursor !== "0");
 
-      const candidates = await load(ids);
-
-      candidates.forEach((result) => {
-        const score = Score(query, result);
-        if (score > 0) {
-          questions.push({
-            title: result.title,
-            id: result.id,
-            score,
-          });
-        }
-      });
-
-      // we have enough questions to fill a page
-      if (questions.length >= page_size * page) {
-        return resolve(sortAndPaginate(questions, page_size, page));
-
-        // we have reached the end of the questions and there are no more questions to retrieve
-      } else if (cursor === "0") {
-        return resolve(sortAndPaginate(questions, page_size, page));
-      } else {
-        return client.sscan(key, cursor, iterate);
-      }
-    };
-
-    // iterate over the question ids, retrieve the title, and body of each question and see if they contain the query
-    client.sscan(key, cursor, iterate);
-  });
+  return sortAndPaginate(questions, page_size, page);
 };

--- a/app/models/question/tags.js
+++ b/app/models/question/tags.js
@@ -1,39 +1,34 @@
-const client = require("models/client");
+const client = require("models/client-new");
 const keys = require("./keys");
 const PAGE_SIZE = 10;
 
 // returns tags, sorted by popularity
 // paginated by PAGE_SIZE
 
-module.exports = ({ page = 1 } = {}) => {
-  return new Promise((resolve, reject) => {
-    client.smembers(keys.all_tags, (err, tags) => {
-      Promise.all(
-        tags.map((tag) => {
-          return client.zcard(keys.by_tag(tag));
-        })
-      ).then((counts) => {
-        const tagsWithCounts = tags.map((tag, i) => {
-          return {
-            tag,
-            count: counts[i],
-          };
-        });
+module.exports = async ({ page = 1 } = {}) => {
+  const tags = await client.sMembers(keys.all_tags);
 
-        const sortedTags = tagsWithCounts.sort((a, b) => {
-          return b.count - a.count;
-        });
+  const counts = await Promise.all(
+    tags.map((tag) => {
+      return client.zCard(keys.by_tag(tag));
+    })
+  );
 
-        const pageOfTags = sortedTags.slice(
-          (page - 1) * PAGE_SIZE,
-          page * PAGE_SIZE
-        );
-
-        resolve({
-          tags: pageOfTags,
-          stats: { page, page_size: PAGE_SIZE, total: sortedTags.length },
-        });
-      }).catch(reject);
-    });
+  const tagsWithCounts = tags.map((tag, i) => {
+    return {
+      tag,
+      count: counts[i],
+    };
   });
+
+  const sortedTags = tagsWithCounts.sort((a, b) => {
+    return b.count - a.count;
+  });
+
+  const pageOfTags = sortedTags.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  return {
+    tags: pageOfTags,
+    stats: { page, page_size: PAGE_SIZE, total: sortedTags.length },
+  };
 };

--- a/app/models/question/tests/create.js
+++ b/app/models/question/tests/create.js
@@ -1,5 +1,3 @@
-const { hset, setnx } = require("../../client");
-
 describe("questions.create", function () {
   require("./setup")();
   const create = require("../create");
@@ -20,7 +18,7 @@ describe("questions.create", function () {
     expect(question.title).toEqual("How?");
     expect(question.body).toEqual("");
     expect(question.tags).toEqual([]);
-  });  
+  });
 
   it("respects the ID you supply it as long as it is not new", async function () {
     const question = await create({
@@ -55,16 +53,15 @@ describe("questions.create", function () {
   });
 
   it("will throw an error if you trigger an issue with redis multi.exec", async function () {
-
-    const client = require("models/client");
+    const client = require("models/client-new");
 
     spyOn(client, "multi").and.returnValue({
-      zadd: () => {},
-      sadd: () => {},
-      zincrby: () => {},
-      hset: () => {},
-      setnx: () => {},
-      exec: (cb) => cb(new Error("Oh no!")),
+      zAdd: () => {},
+      sAdd: () => {},
+      zIncrBy: () => {},
+      hSet: () => {},
+      setNX: () => {},
+      exec: () => Promise.reject(new Error("Oh no!")),
     });
 
     try {
@@ -73,14 +70,12 @@ describe("questions.create", function () {
     } catch (e) {
       expect(e.message).toEqual("Oh no!");
     }
-
   });
 
   it("will throw an error if you trigger an issue with redis exists", async function () {
-    
-    const client = require("models/client");
+    const client = require("models/client-new");
 
-    spyOn(client, "exists").and.callFake((id, cb) => cb(new Error("REDIS EXISTS ISSUE")));
+    spyOn(client, "exists").and.returnValue(Promise.reject(new Error("REDIS EXISTS ISSUE")));
 
     try {
       await create({ title: "How?", id: "1" });
@@ -90,12 +85,10 @@ describe("questions.create", function () {
     }
   });
 
-
   it("will throw an error if you trigger an issue with redis incr", async function () {
-    
-    const client = require("models/client");
+    const client = require("models/client-new");
 
-    spyOn(client, "incr").and.callFake((id, cb) => cb(new Error("REDIS INCR ISSUE")));
+    spyOn(client, "incr").and.returnValue(Promise.reject(new Error("REDIS INCR ISSUE")));
 
     try {
       await create({ title: "How?", body: "Yes" });
@@ -104,7 +97,6 @@ describe("questions.create", function () {
       expect(e.message).toEqual("REDIS INCR ISSUE");
     }
   });
-
 
   it("saves tags if you supply them", async function () {
     const question = await create({

--- a/app/models/question/tests/export.js
+++ b/app/models/question/tests/export.js
@@ -3,7 +3,7 @@ const tags = require("../../tags");
 describe("exportQuestions", function () {
     require("./setup")();
   
-    const client = require("models/client"); // Ensure this client is correctly initialized
+    const client = require("models/client-new"); // Ensure this client is correctly initialized
     const exportQuestions = require('../export'); // Adjust the path as needed
     const create = require("../create"); // Function to create questions/replies
     
@@ -251,43 +251,43 @@ describe("exportQuestions", function () {
         done();
       });
 
-      it("will throw an error if you trigger an issue with redis smembers", async function () {
+      it("will throw an error if you trigger an issue with redis sMembers", async function () {
         
-        spyOn(require("models/client"), "smembers").and.callFake((id, cb) => cb(new Error("REDIS smembers ISSUE")));
+        spyOn(require("models/client-new"), "sMembers").and.returnValue(Promise.reject(new Error("REDIS sMembers ISSUE")));
         
         try {
           await exportQuestions();
           fail("Should have thrown");
         } catch (e) {
-          expect(e.message).toEqual("REDIS smembers ISSUE");
+          expect(e.message).toEqual("REDIS sMembers ISSUE");
         }
       });
 
-      it("will throw an error if you trigger an issue with redis hgetall", async function () {
+      it("will throw an error if you trigger an issue with redis hGetAll", async function () {
         
         const question = await create({ title: 'How?', body: 'Yes' });
 
-        spyOn(require("models/client"), "hgetall").and.callFake((id, cb) => cb(new Error("REDIS hgetall ISSUE")));
+        spyOn(require("models/client-new"), "hGetAll").and.returnValue(Promise.reject(new Error("REDIS hGetAll ISSUE")));
         
         try {
           await exportQuestions();
           fail("Should have thrown");
         } catch (e) {
-          expect(e.message).toEqual("REDIS hgetall ISSUE");
+          expect(e.message).toEqual("REDIS hGetAll ISSUE");
         }
       });
 
-      it("will throw an error if you trigger an issue with redis zrange", async function () {
+      it("will throw an error if you trigger an issue with redis zRange", async function () {
         
         const question = await create({ title: 'How?', body: 'Yes' });
 
-        spyOn(require("models/client"), "zrange").and.callFake((id, start, end, cb) => cb(new Error("REDIS zrange ISSUE")));
+        spyOn(require("models/client-new"), "zRange").and.returnValue(Promise.reject(new Error("REDIS zRange ISSUE")));
         
         try {
           await exportQuestions();
           fail("Should have thrown");
         } catch (e) {
-          expect(e.message).toEqual("REDIS zrange ISSUE");
+          expect(e.message).toEqual("REDIS zRange ISSUE");
         }
       });
   });

--- a/app/models/question/tests/import.js
+++ b/app/models/question/tests/import.js
@@ -1,7 +1,7 @@
 describe("importQuestions", function () {
     require("./setup")();
   
-    const client = require("models/client"); // Ensure this client is correctly initialized
+    const client = require("models/client-new"); // Ensure this client is correctly initialized
     const importQuestions = require('../import'); // Adjust the path as needed
     const exportQuestions = require('../export'); // We'll use this to verify the import
   

--- a/app/models/question/tests/setup.js
+++ b/app/models/question/tests/setup.js
@@ -1,35 +1,21 @@
 module.exports = function setup(options) {
   // remove all keys from the redis-db with the prefix 'blot:questions
-  beforeEach(function (done) {
-    const client = require("models/client");
+  beforeEach(async function () {
+    const client = require("models/client-new");
 
-    client.keys("blot:questions:*", function (err, keys) {
-      if (err) return done(err);
-      if (keys.length > 0) {
-        client.del(keys, function (err, response) {
-          if (err) return done(err);
-          done();
-        });
-      } else {
-        done();
-      }
-    });
+    const keys = await client.keys("blot:questions:*");
+    if (keys.length > 0) {
+      await client.del(keys);
+    }
   });
 
   // remove all keys from the redis-db with the prefix 'blot:questions
-  afterEach(function (done) {
-    const client = require("models/client");
+  afterEach(async function () {
+    const client = require("models/client-new");
 
-    client.keys("blot:questions:*", function (err, keys) {
-      if (err) return done(err);
-      if (keys.length > 0) {
-        client.del(keys, function (err, response) {
-          if (err) return done(err);
-          done();
-        });
-      } else {
-        done();
-      }
-    });
+    const keys = await client.keys("blot:questions:*");
+    if (keys.length > 0) {
+      await client.del(keys);
+    }
   });
 };

--- a/app/models/question/update.js
+++ b/app/models/question/update.js
@@ -1,4 +1,4 @@
-const client = require("models/client");
+const client = require("models/client-new");
 const keys = require("./keys");
 const get = require("./get");
 
@@ -23,19 +23,19 @@ module.exports = async (id, updates) => {
       value = value.toString();
     }
 
-    multi.hset(keys.item(id), key, value);
+    multi.hSet(keys.item(id), key, value);
   }
 
   // we need to update any tags
   if (updates.tags) {
     for (const tag of updates.tags) {
-      multi.sadd(keys.all_tags, tag);
-      multi.zadd(keys.by_tag(tag),  parseInt(created_at), id);
+      multi.sAdd(keys.all_tags, tag);
+      multi.zAdd(keys.by_tag(tag), { score: parseInt(created_at, 10), value: id });
     }
 
     for (const tag of existing.tags) {
       if (!updates.tags.includes(tag)) {
-        multi.zrem(keys.by_tag(tag), id);
+        multi.zRem(keys.by_tag(tag), id);
         removedTags.push(tag);
       }
     }
@@ -44,36 +44,23 @@ module.exports = async (id, updates) => {
   const tagsToRemove = await identifyTagsToRemove(removedTags);
 
   for (const tag of tagsToRemove) {
-    multi.srem(keys.all_tags, tag);
+    multi.sRem(keys.all_tags, tag);
   }
 
-  return new Promise((resolve, reject) => {
-    multi.exec((err) => {
-      if (err) {
-        reject(err);
-      }
-      // get the latest version of the question
-      // and return it
-      get(id).then(resolve).catch(reject);
-    });
-  });
+  await multi.exec();
+
+  // get the latest version of the question
+  // and return it
+  return get(id);
 };
 
 // clean up any tags that are no longer used
-function identifyTagsToRemove(removedTags) {
-  const tagsToRemove = [];
-
-  return Promise.all(
+async function identifyTagsToRemove(removedTags) {
+  const replies = await Promise.all(
     removedTags.map((tag) => {
-      return client.zcard(keys.by_tag(tag));
+      return client.zCard(keys.by_tag(tag));
     })
-  ).then((replies) => {
-    for (let i = 0; i < replies.length; i++) {
-      if (replies[i] <= 1) {
-        tagsToRemove.push(removedTags[i]);
-      }
-    }
+  );
 
-    return tagsToRemove;
-  });
+  return removedTags.filter((_, i) => replies[i] <= 1);
 }


### PR DESCRIPTION
### Motivation
- Move the `question` model off the old callback-style Redis adapter to the modern promise-based shared client to align with project Redis conventions. 
- Replace legacy callback wrappers and deprecated command shapes with the Redis v5-style promise API to simplify code and make tests reflect production behaviour. 

### Description
- Replaced `require("models/client")` with `require("models/client-new")` across `app/models/question` runtime files and updated related test files and setup to use `models/client-new` instead of the legacy client. 
- Converted callback-based wrappers to `async`/`await` and direct promise-returning Redis calls (e.g. `sMembers`, `hGetAll`, `zRange`, `zScore`, `zCard`, `incr`), and preserved the public function contracts and returned payload shapes. 
- Kept `multi()` only for atomic write paths in `create.js` and `update.js`, and now `await multi.exec()`; updated multi command usages to modern names (`zAdd`, `sAdd`, `hSet`, `setNX`, `zIncrBy`, `zRem`, `sRem`). 
- Updated tests (`tests/setup.js`, `tests/create.js`, `tests/export.js`, `tests/import.js`, etc.) to require `models/client-new` and to spy/mock the new promise-based methods (including stubbing `multi()` to return an object whose `exec()` returns a rejected Promise for error-path tests). 
- Rewrote the migration guidance in `app/models/README` (replacing the old 404-specific template) into a reusable model-agnostic migration section and added a short migration note in `app/models/question/README` documenting the `client-new` switch and command translation choices.

### Testing
- Ran static syntax checks with `node --check` against the modified model and test files (`app/models/question/*.js` and the updated tests) and they succeeded. 
- Attempted to run the question test suite with the project test harness (`./scripts/tests/invoke.sh app/models/question/tests`), but the CI-like script requires Docker and failed in this environment because `docker` is not available. 
- Attempted local Jasmine runs (`NODE_PATH=app ./node_modules/.bin/jasmine ...`) but they could not complete here due to Redis being unavailable (connection errors / environment differences), so full runtime test execution could not be validated in this workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c1233af0832994cd7e7cc2b5d7b7)