### PR TITLE
Migrate Redis listeners to redis-new and add explicit lifecycle cleanup

### DIFF
--- a/app/blog/draft.js
+++ b/app/blog/draft.js
@@ -2,16 +2,34 @@ module.exports = function route(server) {
   var Entry = require("models/entry");
   var Entries = require("models/entries");
   var drafts = require("sync/update/drafts");
-  var redis = require("models/redis");
+  const createRedisClient = require("models/redis-new");
 
   // (node:73631) TimeoutOverflowWarning: 1.7976931348623157e+308 does not fit into a 32-bit signed integer.
   // Timer duration was truncated to 2147483647.
   const MAX_TIMEOUT = 2147483647;
 
-  server.get(drafts.streamRoute, function (req, res, next) {
+  server.get(drafts.streamRoute, async function (req, res, next) {
     var blogID = req.blog.id;
-    var client = new redis();
+    const client = createRedisClient();
     var path = drafts.getPath(req.url, drafts.streamRoute);
+    let cleanedUp = false;
+
+    const cleanup = async function () {
+      if (cleanedUp) return;
+      cleanedUp = true;
+
+      try {
+        if (client.isOpen) {
+          await client.unsubscribe(channel);
+        }
+      } catch (e) {}
+
+      try {
+        if (client.isOpen) {
+          await client.quit();
+        }
+      } catch (e) {}
+    };
 
     req.socket.setTimeout(MAX_TIMEOUT);
 
@@ -31,19 +49,24 @@ module.exports = function route(server) {
 
     var channel = "blog:" + blogID + ":draft:" + path;
 
-    client.subscribe(channel, function (_message, _channel) {
-      renderDraft(req, res, next, path, function (html, bodyHTML) {
-        try {
-          res.write("\n");
-          res.write("data: " + JSON.stringify(bodyHTML.trim()) + "\n\n");
-          res.flushHeaders();
-        } catch (e) {}
+    try {
+      await client.connect();
+      await client.subscribe(channel, function (_message, _channel) {
+        renderDraft(req, res, next, path, function (html, bodyHTML) {
+          try {
+            res.write("\n");
+            res.write("data: " + JSON.stringify(bodyHTML.trim()) + "\n\n");
+            res.flushHeaders();
+          } catch (e) {}
+        });
       });
-    });
+    } catch (err) {
+      await cleanup();
+      return next(err);
+    }
 
-    req.on("close", function () {
-      client.unsubscribe();
-      client.quit();
+    req.on("close", async function () {
+      await cleanup();
     });
   });
 

--- a/app/clients/dropbox/routes/setup/index.js
+++ b/app/clients/dropbox/routes/setup/index.js
@@ -1,5 +1,5 @@
 const sync = require("sync");
-const redis = require("models/redis");
+const createRedisClient = require("models/redis-new");
 
 const promisify = require("util").promisify;
 const database = require("clients/dropbox/database");
@@ -13,26 +13,37 @@ function setup(account, session, callback) {
   sync(account.blog.id, async function (err, folder, done) {
     if (err) return callback(err);
 
-    const client = new redis();
+    const client = createRedisClient();
     const signal = { aborted: false };
+    const abortChannel = "sync:status:" + account.blog.id;
     let abortHandled = false;
     let cleaned = false;
     let finished = false;
 
-    const cleanup = () => {
+    const cleanup = async () => {
       if (cleaned) return;
       cleaned = true;
       console.log("Cleaning up Dropbox setup");
       try {
         delete session.dropbox;
         session.save();
-        client.unsubscribe();
-        client.quit();
       } catch (e) {
-        if (e && e.code === "NR_CLOSED") {
-          console.log("Redis connection already closed during cleanup:", e);
-          return;
+        console.log("Error cleaning up:", e);
+      }
+
+      try {
+        if (client.isOpen) {
+          await client.unsubscribe(abortChannel);
         }
+      } catch (e) {
+        console.log("Error unsubscribing:", e);
+      }
+
+      try {
+        if (client.isOpen) {
+          await client.quit();
+        }
+      } catch (e) {
         console.log("Error cleaning up:", e);
       }
     };
@@ -43,21 +54,22 @@ function setup(account, session, callback) {
       return true;
     };
 
-    const finish = (err) => {
+    const finish = async (err) => {
       if (finished) return;
       finished = true;
-      cleanup();
+      await cleanup();
       done(err, callback);
     };
 
-    client.subscribe("sync:status:" + account.blog.id, function (message, channel) {
-      if (message !== "Attempting to disconnect from Dropbox") return;
-      signal.aborted = true;
-      abortHandled = true;
-      handleAbort();
-    });
-
     try {
+      await client.connect();
+      await client.subscribe(abortChannel, function (message, channel) {
+        if (message !== "Attempting to disconnect from Dropbox") return;
+        signal.aborted = true;
+        abortHandled = true;
+        handleAbort();
+      });
+
       folder.status("Loading Dropbox account");
       account = await getAccount(account);
       if (handleAbort()) return;

--- a/app/clients/local/init.js
+++ b/app/clients/local/init.js
@@ -4,19 +4,43 @@
 const async = require("async");
 const debug = require("debug")("blot:clients:local:setup");
 const setup = require("./setup");
-const redis = require("models/redis");
-const client = new redis();
+const createRedisClient = require("models/redis-new");
+const client = createRedisClient();
 const clfdate = require("helper/clfdate");
 const Blog = require("models/blog");
 const prefix = () => clfdate() + " Local folder client:";
 
-module.exports = () => {
+module.exports = async () => {
   // This communication channel allows us to load in and out
   // new blogs in external scripts. We send a message to this
   // channel in scripts/load/info.js
   var CHANNEL = "clients:local:new-folder";
   console.log(prefix(), "Listening");
-  client.subscribe(CHANNEL, function (message, channel) {
+
+  const cleanup = async function () {
+    try {
+      if (client.isOpen) {
+        await client.unsubscribe(CHANNEL);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+
+    try {
+      if (client.isOpen) {
+        await client.quit();
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  process.once("SIGTERM", cleanup);
+  process.once("SIGINT", cleanup);
+  process.once("exit", cleanup);
+
+  await client.connect();
+  await client.subscribe(CHANNEL, function (message, channel) {
     debug("recieved", message, "on", channel);
     if (channel !== CHANNEL) return;
     let { blogID } = JSON.parse(message);

--- a/app/helper/redisSubscriber.js
+++ b/app/helper/redisSubscriber.js
@@ -1,4 +1,4 @@
-const redis = require("models/redis");
+const createRedisClient = require("models/redis-new");
 
 module.exports = function redisSubscriber({
   channel,
@@ -6,7 +6,7 @@ module.exports = function redisSubscriber({
   onError,
   logger = console,
 }) {
-  const client = new redis();
+  const client = createRedisClient();
   const messageHandler = typeof onMessage === "function" ? onMessage : function () {};
   let cleanedUp = false;
 
@@ -20,28 +20,38 @@ module.exports = function redisSubscriber({
 
   client.on("error", logRedisError);
 
-  Promise.resolve(
-    client.subscribe(channel, function (message, subscribedChannel) {
-      try {
-        messageHandler(message, subscribedChannel || channel);
-      } catch (err) {
-        logRedisError(err);
-      }
+  const setupPromise = Promise.resolve()
+    .then(async function () {
+      await client.connect();
+      await client.subscribe(channel, function (message, subscribedChannel) {
+        try {
+          messageHandler(message, subscribedChannel || channel);
+        } catch (err) {
+          logRedisError(err);
+        }
+      });
     })
-  ).catch(logRedisError);
+    .catch(async function (err) {
+      logRedisError(err);
+      await cleanup();
+    });
 
   async function cleanup() {
     if (cleanedUp) return;
     cleanedUp = true;
 
     try {
-      await client.unsubscribe(channel);
+      if (client.isOpen) {
+        await client.unsubscribe(channel);
+      }
     } catch (err) {
       logRedisError(err);
     }
 
     try {
-      await client.quit();
+      if (client.isOpen) {
+        await client.quit();
+      }
     } catch (err) {
       logRedisError(err);
     }
@@ -50,5 +60,6 @@ module.exports = function redisSubscriber({
   return {
     client,
     cleanup,
+    setupPromise,
   };
 };

--- a/scripts/util/redisKeys.js
+++ b/scripts/util/redisKeys.js
@@ -1,33 +1,58 @@
-const { promisify } = require("util");
-const redis = require("models/redis");
-const client = new redis();
-
-const scan = promisify(client.scan.bind(client));
+const createRedisClient = require("models/redis-new");
 
 async function redisKeys(pattern, iterator) {
+  const client = createRedisClient();
+
   let cursor = "0";
   let complete = false;
 
-  while (!complete) {
-    try {
-      const [nextCursor, results] = await scan(
-        cursor,
-        "match",
-        pattern,
-        "count",
-        1000
-      );
-      cursor = nextCursor;
+  try {
+    await client.connect();
 
-      for (const result of results) {
+    while (!complete) {
+      const scanReply = await client.scan(cursor, {
+        MATCH: pattern,
+        COUNT: 1000,
+      });
+      const normalizedScanReply = normalizeScanReply(scanReply);
+      cursor = normalizedScanReply.cursor;
+
+      for (const result of normalizedScanReply.keys) {
         await iterator(result);
       }
 
       complete = cursor === "0";
-    } catch (err) {
-      throw err;
+    }
+  } finally {
+    if (client.isOpen) {
+      await client.quit();
     }
   }
+}
+
+function normalizeScanReply(reply) {
+  if (Array.isArray(reply)) {
+    return {
+      cursor: String(reply[0] || "0"),
+      keys: Array.isArray(reply[1]) ? reply[1] : [],
+    };
+  }
+
+  if (reply && typeof reply === "object") {
+    const cursor = Object.prototype.hasOwnProperty.call(reply, "cursor")
+      ? String(reply.cursor)
+      : "0";
+
+    const keys = Array.isArray(reply.keys)
+      ? reply.keys
+      : Array.isArray(reply.results)
+      ? reply.results
+      : [];
+
+    return { cursor, keys };
+  }
+
+  return { cursor: "0", keys: [] };
 }
 
 module.exports = redisKeys;


### PR DESCRIPTION
### Motivation
- Replace legacy `models/redis` instantiation with the new `models/redis-new` client factory to use the modern Redis client API. 
- Ensure lifecycle-owned Redis clients always `connect()` before use and are closed cleanly in all code paths. 
- Guarantee subscribers unsubscribe from specific channels during cleanup and socket/process shutdown to avoid leaked subscriptions. 
- Apply these changes to SSE draft streaming, the reusable subscriber helper, Dropbox setup abort handling, the local client listener, and the SCAN helper.

### Description
- Replaced `require("models/redis")` + `new redis()` with `const createRedisClient = require("models/redis-new")` and `const client = createRedisClient()` across the targeted files. 
- Ensure `await client.connect()` is called before `subscribe()` or `scan()` operations and added idempotent async `cleanup()` functions which `unsubscribe(channel)` and `quit()` only when `client.isOpen`. 
- Updated `app/helper/redisSubscriber.js` to connect before subscribing, add guarded cleanup, and expose a `setupPromise` for optional readiness/error handling. 
- Updated `app/blog/draft.js`, `app/clients/dropbox/routes/setup/index.js`, `app/clients/local/init.js` to subscribe with the new client, unsubscribe specific channels during cleanup, await cleanup on finish/close, and add process exit/signal hooks for the long-lived local listener. 
- Reworked `scripts/util/redisKeys.js` to create a per-call client, connect before scanning, normalize SCAN replies (`normalizeScanReply`) for compatibility, and always quit the client in `finally`.

### Testing
- Performed syntax checks with `node -c` on the modified files: `app/blog/draft.js`, `app/helper/redisSubscriber.js`, `app/clients/dropbox/routes/setup/index.js`, `app/clients/local/init.js`, and `scripts/util/redisKeys.js`; they compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2be1b8d1883299ceecd1133dbcc53)