### PR TITLE
Migrate tags model to models/client-new and modern Redis API

### DIFF
--- a/app/models/README
+++ b/app/models/README
@@ -52,6 +52,17 @@ Use this checklist when updating a model:
 Model migration guidance (reusable)
 -----------------------------------
 
+
+Migration lessons for callback-based models
+-------------------------------------------
+
+- **Keep callback contracts stable while migrating internals.** You can move Redis logic to `async`/`await` and promises internally, but preserve existing callback signatures and output shapes at module boundaries.
+
+- **Prefer direct awaited Redis commands in read paths.** Replace callback wrapper shims with direct promise-based calls (`await client.sMembers(...)`, `await client.zCard(...)`) when atomicity is not required.
+
+- **Keep `multi()` + `exec()` for atomic writes.** For write flows that must update several related keys consistently, keep transactional grouping and only update command names/argument shapes to the modern API.
+
+- **Update tests for API-surface changes, not implementation details.** When command names change (`zcard` -> `zCard`, etc.), adjust spies/stubs accordingly and keep assertions focused on behavior (filtering, pagination, counts, and callback results).
 - **Preserve public API contracts while modernizing internals.** Keep existing return shapes/callback signatures stable, but move Redis internals to `async`/`await` with promise-based `models/client-new` commands.
 
 - **Reserve `multi()` for true atomic write paths.** For create/update flows that must commit several writes together, keep them inside `client.multi() ... await multi.exec()`. Use direct awaited calls for non-atomic reads.

--- a/app/models/tags/_get.js
+++ b/app/models/tags/_get.js
@@ -1,4 +1,4 @@
-const client = require("models/client");
+const client = require("models/client-new");
 const ensure = require("helper/ensure");
 const type = require("helper/type");
 const key = require("./key");
@@ -35,8 +35,8 @@ module.exports = function get(blogID, tag, options, callback) {
     var stop = limit === undefined ? -1 : offset + limit - 1;
 
     const [totalResult, entryIDsResult] = await Promise.all([
-      client.zcard(sortedTagKey),
-      client.zrevrange(sortedTagKey, start, stop),
+      client.zCard(sortedTagKey),
+      client.zRange(sortedTagKey, start, stop, { REV: true }),
     ]);
 
     const total = totalResult || 0;

--- a/app/models/tags/list.js
+++ b/app/models/tags/list.js
@@ -1,4 +1,4 @@
-const client = require("models/client");
+const client = require("models/client-new");
 const ensure = require("helper/ensure");
 const { normalizePathPrefix, filterEntryIDsByPathPrefix } = require("helper/pathPrefix");
 const key = require("./key");
@@ -15,13 +15,7 @@ module.exports = async function getAll(blogID, options, callback) {
     options = options || {};
     const pathPrefix = normalizePathPrefix(options.pathPrefix || options.path_prefix);
 
-    // Fetch all tags using SMEMBERS
-    const allTags = await new Promise((resolve, reject) => {
-      client.smembers(key.all(blogID), (err, result) => {
-        if (err) return reject(err);
-        resolve(result || []);
-      });
-    });
+    const allTags = (await client.sMembers(key.all(blogID))) || [];
 
     if (allTags.length === 0) {
       return callback(null, []); // No tags to process
@@ -30,20 +24,13 @@ module.exports = async function getAll(blogID, options, callback) {
     // Iterate over tags and fetch their details
     const tags = [];
     for (const tag of allTags) {
-      const name = await new Promise((resolve, reject) => {
-        client.get(key.name(blogID, tag), (err, result) => {
-          if (err) return reject(err);
-          resolve(result || "");
-        });
-      });
+      const name = (await client.get(key.name(blogID, tag))) || "";
 
       if (pathPrefix) {
-        const entries = await new Promise((resolve, reject) => {
-          client.zrange(key.sortedTag(blogID, tag), 0, -1, (err, result) => {
-            if (err) return reject(err);
-            resolve(filterEntryIDsByPathPrefix(result, pathPrefix));
-          });
-        });
+        const entries = filterEntryIDsByPathPrefix(
+          (await client.zRange(key.sortedTag(blogID, tag), 0, -1)) || [],
+          pathPrefix
+        );
 
         if (!entries.length) continue;
 
@@ -56,12 +43,7 @@ module.exports = async function getAll(blogID, options, callback) {
         continue;
       }
 
-      const count = await new Promise((resolve, reject) => {
-        client.zcard(key.sortedTag(blogID, tag), (err, result) => {
-          if (err) return reject(err);
-          resolve(result || 0);
-        });
-      });
+      const count = (await client.zCard(key.sortedTag(blogID, tag))) || 0;
 
       if (count > 0) {
         tags.push({

--- a/app/models/tags/popular.js
+++ b/app/models/tags/popular.js
@@ -1,4 +1,4 @@
-const client = require("models/client");
+const client = require("models/client-new");
 const ensure = require("helper/ensure");
 const type = require("helper/type");
 const key = require("./key");
@@ -33,67 +33,64 @@ module.exports = function getPopular(blogID, options, callback) {
   if (limit === 0) return callback(null, []);
 
   const popularityKey = key.popular(blogID);
-  client.zcard(popularityKey, function (err, total) {
-    if (err) return callback(err);
 
-    if (!total) return callback(null, []);
+  (async function () {
+    try {
+      const total = await client.zCard(popularityKey);
 
-    var start = offset;
-    var stop = offset + limit - 1;
+      if (!total) return callback(null, []);
 
-    client.zrevrange(
-      popularityKey,
-      start,
-      stop,
-      "WITHSCORES",
-      function (err, tagScores) {
-        if (err) return callback(err);
+      var start = offset;
+      var stop = offset + limit - 1;
 
-        if (!tagScores || tagScores.length === 0) {
-          return callback(null, []);
-        }
+      const tagScores = await client.zRangeWithScores(popularityKey, start, stop, {
+        REV: true,
+      });
 
-        const tagsWithCounts = [];
-
-        for (var i = 0; i < tagScores.length; i += 2) {
-          const slug = tagScores[i];
-          const count = parseInt(tagScores[i + 1], 10) || 0;
-
-          if (!slug) continue;
-
-          tagsWithCounts.push({ slug, count });
-        }
-
-        if (!tagsWithCounts.length) {
-          return callback(null, []);
-        }
-
-        Promise.all(
-          tagsWithCounts.map(function ({ slug }) {
-            return client.get(key.name(blogID, slug));
-          })
-        )
-          .then(function (details) {
-            const hydrated = [];
-
-            tagsWithCounts.forEach(function ({ slug, count }, index) {
-              if (!count) return;
-
-              const name = details[index] || slug;
-              const entries = Array.from({ length: count });
-
-              hydrated.push({
-                name,
-                slug,
-                entries,
-                count,
-              });
-            });
-
-            callback(null, hydrated);
-          })
-          .catch(callback);
+      if (!tagScores || tagScores.length === 0) {
+        return callback(null, []);
       }
-    );
-  });
+
+      const tagsWithCounts = [];
+
+      tagScores.forEach(function (item) {
+        if (!item || !item.value) return;
+
+        tagsWithCounts.push({
+          slug: item.value,
+          count: parseInt(item.score, 10) || 0,
+        });
+      });
+
+      if (!tagsWithCounts.length) {
+        return callback(null, []);
+      }
+
+      const details = await Promise.all(
+        tagsWithCounts.map(function ({ slug }) {
+          return client.get(key.name(blogID, slug));
+        })
+      );
+
+      const hydrated = [];
+
+      tagsWithCounts.forEach(function ({ slug, count }, index) {
+        if (!count) return;
+
+        const name = details[index] || slug;
+        const entries = Array.from({ length: count });
+
+        hydrated.push({
+          name,
+          slug,
+          entries,
+          count,
+        });
+      });
+
+      return callback(null, hydrated);
+    } catch (err) {
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/tags/set.js
+++ b/app/models/tags/set.js
@@ -1,4 +1,4 @@
-var client = require("models/client");
+var client = require("models/client-new");
 var key = require("./key");
 var _ = require("lodash");
 var ensure = require("helper/ensure");
@@ -67,60 +67,59 @@ module.exports = function (blogID, entry, callback) {
 
   // First we retrieve a list of all the tags used
   // across the user's blog
-  client.SMEMBERS(existingKey, function (err, existing) {
-    if (err) throw err;
+  (async function () {
+    try {
+      var existing = (await client.sMembers(existingKey)) || [];
 
-    // Then we compute a list of tags which the entry
-    // should NOT be present on (intersection of entry's
-    // current tags and all the tags used on the blog)
-    var removed = _.difference(existing, tags);
-    var added = _.difference(tags, existing);
-    var names = [];
+      // Then we compute a list of tags which the entry
+      // should NOT be present on (intersection of entry's
+      // current tags and all the tags used on the blog)
+      var removed = _.difference(existing, tags);
+      var added = _.difference(tags, existing);
 
-    var multi = client.multi();
-    var popularityKey = key.popular(blogID);
+      var multi = client.multi();
+      var popularityKey = key.popular(blogID);
 
-    added.forEach(function (tag) {
-      multi.zincrby(popularityKey, 1, tag);
-    });
+      added.forEach(function (tag) {
+        multi.zIncrBy(popularityKey, 1, tag);
+      });
 
-    tags.forEach(function (tag, i) {
-      names.push(key.name(blogID, tag));
-      names.push(prettyTags[i]);
+      tags.forEach(function (tag, i) {
+        var score = entry.dateStamp;
+        if (typeof score !== "number" || isNaN(score)) {
+          score = Date.now();
+        }
 
-      var score = entry.dateStamp;
-      if (typeof score !== "number" || isNaN(score)) {
-        score = Date.now();
+        multi.set(key.name(blogID, tag), prettyTags[i]);
+        multi.zAdd(key.sortedTag(blogID, tag), { score: score, value: entry.id });
+      });
+
+      // For each tagName in the list of tags which the
+      // entry is NOT on, make sure that is so. This is
+      // neccessary when the user updates an entry and
+      // removes a previously existing tag
+      removed.forEach(function (tag) {
+        multi.zRem(key.sortedTag(blogID, tag), entry.id);
+        multi.sRem(existingKey, tag);
+        multi.zIncrBy(popularityKey, -1, tag);
+      });
+
+      // Finally add all the entry's tags to the
+      // list of tags used across the blog...
+      if (tags.length) {
+        multi.sAdd(key.all(blogID), tags);
+        multi.sAdd(existingKey, tags);
       }
-      multi.zadd(key.sortedTag(blogID, tag), score, entry.id);
-    });
 
-    // For each tagName in the list of tags which the
-    // entry is NOT on, make sure that is so. This is
-    // neccessary when the user updates an entry and
-    // removes a previously existing tag
-    removed.forEach(function (tag) {
-      multi.zrem(key.sortedTag(blogID, tag), entry.id);
-      multi.srem(existingKey, tag);
-      multi.zincrby(popularityKey, -1, tag);
-    });
+      multi.zRemRangeByScore(popularityKey, "-inf", 0);
 
-    // Finally add all the entry's tags to the
-    // list of tags used across the blog...
-    if (tags.length) {
-      multi.mset(names);
-      multi.sadd(key.all(blogID), tags);
-      multi.sadd(existingKey, tags);
-    }
-
-    multi.zremrangebyscore(popularityKey, "-inf", 0);
-
-    multi.exec(function (err) {
-      if (err) throw err;
+      await multi.exec();
 
       callback();
-    });
-  });
+    } catch (err) {
+      callback(err);
+    }
+  })();
 };
 
 // we need a better way to determine if we should ignore the entry (i.e. if has an underscore in its path)

--- a/app/models/tags/tests/list.js
+++ b/app/models/tags/tests/list.js
@@ -88,14 +88,14 @@ describe("tags.list", function () {
 
     it("does not call zcard when filtering by pathPrefix", function (done) {
         const blogID = this.blog.id;
-        const client = require("models/client");
+        const client = require("models/client-new");
 
         set(blogID, {
             id: "/Blog/one",
             path: "/Blog/one",
             tags: ["TagA"],
         }, function () {
-            spyOn(client, "zcard").and.callThrough();
+            spyOn(client, "zCard").and.callThrough();
 
             list(blogID, { pathPrefix: "Blog" }, function (err, tags) {
                 expect(err).toBeNull();
@@ -106,7 +106,7 @@ describe("tags.list", function () {
                         entries: ["/Blog/one"],
                     },
                 ]);
-                expect(client.zcard).not.toHaveBeenCalled();
+                expect(client.zCard).not.toHaveBeenCalled();
                 done();
             });
         });


### PR DESCRIPTION
### Motivation

- Move tags model internals off the legacy `models/client` callback adapter and onto the promise-based `models/client-new` client to match other migrated models.  
- Preserve the public callback-based API (`get`, `set`, `list`, `popular`) so external callers see no behavioral change.  
- Standardize Redis command names/argument shapes to the modern client conventions used elsewhere in the codebase.  
- Update tests and documentation guidance so future migrations follow the same patterns.

### Description

- Replaced `require("models/client")` with `require("models/client-new")` in `app/models/tags/set.js`, `app/models/tags/_get.js`, `app/models/tags/list.js`, and `app/models/tags/popular.js`.  
- Converted internal Redis usage to promise/`async`-`await` flows and modern commands (examples: `sMembers`, `zCard`, `zRange(..., { REV: true })`, `zRangeWithScores`, `zAdd`, `zIncrBy`, `sAdd`, `zRemRangeByScore`).  
- Preserved atomic multi-command writes in `app/models/tags/set.js` by keeping `client.multi()` and switching the multi body to modern command shapes and `await multi.exec()`.  
- Removed callback-wrapper shims in `list.js` and `popular.js` and used direct awaited client calls while preserving the original return shapes and callback signatures.  
- Adjusted tests under `app/models/tags/tests/` (notably `list.js`) to spy on the new client surface (`models/client-new` and `zCard`) rather than legacy lowercase callback-style methods.  
- Added a small, reusable migration guidance section to `app/models/README` describing lessons learned: preserve callback contracts, convert internals to async/await, update spies for command-name changes, and when to keep `multi()` transactions.

### Testing

- Ran syntax/type checks with `node --check` on the modified files via `node --check app/models/tags/set.js && node --check app/models/tags/_get.js && node --check app/models/tags/list.js && node --check app/models/tags/popular.js && node --check app/models/tags/tests/list.js`, which completed successfully.  
- Attempted to run the model tests with `npm test -- app/models/tags/tests`, but the test harness requires Docker and failed in this environment because `docker` is not available in PATH.  
- No other automated test failures were observed in this environment; updated tests were adjusted to assert behavior (filtering, pagination, and the "don't call count when filtering" check) rather than implementation details.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c75bddf08329bd6519b0f6dbae02)