### PR TITLE
Migrate user model to promise-based Redis client (models/client-new)

### DIFF
--- a/app/models/README
+++ b/app/models/README
@@ -45,9 +45,10 @@ Use this checklist when updating a model:
 - [ ] Replace `require("models/client")` with `require("models/client-new")` unless the module needs an isolated client lifecycle.
 - [ ] If isolated lifecycle is required, switch to `const createRedisClient = require("models/redis-new")` and manage `connect()` + shutdown in that module.
 - [ ] Convert callback-last Redis calls to promise/`async`-`await` style where needed.
-- [ ] If module exports still use callbacks, keep the public callback contract and wrap awaited Redis calls so rejected promises are forwarded via `(err, result)` callbacks.
-- [ ] Re-validate Redis command names/arguments against the new client API (no dependence on legacy aliasing/shims).
-- [ ] Update tests/mocks/spies for renamed commands and promise-returning call style (including `multi().exec()` rejection paths).
+- [ ] If module exports still use callbacks, keep the public callback contract unchanged and forward promise rejections through the existing callback error channel.
+- [ ] Re-validate Redis command names/arguments against the new client API (e.g. `sMembers`, `setEx`, `setNX`, `zAdd`) without relying on legacy aliasing/shims.
+- [ ] Keep atomic write paths in `multi()` transactions and add test coverage for `await multi.exec()` rejection/error forwarding.
+- [ ] Update tests/mocks/spies for `client-new` method names and promise-returning behavior.
 - [ ] Audit pub/sub code paths for explicit unsubscribe/cleanup on shutdown.
 - [ ] Verify tests cover connection lifecycle and module teardown behavior after the migration.
 

--- a/app/models/user/checkAccessToken.js
+++ b/app/models/user/checkAccessToken.js
@@ -1,20 +1,24 @@
-var client = require("models/client");
+var client = require("models/client-new");
 var key = require("./key");
 
 // You cannot check an access token multiple times
-// Once checked, it is no longer valid. The value 
+// Once checked, it is no longer valid. The value
 // stored against an access token might be meaningless
 // (in the case of creating a new account) or it might
 // be an existing user's UID, in the case of the forgot
 // password flow.
 module.exports = function (token, callback) {
-  client.get(key.accessToken(token), function (err, value) {
-    if (err || !value) return callback(new Error("Invalid access token"));
+  (async function () {
+    try {
+      var value = await client.get(key.accessToken(token));
 
-    client.del(key.accessToken(token), function (err) {
-      if (err) throw err;
+      if (!value) return callback(new Error("Invalid access token"));
 
-      callback(null, value);
-    });
-  });
+      await client.del(key.accessToken(token));
+
+      return callback(null, value);
+    } catch (err) {
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/user/create.js
+++ b/app/models/user/create.js
@@ -1,6 +1,6 @@
 var ensure = require("helper/ensure");
 var key = require("./key");
-var client = require("models/client");
+var client = require("models/client-new");
 var validate = require("./validate");
 var generateId = require("./generateId");
 var scheduleSubscriptionEmail = require("./scheduleSubscriptionEmail");
@@ -18,63 +18,63 @@ module.exports = function create (
     .and(paypal, "object")
     .and(callback, "function");
 
-  var multi, userString;
-  var uid = generateId();
-
-  var user = {
-    uid: uid,
-    isDisabled: false,
-    blogs: [],
-    lastSession: "",
-    created: Date.now(),
-    welcomeEmailSent: false,
-    email: email,
-    subscription: subscription,
-    paypal: paypal,
-    passwordHash: passwordHash
-  };
-
-  validate({ uid: uid }, user, function (err, user) {
-    if (err) return callback(err);
-
+  (async function () {
     try {
-      userString = JSON.stringify(user);
-    } catch (e) {
-      return callback(e);
-    }
+      var uid = generateId();
 
-    // If I add or remove methods here
-    // also remove them from set.js
-    multi = client.multi();
-    multi.sadd(key.uids, uid);
-    multi.setnx(key.user(uid), userString);
-    multi.set(key.email(user.email), uid);
-    multi.set(key.user(uid), userString);
+      var user = {
+        uid: uid,
+        isDisabled: false,
+        blogs: [],
+        lastSession: "",
+        created: Date.now(),
+        welcomeEmailSent: false,
+        email: email,
+        subscription: subscription,
+        paypal: paypal,
+        passwordHash: passwordHash
+      };
 
-    // some users might not have stripe subscriptions
-    if (user.subscription && user.subscription.customer)
-      multi.set(key.customer(user.subscription.customer), uid);
+      user = await new Promise(function (resolve, reject) {
+        validate({ uid: uid }, user, function (err, validatedUser) {
+          if (err) return reject(err);
+          return resolve(validatedUser);
+        });
+      });
 
-    // some users might not have paypal subscriptions
-    if (user.paypal && user.paypal.id)
-      multi.set(key.paypal(user.paypal.id), uid);
+      var userString = JSON.stringify(user);
 
-    multi.exec(function (err) {
+      // If I add or remove methods here
+      // also remove them from set.js
+      var multi = client.multi();
+      multi.sAdd(key.uids, uid);
+      multi.setNX(key.user(uid), userString);
+      multi.set(key.email(user.email), uid);
+      multi.set(key.user(uid), userString);
+
+      // some users might not have stripe subscriptions
+      if (user.subscription && user.subscription.customer)
+        multi.set(key.customer(user.subscription.customer), uid);
+
+      // some users might not have paypal subscriptions
+      if (user.paypal && user.paypal.id)
+        multi.set(key.paypal(user.paypal.id), uid);
+
+      var results = await multi.exec();
+
       // Retry if generated ID was in use
-      if (err && err.code === "SETNX")
-        return create(email, passwordHash, subscription, callback);
-
-      // I need to handle uid collision gracefully
-      if (err) console.log(err);
-
-      if (err) return callback(err);
+      if (results && results[1] === 0)
+        return create(email, passwordHash, subscription, paypal, callback);
 
       // Schedule a notifcation email for their subscription renewal
       scheduleSubscriptionEmail(user.uid, function (err) {
         if (err) console.log(err);
       });
 
-      callback(null, user);
-    });
-  });
+      return callback(null, user);
+    } catch (err) {
+      console.log(err);
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/user/generateAccessToken.js
+++ b/app/models/user/generateAccessToken.js
@@ -1,10 +1,10 @@
 var crypto = require("crypto");
-var client = require("models/client");
+var client = require("models/client-new");
 var key = require("./key");
 
 var TOKEN_LENGTH = 16; // characters long
 
-// We can store anything against the generated access 
+// We can store anything against the generated access
 // token – in the case we want to use this token
 // to authenticate the log in of an existing user, we
 // might store that user's UID. In the case we want to use
@@ -21,10 +21,13 @@ module.exports = function generateAccessToken(options, callback) {
 
     token = token.toString("hex");
 
-    client.SETEX(key.accessToken(token), seconds, value, function (err) {
-      if (err) return callback(err);
-
-      callback(null, token);
-    });
+    (async function () {
+      try {
+        await client.setEx(key.accessToken(token), seconds, value);
+        return callback(null, token);
+      } catch (err) {
+        return callback(err);
+      }
+    })();
   });
 };

--- a/app/models/user/getAllIds.js
+++ b/app/models/user/getAllIds.js
@@ -1,9 +1,16 @@
-var client = require("models/client");
+var client = require("models/client-new");
 var ensure = require("helper/ensure");
 var key = require("./key");
 
 module.exports = function getAllIds(callback) {
   ensure(callback, "function");
 
-  client.SMEMBERS(key.uids, callback);
+  (async function () {
+    try {
+      var uids = await client.sMembers(key.uids);
+      return callback(null, uids);
+    } catch (err) {
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/user/getByCustomerId.js
+++ b/app/models/user/getByCustomerId.js
@@ -1,16 +1,20 @@
 var ensure = require("helper/ensure");
-var client = require("models/client");
+var client = require("models/client-new");
 var key = require("./key");
 var getById = require("./getById");
 
 module.exports = function getByCustomerId(customerId, callback) {
   ensure(customerId, "string").and(callback, "function");
 
-  client.get(key.customer(customerId), function (err, uid) {
-    if (err) return callback(err);
+  (async function () {
+    try {
+      var uid = await client.get(key.customer(customerId));
 
-    if (!uid) return callback(null, null);
+      if (!uid) return callback(null, null);
 
-    getById(uid, callback);
-  });
+      return getById(uid, callback);
+    } catch (err) {
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/user/getByEmail.js
+++ b/app/models/user/getByEmail.js
@@ -1,5 +1,5 @@
 var ensure = require("helper/ensure");
-var client = require("models/client");
+var client = require("models/client-new");
 var key = require("./key");
 var getById = require("./getById");
 
@@ -8,11 +8,15 @@ module.exports = function getBy(email, callback) {
 
   email = email.trim().toLowerCase();
 
-  client.get(key.email(email), function (err, uid) {
-    if (err) return callback(err);
+  (async function () {
+    try {
+      var uid = await client.get(key.email(email));
 
-    if (!uid) return callback(null, null);
+      if (!uid) return callback(null, null);
 
-    getById(uid, callback);
-  });
+      return getById(uid, callback);
+    } catch (err) {
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/user/getById.js
+++ b/app/models/user/getById.js
@@ -1,5 +1,5 @@
 var ensure = require("helper/ensure");
-var client = require("models/client");
+var client = require("models/client-new");
 var key = require("./key");
 function applyUserDefaults(user) {
   if (!user || typeof user !== "object") return user;
@@ -14,18 +14,22 @@ function applyUserDefaults(user) {
 module.exports = function getById(uid, callback) {
   ensure(uid, "string").and(callback, "function");
 
-  client.get(key.user(uid), function (err, user) {
-    if (err) return callback(err);
-
-    if (!user) return callback(null, null);
-
+  (async function () {
     try {
-      user = JSON.parse(user);
-      ensure(user, "object");
-    } catch (err) {
-      return callback(new Error("BADJSON"));
-    }
+      var user = await client.get(key.user(uid));
 
-    return callback(null, applyUserDefaults(user));
-  });
+      if (!user) return callback(null, null);
+
+      try {
+        user = JSON.parse(user);
+        ensure(user, "object");
+      } catch (err) {
+        return callback(new Error("BADJSON"));
+      }
+
+      return callback(null, applyUserDefaults(user));
+    } catch (err) {
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/user/getByPayPalSubscriptionId.js
+++ b/app/models/user/getByPayPalSubscriptionId.js
@@ -1,16 +1,20 @@
 var ensure = require("helper/ensure");
-var client = require("models/client");
+var client = require("models/client-new");
 var key = require("./key");
 var getById = require("./getById");
 
-module.exports = function getByPayPalSubscriptionId (subscriptionId, callback) {
+module.exports = function getByPayPalSubscriptionId(subscriptionId, callback) {
   ensure(subscriptionId, "string").and(callback, "function");
 
-  client.get(key.paypal(subscriptionId), function (err, uid) {
-    if (err) return callback(err);
+  (async function () {
+    try {
+      var uid = await client.get(key.paypal(subscriptionId));
 
-    if (!uid) return callback(null, null);
+      if (!uid) return callback(null, null);
 
-    getById(uid, callback);
-  });
+      return getById(uid, callback);
+    } catch (err) {
+      return callback(err);
+    }
+  })();
 };

--- a/app/models/user/remove.js
+++ b/app/models/user/remove.js
@@ -1,34 +1,43 @@
 var getById = require("./getById");
 var ensure = require("helper/ensure");
-var client = require("models/client");
+var client = require("models/client-new");
 var key = require("./key");
 
-module.exports = function remove (uid, callback) {
+module.exports = function remove(uid, callback) {
   ensure(uid, "string").and(callback, "function");
 
-  var multi = client.multi();
-
   getById(uid, function (err, user) {
-    if (err) throw err;
+    if (err) return callback(err);
+    if (!user) return callback(new Error("No user"));
 
     var keys = [
       key.user(uid),
       key.email(user.email),
       "sync:lease:" + uid,
-      "sync:again:" + uid
+      "sync:again:" + uid,
     ];
 
-    if (user.subscription.customer) {
+    if (user.subscription && user.subscription.customer) {
       keys.push(key.customer(user.subscription.customer));
     }
 
-    if (user.paypal.id) {
+    if (user.paypal && user.paypal.id) {
       keys.push(key.paypal(user.paypal.id));
     }
 
-    multi.srem(key.uids, uid);
-    multi.del(keys);
+    (async function () {
+      try {
+        var multi = client.multi();
 
-    multi.exec(callback);
+        multi.sRem(key.uids, uid);
+        multi.del(keys);
+
+        await multi.exec();
+
+        return callback();
+      } catch (err) {
+        return callback(err);
+      }
+    })();
   });
 };

--- a/app/models/user/set.js
+++ b/app/models/user/set.js
@@ -1,14 +1,12 @@
 var ensure = require("helper/ensure");
 var validate = require("./validate");
-var client = require("models/client");
+var client = require("models/client-new");
 var updateBillingEmail = require("./updateBillingEmail");
 var key = require("./key");
 var getById = require("./getById");
 
 module.exports = function save(uid, updates, callback) {
   ensure(uid, "string").and(updates, "object").and(callback, "function");
-
-  var multi, userString, former;
 
   getById(uid, function (err, user) {
     if (err) return callback(err);
@@ -17,7 +15,7 @@ module.exports = function save(uid, updates, callback) {
 
     // Clone the state of the user so we can
     // compare any changes further down
-    former = JSON.parse(JSON.stringify(user));
+    var former = JSON.parse(JSON.stringify(user));
 
     if (typeof user.created === "undefined") user.created = 0;
     if (typeof user.welcomeEmailSent === "undefined")
@@ -26,44 +24,44 @@ module.exports = function save(uid, updates, callback) {
     validate(user, updates, function (err, user, changes) {
       if (err) return callback(err);
 
-      try {
-        userString = JSON.stringify(user);
-      } catch (e) {
-        return callback(e);
-      }
+      (async function () {
+        try {
+          var userString = JSON.stringify(user);
 
-      // If I add or remove methods here
-      // also remove them from create.js
-      multi = client.multi();
+          // If I add or remove methods here
+          // also remove them from create.js
+          var multi = client.multi();
 
-      // Should this be setNX? We don't want to clobber
-      // emails which are set between validation and here.
-      if (user.email) multi.set(key.email(user.email), uid);
+          // Should this be setNX? We don't want to clobber
+          // emails which are set between validation and here.
+          if (user.email) multi.set(key.email(user.email), uid);
 
-      // If the user changes their email, remove the old
-      // email pointing to the User's ID.
-      if (former.email && former.email !== user.email) {
-        multi.del(key.email(former.email));
-        updateBillingEmail(user, function (err) {
-          console.log("Error updating email for customer on Stripe:", err);
-        });
-      }
+          // If the user changes their email, remove the old
+          // email pointing to the User's ID.
+          if (former.email && former.email !== user.email) {
+            multi.del(key.email(former.email));
+            updateBillingEmail(user, function (err) {
+              console.log("Error updating email for customer on Stripe:", err);
+            });
+          }
 
-      multi.set(key.user(uid), userString);
+          multi.set(key.user(uid), userString);
 
-      // some users might not have stripe subscriptions
-      if (user.subscription && user.subscription.customer)
-        multi.set(key.customer(user.subscription.customer), uid);
+          // some users might not have stripe subscriptions
+          if (user.subscription && user.subscription.customer)
+            multi.set(key.customer(user.subscription.customer), uid);
 
-      // some users might not have paypal subscriptions
-      if (user.paypal && user.paypal.id)
-        multi.set(key.paypal(user.paypal.id), uid);
+          // some users might not have paypal subscriptions
+          if (user.paypal && user.paypal.id)
+            multi.set(key.paypal(user.paypal.id), uid);
 
-      multi.exec(function (err) {
-        if (err) return callback(err);
+          await multi.exec();
 
-        callback(null, changes);
-      });
+          return callback(null, changes);
+        } catch (err) {
+          return callback(err);
+        }
+      })();
     });
   });
 };

--- a/app/models/user/tests/scheduleWelcomeEmail.js
+++ b/app/models/user/tests/scheduleWelcomeEmail.js
@@ -2,7 +2,7 @@ describe("user", function () {
   global.test.user();
 
   var User = require("models/user");
-  var client = require("models/client");
+  var client = require("models/client-new");
   var key = require("models/user/key");
 
   it("sends welcome email immediately when overdue", function (done) {
@@ -51,29 +51,33 @@ describe("user", function () {
   it("defaults missing fields when loading legacy users", function (done) {
     var uid = this.user.uid;
 
-    client.get(key.user(uid), function (err, original) {
-      if (err) return done.fail(err);
+    (async function () {
+      try {
+        var original = await client.get(key.user(uid));
 
-      client.set(
-        key.user(uid),
-        JSON.stringify({ uid: uid, email: "legacy@example.com" }),
-        function (err) {
+        await client.set(
+          key.user(uid),
+          JSON.stringify({ uid: uid, email: "legacy@example.com" })
+        );
+
+        User.getById(uid, function (err, user) {
           if (err) return done.fail(err);
 
-          User.getById(uid, function (err, user) {
-            if (err) return done.fail(err);
+          expect(user.created).toBe(0);
+          expect(user.welcomeEmailSent).toBe(true);
 
-            expect(user.created).toBe(0);
-            expect(user.welcomeEmailSent).toBe(true);
-
-            client.set(key.user(uid), original, function (restoreErr) {
-              if (restoreErr) return done.fail(restoreErr);
+          (async function () {
+            try {
+              await client.set(key.user(uid), original);
               done();
-            });
-          });
-        }
-      );
-    });
+            } catch (restoreErr) {
+              done.fail(restoreErr);
+            }
+          })();
+        });
+      } catch (err) {
+        done.fail(err);
+      }
+    })();
   });
 });
-

--- a/app/models/user/tests/set.js
+++ b/app/models/user/tests/set.js
@@ -2,22 +2,31 @@ describe("user", function () {
   global.test.user();
 
   var set = require("../index").set;
-  var client = require("models/client");
+  var client = require("models/client-new");
   var key = require("../key");
 
   it("set will remove key for old email when email changes", function (done) {
     var test = this;
-    client.get(key.email(test.user.email), function (err, uid) {
-      if (err) return done.fail(err);
-      expect(uid).toEqual(test.user.uid);
-      set(uid, { email: "foo@gmail.com" }, function (err) {
-        if (err) return done.fail(err);
-        client.get(key.email(test.user.email), function (err, uid) {
+
+    (async function () {
+      try {
+        var uid = await client.get(key.email(test.user.email));
+        expect(uid).toEqual(test.user.uid);
+
+        set(uid, { email: "foo@gmail.com" }, async function (err) {
           if (err) return done.fail(err);
-          expect(uid).toEqual(null);
-          done();
+
+          try {
+            var updatedUid = await client.get(key.email(test.user.email));
+            expect(updatedUid).toEqual(null);
+            done();
+          } catch (err) {
+            done.fail(err);
+          }
         });
-      });
-    });
+      } catch (err) {
+        done.fail(err);
+      }
+    })();
   });
 });


### PR DESCRIPTION
### Motivation
- Modernize Redis usage in the `user` model to the new shared client (`models/client-new`) which exposes promise-based commands while preserving existing public callback contracts. 
- Keep atomic semantics for multi-key writes and update tests and documentation to reflect the new client API and patterns.

### Description
- Replaced `require("models/client")` with `require("models/client-new")` across `app/models/user/*` and updated read/write modules: `create`, `set`, `remove`, `getById`, `getByEmail`, `getByCustomerId`, `getByPayPalSubscriptionId`, `getAllIds`, `generateAccessToken`, and `checkAccessToken`.
- Converted internal Redis usage to `async`/`await` wrapped in IIFEs so the public callback signatures remain unchanged and promise rejections are forwarded to the callbacks.
- Updated Redis command names/shape to the modern client API (e.g. `sAdd`/`sRem`, `setEx`, `setNX`, `sMembers`) and preserved atomic `multi()` flows by using `await multi.exec()` and handling rejection-based errors.
- Updated tests under `app/models/user/tests` to use `models/client-new` and promise-style calls while keeping behavior-focused assertions, and expanded `app/models/README` migration checklist with model-agnostic guidance (callback-surface preservation, command naming, `multi().exec()` coverage, and test-double updates).

### Testing
- Ran a syntax/load smoke check via `node -e "new Function(fs.readFileSync(...))"` across the modified modules which completed successfully.
- Verified no remaining `require("models/client")` occurrences in `app/models/user` and its tests with `rg`, which returned none for the migrated files.
- Attempted to run the test suite with `npm test -- app/models/user/tests`, but the project test harness depends on Docker and `docker` was not available in this environment, so the full test run could not be executed.
- Attempted direct `node tests ...` invocation but the repo tests runner invocation failed in this environment (`MODULE_NOT_FOUND`), so end-to-end test execution is pending in CI or a Docker-capable environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c90484708329a72c23d1a5a668db)