### PR TITLE
Fix Redis failure handling spy in Entries.random test

### DIFF
--- a/app/models/entries/tests.js
+++ b/app/models/entries/tests.js
@@ -792,11 +792,17 @@ describe("entries", function () {
     });
 
     it("handles Redis failures without unhandled rejections", function (done) {
-      spyOn(redis, "zRandMember").and.rejectWith(new Error("boom"));
+      spyOn(redis, "zRandMember").and.returnValue(
+        Promise.reject(new Error("boom"))
+      );
 
       Entries.random(this.blog.id, function (entry) {
-        expect(entry).toBeUndefined();
-        done();
+        try {
+          expect(entry).toBeUndefined();
+          done();
+        } catch (err) {
+          done.fail(err);
+        }
       });
     });
   });


### PR DESCRIPTION
### Motivation
- The test used a Jasmine spy pattern (`and.rejectWith(...)`) that is incompatible with the promise-returning Redis mock, which could produce unhandled rejections; the intent is to make the spy return a rejected Promise and ensure the callback-path is exercised safely.

### Description
- Replaced `spyOn(redis, "zRandMember").and.rejectWith(new Error("boom"))` with `spyOn(redis, "zRandMember").and.returnValue(Promise.reject(new Error("boom")))` in `app/models/entries/tests.js` to use a version-compatible rejected-promise spy.
- Wrapped the assertion in the test callback with `try/catch` and use `done.fail(err)` on exceptions to ensure stable failure reporting and that the callback path completes.

### Testing
- Attempted to run the spec directly with `npx jasmine app/models/entries/tests.js`, which failed in this environment due to module resolution errors (`Cannot find module 'models/client-new'`), so the change could not be validated end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2183fd0788329971e8c7e0854d427)