### PR TITLE
Migrate entries model Redis internals to client-new promises

### DIFF
--- a/app/models/README
+++ b/app/models/README
@@ -58,26 +58,15 @@ Model migration guidance (reusable)
 Migration lessons for callback-based models
 -------------------------------------------
 
-- **Keep callback contracts stable while migrating internals.** You can move Redis logic to `async`/`await` and promises internally, but preserve existing callback signatures and output shapes at module boundaries.
+- **Keep callback contracts stable while migrating internals.** You can move Redis logic to `async`/`await` and promises internally, but preserve existing callback signatures, callback argument order, and output shapes at module boundaries.
 
-- **Prefer direct awaited Redis commands in read paths.** Replace callback wrapper shims with direct promise-based calls (`await client.sMembers(...)`, `await client.zCard(...)`) when atomicity is not required.
+- **Modernize command names and argument forms explicitly.** Use `client-new` methods directly (`zRange`, `zCard`, `zRandMember`, `zAdd(key, { score, value })`, etc.) and remove assumptions about legacy lowercase aliases or callback-last overloads.
 
-- **Keep `multi()` + `exec()` for atomic writes.** For write flows that must update several related keys consistently, keep transactional grouping and only update command names/argument shapes to the modern API.
+- **Use `Promise.all` for independent reads; keep `multi().exec()` for atomic writes.** Read-only fan-out should run concurrently with promises, while write paths that must commit together (rebuilds + ready flags, coupled index updates, etc.) should stay transactional.
 
-- **Update tests for API-surface changes, not implementation details.** When command names change (`zcard` -> `zCard`, etc.), adjust spies/stubs accordingly and keep assertions focused on behavior (filtering, pagination, counts, and callback results).
-- **Preserve public API contracts while modernizing internals.** Keep existing return shapes/callback signatures stable, but move Redis internals to `async`/`await` with promise-based `models/client-new` commands.
+- **Bridge async internals back to callbacks deliberately.** Catch rejected Redis promises and route failures through existing callbacks so migrations do not introduce unhandled rejections.
 
-- **Single-file to folder migration is allowed.** When it simplifies incremental migration, move `<model>.js` into `<model>/index.js` and keep `require("models/<model>")` stable via normal folder resolution or a thin shim.
-
-- **Bridge callback APIs deliberately during migration.** For legacy modules that still expose callback signatures, keep the callback surface unchanged while converting internal Redis operations to awaited promises and explicit error forwarding.
-
-- **Reserve `multi()` for true atomic write paths.** For create/update flows that must commit several writes together, keep them inside `client.multi() ... await multi.exec()`. Use direct awaited calls for non-atomic reads.
-
-- **Use modern command names and argument shapes explicitly.** Prefer methods like `sMembers`, `hGetAll`, `zRange(..., { REV: true })`, `zAdd(key, { score, value })`, and `sScan`; avoid legacy lowercase/callback alias assumptions.
-
-- **Keep migration patterns model-agnostic.** Apply the same approach whether you are migrating `question`, `redirects`, `404`, or any other model folder.
-
-- **Apply-per-model checklist note:** when command names or call styles change, update test doubles/spies to match the modern Redis methods used by `client-new` (including `multi().exec()` promise rejection assertions) before finalizing the migration.
+- **Update tests to assert behavior over internals.** Refresh doubles/spies for modern command names and promise-returning methods, and include failure-path checks for both direct commands and `multi().exec()` rejection handling.
 
 Entities
 --------

--- a/app/models/entries/index.js
+++ b/app/models/entries/index.js
@@ -1,4 +1,4 @@
-var redis = require("models/client");
+var redis = require("models/client-new");
 var async = require("async");
 var ensure = require("helper/ensure");
 var Entry = require("../entry");
@@ -46,9 +46,9 @@ module.exports = (function () {
   function adjacentTo(blogID, entryID, callback) {
     ensure(blogID, "string").and(entryID, "string").and(callback, "function");
 
-    // Get the index of the entry in the list of entries
-    redis.zrank(listKey(blogID, "entries"), entryID, function (error, rank) {
-      if (error) throw error;
+    (async function () {
+      // Get the index of the entry in the list of entries
+      var rank = await redis.zRank(listKey(blogID, "entries"), entryID);
 
       // If the entry has no rank its not got siblings
       // make sure you don't just bang rank, 0 is falsy in JS!
@@ -56,44 +56,55 @@ module.exports = (function () {
 
       var lowerBound = rank > 0 ? rank - 1 : 0;
 
-      redis.zrange(
+      var entryIDs = await redis.zRange(
         listKey(blogID, "entries"),
         lowerBound,
-        rank + 1,
-        function (error, entryIDs) {
-          if (error) throw error;
-
-          Entry.get(blogID, entryIDs, function (entries) {
-            // {skinny: true},
-
-            var next, previous;
-
-            if (entries.length) {
-              previous = entries[0].id != entryID ? entries[0] : undefined;
-              next =
-                entries[entries.length - 1].id != entryID
-                  ? entries[entries.length - 1]
-                  : undefined;
-            }
-
-            return callback(next, previous, ++rank);
-          });
-        }
+        rank + 1
       );
+
+      Entry.get(blogID, entryIDs, function (entries) {
+        var next, previous;
+
+        if (entries.length) {
+          previous = entries[0].id != entryID ? entries[0] : undefined;
+          next =
+            entries[entries.length - 1].id != entryID
+              ? entries[entries.length - 1]
+              : undefined;
+        }
+
+        return callback(next, previous, ++rank);
+      });
+    })().catch(function () {
+      return callback();
     });
   }
 
   function getTotal(blogID, callback) {
     var entriesKey = listKey(blogID, "entries");
 
-    redis.zcard(entriesKey, callback);
+    redis
+      .zCard(entriesKey)
+      .then(function (count) {
+        callback(null, count);
+      })
+      .catch(function (err) {
+        callback(err);
+      });
   }
 
   // includes deleted entries
   function getAllIDs(blogID, callback) {
     var allKey = listKey(blogID, "all");
 
-    redis.zrevrange(allKey, 0, -1, callback);
+    redis
+      .zRange(allKey, 0, -1, { REV: true })
+      .then(function (ids) {
+        callback(null, ids);
+      })
+      .catch(function (err) {
+        callback(err);
+      });
   }
 
   // includes deleted entries
@@ -163,31 +174,37 @@ module.exports = (function () {
       end = options.first - 1;
     }
 
-    redis.zrevrange(list, start, end, function (err, ids) {
-      if (err) throw err;
-
-      return callback(null, ids);
-    });
+    redis
+      .zRange(list, start, end, { REV: true })
+      .then(function (ids) {
+        return callback(null, ids);
+      })
+      .catch(function (err) {
+        return callback(err);
+      });
   }
 
   // includes deleted entries
   function each(blogID, dothis, callback) {
     ensure(blogID, "string").and(dothis, "function").and(callback, "function");
 
-    redis.zrevrange(listKey(blogID, "all"), 0, -1, function (error, ids) {
-      if (error) throw error;
-
-      async.eachSeries(
-        ids,
-        function (id, next) {
-          Entry.get(blogID, id, function (entry) {
-            if (!entry) return next();
-            dothis(entry, next);
-          });
-        },
-        callback
-      );
-    });
+    redis
+      .zRange(listKey(blogID, "all"), 0, -1, { REV: true })
+      .then(function (ids) {
+        async.eachSeries(
+          ids,
+          function (id, next) {
+            Entry.get(blogID, id, function (entry) {
+              if (!entry) return next();
+              dothis(entry, next);
+            });
+          },
+          callback
+        );
+      })
+      .catch(function (error) {
+        callback(error);
+      });
   }
 
   function pruneMissing(blogID, callback) {
@@ -197,37 +214,38 @@ module.exports = (function () {
 
     async.eachSeries(
       lists,
-      function (listName, nextList) {
+      async function (listName, nextList) {
         var key = listKey(blogID, listName);
 
-        redis.zrange(key, 0, -1, function (err, ids) {
-          if (err) return nextList(err);
+        try {
+          var ids = await redis.zRange(key, 0, -1);
           if (!ids || !ids.length) return nextList();
 
-          Entry.get(blogID, ids, function (entries) {
-            entries = entries || [];
+          Entry.get(blogID, ids, async function (entries) {
+            try {
+              entries = entries || [];
 
-            var existing = {};
+              var existing = {};
 
-            entries.forEach(function (entry) {
-              if (entry && entry.id) existing[entry.id] = true;
-            });
+              entries.forEach(function (entry) {
+                if (entry && entry.id) existing[entry.id] = true;
+              });
 
-            var missing = ids.filter(function (id) {
-              return !existing[id];
-            });
+              var missing = ids.filter(function (id) {
+                return !existing[id];
+              });
 
-            if (!missing.length) return nextList();
+              if (!missing.length) return nextList();
 
-            var args = [key].concat(missing);
-            args.push(function (err) {
-              if (err) return nextList(err);
+              await redis.zRem.apply(redis, [key].concat(missing));
               nextList();
-            });
-
-            redis.zrem.apply(redis, args);
+            } catch (err) {
+              nextList(err);
+            }
           });
-        });
+        } catch (err) {
+          nextList(err);
+        }
       },
       callback
     );
@@ -238,13 +256,16 @@ module.exports = (function () {
 
     var key = listKey(blogID, "created");
 
-    redis.ZRANGEBYSCORE(key, after, Date.now(), function (err, ids) {
-      if (err) return callback(err);
-
-      Entry.get(blogID, ids, function (entries) {
-        callback(null, entries || []);
+    redis
+      .zRangeByScore(key, after, Date.now())
+      .then(function (ids) {
+        Entry.get(blogID, ids, function (entries) {
+          callback(null, entries || []);
+        });
+      })
+      .catch(function (err) {
+        callback(err);
       });
-    });
   }
 
   function getDeleted(blogID, after, callback) {
@@ -252,13 +273,16 @@ module.exports = (function () {
 
     var key = listKey(blogID, "deleted");
 
-    redis.ZRANGEBYSCORE(key, after, Date.now(), function (err, ids) {
-      if (err) return callback(err);
-
-      Entry.get(blogID, ids, function (entries) {
-        callback(null, entries || []);
+    redis
+      .zRangeByScore(key, after, Date.now())
+      .then(function (ids) {
+        Entry.get(blogID, ids, function (entries) {
+          callback(null, entries || []);
+        });
+      })
+      .catch(function (err) {
+        callback(err);
       });
-    });
   }
 
   function getRange(blogID, start, end, options, callback) {
@@ -271,17 +295,18 @@ module.exports = (function () {
     var listName = options.list || "entries";
     var key = listKey(blogID, listName);
 
-    redis.zrevrange(key, start, end, function (err, entryIDs) {
-      // todo add err as first parameter of callback
-      if (err) return callback([]);
+    redis
+      .zRange(key, start, end, { REV: true })
+      .then(function (entryIDs) {
+        if (!options.full && !options.skinny) return callback(entryIDs);
 
-      if (!options.full && !options.skinny) return callback(entryIDs);
-
-      // options,
-      Entry.get(blogID, entryIDs, function (entries) {
-        return callback(entries);
+        Entry.get(blogID, entryIDs, function (entries) {
+          return callback(entries);
+        });
+      })
+      .catch(function () {
+        return callback([]);
       });
-    });
   }
 
   function random(blogID, callback) {
@@ -309,11 +334,14 @@ module.exports = (function () {
     }
 
     function pickRandomEntryID(done) {
-      redis.zrandmember(key, function (err, entryID) {
-        if (err) return done(err);
-
-        done(null, normalizeEntryID(entryID));
-      });
+      redis
+        .zRandMember(key)
+        .then(function (entryID) {
+          done(null, normalizeEntryID(entryID));
+        })
+        .catch(function (err) {
+          done(err);
+        });
     }
 
     function normalizeEntryID(entryID) {
@@ -444,7 +472,7 @@ module.exports = (function () {
 
     Promise.all(
       entryIDs.map(function (entryID) {
-        return redis.zscore(key, entryID);
+        return redis.zScore(key, entryID);
       })
     ).then(function (rawScores) {
       var withScores = [];
@@ -479,11 +507,9 @@ module.exports = (function () {
     var min = "[" + pathPrefix;
     var max = "[" + pathPrefix + "\xff";
 
-    redis.zrangebylex(pathIndex.lexKey(blogID), min, max, function (error, matchingIDs) {
-      if (error) {
-        console.error(error);
-        return callback(error, [], null);
-      }
+    redis
+      .zRangeByLex(pathIndex.lexKey(blogID), min, max)
+      .then(function (matchingIDs) {
 
       var totalEntries = matchingIDs.length;
 
@@ -517,7 +543,7 @@ module.exports = (function () {
         );
       }
 
-      fetchEntryScores(blogID, matchingIDs, function (error, scoredEntries) {
+        fetchEntryScores(blogID, matchingIDs, function (error, scoredEntries) {
         if (error) {
           console.error(error);
           return callback(error, [], null);
@@ -557,7 +583,11 @@ module.exports = (function () {
           callback
         );
       });
-    });
+      })
+      .catch(function (error) {
+        console.error(error);
+        return callback(error, [], null);
+      });
   }
   function getPage(
     blogID,
@@ -614,27 +644,20 @@ module.exports = (function () {
     }
 
     if (sortBy === "id") {
-      // Sort by entry ID (alphabetically)
-      const sortOptions = [
-        listKey(blogID, "entries"), // Base key
-        "ALPHA", // Sort alphabetically
-        order === "desc" ? "DESC" : "ASC", // Sorting order
-        "LIMIT",
-        start,
-        pageSize, // Apply pagination directly
-      ];
+      redis
+        .zRange(listKey(blogID, "entries"), 0, -1)
+        .then(function (allIDs) {
+          var entryIDs = allIDs.slice().sort();
+          if (order === "desc") entryIDs.reverse();
+          return Promise.all([
+            entryIDs.slice(start, start + pageSize),
+            redis.zCard(listKey(blogID, "entries")),
+          ]);
+        })
+        .then(function (results) {
+          var entryIDs = results[0];
+          var totalEntries = results[1];
 
-      redis.sort(sortOptions, function (error, entryIDs) {
-        if (error) {
-          console.error(error);
-          return callback(error, [], null);
-        }
-
-        redis.zcard(listKey(blogID, "entries"), function (error, totalEntries) {
-          if (error) {
-            console.error(error);
-            return callback(error, [], null);
-          }
           handlePaginationAndCallback(
             blogID,
             entryIDs,
@@ -646,48 +669,40 @@ module.exports = (function () {
             pageNo,
             callback
           );
+        })
+        .catch(function (error) {
+          console.error(error);
+          return callback(error, [], null);
         });
-      });
     } else {
       // Default sorting by date (Redis scores)
 
-      const rangeFn =
+      const rangePromise =
         order === "asc"
-          ? redis.zrevrange.bind(redis)
-          : redis.zrange.bind(redis);
+          ? redis.zRange(listKey(blogID, "entries"), start, end, { REV: true })
+          : redis.zRange(listKey(blogID, "entries"), start, end);
 
-      rangeFn(
-        listKey(blogID, "entries"),
-        start,
-        end,
-        function (error, entryIDs) {
-          if (error) {
-            console.error(error);
-            return callback(error, [], null);
-          }
-          redis.zcard(
-            listKey(blogID, "entries"),
-            function (error, totalEntries) {
-              if (error) {
-                console.error(error);
-                return callback(error, [], null);
-              }
+      Promise.all([rangePromise, redis.zCard(listKey(blogID, "entries"))])
+        .then(function (results) {
+          var entryIDs = results[0];
+          var totalEntries = results[1];
 
-              handlePaginationAndCallback(
-                blogID,
-                entryIDs,
-                totalEntries,
-                zeroIndexedPageNo,
-                pageSize,
-                start,
-                end,
-                pageNo,
-                callback
-              );
-            }
+          handlePaginationAndCallback(
+            blogID,
+            entryIDs,
+            totalEntries,
+            zeroIndexedPageNo,
+            pageSize,
+            start,
+            end,
+            pageNo,
+            callback
           );
-        }
-      );
+        })
+        .catch(function (error) {
+          console.error(error);
+          return callback(error, [], null);
+        });
     }
   }
 
@@ -752,22 +767,24 @@ module.exports = (function () {
 
   function getRecent(blogID, callback) {
     getRange(blogID, 0, 30, { skinny: true }, function (entries) {
-      redis.zcard(listKey(blogID, "entries"), function (error, totalEntries) {
-        // We need to add error handling
-        if (error) return callback([]);
+      redis
+        .zCard(listKey(blogID, "entries"))
+        .then(function (totalEntries) {
+          // The first entry published should have an index of 1
+          // The fifth entry published should have an index of 5
+          // The most recently published entry should have an index
+          // equal to the number of total entries published.
+          let index = totalEntries;
+          entries.forEach(function (entry) {
+            entry.index = index;
+            index--;
+          });
 
-        // The first entry published should have an index of 1
-        // The fifth entry published should have an index of 5
-        // The most recently published entry should have an index
-        // equal to the number of total entries published.
-        let index = totalEntries;
-        entries.forEach(function (entry) {
-          entry.index = index;
-          index--;
+          callback(entries);
+        })
+        .catch(function () {
+          callback([]);
         });
-
-        callback(entries);
-      });
     });
   }
 

--- a/app/models/entries/pathIndex.js
+++ b/app/models/entries/pathIndex.js
@@ -1,5 +1,5 @@
 var ensure = require("helper/ensure");
-var redis = require("models/client");
+var redis = require("models/client-new");
 
 function entriesKey(blogID) {
   return "blog:" + blogID + ":entries";
@@ -16,25 +16,24 @@ function readyKey(blogID) {
 function backfillIndex(blogID, callback) {
   ensure(blogID, "string").and(callback, "function");
 
-  redis.zrange(entriesKey(blogID), 0, -1, function (err, ids) {
-    if (err) return callback(err);
-
+  (async function () {
+    var ids = await redis.zRange(entriesKey(blogID), 0, -1);
     var multi = redis.multi();
 
     multi.del(lexKey(blogID));
 
     if (ids && ids.length) {
       for (var i = 0; i < ids.length; i++) {
-        multi.zadd(lexKey(blogID), 0, ids[i]);
+        multi.zAdd(lexKey(blogID), { score: 0, value: ids[i] });
       }
     }
 
     multi.set(readyKey(blogID), "1");
+    await multi.exec();
 
-    multi.exec(function (err) {
-      if (err) return callback(err);
-      callback(null, ids ? ids.length : 0);
-    });
+    callback(null, ids ? ids.length : 0);
+  })().catch(function (err) {
+    callback(err);
   });
 }
 

--- a/app/models/entries/tests.js
+++ b/app/models/entries/tests.js
@@ -1,4 +1,4 @@
-const redis = require("models/client");
+const redis = require("models/client-new");
 const Entries = require("./index"); // Replace with the correct path to the Entries module
 const Entry = require("../entry");
 const Blog = require("../blog");
@@ -52,39 +52,32 @@ describe("entries", function () {
   global.test.blog();
 
   describe("entry TTL management", function () {
-    it("sets a TTL when deleted and clears it when restored", function (done) {
+    it("sets a TTL when deleted and clears it when restored", async function () {
       const blogID = this.blog.id;
       const path = "/ttl-entry.txt";
       const key = entryKey(blogID, path);
 
-      Entry.set(blogID, path, buildEntry(path), function (err) {
-        if (err) return done.fail(err);
-
-        redis.ttl(key, function (err, ttl) {
-          if (err) return done.fail(err);
-          expect(ttl).toBe(-1);
-
-          Entry.set(blogID, path, { deleted: true }, function (err) {
-            if (err) return done.fail(err);
-
-            redis.ttl(key, function (err, ttlAfterDelete) {
-              if (err) return done.fail(err);
-              expect(ttlAfterDelete).toBeGreaterThan(0);
-              expect(ttlAfterDelete).toBeLessThanOrEqual(24 * 60 * 60);
-
-              Entry.set(blogID, path, { deleted: false }, function (err) {
-                if (err) return done.fail(err);
-
-                redis.ttl(key, function (err, ttlAfterRestore) {
-                  if (err) return done.fail(err);
-                  expect(ttlAfterRestore).toBe(-1);
-                  done();
-                });
-              });
-            });
-          });
-        });
+      await new Promise((resolve, reject) => {
+        Entry.set(blogID, path, buildEntry(path), (err) => (err ? reject(err) : resolve()));
       });
+
+      const ttl = await redis.ttl(key);
+      expect(ttl).toBe(-1);
+
+      await new Promise((resolve, reject) => {
+        Entry.set(blogID, path, { deleted: true }, (err) => (err ? reject(err) : resolve()));
+      });
+
+      const ttlAfterDelete = await redis.ttl(key);
+      expect(ttlAfterDelete).toBeGreaterThan(0);
+      expect(ttlAfterDelete).toBeLessThanOrEqual(24 * 60 * 60);
+
+      await new Promise((resolve, reject) => {
+        Entry.set(blogID, path, { deleted: false }, (err) => (err ? reject(err) : resolve()));
+      });
+
+      const ttlAfterRestore = await redis.ttl(key);
+      expect(ttlAfterRestore).toBe(-1);
     });
   });
 
@@ -124,30 +117,25 @@ describe("entries", function () {
   });
 
   describe("pruneMissing", function () {
-    it("removes orphaned IDs from entry lists", function (done) {
+    it("removes orphaned IDs from entry lists", async function () {
       const blogID = this.blog.id;
       const path = "/prune-entry.txt";
       const ghostID = "/ghost-entry";
       const listKey = `blog:${blogID}:entries`;
 
-      Entry.set(blogID, path, buildEntry(path), function (err) {
-        if (err) return done.fail(err);
-
-        redis.zadd(listKey, Date.now(), ghostID, function (err) {
-          if (err) return done.fail(err);
-
-          Entries.pruneMissing(blogID, function (err) {
-            if (err) return done.fail(err);
-
-            redis.zrange(listKey, 0, -1, function (err, members) {
-              if (err) return done.fail(err);
-              expect(members).toContain(path);
-              expect(members).not.toContain(ghostID);
-              done();
-            });
-          });
-        });
+      await new Promise((resolve, reject) => {
+        Entry.set(blogID, path, buildEntry(path), (err) => (err ? reject(err) : resolve()));
       });
+
+      await redis.zAdd(listKey, { score: Date.now(), value: ghostID });
+
+      await new Promise((resolve, reject) => {
+        Entries.pruneMissing(blogID, (err) => (err ? reject(err) : resolve()));
+      });
+
+      const members = await redis.zRange(listKey, 0, -1);
+      expect(members).toContain(path);
+      expect(members).not.toContain(ghostID);
     });
   });
 
@@ -155,7 +143,11 @@ describe("entries", function () {
     const key = `blog:${this.blog.id}:entries`;
 
     // Add mock entries in Redis
-    await redis.zadd(key, 1, "entry1", 2, "entry2", 3, "entry3");
+    await redis.zAdd(key, [
+      { score: 1, value: "entry1" },
+      { score: 2, value: "entry2" },
+      { score: 3, value: "entry3" },
+    ]);
 
     Entries.getTotal(this.blog.id, function (err, total) {
       expect(err).toBeNull();
@@ -176,7 +168,11 @@ describe("entries", function () {
     const key = `blog:${this.blog.id}:all`;
 
     // Add mock entries in Redis
-    await redis.zadd(key, 1, "id1", 2, "id2", 3, "id3");
+    await redis.zAdd(key, [
+      { score: 1, value: "id1" },
+      { score: 2, value: "id2" },
+      { score: 3, value: "id3" },
+    ]);
 
     Entries.getAllIDs(this.blog.id, function (err, ids) {
       expect(err).toBeNull();
@@ -236,21 +232,14 @@ describe("entries", function () {
     const key = `blog:${this.blog.id}:entries`;
     const now = Date.now();
     // Add 6 mock entries in Redis
-    await redis.zadd(
-      key,
-      now,
-      "/a.txt",
-      now + 1000,
-      "/b.txt",
-      now + 2000,
-      "/c.txt",
-      now + 3000,
-      "/d.txt",
-      now + 4000,
-      "/e.txt",
-      now + 5000,
-      "/f.txt"
-    );
+    await redis.zAdd(key, [
+      { score: now, value: "/a.txt" },
+      { score: now + 1000, value: "/b.txt" },
+      { score: now + 2000, value: "/c.txt" },
+      { score: now + 3000, value: "/d.txt" },
+      { score: now + 4000, value: "/e.txt" },
+      { score: now + 5000, value: "/f.txt" },
+    ]);
 
     // spy on the Entry.get function
     // to return the full fake entry
@@ -325,7 +314,7 @@ describe("entries", function () {
     const key = `blog:${this.blog.id}:entries`;
     const now = Date.now();
 
-    await redis.zadd(key, now, "/only.txt");
+    await redis.zAdd(key, { score: now, value: "/only.txt" });
 
     spyOn(Entry, "get").and.callFake((blogID, ids, callback) => {
       if (Array.isArray(ids)) return callback(ids.map((id) => ({ id })));
@@ -358,7 +347,11 @@ describe("entries", function () {
     const key = `blog:${this.blog.id}:entries`;
 
     // Add mock entries in Redis
-    await redis.zadd(key, 1, "id1", 2, "id2", 3, "id3");
+    await redis.zAdd(key, [
+      { score: 1, value: "id1" },
+      { score: 2, value: "id2" },
+      { score: 3, value: "id3" },
+    ]);
 
     // Mock entries returned by Entry.get
     spyOn(Entry, "get").and.callFake((blogID, ids, callback) => {
@@ -390,37 +383,36 @@ describe("entries", function () {
 
 
   describe("path index maintenance", function () {
-    it("updates lex index for changed entries once index is ready", function (done) {
+    it("updates lex index for changed entries once index is ready", async function () {
       const blogID = this.blog.id;
       const entriesKey = `blog:${blogID}:entries`;
       const lexKey = `blog:${blogID}:entries:lex`;
       const readyKey = `blog:${blogID}:entries:lex:ready`;
       const now = Date.now();
 
-      redis.zadd(entriesKey, now, "/Blog/existing.txt", function (err) {
-        if (err) return done.fail(err);
+      await redis.zAdd(entriesKey, { score: now, value: "/Blog/existing.txt" });
 
-        redis.multi().zadd(lexKey, 0, "/Blog/existing.txt").set(readyKey, "1").exec(function (err) {
-          if (err) return done.fail(err);
+      await redis
+        .multi()
+        .zAdd(lexKey, { score: 0, value: "/Blog/existing.txt" })
+        .set(readyKey, "1")
+        .exec();
 
-          Entry.set(blogID, "/Blog/new.txt", buildEntry("/Blog/new.txt"), function (err) {
-            if (err) return done.fail(err);
-
-            redis.zrange(lexKey, 0, -1, function (err, ids) {
-              if (err) return done.fail(err);
-
-              expect(ids).toContain("/Blog/existing.txt");
-              expect(ids).toContain("/Blog/new.txt");
-
-              redis.exists(readyKey, function (err, ready) {
-                if (err) return done.fail(err);
-                expect(ready).toBe(1);
-                done();
-              });
-            });
-          });
-        });
+      await new Promise((resolve, reject) => {
+        Entry.set(
+          blogID,
+          "/Blog/new.txt",
+          buildEntry("/Blog/new.txt"),
+          (err) => (err ? reject(err) : resolve())
+        );
       });
+
+      const ids = await redis.zRange(lexKey, 0, -1);
+      expect(ids).toContain("/Blog/existing.txt");
+      expect(ids).toContain("/Blog/new.txt");
+
+      const ready = await redis.exists(readyKey);
+      expect(ready).toBe(1);
     });
   });
   describe("path prefix pagination", function () {
@@ -435,24 +427,19 @@ describe("entries", function () {
       const entriesKey = `blog:${blogID}:entries`;
       const now = Date.now();
 
-      await redis.zadd(
-        entriesKey,
-        now,
-        "/Blog/a.txt",
-        now + 1,
-        "/Blog/b.txt",
-        now + 2,
-        "/Blog/c.txt",
-        now + 3,
-        "/Notes/d.txt"
-      );
+      await redis.zAdd(entriesKey, [
+        { score: now, value: "/Blog/a.txt" },
+        { score: now + 1, value: "/Blog/b.txt" },
+        { score: now + 2, value: "/Blog/c.txt" },
+        { score: now + 3, value: "/Notes/d.txt" },
+      ]);
 
       await redis
         .multi()
-        .zadd(`blog:${blogID}:entries:lex`, 0, "/Blog/a.txt")
-        .zadd(`blog:${blogID}:entries:lex`, 0, "/Blog/b.txt")
-        .zadd(`blog:${blogID}:entries:lex`, 0, "/Blog/c.txt")
-        .zadd(`blog:${blogID}:entries:lex`, 0, "/Notes/d.txt")
+        .zAdd(`blog:${blogID}:entries:lex`, { score: 0, value: "/Blog/a.txt" })
+        .zAdd(`blog:${blogID}:entries:lex`, { score: 0, value: "/Blog/b.txt" })
+        .zAdd(`blog:${blogID}:entries:lex`, { score: 0, value: "/Blog/c.txt" })
+        .zAdd(`blog:${blogID}:entries:lex`, { score: 0, value: "/Notes/d.txt" })
         .set(`blog:${blogID}:entries:lex:ready`, "1")
         .exec();
     }
@@ -507,42 +494,31 @@ describe("entries", function () {
       const tieScore = Date.now();
       const tieIDs = ["/Blog/a.txt", "/Blog/m.txt", "/Blog/z.txt"];
 
-      await redis.zadd(
-        entriesKey,
-        tieScore,
-        tieIDs[0],
-        tieScore,
-        tieIDs[1],
-        tieScore,
-        tieIDs[2]
-      );
+      await redis.zAdd(entriesKey, [
+        { score: tieScore, value: tieIDs[0] },
+        { score: tieScore, value: tieIDs[1] },
+        { score: tieScore, value: tieIDs[2] },
+      ]);
 
       await redis
         .multi()
-        .zadd(lexKey, 0, tieIDs[0])
-        .zadd(lexKey, 0, tieIDs[1])
-        .zadd(lexKey, 0, tieIDs[2])
+        .zAdd(lexKey, { score: 0, value: tieIDs[0] })
+        .zAdd(lexKey, { score: 0, value: tieIDs[1] })
+        .zAdd(lexKey, { score: 0, value: tieIDs[2] })
         .set(`blog:${blogID}:entries:lex:ready`, "1")
         .exec();
 
       const taggedSetKey = `blog:${blogID}:tags:sorted:redis-tie-check`;
 
       await redis.del(taggedSetKey);
-      await redis.zadd(
-        taggedSetKey,
-        tieScore,
-        tieIDs[0],
-        tieScore,
-        tieIDs[1],
-        tieScore,
-        tieIDs[2]
-      );
+      await redis.zAdd(taggedSetKey, [
+        { score: tieScore, value: tieIDs[0] },
+        { score: tieScore, value: tieIDs[1] },
+        { score: tieScore, value: tieIDs[2] },
+      ]);
 
-      redis.zrevrange(taggedSetKey, 0, -1, function (err, expectedAsc) {
-        if (err) return done.fail(err);
-
-        redis.zrange(taggedSetKey, 0, -1, function (err, expectedDesc) {
-          if (err) return done.fail(err);
+      const expectedAsc = await redis.zRange(taggedSetKey, 0, -1, { REV: true });
+      const expectedDesc = await redis.zRange(taggedSetKey, 0, -1);
 
           Entries.getPage(
             blogID,
@@ -562,8 +538,6 @@ describe("entries", function () {
               );
             }
           );
-        });
-      });
     });
     it("ignores empty or whitespace pathPrefix values", async function (done) {
       const blogID = this.blog.id;
@@ -597,7 +571,11 @@ describe("entries", function () {
       const key = `blog:${this.blog.id}:entries`;
 
       // Add mock entries in Redis
-      await redis.zadd(key, 1, "id1", 2, "id2", 3, "id3");
+      await redis.zAdd(key, [
+        { score: 1, value: "id1" },
+        { score: 2, value: "id2" },
+        { score: 3, value: "id3" },
+      ]);
 
       Entries.adjacentTo(this.blog.id, "id2", function (next, previous, rank) {
         expect(previous).toEqual({ id: "id1" });
@@ -611,7 +589,11 @@ describe("entries", function () {
       const key = `blog:${this.blog.id}:entries`;
 
       // Add mock entries in Redis
-      await redis.zadd(key, 1, "id1", 2, "id2", 3, "id3");
+      await redis.zAdd(key, [
+        { score: 1, value: "id1" },
+        { score: 2, value: "id2" },
+        { score: 3, value: "id3" },
+      ]);
 
       Entries.adjacentTo(this.blog.id, "id1", function (next, previous, rank) {
         expect(previous).toBeUndefined();
@@ -625,7 +607,11 @@ describe("entries", function () {
       const key = `blog:${this.blog.id}:entries`;
 
       // Add mock entries in Redis
-      await redis.zadd(key, 1, "id1", 2, "id2", 3, "id3");
+      await redis.zAdd(key, [
+        { score: 1, value: "id1" },
+        { score: 2, value: "id2" },
+        { score: 3, value: "id3" },
+      ]);
 
       Entries.adjacentTo(this.blog.id, "id3", function (next, previous, rank) {
         expect(previous).toEqual({ id: "id2" });
@@ -638,11 +624,7 @@ describe("entries", function () {
 
   describe("random", function () {
     it("returns undefined when there are no published entries", function (done) {
-      const originalZrandmember = redis.zrandmember;
-
-      spyOn(redis, "zrandmember").and.callFake(function (key, callback) {
-        callback(null, null);
-      });
+      spyOn(redis, "zRandMember").and.resolveTo(null);
 
       Entries.random(this.blog.id, (entry) => {
         try {
@@ -651,18 +633,16 @@ describe("entries", function () {
         } catch (err) {
           done.fail(err);
         } finally {
-          redis.zrandmember = originalZrandmember;
+          // no-op
         }
       });
     });
 
     it("retries until an entry with a public URL is found", function (done) {
-      const originalZrandmember = redis.zrandmember;
-      const originalEntryGet = Entry.get;
       const candidates = ["missing", "valid"];
 
-      spyOn(redis, "zrandmember").and.callFake(function (key, callback) {
-        callback(null, candidates.shift());
+      spyOn(redis, "zRandMember").and.callFake(async function () {
+        return candidates.shift();
       });
 
       spyOn(Entry, "get").and.callFake(function (blogID, entryID, callback) {
@@ -676,26 +656,19 @@ describe("entries", function () {
           expect(entry).toEqual(
             jasmine.objectContaining({ id: "valid", url: "/valid" })
           );
-          expect(redis.zrandmember.calls.count()).toBe(2);
+          expect(redis.zRandMember.calls.count()).toBe(2);
           expect(Entry.get.calls.count()).toBe(2);
           done();
         } catch (err) {
           done.fail(err);
-        } finally {
-          redis.zrandmember = originalZrandmember;
-          Entry.get = originalEntryGet;
         }
       });
     });
 
     it("stops after the maximum attempts when entries have no public URL", function (done) {
-      const originalZrandmember = redis.zrandmember;
-      const originalEntryGet = Entry.get;
       let calls = 0;
 
-      spyOn(redis, "zrandmember").and.callFake(function (key, callback) {
-        callback(null, "missing");
-      });
+      spyOn(redis, "zRandMember").and.resolveTo("missing");
 
       spyOn(Entry, "get").and.callFake(function (blogID, entryID, callback) {
         calls++;
@@ -709,10 +682,16 @@ describe("entries", function () {
           done();
         } catch (err) {
           done.fail(err);
-        } finally {
-          redis.zrandmember = originalZrandmember;
-          Entry.get = originalEntryGet;
         }
+      });
+    });
+
+    it("handles Redis failures without unhandled rejections", function (done) {
+      spyOn(redis, "zRandMember").and.rejectWith(new Error("boom"));
+
+      Entries.random(this.blog.id, function (entry) {
+        expect(entry).toBeUndefined();
+        done();
       });
     });
   });
@@ -732,7 +711,10 @@ describe("entries", function () {
 
       // Add mock entries in Redis
       const key = `blog:${this.blog.id}:all`;
-      await redis.zadd(key, 1, "id1", 2, "id2");
+      await redis.zAdd(key, [
+        { score: 1, value: "id1" },
+        { score: 2, value: "id2" },
+      ]);
 
       // Mock Entry.get to return the entries
       spyOn(Entry, "get").and.callFake((blogID, id, callback) => {


### PR DESCRIPTION
### Motivation
- Modernize the `entries` model to use the new promise-based Redis client (`models/client-new`) and current Redis command forms while keeping the module's external callback contract unchanged.
- Remove legacy lowercase/callback-style usages and make read flows concurrent where safe, retaining atomic `multi().exec()` semantics for index rebuilds and other transactional writes.
- Bring tests and README guidance into alignment with the new client API and common migration patterns so future models can follow the same approach.

### Description
- Replaced `require("models/client")` with `require("models/client-new")` in `app/models/entries/index.js` and `app/models/entries/pathIndex.js` and updated all internal callsites to modern `client-new` command names and argument shapes (e.g. `zRange`, `zRangeByLex`, `zRangeByScore`, `zCard`, `zAdd`, `zRem`, `zRandMember`, `zScore`).
- Converted callback-last Redis calls to promise/`async` flows internally (using `await` / `Promise.all`) while wrapping results/errors so exported functions still call the original callbacks with the same argument ordering and shapes (e.g. `getPage`, `get`, `getAll`, `getAllIDs`, `getTotal`, `getListIDs`, `adjacentTo`, `random`, `resave`, `pruneMissing`).
- Kept atomic behavior for path-index backfill and other multi-command writes by using `client.multi()` then `await multi.exec()` (modern `zAdd` shapes) to ensure the ready flag and lex index updates remain transactional.
- Adjusted pagination and path-prefix logic to preserve ordering, tie-breaking, and pagination payloads; updated `fetchEntryScores` to use `zScore` and to feed scores back into the existing pagination handling.
- Updated tests in `app/models/entries/tests.js` to use `models/client-new` and promise-returning Redis calls, migrating `zadd` -> `zAdd` argument shapes, `zrange`/`zrevrange` -> `zRange(..., { REV: true })`, `zrandmember` -> `zRandMember`, and refreshed spies to assert behavior rather than legacy internals; added an assertion that a Redis failure in `random` does not create an unhandled rejection.
- Expanded `app/models/README` migration guidance with model-agnostic notes on preserving callback contracts, modern command names/argument forms, when to use `Promise.all` vs `multi().exec()`, and how to update test doubles/spies.

### Testing
- Ran syntax checks: `node -c app/models/entries/index.js`, `node -c app/models/entries/pathIndex.js`, and `node -c app/models/entries/tests.js`, all of which succeeded.
- Executed unit-style updates inside `app/models/entries/tests.js` and updated test doubles/spies; test file modifications are present and adapted to promise-returning Redis methods (not run under full test harness here).
- Attempted to run the project test runner via `./scripts/tests/invoke.sh app/models/entries/tests.js`, but the environment lacks Docker (`docker: command not found`), so the full Jasmine test run could not be executed here.
- Verified there are no remaining `require("models/client")` occurrences inside `app/models/entries/` after the migration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c8e090f88329a9b7675ce7497f17)