### PR TITLE
Migrate redirects model to client-new with async Redis internals

### DIFF
--- a/app/models/README
+++ b/app/models/README
@@ -45,7 +45,9 @@ Use this checklist when updating a model:
 - [ ] Replace `require("models/client")` with `require("models/client-new")` unless the module needs an isolated client lifecycle.
 - [ ] If isolated lifecycle is required, switch to `const createRedisClient = require("models/redis-new")` and manage `connect()` + shutdown in that module.
 - [ ] Convert callback-last Redis calls to promise/`async`-`await` style where needed.
+- [ ] If module exports still use callbacks, keep the public callback contract and wrap awaited Redis calls so rejected promises are forwarded via `(err, result)` callbacks.
 - [ ] Re-validate Redis command names/arguments against the new client API (no dependence on legacy aliasing/shims).
+- [ ] Update tests/mocks/spies for renamed commands and promise-returning call style (including `multi().exec()` rejection paths).
 - [ ] Audit pub/sub code paths for explicit unsubscribe/cleanup on shutdown.
 - [ ] Verify tests cover connection lifecycle and module teardown behavior after the migration.
 
@@ -53,6 +55,8 @@ Model migration guidance (reusable)
 -----------------------------------
 
 - **Preserve public API contracts while modernizing internals.** Keep existing return shapes/callback signatures stable, but move Redis internals to `async`/`await` with promise-based `models/client-new` commands.
+
+- **Bridge callback APIs deliberately during migration.** For legacy modules that still expose callback signatures, keep the callback surface unchanged while converting internal Redis operations to awaited promises and explicit error forwarding.
 
 - **Reserve `multi()` for true atomic write paths.** For create/update flows that must commit several writes together, keep them inside `client.multi() ... await multi.exec()`. Use direct awaited calls for non-atomic reads.
 

--- a/app/models/redirects/README
+++ b/app/models/redirects/README
@@ -69,7 +69,7 @@ Resolves the redirect destination for an arbitrary request URL.
 Resolution order:
 
 1. Attempts a direct key lookup via `get(blogID, input, ...)`.
-2. If no direct match, scans the sorted set with `ZSCAN`, testing each member that is identified as a regex pattern against `input`.
+2. If no direct match, scans the sorted set with `zScan`, testing each member that is identified as a regex pattern against `input`.
 3. Returns `undefined` if no rule matches.
 
 ### `list(blogID, callback)`
@@ -85,7 +85,7 @@ Removes the redirect rule whose source path is `from`.
 
 - `blogID` — string
 - `from` — string
-- `callback` — called with no arguments on success; throws on Redis error
+- `callback` — called with `(err)`; errors are forwarded instead of thrown
 
 ### `key`
 
@@ -129,6 +129,5 @@ Exported for use by callers that need regex-awareness outside the standard CRUD 
 ## Known constraints
 
 - Regex detection in `util.isRegex` is heuristic: a string is treated as a regex only if it starts with `\` or contains the literal substrings `(.*)` or `$1`. Arbitrary regular expression syntax is not detected.
-- `check` uses `ZSCAN` for regex scanning, which does not guarantee full-set iteration in a single call on very large sets; cursor-based pagination is implemented.
-- `drop` throws synchronously on Redis error rather than forwarding the error to its callback.
-- There are no tests specific to this module. Integration coverage exists in `app/blog/tests/error.js`.
+- `check` uses `zScan` for regex scanning, which does not guarantee full-set iteration in a single call on very large sets; cursor-based pagination is implemented.
+- Unit coverage for migration behavior exists in `app/models/redirects/tests/index.js`, with integration coverage in `app/blog/tests/error.js`.

--- a/app/models/redirects/check.js
+++ b/app/models/redirects/check.js
@@ -1,4 +1,4 @@
-var client = require("models/client");
+var client = require("models/client-new");
 var ensure = require("helper/ensure");
 var key = require("./key");
 var get = require("./get");
@@ -12,42 +12,42 @@ module.exports = function (blogID, input, callback) {
   var redirects = key.redirects(blogID);
 
   get(blogID, input, function (err, redirect) {
-    if (err) throw err;
+    if (err) return callback(err);
 
     if (redirect) return callback(null, redirect);
 
-    check(0);
+    (async function () {
+      try {
+        var cursor = "0";
 
-    function check(cursor) {
-      // SORTED SET, precedence is important
-      // SSCAN myset 0 match 'Wo*'
+        while (true) {
+          // SORTED SET, precedence is important
+          var response = await client.zScan(redirects, cursor);
 
-      client.ZSCAN(redirects, cursor, function (err, response) {
-        if (err) throw err;
+          if (!response) return callback();
 
-        if (!response || !response.length) {
-          return callback();
+          cursor = response.cursor;
+          var matches = response.members || [];
+
+          if (!matches.length && cursor === "0") {
+            return callback();
+          }
+
+          for (var i = 0; i < matches.length; i++) {
+            var from = matches[i].value;
+
+            if (isRegex(from) && is(input, from)) {
+              return get(blogID, from, callback, input);
+            }
+          }
+
+          if (cursor === "0") {
+            return callback();
+          }
         }
-
-        var cursor = response[0];
-        var matches = response[1];
-
-        if (!matches.length) return callback();
-
-        for (var i = 0; i < matches.length; i = i + 2)
-          if (isRegex(matches[i]) && is(input, matches[i]))
-            return get(blogID, matches[i], callback, input);
-
-        // Nothing found :(
-        if (cursor === "0") {
-          return callback();
-        }
-
-        // Nothing found here, but more to search
-        if (cursor !== "0") {
-          return check(cursor);
-        }
-      });
-    }
+      } catch (scanErr) {
+        return callback(scanErr);
+      }
+    })();
   });
 };

--- a/app/models/redirects/drop.js
+++ b/app/models/redirects/drop.js
@@ -1,4 +1,4 @@
-var client = require("models/client");
+var client = require("models/client-new");
 var ensure = require("helper/ensure");
 var key = require("./key");
 
@@ -6,16 +6,16 @@ module.exports = function (blogID, from, callback) {
   ensure(blogID, "string").and(from, "string").and(callback, "function");
 
   var redirects = key.redirects(blogID);
+  var fromKey = key.redirect(blogID, from);
 
-  client.zrem(redirects, from, function (err) {
-    if (err) throw err;
-
-    var fromKey = key.redirect(blogID, from);
-
-    client.del(fromKey, function (err) {
-      if (err) throw err;
+  (async function () {
+    try {
+      await client.zRem(redirects, from);
+      await client.del(fromKey);
 
       callback();
-    });
-  });
+    } catch (err) {
+      callback(err);
+    }
+  })();
 };

--- a/app/models/redirects/get.js
+++ b/app/models/redirects/get.js
@@ -1,4 +1,4 @@
-var client = require("models/client");
+var client = require("models/client-new");
 var ensure = require("helper/ensure");
 var key = require("./key");
 var util = require("./util");
@@ -10,22 +10,28 @@ module.exports = function (blogID, from, callback, input) {
 
   var fromKey = key.redirect(blogID, from);
 
-  client.get(fromKey, function (err, to) {
-    if (notRegex(to) || !input) {
-      return callback(null, to);
-    }
-
-    // this is only neccessary for from, if from is a regex
-    var redirect;
-
+  (async function () {
     try {
-      redirect = map(input, from, to);
-    } catch (e) {}
+      var to = await client.get(fromKey);
 
-    // WE SHOULD CACHE THIS RESPONSE HERE.... ?
-    // HOW TO BIND IT to the core FROM PATTERN ?
-    redirect = redirect !== from ? redirect : null;
+      if (notRegex(to) || !input) {
+        return callback(null, to);
+      }
 
-    return callback(err, redirect);
-  });
+      // this is only neccessary for from, if from is a regex
+      var redirect;
+
+      try {
+        redirect = map(input, from, to);
+      } catch (e) {}
+
+      // WE SHOULD CACHE THIS RESPONSE HERE.... ?
+      // HOW TO BIND IT to the core FROM PATTERN ?
+      redirect = redirect !== from ? redirect : null;
+
+      return callback(null, redirect);
+    } catch (err) {
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/redirects/list.js
+++ b/app/models/redirects/list.js
@@ -1,4 +1,4 @@
-var client = require("models/client");
+var client = require("models/client-new");
 var ensure = require("helper/ensure");
 var key = require("./key");
 var _ = require("lodash");
@@ -8,19 +8,21 @@ module.exports = function (blogID, callback) {
 
   var redirects = key.redirects(blogID);
 
-  client.zrange(redirects, 0, -1, function (err, froms) {
-    if (err) throw err;
+  (async function () {
+    try {
+      var froms = await client.zRange(redirects, 0, -1);
 
-    if (!froms.length) return callback(null, []);
+      if (!froms.length) return callback(null, []);
 
-    var fromKeys = _.map(froms, function (from) {
-      return key.redirect(blogID, from);
-    });
+      var fromKeys = _.map(froms, function (from) {
+        return key.redirect(blogID, from);
+      });
 
-    client.mget(fromKeys, function (err, tos) {
-      if (err) throw err;
+      var tos = await client.mGet(fromKeys);
 
-      if (tos.length !== froms.length) throw "Length mismatch";
+      if (tos.length !== froms.length) {
+        throw new Error("Length mismatch");
+      }
 
       // console.log(tos);
 
@@ -39,6 +41,8 @@ module.exports = function (blogID, callback) {
       // console.log(allRedirects);
 
       callback(null, allRedirects);
-    });
-  });
+    } catch (err) {
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/redirects/set.js
+++ b/app/models/redirects/set.js
@@ -1,4 +1,4 @@
-var client = require("models/client");
+var client = require("models/client-new");
 var ensure = require("helper/ensure");
 var key = require("./key");
 var util = require("./util");
@@ -10,50 +10,51 @@ module.exports = function (blogID, mappings, callback) {
   ensure(blogID, "string").and(mappings, "array").and(callback, "function");
 
   var redirects = key.redirects(blogID);
-  var multi = client.multi();
 
-  client.zrange(redirects, 0, -1, function (err, all_keys) {
-    if (err) return callback(err);
+  (async function () {
+    try {
+      var allKeys = await client.zRange(redirects, 0, -1);
+      var multi = client.multi();
 
-    all_keys = all_keys || [];
+      allKeys = allKeys || [];
+      allKeys = allKeys.map(function (from) {
+        return key.redirect(blogID, from);
+      });
+      allKeys.push(redirects);
 
-    all_keys = all_keys.map(function (from) {
-      return key.redirect(blogID, from);
-    });
+      multi.del(allKeys);
 
-    all_keys.push(redirects);
+      mappings.forEach(function (redirect, index) {
+        var from = redirect.from;
+        var to = redirect.to;
+        var fromKey = key.redirect(blogID, from);
 
-    multi.del(all_keys);
+        index = parseInt(index);
 
-    mappings.forEach(function (redirect, index) {
-      var from = redirect.from;
-      var to = redirect.to;
-      var fromKey = key.redirect(blogID, from);
+        if (isNaN(index)) throw new Error("forEach returned a NaN index");
 
-      index = parseInt(index);
+        var candidates = mappings.slice(0, index);
 
-      if (isNaN(index)) throw new Error("forEach returned a NaN index");
+        if (!from || !to || matches(to, candidates)) return;
 
-      var candidates = mappings.slice(0, index);
+        ensure(from, "string")
+          .and(to, "string")
+          .and(index, "number")
+          .and(fromKey, "string")
+          .and(redirects, "string");
 
-      // If either the 'from' rule or the 'to' rule
-      // are empty strings then delete this rule.
-      // If the 'to' rule matches a 'from' rule which
-      // comes before it ('candidates') this would cause
-      // a re-direct loop, so drop this rule.
-      // drop(blogID, from, next);
-      if (!from || !to || matches(to, candidates)) return;
+        multi.zAdd(redirects, {
+          score: index,
+          value: from,
+        });
+        multi.set(fromKey, to);
+      });
 
-      ensure(from, "string")
-        .and(to, "string")
-        .and(index, "number")
-        .and(fromKey, "string")
-        .and(redirects, "string");
+      await multi.exec();
 
-      multi.zadd(redirects, index, from);
-      multi.set(fromKey, to);
-    });
-
-    multi.exec(callback);
-  });
+      return callback();
+    } catch (err) {
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/redirects/tests/index.js
+++ b/app/models/redirects/tests/index.js
@@ -1,0 +1,259 @@
+describe("models/redirects migration", function () {
+  function withMockedRedirectModules(clientImpl, run) {
+    var getPath = require.resolve("../get");
+    var listPath = require.resolve("../list");
+    var checkPath = require.resolve("../check");
+    var dropPath = require.resolve("../drop");
+    var setPath = require.resolve("../set");
+    var clientPath = require.resolve("models/client-new");
+
+    var oldGet = require.cache[getPath];
+    var oldList = require.cache[listPath];
+    var oldCheck = require.cache[checkPath];
+    var oldDrop = require.cache[dropPath];
+    var oldSet = require.cache[setPath];
+    var oldClient = require.cache[clientPath];
+
+    require.cache[clientPath] = {
+      id: clientPath,
+      filename: clientPath,
+      loaded: true,
+      exports: clientImpl,
+    };
+
+    delete require.cache[getPath];
+    delete require.cache[listPath];
+    delete require.cache[checkPath];
+    delete require.cache[dropPath];
+    delete require.cache[setPath];
+
+    try {
+      run({
+        get: require("../get"),
+        list: require("../list"),
+        check: require("../check"),
+        drop: require("../drop"),
+        set: require("../set"),
+      });
+    } finally {
+      delete require.cache[getPath];
+      delete require.cache[listPath];
+      delete require.cache[checkPath];
+      delete require.cache[dropPath];
+      delete require.cache[setPath];
+
+      if (oldClient) require.cache[clientPath] = oldClient;
+      else delete require.cache[clientPath];
+
+      if (oldGet) require.cache[getPath] = oldGet;
+      if (oldList) require.cache[listPath] = oldList;
+      if (oldCheck) require.cache[checkPath] = oldCheck;
+      if (oldDrop) require.cache[dropPath] = oldDrop;
+      if (oldSet) require.cache[setPath] = oldSet;
+    }
+  }
+
+  it("set replaces redirects atomically using client-new multi command shapes", function (done) {
+    var calls = [];
+
+    withMockedRedirectModules(
+      {
+        zRange: async function () {
+          return ["/old"];
+        },
+        multi: function () {
+          return {
+            del: function (keys) {
+              calls.push(["del", keys]);
+              return this;
+            },
+            zAdd: function (key, payload) {
+              calls.push(["zAdd", key, payload]);
+              return this;
+            },
+            set: function (key, value) {
+              calls.push(["set", key, value]);
+              return this;
+            },
+            exec: async function () {
+              calls.push(["exec"]);
+              return [1, 1, 1];
+            },
+          };
+        },
+      },
+      function (redirects) {
+        redirects.set(
+          "blog-1",
+          [
+            { from: "/a", to: "/b" },
+            { from: "/b", to: "/a" }, // dropped by loop prevention
+          ],
+          function (err) {
+            expect(err).toBeUndefined();
+            expect(calls[0]).toEqual([
+              "del",
+              ["blog:blog-1:redirect:/old", "blog:blog-1:redirects"],
+            ]);
+            expect(calls[1]).toEqual([
+              "zAdd",
+              "blog:blog-1:redirects",
+              { score: 0, value: "/a" },
+            ]);
+            expect(calls[2]).toEqual([
+              "set",
+              "blog:blog-1:redirect:/a",
+              "/b",
+            ]);
+            expect(calls[3]).toEqual(["exec"]);
+            done();
+          }
+        );
+      }
+    );
+  });
+
+  it("list returns ordered redirects", function (done) {
+    withMockedRedirectModules(
+      {
+        zRange: async function () {
+          return ["/from-1", "/from-2"];
+        },
+        mGet: async function () {
+          return ["/to-1", "/to-2"];
+        },
+      },
+      function (redirects) {
+        redirects.list("blog-1", function (err, allRedirects) {
+          expect(err).toBeNull();
+          expect(allRedirects).toEqual([
+            { from: "/from-1", to: "/to-1", index: 0 },
+            { from: "/from-2", to: "/to-2", index: 1 },
+          ]);
+          done();
+        });
+      }
+    );
+  });
+
+  it("check resolves regex redirects after exact miss", function (done) {
+    withMockedRedirectModules(
+      {
+        get: async function (redisKey) {
+          if (redisKey === "blog:blog-1:redirect:/post/(.*)") {
+            return "/new/$1";
+          }
+
+          return null;
+        },
+        zScan: async function () {
+          return {
+            cursor: "0",
+            members: [{ value: "/post/(.*)", score: 0 }],
+          };
+        },
+      },
+      function (redirects) {
+        redirects.check("blog-1", "/post/title", function (err, result) {
+          expect(err).toBeNull();
+          expect(result).toBe("/new/title");
+          done();
+        });
+      }
+    );
+  });
+
+  it("drop removes zset member and value key", function (done) {
+    var calls = [];
+
+    withMockedRedirectModules(
+      {
+        zRem: async function (setKey, from) {
+          calls.push(["zRem", setKey, from]);
+        },
+        del: async function (valueKey) {
+          calls.push(["del", valueKey]);
+        },
+      },
+      function (redirects) {
+        redirects.drop("blog-1", "/from", function (err) {
+          expect(err).toBeUndefined();
+          expect(calls).toEqual([
+            ["zRem", "blog:blog-1:redirects", "/from"],
+            ["del", "blog:blog-1:redirect:/from"],
+          ]);
+          done();
+        });
+      }
+    );
+  });
+
+  it("forwards redis rejections to callbacks including multi exec failure", function (done) {
+    var getCalls = 0;
+
+    withMockedRedirectModules(
+      {
+        zRange: async function () {
+          return ["/from"];
+        },
+        multi: function () {
+          return {
+            del: function () {
+              return this;
+            },
+            zAdd: function () {
+              return this;
+            },
+            set: function () {
+              return this;
+            },
+            exec: async function () {
+              throw new Error("exec failed");
+            },
+          };
+        },
+        mGet: async function () {
+          throw new Error("mGet failed");
+        },
+        get: async function () {
+          getCalls++;
+
+          if (getCalls === 1) throw new Error("get failed");
+
+          return null;
+        },
+        zScan: async function () {
+          throw new Error("zScan failed");
+        },
+        zRem: async function () {
+          throw new Error("zRem failed");
+        },
+        del: async function () {
+          throw new Error("del failed");
+        },
+      },
+      function (redirects) {
+        redirects.set("blog-1", [], function (setErr) {
+          expect(setErr.message).toBe("exec failed");
+
+          redirects.list("blog-1", function (listErr) {
+            expect(listErr.message).toBe("mGet failed");
+
+            redirects.get("blog-1", "/from", function (getErr) {
+              expect(getErr.message).toBe("get failed");
+
+              redirects.check("blog-1", "/x", function (checkErr) {
+                expect(checkErr.message).toBe("zScan failed");
+
+                redirects.drop("blog-1", "/from", function (dropErr) {
+                  expect(dropErr.message).toBe("zRem failed");
+                  done();
+                });
+              });
+            });
+          });
+        });
+      }
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Move redirects model to the modern promise-based Redis client (`models/client-new`) and adopt `async`/`await` internally while preserving existing callback-style public APIs. 
- Ensure atomic "replace all redirects" semantics continue to work with the new client API and update docs and tests for the new command shapes and promise-returning call style.

### Description
- Replaced `require("models/client")` with `require("models/client-new")` in `app/models/redirects/{get,list,check,drop,set}.js` and updated internals to await `client-new` commands while keeping `(err, result)` callbacks for callers. 
- Converted Redis calls to promise-based flows (`get`, `zRange`, `mGet`, `zScan`/`zScan` → `zScan`, `zRem`, `del`, `zAdd`) and wrapped async internals so Redis errors are forwarded to callbacks. 
- Reworked `set.js` transaction to preserve atomic replace semantics using `client.multi()` with `zAdd` payloads and `await multi.exec()` and ensured delete + rewrite ordering and argument shapes match the new API. 
- Added unit tests at `app/models/redirects/tests/index.js` that use promise-returning stubs for `client-new` methods to assert happy paths and failure-path propagation (including `multi().exec()` rejection handling). 
- Updated migration guidance in `app/models/README` to include a model-agnostic note about keeping callback-facing APIs while using awaited Redis internals and to remind maintainers to update test doubles/spies when command names or call styles change. 
- Updated `app/models/redirects/README` to reflect the new `zScan` usage, callback error-forwarding behavior, and the presence of unit tests.

### Testing
- Ran syntax/parse checks on modified files with `node -c` for `app/models/redirects/{get,list,check,drop,set}.js` and `app/models/redirects/tests/index.js`, which completed successfully. 
- Loaded the new redirects test file via `node -c app/models/redirects/tests/index.js` to validate it is syntactically valid, which succeeded. 
- Attempted to run the focused specs with `npm test -- app/models/redirects/tests/index.js`, but the project test harness (`scripts/tests/invoke.sh`) depends on Docker and the environment lacks Docker, so the full test run could not be executed in this CI environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c527f568832984aadb3b157af600)