### PR TITLE
Migrate Redis calls to models/client-new and modern command APIs

### DIFF
--- a/app/helper/transformer/index.js
+++ b/app/helper/transformer/index.js
@@ -1,5 +1,5 @@
 var debug = require("debug")("blot:helper:transformer");
-var client = require("models/client");
+var client = require("models/client-new");
 var isURL = require("./isURL");
 var Keys = require("./keys");
 var HashFile = require("./hash");
@@ -283,37 +283,45 @@ function Transformer(blogID, name) {
   function getURL(url, callback) {
     var info = [keys.url.headers(url), keys.url.content(url)];
 
-    client.mget(info, function (err, res) {
-      if (err) throw err;
-
-      var headers = null;
-      var hash = null;
-
+    (async function () {
       try {
-        headers = JSON.parse(res[0]);
-        hash = res[1];
-      } catch (e) {}
+        const res = await client.mGet(info);
 
-      if (hash === null) return callback(err, headers, hash, null);
+        var headers = null;
+        var hash = null;
 
-      get(hash, function (err, result) {
-        callback(err, headers, hash, result);
-      });
-    });
+        try {
+          headers = JSON.parse(res[0]);
+          hash = res[1];
+        } catch (e) {}
+
+        if (hash === null) return callback(null, headers, hash, null);
+
+        get(hash, function (err, result) {
+          callback(err, headers, hash, result);
+        });
+      } catch (err) {
+        callback(err);
+      }
+    })();
   }
 
   function get(hash, callback) {
-    client.get(keys.content(hash), function (err, stringifiedResult) {
-      if (err) throw err;
-
-      var res = null;
-
+    (async function () {
       try {
-        res = JSON.parse(stringifiedResult);
-      } catch (e) {}
+        const stringifiedResult = await client.get(keys.content(hash));
 
-      return callback(null, res);
-    });
+        var res = null;
+
+        try {
+          res = JSON.parse(stringifiedResult);
+        } catch (e) {}
+
+        return callback(null, res);
+      } catch (err) {
+        callback(err);
+      }
+    })();
   }
 
   function setURL(url, headers, hash, result, callback) {
@@ -332,18 +340,21 @@ function Transformer(blogID, name) {
     var stringifiedHeaders = JSON.stringify(headers);
     var stringifiedResult = JSON.stringify(result);
 
-    client
-      .multi()
-      .sadd(keys.everything, contentKey, urlContentKey, urlHeadersKey)
-      .mset(
-        urlContentKey,
-        hash,
-        urlHeadersKey,
-        stringifiedHeaders,
-        contentKey,
-        stringifiedResult
-      )
-      .exec(callback);
+    (async function () {
+      try {
+        const tx = client.multi();
+        tx.sAdd(keys.everything, [contentKey, urlContentKey, urlHeadersKey]);
+        tx.mSet({
+          [urlContentKey]: hash,
+          [urlHeadersKey]: stringifiedHeaders,
+          [contentKey]: stringifiedResult,
+        });
+        await tx.exec();
+        callback();
+      } catch (err) {
+        callback(err);
+      }
+    })();
   }
 
   function set(hash, result, callback) {
@@ -354,19 +365,31 @@ function Transformer(blogID, name) {
     var stringifiedResult = JSON.stringify(result);
     var contentKey = keys.content(hash);
 
-    client
-      .multi()
-      .sadd(keys.everything, contentKey)
-      .set(contentKey, stringifiedResult)
-      .exec(callback);
+    (async function () {
+      try {
+        const tx = client.multi();
+        tx.sAdd(keys.everything, contentKey);
+        tx.set(contentKey, stringifiedResult);
+        await tx.exec();
+        callback();
+      } catch (err) {
+        callback(err);
+      }
+    })();
   }
 
   function flush(callback) {
-    client.smembers(keys.everything, function (err, keys) {
-      client.del(keys, function () {
+    (async function () {
+      try {
+        const toDelete = await client.sMembers(keys.everything);
+        if (toDelete && toDelete.length) {
+          await client.del(toDelete);
+        }
         callback();
-      });
-    });
+      } catch (err) {
+        callback(err);
+      }
+    })();
   }
 
   return {

--- a/app/helper/transformer/tests/lookup.js
+++ b/app/helper/transformer/tests/lookup.js
@@ -1,7 +1,7 @@
 describe("transformer", function () {
   var fs = require("fs-extra");
   var Keys = require("../keys");
-  var client = require("models/client");
+  var client = require("models/client-new");
   var STATIC_DIRECTORY = require("config").blog_static_files_dir;
 
   // Creates test environment

--- a/app/setup.js
+++ b/app/setup.js
@@ -2,7 +2,7 @@ const config = require("config");
 const fs = require("fs-extra");
 const path = require("path");
 
-const client = require("models/client");
+const client = require("models/client-new");
 const documentation = require("./documentation/build");
 const templates = require("./templates");
 const folders = require("./templates/folders");
@@ -156,22 +156,24 @@ function main(callback) {
         // Typically, domain keys like domain:example.com store a blog's ID
         // but since the homepage is not a blog, we just use a placeholder 'X'
         log("Creating SSL key for redis");
-        client.msetnx(
-          ["domain:" + config.host, "X", "domain:www." + config.host, "X"],
-          function (err) {
-            if (err) {
-              console.error(
-                "Unable to set domain flag for host" +
-                  config.host +
-                  ". SSL may not work on site."
-              );
-              console.error(err);
-            }
-
-            log("Created SSL key for redis");
-            callback();
+        (async function () {
+          try {
+            await client.mSetNX({
+              ["domain:" + config.host]: "X",
+              ["domain:www." + config.host]: "X",
+            });
+          } catch (err) {
+            console.error(
+              "Unable to set domain flag for host" +
+                config.host +
+                ". SSL may not work on site."
+            );
+            console.error(err);
           }
-        );
+
+          log("Created SSL key for redis");
+          callback();
+        })();
       },
 
       function (callback) {

--- a/app/sync/tests/rebuildDependents.js
+++ b/app/sync/tests/rebuildDependents.js
@@ -1,0 +1,43 @@
+describe("rebuildDependents", function () {
+  var rebuildDependents = require("../update/rebuildDependents");
+  var Blog = require("models/blog");
+  var Entry = require("models/entry");
+  var client = require("models/client-new");
+
+  it("uses sMembers and routes redis rejections to callback", function (done) {
+    spyOn(Blog, "get").and.callFake(function (_, callback) {
+      callback(null, { id: "blog-1" });
+    });
+
+    spyOn(client, "sMembers").and.returnValue(
+      Promise.reject(new Error("redis-fail"))
+    );
+
+    rebuildDependents("blog-1", "/post.md", function (err) {
+      expect(err).toEqual(jasmine.any(Error));
+      expect(err.message).toBe("redis-fail");
+      done();
+    });
+  });
+
+  it("iterates over dependent paths returned by sMembers", function (done) {
+    var paths = ["/a.md", "/b.md"];
+
+    spyOn(Blog, "get").and.callFake(function (_, callback) {
+      callback(null, { id: "blog-2" });
+    });
+
+    spyOn(client, "sMembers").and.returnValue(Promise.resolve(paths));
+
+    spyOn(Entry, "get").and.callFake(function (_, __, callback) {
+      callback(null);
+    });
+
+    rebuildDependents("blog-2", "/post.md", function (err) {
+      expect(err).toBeFalsy();
+      expect(client.sMembers).toHaveBeenCalled();
+      expect(Entry.get.calls.count()).toBe(paths.length);
+      done();
+    });
+  });
+});

--- a/app/sync/update/rebuildDependents.js
+++ b/app/sync/update/rebuildDependents.js
@@ -1,6 +1,6 @@
 var async = require("async");
 var Entry = require("models/entry");
-var client = require("models/client");
+var client = require("models/client-new");
 var Blog = require("models/blog");
 var build = require("build");
 var dependentsKey = Entry.key.dependents;
@@ -23,46 +23,47 @@ module.exports = function (blogID, path, callback) {
   };
   Blog.get({ id: blogID }, function (err, blog) {
     if (err || !blog) return callback(err || new Error("No blog"));
-    client.SMEMBERS(dependentsKey(blogID, path), function (
-      err,
-      dependent_paths
-    ) {
-      if (err) return callback(err);
+    (async function () {
+      try {
+        const dependent_paths = await client.sMembers(dependentsKey(blogID, path));
 
-      async.eachSeries(
-        dependent_paths,
-        function (dependent_path, next) {
-          Entry.get(blogID, dependent_path, function (entry) {
-            if (!entry) {
-              log("No entry for dependent_path:", dependent_path);
-              return next();
-            }
-
-            build(blog, dependent_path, function (
-              err,
-              updated_dependent
-            ) {
-              if (err) {
-                log("Error rebuilding dependent_path:", dependent_path, err);
+        async.eachSeries(
+          dependent_paths,
+          function (dependent_path, next) {
+            Entry.get(blogID, dependent_path, function (entry) {
+              if (!entry) {
+                log("No entry for dependent_path:", dependent_path);
                 return next();
               }
 
-              Entry.set(
-                blogID,
-                dependent_path,
-                updated_dependent,
-                function (err) {
-                  if (err) log("Error saving dependent_path entry", err);
+              build(blog, dependent_path, function (
+                err,
+                updated_dependent
+              ) {
+                if (err) {
+                  log("Error rebuilding dependent_path:", dependent_path, err);
+                  return next();
+                }
 
-                  next();
-                },
-                false
-              );
+                Entry.set(
+                  blogID,
+                  dependent_path,
+                  updated_dependent,
+                  function (err) {
+                    if (err) log("Error saving dependent_path entry", err);
+
+                    next();
+                  },
+                  false
+                );
+              });
             });
-          });
-        },
-        callback
-      );
-    });
+          },
+          callback
+        );
+      } catch (err) {
+        callback(err);
+      }
+    })();
   });
 };

--- a/app/tests/setup.js
+++ b/app/tests/setup.js
@@ -1,0 +1,37 @@
+describe("setup", function () {
+  var async = require("async");
+  var config = require("config");
+  var client = require("models/client-new");
+  var setup = require("../setup");
+
+  it("uses mSetNX object argument shape for SSL bootstrap keys", function (done) {
+    spyOn(async, "series").and.callFake(function (tasks, callback) {
+      tasks[2](callback);
+    });
+
+    spyOn(client, "mSetNX").and.returnValue(Promise.resolve(1));
+
+    setup(function (err) {
+      expect(err).toBeFalsy();
+      expect(client.mSetNX).toHaveBeenCalledWith({
+        ["domain:" + config.host]: "X",
+        ["domain:www." + config.host]: "X",
+      });
+      done();
+    });
+  });
+
+  it("swallows bootstrap write rejection and still calls callback", function (done) {
+    spyOn(async, "series").and.callFake(function (tasks, callback) {
+      tasks[2](callback);
+    });
+
+    spyOn(client, "mSetNX").and.returnValue(Promise.reject(new Error("boom")));
+
+    setup(function (err) {
+      expect(err).toBeFalsy();
+      expect(client.mSetNX).toHaveBeenCalled();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

- Replace legacy `models/client` usage with the new promise-based `models/client-new` singleton across touched modules.  
- Use modern Redis command names/argument shapes (`sMembers`, `mGet`, `mSet`, `sAdd`, `mSetNX`, etc.) provided by the new client.  
- Preserve existing public callback signatures while moving internal Redis calls to `async/await` and ensure promise rejections are routed back through existing callbacks.

### Description

- Switched imports from `models/client` to `models/client-new` and modernized Redis calls in `app/sync/update/rebuildDependents.js`, replacing uppercase `SMEMBERS` with `sMembers` and wrapping the call in an internal `async/await` flow that forwards errors to the original callback.  
- Refactored `app/helper/transformer/index.js` to use `models/client-new` and modern command shapes: replaced `mget` with `mGet`, `smembers` with `sMembers`, and converted transaction usage to `multi()` with `sAdd`/`mSet`/`set` and awaited `exec()`; internal Promise rejections are converted to callback errors.  
- Updated bootstrap logic in `app/setup.js` to call `client.mSetNX` with the object-shaped argument expected by the new client and kept the same callback flow and error-swallowing behavior.  
- Updated test imports to `models/client-new` and added focused regression Jasmine specs: `app/sync/tests/rebuildDependents.js` to assert `sMembers` usage and rejection->callback propagation, and `app/tests/setup.js` to assert `mSetNX` argument shape and rejection handling.  

### Testing

- Ran `node --check` on the modified files (`app/sync/update/rebuildDependents.js`, `app/helper/transformer/index.js`, `app/setup.js`, `app/sync/tests/rebuildDependents.js`, `app/tests/setup.js`, `app/helper/transformer/tests/lookup.js`) and checks passed.  
- Added focused Jasmine specs in `app/sync/tests/rebuildDependents.js` and `app/tests/setup.js` for the migrated behaviors.  
- Attempted to run `npm test -- app/sync/tests/rebuildDependents.js`, but the project test harness requires Docker and `docker` is not available in this execution environment so the full test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2be1a5ab08329a13abbffeb19ed74)