### PR TITLE
Refactor entries pruneMissing to consistent callback/promise style

### DIFF
--- a/app/models/entries/index.js
+++ b/app/models/entries/index.js
@@ -214,15 +214,15 @@ module.exports = (function () {
 
     async.eachSeries(
       lists,
-      async function (listName, nextList) {
+      function (listName, nextList) {
         var key = listKey(blogID, listName);
 
-        try {
-          var ids = await redis.zRange(key, 0, -1);
-          if (!ids || !ids.length) return nextList();
+        redis
+          .zRange(key, 0, -1)
+          .then(function (ids) {
+            if (!ids || !ids.length) return nextList();
 
-          Entry.get(blogID, ids, async function (entries) {
-            try {
+            Entry.get(blogID, ids, function (entries) {
               entries = entries || [];
 
               var existing = {};
@@ -237,15 +237,19 @@ module.exports = (function () {
 
               if (!missing.length) return nextList();
 
-              await redis.zRem.apply(redis, [key].concat(missing));
-              nextList();
-            } catch (err) {
-              nextList(err);
-            }
+              redis
+                .zRem.apply(redis, [key].concat(missing))
+                .then(function () {
+                  nextList();
+                })
+                .catch(function (err) {
+                  nextList(err);
+                });
+            });
+          })
+          .catch(function (err) {
+            nextList(err);
           });
-        } catch (err) {
-          nextList(err);
-        }
       },
       callback
     );


### PR DESCRIPTION
### Motivation
- Remove the mixed `async/await` + callback usage in `pruneMissing` to make the control flow consistent and avoid confusing/fragile error/continuation handling.
- Minimize churn while keeping existing behavior for empty lists and missing entry IDs.

### Description
- Changed the iteratee from `async function (listName, nextList)` to classic callback form `function (listName, nextList)` in `pruneMissing`.
- Replaced `await redis.zRange(...)` with `redis.zRange(...).then(...).catch(nextList)` and routed errors through `nextList(err)`.
- Replaced `await redis.zRem.apply(...)` with promise chaining and `.then(...).catch(nextList)` to ensure `nextList()` / `nextList(err)` is called exactly once per list.
- Preserved the `Entry.get(blogID, ids, function (entries) { ... })` callback usage and left the final `async.eachSeries(..., callback)` completion behavior unchanged.

### Testing
- Ran `node --check app/models/entries/index.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a218411bf48329a83166e5c81a02b4)