### PR TITLE
Migrate tests to models/client-new and promise-style Redis checks

### DIFF
--- a/app/site/tests/config.js
+++ b/app/site/tests/config.js
@@ -59,10 +59,12 @@ describe("Blot configuration", function () {
   });
 
   it("can connect to redis", function (done) {
-    require("models/client").ping(function (err, res) {
-      expect(err).toBe(null);
-      expect(res).toBe("PONG");
-      done();
-    });
+    require("models/client-new")
+      .ping()
+      .then(function (res) {
+        expect(res).toBe("PONG");
+        done();
+      })
+      .catch(done.fail);
   });
 });

--- a/app/sync/tests/renames.js
+++ b/app/sync/tests/renames.js
@@ -2,7 +2,7 @@ describe("update", function () {
   var sync = require("../index");
   var fs = require("fs-extra");
   var async = require("async");
-  var redis = require("models/client");
+  var redis = require("models/client-new");
   var entryKey = require("models/entry/key").entry;
 
   it("detects a renamed file across multiple syncs", function (done) {
@@ -209,18 +209,18 @@ describe("update", function () {
                     });
                   },
                   function (next) {
-                    redis.del(entryKey(blogID, ghostPath), function (err) {
-                      if (err) return next(err);
+                    redis
+                      .del(entryKey(blogID, ghostPath))
+                      .then(function () {
+                        var deletedListKey = "blog:" + blogID + ":deleted";
 
-                      var deletedListKey = "blog:" + blogID + ":deleted";
-
-                      redis.zscore(deletedListKey, ghostEntryID, function (err, score) {
-                        if (err) return next(err);
-
+                        return redis.zScore(deletedListKey, ghostEntryID);
+                      })
+                      .then(function (score) {
                         expect(score).not.toBeNull();
                         next();
-                      });
-                    });
+                      })
+                      .catch(next);
                   },
                 ],
                 function (err) {

--- a/scripts/tests/index.js
+++ b/scripts/tests/index.js
@@ -1,7 +1,7 @@
 var Jasmine = require("jasmine");
 var jasmine = new Jasmine();
 var colors = require("colors");
-var client = require("models/client");
+var client = require("models/client-new");
 var clfdate = require("helper/clfdate");
 var seedrandom = require("seedrandom");
 var async = require("async");
@@ -215,15 +215,21 @@ global.test = {
 };
 
 // get the number of keys in the database
-client.keys("*", function (err, keys) {
-  if (err) {
-    throw err;
+(async function ensureEmptyDatabase() {
+  let hasKeys = false;
+
+  for await (const _ of client.scanIterator({ MATCH: "*", COUNT: 1 })) {
+    hasKeys = true;
+    break;
   }
-  if (keys.length === 0) {
+
+  if (!hasKeys) {
     // if there are no keys, we need to run the tests
     jasmine.execute();
   } else {
     // if there are keys, we need to throw an error
-    throw new Error("Database is not empty: " + keys.length + " keys found");
+    throw new Error("Database is not empty: keys found");
   }
+})().catch(function (err) {
+  throw err;
 });


### PR DESCRIPTION
### Motivation

- Align tests with the new Redis client (`models/client-new`) which uses promise-based APIs and modern method names. 
- Replace legacy callback patterns in test preflight and internal assertions so mocks/spies and test runtime behavior match production usage.  
- Keep the original test-run gating semantics (only run when DB is empty) while using `client-new`-compatible APIs. 

### Description

- Switched test imports from `models/client` to `models/client-new` in `scripts/tests/index.js`, `app/sync/tests/renames.js`, and `app/site/tests/config.js`.  
- Replaced the preflight `keys("*")` check in `scripts/tests/index.js` with an async IIFE using `client.scanIterator({ MATCH: "*", COUNT: 1 })` to detect any existing keys and preserve the empty-DB gate behavior.  
- Updated `app/sync/tests/renames.js` to use promise-style Redis calls: `redis.del(...).then(...).then(...).catch(next)` and modernized the `zscore` call to `zScore` to match the new client API.  
- Updated `app/site/tests/config.js` to call `require("models/client-new").ping()` and assert the returned promise rather than using a callback.  

### Testing

- Ran syntax checks with `node -c scripts/tests/index.js && node -c app/sync/tests/renames.js && node -c app/site/tests/config.js` and they succeeded.  
- Verified the modified files compile and the repository working tree was clean after changes (local checks completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2be2c91608329ba0c6801e5ba6d19)