### PR TITLE
Normalize template metadata scalars before Redis hSet

### DIFF
--- a/app/models/template/util/serialize.js
+++ b/app/models/template/util/serialize.js
@@ -12,6 +12,16 @@ module.exports = function serialize(sourceObj, model) {
   for (var i in obj) {
     if (model[i] === "object" || model[i] === "array") {
       obj[i] = JSON.stringify(obj[i]);
+      continue;
+    }
+
+    if (model[i] === "boolean" && obj[i] !== undefined && obj[i] !== null) {
+      obj[i] = obj[i] === true || obj[i] === "true" ? "true" : "false";
+      continue;
+    }
+
+    if (model[i] === "number" && obj[i] !== undefined && obj[i] !== null) {
+      obj[i] = String(obj[i]);
     }
   }
 


### PR DESCRIPTION
### Motivation
- Redis hash fields must be strings when using strict client encodings, so metadata written with `client.hSet(...)` should have scalar values normalized to string form.
- Preserve existing behavior for `object`/`array` fields (JSON stringification) and remain compatible with the deserializer that JSON-parses objects/arrays and parses booleans from their string form.

### Description
- Updated `app/models/template/util/serialize.js` to keep JSON stringification for `object`/`array` fields and `continue` afterward so later scalar handling does not overwrite them.
- Added boolean serialization for `model[i] === "boolean"` to produce Redis-safe `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a21841aae88329b3c66e783cd6ce1f)