### PR TITLE
Normalize Redis hash values before HSET/MULTI.HSET on client-new path

### DIFF
--- a/app/models/blog/set.js
+++ b/app/models/blog/set.js
@@ -14,6 +14,7 @@ var normalizeConverters = require("./util/converters").normalize;
 var updateCdnManifest = require("../template/util/updateCdnManifest");
 var forkSiteTemplate = require("../template/util/forkSiteTemplate");
 var renameGitRepo = require("clients/git/renameRepo");
+var serializeRedisHashValues = require("models/redisHashSerializer");
 var promisify = require("util").promisify;
 var updateCdnManifestAsync = promisify(updateCdnManifest);
 
@@ -172,7 +173,7 @@ module.exports = function (blogID, blog, callback) {
         return callback(null, changesList);
       }
 
-      multi.hSet(key.info(blogID), serial(latest));
+      multi.hSet(key.info(blogID), serializeRedisHashValues(serial(latest)));
 
       try {
         await multi.exec();

--- a/app/models/question/create.js
+++ b/app/models/question/create.js
@@ -1,4 +1,5 @@
 const client = require("models/client-new");
+const serializeRedisHashValues = require("models/redisHashSerializer");
 const keys = require("./keys");
 const get = require("./get");
 
@@ -57,7 +58,7 @@ module.exports = async function ({
     multi.zAdd(keys.by_number_of_replies, { score: 0, value: id });
   }
 
-  multi.hSet(keys.item(id), item);
+  multi.hSet(keys.item(id), serializeRedisHashValues(item));
 
   // ensure the multi command fails if the ID
   // is already in use

--- a/app/models/question/update.js
+++ b/app/models/question/update.js
@@ -1,4 +1,5 @@
 const client = require("models/client-new");
+const serializeRedisHashValue = require("models/redisHashSerializer").value;
 const keys = require("./keys");
 const get = require("./get");
 
@@ -13,17 +14,7 @@ module.exports = async (id, updates) => {
   const removedTags = [];
 
   for (const key in updates) {
-    let value = updates[key];
-
-    if (typeof value === "object" || Array.isArray(value)) {
-      value = JSON.stringify(value);
-    } else if (typeof value === "boolean") {
-      value = value ? "true" : "false";
-    } else if (typeof value === "number") {
-      value = value.toString();
-    }
-
-    multi.hSet(keys.item(id), key, value);
+    multi.hSet(keys.item(id), key, serializeRedisHashValue(updates[key]));
   }
 
   // we need to update any tags

--- a/app/models/redisHashSerializer.js
+++ b/app/models/redisHashSerializer.js
@@ -1,0 +1,41 @@
+function serializeRedisHashValue(value, options) {
+  const settings = options || {};
+  const omitNullish = settings.omitNullish === true;
+
+  if (value === null || typeof value === "undefined") {
+    return omitNullish ? undefined : "";
+  }
+
+  if (Buffer.isBuffer(value)) return value;
+
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+
+  if (typeof value === "number" || typeof value === "bigint") {
+    return String(value);
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+}
+
+module.exports = function serializeRedisHashValues(payload, options) {
+  const output = {};
+
+  Object.keys(payload || {}).forEach((field) => {
+    const value = serializeRedisHashValue(payload[field], options);
+    if (typeof value !== "undefined") output[field] = value;
+  });
+
+  return output;
+};
+
+module.exports.value = serializeRedisHashValue;

--- a/app/models/template/setMetadata.js
+++ b/app/models/template/setMetadata.js
@@ -7,6 +7,7 @@ var ensure = require("helper/ensure");
 var Blog = require("models/blog");
 var injectLocals = require("./injectLocals");
 var updateCdnManifest = require("./util/updateCdnManifest");
+var serializeRedisHashValues = require("models/redisHashSerializer");
 
 module.exports = function setMetadata(id, updates, callback) {
   try {
@@ -37,7 +38,7 @@ module.exports = function setMetadata(id, updates, callback) {
       console.log("error injecting locals:", e);
     }
 
-    metadata = serialize(metadata, metadataModel);
+    metadata = serializeRedisHashValues(serialize(metadata, metadataModel));
 
     (async function () {
       try {

--- a/app/models/template/setView.js
+++ b/app/models/template/setView.js
@@ -14,6 +14,7 @@ var Blog = require("models/blog");
 var parseTemplate = require("./parseTemplate");
 var ERROR = require("../../blog/render/error");
 var updateCdnManifest = require("./util/updateCdnManifest");
+var serializeRedisHashValues = require("models/redisHashSerializer");
 var clfdate = require("helper/clfdate");
 const MAX_VIEW_PAYLOAD_SIZE = 2 * 1024 * 1024;
 
@@ -272,7 +273,7 @@ module.exports = function setView(templateID, updates, callback) {
 
 						view.retrieve = parseResult.retrieve || {};
 
-						view = serialize(view, viewModel);
+						view = serializeRedisHashValues(serialize(view, viewModel));
 
 						// Delete url and urlPatterns from Redis hash if they were removed
 						var multi = client.multi();

--- a/app/models/template/tests/setView.js
+++ b/app/models/template/tests/setView.js
@@ -49,6 +49,55 @@ describe("template", () => {
 		expect(savedView.content).toEqual(view.content);
 	});
 
+	it("handles boolean-heavy draft updates without Redis encoder errors", async function () {
+		const templateID = this.template.id;
+
+		await setMetadata(templateID, {
+			localEditing: true,
+			isPublic: false,
+			locals: {
+				featureFlags: {
+					livePreview: true,
+					showDraftBadge: false,
+				},
+			},
+		});
+
+		await setView(templateID, {
+			name: "draft.html",
+			content: "{{title}}",
+			locals: {
+				showHero: true,
+				rollout: [true, false],
+			},
+			retrieve: {
+				includeDraft: true,
+				filters: {
+					featured: false,
+				},
+			},
+		});
+
+		await setView(templateID, {
+			name: "draft.html",
+			content: "{{title}} updated",
+			locals: {
+				showHero: false,
+				rollout: [false, true],
+			},
+			retrieve: {
+				includeDraft: false,
+				filters: {
+					featured: true,
+				},
+			},
+		});
+
+		const view = await getView(templateID, "draft.html");
+		expect(view.locals.showHero).toBe(false);
+		expect(view.retrieve.includeDraft).toBe(false);
+	});
+
 	it("won't set a view with invalid mustache content", async function () {
 		const test = this;
 		const view = {


### PR DESCRIPTION
### Motivation
- Prevent Redis client encoder/type errors by ensuring all hash field values are safe scalars before calling `hSet`/`HSET` on the client-new path.
- Replace ad-hoc per-location conversions with a single shared serializer to keep behavior consistent for booleans, numbers, objects/arrays and nullish values.

### Description
- Add a shared helper `app/models/redisHashSerializer.js` that exposes `serializeRedisHashValues(payload)` and `serializeRedisHashValue(value)` to convert values to Redis-safe scalars (booleans -> `"true"/"false"`, numbers/bigints -> `String(...)`, objects/arrays -> `JSON.stringify(...)`, null/undefined -> `""` by default, with an option to omit nullish fields). 
- Normalize object-payload hash writes by wrapping existing serializations with the helper in `app/models/blog/set.js`, `app/models/template/setMetadata.js`, `app/models/template/setView.js`, and `app/models/question/create.js` so `multi.hSet(...)`/`client.hSet(...)` receive only safe scalars.
- Replace inline conversion logic in `app/models/question/update.js` with the helper’s single-value function to standardize per-field updates.
- Add a regression test in `app/models/template/tests/setView.js` that performs boolean-heavy draft metadata and view updates to assert the flow completes and values persist without Redis encoding errors.

### Testing
- Performed static syntax checks with `node --check` on modified files (passed for `app/models/redisHashSerializer.js`, `app/models/blog/set.js`, `app/models/template/setMetadata.js`, `app/models/template/setView.js`, `app/models/question/create.js`, `app/models/question/update.js`, and the updated test file). 
- Ran a small runtime check using `node -e` to validate the serializer converts booleans/numbers/objects/null to expected string values (succeeded).
- Attempted to run repository tests via `npm test -- app/models/template/tests/setView.js`, but the project test runner requires Docker and the environment returned `docker: command not found`, so the full test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a21a28156c8329a75500fa2a011cbc)