### PR TITLE
Migrate template model to promise-based `models/client-new`

### DIFF
--- a/app/models/README
+++ b/app/models/README
@@ -43,20 +43,11 @@ Migration checklist (copy per module)
 Use this short checklist when migrating any model from legacy Redis code:
 
 - [ ] Switch imports: `models/client` -> `models/client-new` (or `models/redis-new` only when the module owns connect/disconnect lifecycle).
-- [ ] Keep key names, write ordering, and transactional boundaries (`multi().exec()`) unchanged unless fixing a bug.
-- [ ] Convert Redis calls to promise-based command shapes (`hGetAll`, `sMembers`, `lRange`, etc.) and keep exported callback contracts stable.
-- [ ] Preserve return payloads and error flow expected by existing callers.
-- [ ] Update tests to spy/mock `models/client-new` methods and new command names/arguments (including `multi().exec()` rejection paths).
-- [ ] Re-run the migrated model test subset and any directly-coupled model paths.
-- [ ] Replace `require("models/client")` with `require("models/client-new")` unless the module needs an isolated client lifecycle.
-- [ ] If isolated lifecycle is required, switch to `const createRedisClient = require("models/redis-new")` and manage `connect()` + shutdown in that module.
-- [ ] Convert callback-last Redis calls to promise/`async`-`await` style where needed.
-- [ ] If module exports still use callbacks, keep the public callback contract unchanged and forward promise rejections through the existing callback error channel.
-- [ ] Re-validate Redis command names/arguments against the new client API (e.g. `sMembers`, `setEx`, `setNX`, `zAdd`) without relying on legacy aliasing/shims.
-- [ ] Keep atomic write paths in `multi()` transactions and add test coverage for `await multi.exec()` rejection/error forwarding.
-- [ ] Update tests/mocks/spies for `client-new` method names and promise-returning behavior.
-- [ ] Audit pub/sub code paths for explicit unsubscribe/cleanup on shutdown.
-- [ ] Verify tests cover connection lifecycle and module teardown behavior after the migration.
+- [ ] Convert internal Redis calls to promise-based `client-new` command names/arguments (`hGetAll`, `sMembers`, `zAdd`, etc.).
+- [ ] Keep exported callback signatures, result shapes, and error-first semantics unchanged.
+- [ ] Preserve key names, write ordering, and atomic `multi().exec()` boundaries unless intentionally fixing behavior.
+- [ ] Update tests/mocks/spies to target `models/client-new` (including promise rejections and `multi().exec()` failures).
+- [ ] Re-run the migrated model tests and directly-coupled model paths.
 
 Common migration pitfalls
 -------------------------

--- a/app/models/template/create.js
+++ b/app/models/template/create.js
@@ -2,36 +2,24 @@ var clone = require("./clone");
 var ensure = require("helper/ensure");
 var makeSlug = require("helper/makeSlug");
 var makeID = require("./util/makeID");
-var client = require("models/client");
+var client = require("models/client-new");
 var key = require("./key");
 var metadataModel = require("./metadataModel");
 var setMetadata = require("./setMetadata");
 
 // Associates a theme with a UID owner
 // and an existing theme to clone if possible
-module.exports = function create (owner, name, metadata, callback) {
-  // Owner represents the id of a blog
-  // who controls the template
-  // or the string 'SITE' which represents
-  // a BLOT template not editable by any blog
-  // ensure a blogID is always a number, never 'SITE'
+module.exports = function create(owner, name, metadata, callback) {
   ensure(owner, "string")
     .and(metadata, "object")
     .and(name, "string")
     .and(callback, "function");
 
-  // Name is user input, it needs to be trimmed
   name = name.slice(0, 100);
-
-  // The slug cannot contain a slash, or it messes
-  // up the routing middleware.
   metadata.slug = metadata.slug || makeSlug(name).slice(0, 30);
   metadata.slug = metadata.slug.split("/").join("-");
-
-  // Each template has an ID which is namespaced under its owner
   metadata.id = makeID(owner, name);
 
-  // Defaults
   metadata.name = name;
   metadata.owner = owner;
   metadata.locals = metadata.locals || {};
@@ -44,43 +32,39 @@ module.exports = function create (owner, name, metadata, callback) {
 
   ensure(metadata, metadataModel);
 
-  let id = metadata.id;
+  var id = metadata.id;
 
-  client.exists(key.metadata(id), function (err, stat) {
-    if (err) throw err;
+  (async function () {
+    try {
+      var stat = await client.exists(key.metadata(id));
 
-    // Don't overwrite an existing template
-    if (stat) {
-      err = new Error("A template called " + name + " name already exists");
-      err.code = "EEXISTS";
-      return callback(err);
-    }
+      if (stat) {
+        var err = new Error("A template called " + name + " name already exists");
+        err.code = "EEXISTS";
+        return callback(err);
+      }
 
-    client.sadd(key.blogTemplates(owner), id, function (err) {
-      if (err) throw err;
-
+      await client.sAdd(key.blogTemplates(owner), id);
       if (metadata.isPublic) {
-        client.sadd(key.publicTemplates(), id, then);
+        await client.sAdd(key.publicTemplates(), id);
       } else {
-        client.srem(key.publicTemplates(), id, then);
+        await client.sRem(key.publicTemplates(), id);
       }
 
-      function then (err) {
-        if (err) throw err;
+      setMetadata(id, metadata, function (setErr) {
+        if (setErr) return callback(setErr);
 
-        setMetadata(id, metadata, function (err) {
-          if (err) throw err;
-
-          if (metadata.cloneFrom) {
-            clone(metadata.cloneFrom, id, metadata, function (err) {
-              if (err) return callback(err);
-              callback(null, metadata);
-            });
-          } else {
+        if (metadata.cloneFrom) {
+          return clone(metadata.cloneFrom, id, metadata, function (cloneErr) {
+            if (cloneErr) return callback(cloneErr);
             callback(null, metadata);
-          }
-        });
-      }
-    });
-  });
+          });
+        }
+
+        callback(null, metadata);
+      });
+    } catch (err) {
+      callback(err);
+    }
+  })();
 };

--- a/app/models/template/createShareID.js
+++ b/app/models/template/createShareID.js
@@ -1,18 +1,23 @@
 var key = require("./key");
-var client = require("models/client");
+var client = require("models/client-new");
 var getMetadata = require("./getMetadata");
 var setMetadata = require("./setMetadata");
 var uuid = require("uuid/v4");
 
 module.exports = function createShareID(templateID, callback) {
   getMetadata(templateID, function (err, template) {
+    if (err) return callback(err);
+
     template.shareID = uuid();
-    setMetadata(templateID, template, function (err) {
-      if (err) return callback(err);
-      client.set(key.share(template.shareID), templateID, function (err) {
-        if (err) return callback(err);
-        callback(null, template.shareID);
-      });
+    setMetadata(templateID, template, function (setErr) {
+      if (setErr) return callback(setErr);
+
+      client
+        .set(key.share(template.shareID), templateID)
+        .then(function () {
+          callback(null, template.shareID);
+        })
+        .catch(callback);
     });
   });
 };

--- a/app/models/template/drop.js
+++ b/app/models/template/drop.js
@@ -1,6 +1,6 @@
 var getAllViews = require("./getAllViews");
 var ensure = require("helper/ensure");
-var client = require("models/client");
+var client = require("models/client-new");
 var key = require("./key");
 var makeID = require("./util/makeID");
 var Blog = require("models/blog");
@@ -59,16 +59,16 @@ module.exports = function drop(owner, templateName, callback) {
       multi.del(key.renderedOutput(hash));
 
       diskCleanup.push(
-        fs.remove(getRenderedOutputPath(hash, target)).catch(function (err) {
-          if (err.code !== "ENOENT") {
-            console.error("Error removing CDN rendered output from disk:", err);
+        fs.remove(getRenderedOutputPath(hash, target)).catch(function (removeErr) {
+          if (removeErr.code !== "ENOENT") {
+            console.error("Error removing CDN rendered output from disk:", removeErr);
           }
         })
       );
     }
 
-    multi.srem(key.blogTemplates(owner), templateID);
-    multi.srem(key.publicTemplates(), templateID);
+    multi.sRem(key.blogTemplates(owner), templateID);
+    multi.sRem(key.publicTemplates(), templateID);
     multi.del(key.metadata(templateID));
     multi.del(key.urlPatterns(templateID));
     multi.del(key.allViews(templateID));
@@ -82,20 +82,23 @@ module.exports = function drop(owner, templateName, callback) {
       multi.del(key.url(templateID, views[i].url));
     }
 
-    Promise.allSettled(diskCleanup).then(function () {
-      multi.exec(function (err) {
+    Promise.allSettled(diskCleanup)
+      .then(function () {
+        return multi.exec();
+      })
+      .then(function () {
         const ownerID = metadata && metadata.owner ? metadata.owner : owner;
 
         if (purgeUrls.length) {
-          purgeCdnUrls(purgeUrls).catch(function (err) {
-            console.error("Error purging CDN URLs while dropping template:", err);
+          purgeCdnUrls(purgeUrls).catch(function (purgeErr) {
+            console.error("Error purging CDN URLs while dropping template:", purgeErr);
           });
         }
 
-        Blog.set(ownerID, { cacheID: Date.now() }, function (err) {
-          callback(err, "Deleted " + templateID);
+        Blog.set(ownerID, { cacheID: Date.now() }, function (blogErr) {
+          callback(blogErr, "Deleted " + templateID);
         });
-      });
-    });
+      })
+      .catch(callback);
   });
 };

--- a/app/models/template/dropShareID.js
+++ b/app/models/template/dropShareID.js
@@ -1,15 +1,22 @@
 var key = require("./key");
-var client = require("models/client");
+var client = require("models/client-new");
 var getByShareID = require("./getByShareID");
 var setMetadata = require("./setMetadata");
 
 module.exports = function dropShareID(shareID, callback) {
   getByShareID(shareID, function (err, template) {
     if (err) return callback(err);
+
     template.shareID = "";
-    setMetadata(template.id, template, function (err) {
-      if (err) return callback(err);
-      client.del(key.share(shareID), callback);
+    setMetadata(template.id, template, function (setErr) {
+      if (setErr) return callback(setErr);
+
+      client
+        .del(key.share(shareID))
+        .then(function () {
+          callback();
+        })
+        .catch(callback);
     });
   });
 };

--- a/app/models/template/dropView.js
+++ b/app/models/template/dropView.js
@@ -1,5 +1,5 @@
 const key = require("./key");
-const client = require("models/client");
+const client = require("models/client-new");
 const Blog = require("models/blog");
 const getMetadata = require("./getMetadata");
 const getView = require("./getView");
@@ -11,32 +11,32 @@ module.exports = function dropView(templateID, viewName, callback) {
   getMetadata(templateID, function (err, metadata) {
     if (err) return callback(err);
 
-    getView(templateID, viewName, function (err, view) {
-      if (err) return callback(err);
+    getView(templateID, viewName, function (viewErr, view) {
+      if (viewErr) return callback(viewErr);
 
       multi.del(key.view(templateID, viewName));
-      multi.hdel(key.urlPatterns(templateID), viewName);
-      multi.srem(key.allViews(templateID), viewName);
+      multi.hDel(key.urlPatterns(templateID), viewName);
+      multi.sRem(key.allViews(templateID), viewName);
 
-      // View might not neccessarily exist
       if (view) {
         multi.del(key.url(templateID, view.url));
         multi.del(key.view(templateID, view.name));
       }
 
-      multi.exec(function (err) {
-        if (err) return callback(err);
+      multi
+        .exec()
+        .then(function () {
+          Blog.set(metadata.owner, { cacheID: Date.now() }, function (cacheErr) {
+            if (cacheErr) return callback(cacheErr);
 
-        Blog.set(metadata.owner, { cacheID: Date.now() }, function (cacheErr) {
-          if (cacheErr) return callback(cacheErr);
+            updateCdnManifest(templateID, function (manifestErr) {
+              if (manifestErr) return callback(manifestErr);
 
-          updateCdnManifest(templateID, function (manifestErr) {
-            if (manifestErr) return callback(manifestErr);
-
-            callback(null, "Deleted " + templateID);
+              callback(null, "Deleted " + templateID);
+            });
           });
-        });
-      });
+        })
+        .catch(callback);
     });
   });
 };

--- a/app/models/template/getAllViews.js
+++ b/app/models/template/getAllViews.js
@@ -1,5 +1,5 @@
 var key = require("./key");
-var client = require("models/client");
+var client = require("models/client-new");
 var ensure = require("helper/ensure");
 var getMultipleViews = require("./getMultipleViews");
 var getMetadata = require("./getMetadata");
@@ -7,13 +7,17 @@ var getMetadata = require("./getMetadata");
 module.exports = function getAllViews(name, callback) {
   ensure(name, "string").and(callback, "function");
 
-  client.smembers(key.allViews(name), function (err, viewNames) {
-    getMetadata(name, function (err, metadata) {
-      if (err) return callback(err);
-      getMultipleViews(name, viewNames, function (err, views) {
+  client
+    .sMembers(key.allViews(name))
+    .then(function (viewNames) {
+      getMetadata(name, function (err, metadata) {
         if (err) return callback(err);
-        callback(err, views, metadata);
+
+        getMultipleViews(name, viewNames, function (viewErr, views) {
+          if (viewErr) return callback(viewErr);
+          callback(null, views, metadata);
+        });
       });
-    });
-  });
+    })
+    .catch(callback);
 };

--- a/app/models/template/getByShareID.js
+++ b/app/models/template/getByShareID.js
@@ -1,12 +1,16 @@
 var key = require("./key");
-var client = require("models/client");
+var client = require("models/client-new");
 var getMetadata = require("./getMetadata");
 
 module.exports = function getByShareID(shareID, callback) {
-  client.get(key.share(shareID), function (err, id) {
-    if (err || !id)
-      return callback(err || new Error("No template with shareID: " + shareID));
-      
-    getMetadata(id, callback);
-  });
+  client
+    .get(key.share(shareID))
+    .then(function (id) {
+      if (!id) {
+        return callback(new Error("No template with shareID: " + shareID));
+      }
+
+      getMetadata(id, callback);
+    })
+    .catch(callback);
 };

--- a/app/models/template/getMetadata.js
+++ b/app/models/template/getMetadata.js
@@ -1,11 +1,10 @@
 var key = require("./key");
-var client = require("models/client");
+var client = require("models/client-new");
 var deserialize = require("./util/deserialize");
 var metadataModel = require("./metadataModel");
 
 module.exports = function getMetadata(id, callback) {
-  client.hgetall(key.metadata(id), function (err, metadata) {
-    if (err) return callback(err);
+  client.hGetAll(key.metadata(id)).then(function (metadata) {
 
     metadata = deserialize(metadata, metadataModel);
 
@@ -18,5 +17,5 @@ module.exports = function getMetadata(id, callback) {
     metadata.cdn = metadata.cdn || {};
 
     callback(null, metadata);
-  });
+  }).catch(callback);
 };

--- a/app/models/template/getTemplateList.js
+++ b/app/models/template/getTemplateList.js
@@ -1,4 +1,4 @@
-var client = require("models/client");
+var client = require("models/client-new");
 var key = require("./key");
 var async = require("async");
 var getMetadata = require("./getMetadata");
@@ -11,8 +11,13 @@ var ensure = require("helper/ensure");
 module.exports = function getTemplateList(blogID, callback) {
   ensure(blogID, "string").and(callback, "function");
 
-  client.smembers(key.blogTemplates('SITE'), function (err, publicTemplates) {
-    client.smembers(key.blogTemplates(blogID), function (err, blogTemplates) {
+  Promise.all([
+    client.sMembers(key.blogTemplates("SITE")),
+    client.sMembers(key.blogTemplates(blogID)),
+  ])
+    .then(function (results) {
+      var publicTemplates = results[0] || [];
+      var blogTemplates = results[1] || [];
       var templateIDs = publicTemplates.concat(blogTemplates);
       var response = [];
 
@@ -20,17 +25,14 @@ module.exports = function getTemplateList(blogID, callback) {
         templateIDs,
         function (id, next) {
           getMetadata(id, function (err, info) {
-            if (err) return next();
-
-            if (info) response.push(info);
-
+            if (!err && info) response.push(info);
             next();
           });
         },
         function () {
-          callback(err, response);
+          callback(null, response);
         }
       );
-    });
-  });
+    })
+    .catch(callback);
 };

--- a/app/models/template/getView.js
+++ b/app/models/template/getView.js
@@ -1,36 +1,33 @@
 var key = require("./key");
-var client = require("models/client");
+var client = require("models/client-new");
 var deserialize = require("./util/deserialize");
 var viewModel = require("./viewModel");
 
 module.exports = function getView(templateID, viewID, callback) {
   var match;
 
-  client.hgetall(key.view(templateID, viewID), function (err, view) {
-    if (view) {
-      view = deserialize(view, viewModel);
-      return callback(err, view);
-    }
+  client
+    .hGetAll(key.view(templateID, viewID))
+    .then(function (view) {
+      if (view && Object.keys(view).length) {
+        return callback(null, deserialize(view, viewModel));
+      }
 
-    client.smembers(key.allViews(templateID), function (err, views) {
-      if (err) return callback(err);
+      return client.sMembers(key.allViews(templateID)).then(function (views) {
+        views.forEach(function (viewname) {
+          var name = viewname.slice(0, viewname.lastIndexOf("."));
+          if (name === viewID) match = viewname;
+        });
 
-      // goal is to find a view whose extension-less name matches
-      // so we can do. {{> head}} in templates and retrieve head.html
+        if (!match) return callback(new Error("No view: " + viewID));
 
-      views.forEach(function (viewname) {
-        var name = viewname.slice(0, viewname.lastIndexOf("."));
-        if (name === viewID) match = viewname;
+        return client.hGetAll(key.view(templateID, match)).then(function (matchedView) {
+          if (!matchedView || !Object.keys(matchedView).length)
+            return callback(new Error("No view: " + viewID));
+
+          callback(null, deserialize(matchedView, viewModel));
+        });
       });
-
-      if (!match) return callback(new Error("No view: " + viewID));
-
-      client.hgetall(key.view(templateID, match), function (err, view) {
-        if (!view) return callback(new Error("No view: " + viewID));
-
-        view = deserialize(view, viewModel);
-        callback(err, view);
-      });
-    });
-  });
+    })
+    .catch(callback);
 };

--- a/app/models/template/getViewByURL.js
+++ b/app/models/template/getViewByURL.js
@@ -1,8 +1,5 @@
 const key = require("./key");
-const client = require("models/client");
-const { promisify } = require("util");
-const hgetall = promisify(client.hgetall).bind(client);
-const get = promisify(client.get).bind(client);
+const client = require("models/client-new");
 const debug = require("debug")("blot:template:getViewByURLPattern");
 const { match } = require("path-to-regexp");
 const { parse } = require("url");
@@ -37,7 +34,7 @@ module.exports = async function getViewByURLPattern(templateID, url, callback) {
     debug("Normalized URL:", normalizedPathname);
 
     // Fetch all views and their patterns for the given template ID
-    const viewPatternStrings = await hgetall(key.urlPatterns(templateID));
+    const viewPatternStrings = await client.hGetAll(key.urlPatterns(templateID));
 
     if (viewPatternStrings) {
       const views = parseViewPatterns(viewPatternStrings);
@@ -72,7 +69,7 @@ module.exports = async function getViewByURLPattern(templateID, url, callback) {
     }
 
     // Fall back to matching the URL directly
-    const viewName = await get(key.url(templateID, urlNormalizer(url)));
+    const viewName = await client.get(key.url(templateID, urlNormalizer(url)));
 
     if (viewName) {
       debug("Found view by URL:", viewName);

--- a/app/models/template/isOwner.js
+++ b/app/models/template/isOwner.js
@@ -1,6 +1,11 @@
 var key = require("./key");
-var client = require("models/client");
+var client = require("models/client-new");
 
 module.exports = function isOwner(owner, id, callback) {
-  client.SISMEMBER(key.blogTemplates(owner), id, callback);
+  client
+    .sIsMember(key.blogTemplates(owner), id)
+    .then(function (isMember) {
+      callback(null, !!isMember);
+    })
+    .catch(callback);
 };

--- a/app/models/template/readFromFolder.js
+++ b/app/models/template/readFromFolder.js
@@ -10,7 +10,7 @@ const shouldIgnoreFile = require("clients/util/shouldIgnoreFile");
 var MAX_SIZE = 2.5 * 1000 * 1000; // 2.5mb
 var PACKAGE = "package.json";
 var savePackage = require("./package").save;
-var client = require("models/client");
+var client = require("models/client-new");
 var key = require("./key");
 var dropView = require("./dropView");
 const Blog = require("models/blog");
@@ -156,21 +156,23 @@ function loadPackage (id, dir, callback) {
 function removeDeletedViews (templateID, contents, callback) {
   const viewsToRemove = [];
 
-  client.smembers(key.allViews(templateID), function (err, viewNames) {
-    if (err) return callback(err);
-    for (const viewName of viewNames) {
-      let found = contents.find(fileName => fileName.startsWith(viewName));
-      if (!found) viewsToRemove.push(viewName);
-    }
+  client
+    .sMembers(key.allViews(templateID))
+    .then(function (viewNames) {
+      for (const viewName of viewNames) {
+        let found = contents.find(fileName => fileName.startsWith(viewName));
+        if (!found) viewsToRemove.push(viewName);
+      }
 
-    async.eachSeries(
-      viewsToRemove,
-      function (viewName, next) {
-        dropView(templateID, viewName, next);
-      },
-      callback
-    );
-  });
+      async.eachSeries(
+        viewsToRemove,
+        function (viewName, next) {
+          dropView(templateID, viewName, next);
+        },
+        callback
+      );
+    })
+    .catch(callback);
 }
 
 // Maps 'at position 505' to

--- a/app/models/template/setMetadata.js
+++ b/app/models/template/setMetadata.js
@@ -1,5 +1,5 @@
 var key = require("./key");
-var client = require("models/client");
+var client = require("models/client-new");
 var getMetadata = require("./getMetadata");
 var serialize = require("./util/serialize");
 var metadataModel = require("./metadataModel");
@@ -16,8 +16,9 @@ module.exports = function setMetadata(id, updates, callback) {
   }
 
   getMetadata(id, function (err, metadata) {
-    var changes;
+    if (err && err.code !== "ENOENT") return callback(err);
 
+    var changes;
     metadata = metadata || {};
 
     for (var i in updates) {
@@ -28,9 +29,7 @@ module.exports = function setMetadata(id, updates, callback) {
     metadata.cdn = metadata.cdn || {};
 
     if (!metadata.owner)
-      return callback(
-        new Error("No owner: please specify an owner for this template")
-      );
+      return callback(new Error("No owner: please specify an owner for this template"));
 
     try {
       injectLocals(metadata.locals);
@@ -40,17 +39,16 @@ module.exports = function setMetadata(id, updates, callback) {
 
     metadata = serialize(metadata, metadataModel);
 
-    if (metadata.isPublic) {
-      client.sadd(key.publicTemplates(), id);
-    } else {
-      client.srem(key.publicTemplates(), id);
-    }
+    (async function () {
+      try {
+        if (metadata.isPublic) {
+          await client.sAdd(key.publicTemplates(), id);
+        } else {
+          await client.sRem(key.publicTemplates(), id);
+        }
 
-    client.sadd(key.blogTemplates(metadata.owner), id, function (err) {
-      if (err) return callback(err);
-
-      client.hset(key.metadata(id), metadata, function (err) {
-        if (err) return callback(err);
+        await client.sAdd(key.blogTemplates(metadata.owner), id);
+        await client.hSet(key.metadata(id), metadata);
 
         if (!changes) {
           return updateCdnManifest(id, function (manifestErr) {
@@ -59,24 +57,23 @@ module.exports = function setMetadata(id, updates, callback) {
           });
         }
 
-        const shouldBumpCache = !(metadata.isPublic || metadata.owner === "SITE");
-
-        const regenerateManifest = function () {
+        var shouldBumpCache = !(metadata.isPublic || metadata.owner === "SITE");
+        var regenerateManifest = function () {
           updateCdnManifest(id, function (manifestErr) {
             if (manifestErr) return callback(manifestErr);
             callback(null, changes);
           });
         };
 
-        if (!shouldBumpCache) {
-          return regenerateManifest();
-        }
+        if (!shouldBumpCache) return regenerateManifest();
 
         Blog.set(metadata.owner, { cacheID: Date.now() }, function (cacheErr) {
           if (cacheErr) return callback(cacheErr);
           regenerateManifest();
         });
-      });
-    });
+      } catch (redisErr) {
+        callback(redisErr);
+      }
+    })();
   });
 };

--- a/app/models/template/setView.js
+++ b/app/models/template/setView.js
@@ -1,6 +1,6 @@
 var Mustache = require("mustache");
 var type = require("helper/type");
-var client = require("models/client");
+var client = require("models/client-new");
 var key = require("./key");
 var urlNormalizer = require("helper/urlNormalizer");
 var ensure = require("helper/ensure");
@@ -65,8 +65,7 @@ module.exports = function setView(templateID, updates, callback) {
 		if (!metadata)
 			return callback(new Error("There is no template called " + templateID));
 
-		client.sadd(allViews, name, (err) => {
-			if (err) return callback(err);
+		client.sAdd(allViews, name).then(() => {
 
 			// Look up previous state of view if applicable
 			getView(templateID, name, (err, view) => {
@@ -236,7 +235,7 @@ module.exports = function setView(templateID, updates, callback) {
 				if (updates.urlPatterns) {
 					// Store `urlPatterns` in Redis
 					const urlPatternsKey = key.urlPatterns(templateID);
-					client.hset(
+					client.hSet(
 						urlPatternsKey,
 						name,
 						JSON.stringify(updates.urlPatterns),
@@ -244,7 +243,7 @@ module.exports = function setView(templateID, updates, callback) {
 				} else if (shouldRemoveUrlPatterns) {
 					// Delete urlPatterns from Redis if it was removed
 					const urlPatternsKey = key.urlPatterns(templateID);
-					client.hdel(urlPatternsKey, name);
+					client.hDel(urlPatternsKey, name);
 				}
 				view.locals = view.locals || {};
 				view.retrieve = view.retrieve || {};
@@ -277,19 +276,18 @@ module.exports = function setView(templateID, updates, callback) {
 
 						// Delete url and urlPatterns from Redis hash if they were removed
 						var multi = client.multi();
-						multi.hset(viewKey, view);
+						multi.hSet(viewKey, view);
 
 						if (shouldRemoveUrl) {
 							console.log("removing hdel", viewKey, "url");
-							multi.hdel(viewKey, "url");
+							multi.hDel(viewKey, "url");
 						}
 						if (shouldRemoveUrlPatterns) {
 							console.log("removing hdel", viewKey, "urlPatterns");
-							multi.hdel(viewKey, "urlPatterns");
+							multi.hDel(viewKey, "urlPatterns");
 						}
 
-						multi.exec((err) => {
-							if (err) return callback(err);
+						multi.exec().then(() => {
 
 							if (!changes) {
 								if (metadata.errors && metadata.errors[name]) {
@@ -315,12 +313,12 @@ module.exports = function setView(templateID, updates, callback) {
 
 									callback();
 								});
-							});
+							}).catch(callback);
 						});
 					},
 				);
 			});
-		});
+		}).catch(callback);
 	});
 };
 

--- a/app/models/template/tests/drop.js
+++ b/app/models/template/tests/drop.js
@@ -4,7 +4,7 @@ describe("template", function () {
   var drop = require("../index").drop;
   var setMetadata = require("../index").setMetadata;
   var getTemplateList = require("../index").getTemplateList;
-  var client = require("models/client");
+  var client = require("models/client-new");
   var Blog = require("models/blog");
   var key = require("../key");
   var config = require("config");
@@ -54,11 +54,10 @@ describe("template", function () {
       if (err) return done.fail(err);
       drop(test.blog.id, test.template.name, function (err) {
         if (err) return done.fail(err);
-        client.keys("*" + test.template.id + "*", function (err, result) {
-          if (err) return done.fail(err);
+        client.keys("*" + test.template.id + "*").then(function (result) {
           expect(result).toEqual([]);
           done();
-        });
+        }).catch(done.fail);
       });
     });
   });
@@ -67,11 +66,10 @@ describe("template", function () {
     var test = this;
     drop(test.blog.id, test.template.name, function (err) {
       if (err) return done.fail(err);
-      client.keys("*" + test.template.id + "*", function (err, result) {
-        if (err) return done.fail(err);
+      client.keys("*" + test.template.id + "*").then(function (result) {
         expect(result).toEqual([]);
         done();
-      });
+      }).catch(done.fail);
     });
   });
 
@@ -91,23 +89,20 @@ describe("template", function () {
   it("cleans up references when metadata is missing", function (done) {
     var test = this;
 
-    client.del(key.metadata(test.template.id), function (err) {
-      if (err) return done.fail(err);
+    client.del(key.metadata(test.template.id)).then(function () {
 
       drop(test.blog.id, test.template.name, function (err) {
         if (err) return done.fail(err);
 
-        client.sismember(
-          key.blogTemplates(test.blog.id),
-          test.template.id,
-          function (err, isMember) {
-            if (err) return done.fail(err);
+        client
+          .sIsMember(key.blogTemplates(test.blog.id), test.template.id)
+          .then(function (isMember) {
             expect(isMember).toEqual(0);
             done();
-          }
-        );
+          })
+          .catch(done.fail);
       });
-    });
+    }).catch(done.fail);
   });
 
   it("drop resolves without an error when the template does not exist", function (done) {
@@ -137,12 +132,7 @@ describe("template", function () {
             return fs.writeFile(filePath, "rendered");
           })
           .then(function () {
-            return new Promise(function (resolve, reject) {
-              client.set(renderedKey, "rendered", function (err) {
-                if (err) return reject(err);
-                resolve();
-              });
-            });
+            return client.set(renderedKey, "rendered");
           });
       })
     )
@@ -170,12 +160,8 @@ describe("template", function () {
             var filePath = getRenderedOutputPath(hash, target);
 
             return Promise.all([
-              new Promise(function (resolve, reject) {
-                client.get(renderedKey, function (err, result) {
-                  if (err) return reject(err);
-                  expect(result).toBeNull();
-                  resolve();
-                });
+              client.get(renderedKey).then(function (result) {
+                expect(result).toBeNull();
               }),
               fs.pathExists(filePath).then(function (exists) {
                 expect(exists).toBe(false);
@@ -213,18 +199,14 @@ describe("template", function () {
     var dropWithPurgeStub = require("../drop");
 
     new Promise(function (resolve, reject) {
-      client.hset(metadataKey, "cdn", JSON.stringify(manifest), function (err) {
-        if (err) return reject(err);
-        resolve();
-      });
+      client.hSet(metadataKey, "cdn", JSON.stringify(manifest)).then(resolve, reject);
     })
       .then(function () {
         return new Promise(function (resolve, reject) {
-          client.hget(metadataKey, "cdn", function (err, rawCdn) {
-            if (err) return reject(err);
+          client.hGet(metadataKey, "cdn").then(function (rawCdn) {
             expect(JSON.parse(rawCdn)).toEqual(manifest);
             resolve();
-          });
+          }, reject);
         });
       })
       .then(function () {
@@ -277,8 +259,7 @@ describe("template", function () {
     var test = this;
     var metadataKey = key.metadata(test.template.id);
 
-    client.hdel(metadataKey, "cdn", function (err) {
-      if (err) return done.fail(err);
+    client.hDel(metadataKey, "cdn").then(function () {
 
       drop(test.blog.id, test.template.name, function (err) {
         if (err) return done.fail(err);
@@ -287,17 +268,18 @@ describe("template", function () {
           if (err) return done.fail(err);
 
           var malformedTemplateID = test.blog.id + ":malformed-cdn";
-          client.hset(key.metadata(malformedTemplateID), "cdn", '"broken"', function (err) {
-            if (err) return done.fail(err);
-
-            drop(test.blog.id, "malformed-cdn", function (err, message) {
-              if (err) return done.fail(err);
-              expect(typeof message).toBe("string");
-              done();
-            });
-          });
+          client
+            .hSet(key.metadata(malformedTemplateID), "cdn", '"broken"')
+            .then(function () {
+              drop(test.blog.id, "malformed-cdn", function (err, message) {
+                if (err) return done.fail(err);
+                expect(typeof message).toBe("string");
+                done();
+              });
+            })
+            .catch(done.fail);
         });
       });
-    });
+    }).catch(done.fail);
   });
 });

--- a/app/models/template/tests/dropShareID.js
+++ b/app/models/template/tests/dropShareID.js
@@ -3,20 +3,23 @@ describe("template", function () {
 
   var createShareID = require("../index").createShareID;
   var dropShareID = require("../index").dropShareID;
-  var client = require("models/client");
+  var client = require("models/client-new");
 
   it("dropShareID works", function (done) {
     var test = this;
     createShareID(test.template.id, function (err, shareID) {
       if (err) return done.fail(err);
       expect(typeof shareID).toEqual("string");
-      dropShareID(shareID, function (err) {
-        if (err) return done.fail(err);
-        client.keys("*" + shareID + "*", function (err, result) {
-          if (err) return done.fail(err);
-          expect(result).toEqual([]);
-          done();
-        });
+      dropShareID(shareID, function (dropErr) {
+        if (dropErr) return done.fail(dropErr);
+
+        client
+          .keys("*" + shareID + "*")
+          .then(function (result) {
+            expect(result).toEqual([]);
+            done();
+          })
+          .catch(done.fail);
       });
     });
   });

--- a/app/models/template/tests/dropView.js
+++ b/app/models/template/tests/dropView.js
@@ -3,7 +3,7 @@ describe("template", function () {
 
   var dropView = require("../index").dropView;
   var getAllViews = require("../index").getAllViews;
-  var client = require("models/client");
+  var client = require("models/client-new");
 
   it("dropView removes a view", function (done) {
     dropView(this.template.id, this.view.name, done);
@@ -14,84 +14,52 @@ describe("template", function () {
     getAllViews(test.template.id, function (err, views) {
       if (err) return done.fail(err);
       expect(views[test.view.name].content).toEqual(test.view.content);
-      dropView(test.template.id, test.view.name, function (err) {
-        if (err) return done.fail(err);
-        getAllViews(test.template.id, function (err, views) {
-          if (err) return done.fail(err);
-          expect(views).toEqual({});
+      dropView(test.template.id, test.view.name, function (dropErr) {
+        if (dropErr) return done.fail(dropErr);
+        getAllViews(test.template.id, function (allErr, allViews) {
+          if (allErr) return done.fail(allErr);
+          expect(allViews).toEqual({});
           done();
         });
       });
     });
   });
 
-  it("dropView removes the key for the view", function (done) {
-    var test = this;
-    var searchPattern = "template:" + test.template.id + ":view:*";
-
-    client.keys(searchPattern, function (err, result) {
-      if (err) return done.fail(err);
-      expect(result.length).toEqual(1);
-
-      dropView(test.template.id, test.view.name, function (err) {
-        if (err) return done.fail(err);
-
-        client.keys(searchPattern, function (err, result) {
+  function expectKeyDeleted(searchPattern, templateID, viewName, done) {
+    client
+      .keys(searchPattern)
+      .then(function (result) {
+        expect(result.length).toEqual(1);
+        dropView(templateID, viewName, function (err) {
           if (err) return done.fail(err);
 
-          expect(result).toEqual([]);
-          done();
+          client
+            .keys(searchPattern)
+            .then(function (after) {
+              expect(after).toEqual([]);
+              done();
+            })
+            .catch(done.fail);
         });
-      });
-    });
+      })
+      .catch(done.fail);
+  }
+
+  it("dropView removes the key for the view", function (done) {
+    var test = this;
+    expectKeyDeleted("template:" + test.template.id + ":view:*", test.template.id, test.view.name, done);
   });
 
   it("dropView removes the URL key for the view", function (done) {
     var test = this;
-    var searchPattern = "template:" + test.template.id + ":url:*";
-
-    client.keys(searchPattern, function (err, result) {
-      if (err) return done.fail(err);
-      expect(result.length).toEqual(1);
-
-      dropView(test.template.id, test.view.name, function (err) {
-        if (err) return done.fail(err);
-
-        client.keys(searchPattern, function (err, result) {
-          if (err) return done.fail(err);
-
-          expect(result).toEqual([]);
-          done();
-        });
-      });
-    });
+    expectKeyDeleted("template:" + test.template.id + ":url:*", test.template.id, test.view.name, done);
   });
 
   it("dropView removes the URL patterns key for the view", function (done) {
     var test = this;
-    var searchPattern = "template:" + test.template.id + ":url_patterns";
-
-    client.keys(searchPattern, function (err, result) {
-      if (err) return done.fail(err);
-      expect(result.length).toEqual(1);
-
-      dropView(test.template.id, test.view.name, function (err) {
-        if (err) return done.fail(err);
-
-        client.keys(searchPattern, function (err, result) {
-          if (err) return done.fail(err);
-
-          expect(result).toEqual([]);
-          done();
-        });
-      });
-    });
+    expectKeyDeleted("template:" + test.template.id + ":url_patterns", test.template.id, test.view.name, done);
   });
 
-  // dropView does not remove the URL key for the view at the moment
-  // so it might be worth writing a check against this in future...
-
-  // This is not yet implemented
   it("dropView returns an error when the template does not exist", function (done) {
     var test = this;
     dropView("nonexistent:template", test.view.name, function (err) {

--- a/app/models/template/tests/setView.js
+++ b/app/models/template/tests/setView.js
@@ -9,9 +9,9 @@ describe("template", () => {
 	const getView = promisify(require("../index").getView);
 	const getMetadata = promisify(require("../index").getMetadata);
 	const Blog = require("models/blog");
-	const client = require("models/client");
-	const hdel = promisify(client.hdel).bind(client);
-	const get = promisify(client.get).bind(client);
+	const client = require("models/client-new");
+	const hdel = client.hDel.bind(client);
+	const get = client.get.bind(client);
 	const key = require("../key");
 
 	it("sets a view", async function () {

--- a/app/models/template/tests/updateCdnManifest.js
+++ b/app/models/template/tests/updateCdnManifest.js
@@ -3,14 +3,14 @@ const setView = require("../index").setView;
 const getMetadata = require("../index").getMetadata;
 const createTemplate = require("../index").create;
 const key = require("../key");
-const client = require("models/client");
+const client = require("models/client-new");
 const Blog = require("models/blog");
 const path = require("path");
 const fs = require("fs-extra");
 const config = require("config");
 const renderView = require("blog/render/view");
 
-const getAsync = promisify(client.get).bind(client);
+const getAsync = client.get.bind(client);
 const getMetadataAsync = promisify(getMetadata).bind(getMetadata);
 const setViewAsync = promisify(setView).bind(setView);
 const blogSetAsync = promisify(Blog.set).bind(Blog);
@@ -185,11 +185,7 @@ describe("updateCdnManifest", function () {
       cdn: ["style.css", "../secrets.css", "/absolute.css"],
     };
 
-    await new Promise((resolve, reject) => {
-      client.hset(viewKey, "retrieve", JSON.stringify(invalidRetrieve), (err) =>
-        err ? reject(err) : resolve()
-      );
-    });
+    await client.hSet(viewKey, "retrieve", JSON.stringify(invalidRetrieve));
 
     await new Promise((resolve, reject) => {
       require("../util/updateCdnManifest")(test.template.id, (err) =>

--- a/app/models/template/update.js
+++ b/app/models/template/update.js
@@ -1,6 +1,6 @@
 var ensure = require("helper/ensure");
 var makeID = require("./util/makeID");
-var client = require("models/client");
+var client = require("models/client-new");
 var key = require("./key");
 var setMetadata = require("./setMetadata");
 
@@ -11,12 +11,11 @@ module.exports = function update(owner, name, metadata, callback) {
     .and(callback, "function");
 
   var id = makeID(owner, name);
+  var operation = metadata.isPublic
+    ? client.sAdd(key.publicTemplates(), id)
+    : client.sRem(key.publicTemplates(), id);
 
-  if (metadata.isPublic) {
-    client.sadd(key.publicTemplates(), id);
-  } else {
-    client.srem(key.publicTemplates(), id);
-  }
-
-  return setMetadata(id, metadata, callback);
+  operation.then(function () {
+    return setMetadata(id, metadata, callback);
+  }).catch(callback);
 };

--- a/app/models/template/util/updateCdnManifest.js
+++ b/app/models/template/util/updateCdnManifest.js
@@ -1,7 +1,7 @@
 const { promisify } = require("util");
 const ensure = require("helper/ensure");
 const hash = require("helper/hash");
-const client = require("models/client");
+const client = require("models/client-new");
 const key = require("../key");
 const getMetadata = require("../getMetadata");
 const getView = require("../getView");
@@ -17,9 +17,9 @@ const config = require("config");
 const getMetadataAsync = promisify(getMetadata);
 const getAllViewsAsync = promisify(getAllViews);
 const getViewAsync = promisify(getView);
-const hsetAsync = promisify(client.hset).bind(client);
-const delAsync = promisify(client.del).bind(client);
-const setAsync = promisify(client.set).bind(client);
+const hsetAsync = client.hSet.bind(client);
+const delAsync = client.del.bind(client);
+const setAsync = client.set.bind(client);
 
 // Maximum size for rendered output (2MB)
 const MAX_RENDERED_OUTPUT_SIZE = 2 * 1024 * 1024;


### PR DESCRIPTION
### Motivation

- Replace legacy Redis wiring in the template model with the new shared Redis singleton so model internals use the modern promise-based client API. 
- Preserve the template model's existing public, callback-style APIs while modernizing internals to avoid legacy callback-last Redis usage. 
- Align `app/models/template` with patterns used by other migrated models and provide short, general migration guidance in `app/models/README`.

### Description

- Switched imports from `models/client` to `models/client-new` across `app/models/template` and related tests, and adjusted usages to the promise-based command names (e.g. `hGetAll`, `hSet`, `hDel`, `sMembers`, `sAdd`, `sRem`, `sIsMember`).
- Converted internal read/write flows to promise/`async`-`await` shapes and updated `multi().exec()` handling to use promise-based resolution and proper rejection forwarding where appropriate (files updated include `create.js`, `getMetadata.js`, `getView.js`, `getAllViews.js`, `getTemplateList.js`, `getViewByURL.js`, `setView.js`, `setMetadata.js`, `drop.js`, `dropView.js`, `update.js`, and `util/updateCdnManifest.js`).
- Preserved callback-facing model APIs (kept error-first callback signatures) by bridging internal promise rejections back to the existing callback contract. 
- Updated test files under `app/models/template/tests` to mock/await `models/client-new` promise methods and fixed call-site patterns (converted callback-based Redis assertions to promise-based checks and adjusted a few test flows to await `client-new` operations). 
- Condensed and clarified the migration checklist in `app/models/README` to include explicit, repeatable steps for switching to `models/client-new` and guidance for updating tests to target promise-returning `client-new` methods.

### Testing

- Ran syntax checks across modified JS files with `node -c` for each changed file; the check passed for all modified files. 
- Attempted to run the model test subset with `npm test app/models/template/tests`, but the project test harness depends on Docker and the execution environment does not provide `docker`, so the test run could not be completed. 
- Verified updated test code now targets `models/client-new` promise APIs (updated assertions and mocks), and ensured no JavaScript syntax errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1cd6ab7248329a151a6a8cf33a685)