### PR TITLE
Migrate Google Drive DB modules to models/client-new and modern Redis APIs

### DIFF
--- a/app/clients/google-drive/database/blog.js
+++ b/app/clients/google-drive/database/blog.js
@@ -1,14 +1,4 @@
-const { promisify } = require("util");
-
-// Redis client setup
-const client = require("models/client");
-
-const hsetAsync = promisify(client.hset).bind(client);
-const hgetallAsync = promisify(client.hgetall).bind(client);
-const delAsync = promisify(client.del).bind(client);
-const saddAsync = promisify(client.sadd).bind(client);
-const sremAsync = promisify(client.srem).bind(client);
-const smembersAsync = promisify(client.smembers).bind(client);
+const client = require("models/client-new");
 
 const PREFIX = require("./prefix");
 
@@ -38,31 +28,31 @@ const blog = {
     // Serialize and save fields
     for (const [field, value] of Object.entries(data)) {
       const serializedValue = JSON.stringify(value);
-      await hsetAsync(key, field, serializedValue);
+      await client.hSet(key, field, serializedValue);
     }
 
     // Add blog ID to the global set
-    await saddAsync(this._globalSetKey(), blogID);
+    await client.sAdd(this._globalSetKey(), blogID);
 
     // Manage serviceAccountId sets
     const newServiceAccountId = data.serviceAccountId;
     if (newServiceAccountId && newServiceAccountId !== currentServiceAccountId) {
       // Remove blog ID from the old serviceAccountId set
       if (currentServiceAccountId) {
-        await sremAsync(this._serviceAccountSetKey(currentServiceAccountId), blogID);
+        await client.sRem(this._serviceAccountSetKey(currentServiceAccountId), blogID);
       }
       // Add blog ID to the new serviceAccountId set
       if (newServiceAccountId) {
-        await saddAsync(this._serviceAccountSetKey(newServiceAccountId), blogID);
+        await client.sAdd(this._serviceAccountSetKey(newServiceAccountId), blogID);
       }
     }
   },
 
   async get(blogID) {
     const key = this._key(blogID);
-    const result = await hgetallAsync(key);
+    const result = await client.hGetAll(key);
 
-    if (!result) {
+    if (!result || !Object.keys(result).length) {
       return null;
     }
 
@@ -86,19 +76,19 @@ const blog = {
     const currentServiceAccountId = currentData?.serviceAccountId;
 
     // Remove the Redis hash
-    await delAsync(key);
+    await client.del(key);
 
     // Remove blog ID from the global set
-    await sremAsync(this._globalSetKey(), blogID);
+    await client.sRem(this._globalSetKey(), blogID);
 
     // Remove blog ID from the serviceAccountId set if it exists
     if (currentServiceAccountId) {
-      await sremAsync(this._serviceAccountSetKey(currentServiceAccountId), blogID);
+      await client.sRem(this._serviceAccountSetKey(currentServiceAccountId), blogID);
     }
   },
 
   async list() {
-    return await smembersAsync(this._globalSetKey());
+    return await client.sMembers(this._globalSetKey());
   },
 
   async iterate(callback) {
@@ -114,7 +104,7 @@ const blog = {
 
   async iterateByServiceAccountId(serviceAccountId, callback) {
     const setKey = this._serviceAccountSetKey(serviceAccountId);
-    const blogIDs = await smembersAsync(setKey);
+    const blogIDs = await client.sMembers(setKey);
 
 
     for (const blogID of blogIDs) {

--- a/app/clients/google-drive/database/channel.js
+++ b/app/clients/google-drive/database/channel.js
@@ -1,14 +1,4 @@
-const { promisify } = require("util");
-
-// Redis client setup
-const client = require("models/client");
-const hsetAsync = promisify(client.hset).bind(client);
-const hgetallAsync = promisify(client.hgetall).bind(client);
-const delAsync = promisify(client.del).bind(client);
-const saddAsync = promisify(client.sadd).bind(client);
-const sremAsync = promisify(client.srem).bind(client);
-const smembersAsync = promisify(client.smembers).bind(client);
-const sscanAsync = promisify(client.sscan).bind(client);
+const client = require("models/client-new");
 
 const PREFIX = require("./prefix");
 
@@ -42,26 +32,27 @@ const channel = {
 
     // Store each field of the data object in the Redis hash
     for (const [field, value] of Object.entries(data)) {
-      await hsetAsync(key, field, value); // Ensure value is a string
+      await client.hSet(key, field, value);
     }
 
     // Track the channel globally
-    await saddAsync(globalSetKey, channelId);
+    await client.sAdd(globalSetKey, channelId);
 
     // Track the channel under the serviceAccountId
-    await saddAsync(serviceAccountKey, channelId);
+    await client.sAdd(serviceAccountKey, channelId);
 
     // If this is a `files.watch` channel, associate it with the fileId
     if (type === "files.watch" && fileId) {
       const fileKey = this._fileKey(serviceAccountId, fileId);
-      await saddAsync(fileKey, channelId);
+      await client.sAdd(fileKey, channelId);
     }
   },
 
   // Retrieve a channel by its ID
   async get(channelId) {
     const key = this._key(channelId);
-    return await hgetallAsync(key);
+    const data = await client.hGetAll(key);
+    return data && Object.keys(data).length ? data : null;
   },
 
   // Delete a channel by its ID, untracking it globally and from its associations
@@ -77,37 +68,37 @@ const channel = {
 
     if (serviceAccountId) {
       const serviceAccountKey = this._serviceAccountKey(serviceAccountId);
-      await sremAsync(serviceAccountKey, channelId);
+      await client.sRem(serviceAccountKey, channelId);
 
       if (type === "files.watch" && fileId) {
         const fileKey = this._fileKey(serviceAccountId, fileId);
-        await sremAsync(fileKey, channelId);
+        await client.sRem(fileKey, channelId);
       }
     }
 
     // Remove the channel from Redis
-    await delAsync(key);
+    await client.del(key);
 
     // Remove the channel from the global channel set
-    await sremAsync(globalSetKey, channelId);
+    await client.sRem(globalSetKey, channelId);
   },
 
   // List all channels globally
   async list() {
     const globalSetKey = this._globalSetKey();
-    return await smembersAsync(globalSetKey);
+    return await client.sMembers(globalSetKey);
   },
 
   // List all channels associated with a serviceAccountId
   async listByServiceAccount(serviceAccountId) {
     const serviceAccountKey = this._serviceAccountKey(serviceAccountId);
-    return await smembersAsync(serviceAccountKey);
+    return await client.sMembers(serviceAccountKey);
   },
 
   // List all channels associated with a serviceAccountId and fileId
   async listByFile(serviceAccountId, fileId) {
     const fileKey = this._fileKey(serviceAccountId, fileId);
-    return await smembersAsync(fileKey);
+    return await client.sMembers(fileKey);
   },
 
   // Iterate over all channels globally
@@ -115,10 +106,10 @@ const channel = {
     const globalSetKey = this._globalSetKey();
     let cursor = "0";
     do {
-      const [nextCursor, channelIds] = await sscanAsync(globalSetKey, cursor);
+      const { cursor: nextCursor, members: channelIds } = await client.sScan(globalSetKey, cursor);
       for (const channelId of channelIds) {
         const data = await this.get(channelId);
-        if (data) {
+        if (data && Object.keys(data).length) {
           await callback(data);
         }
       }
@@ -131,10 +122,10 @@ const channel = {
     const serviceAccountKey = this._serviceAccountKey(serviceAccountId);
     let cursor = "0";
     do {
-      const [nextCursor, channelIds] = await sscanAsync(serviceAccountKey, cursor);
+      const { cursor: nextCursor, members: channelIds } = await client.sScan(serviceAccountKey, cursor);
       for (const channelId of channelIds) {
         const data = await this.get(channelId);
-        if (data) {
+        if (data && Object.keys(data).length) {
           await callback(data);
         }
       }
@@ -147,10 +138,10 @@ const channel = {
     const fileKey = this._fileKey(serviceAccountId, fileId);
     let cursor = "0";
     do {
-      const [nextCursor, channelIds] = await sscanAsync(fileKey, cursor);
+      const { cursor: nextCursor, members: channelIds } = await client.sScan(fileKey, cursor);
       for (const channelId of channelIds) {
         const data = await this.get(channelId);
-        if (data) {
+        if (data && Object.keys(data).length) {
           await callback(data);
         }
       }

--- a/app/clients/google-drive/database/folder.js
+++ b/app/clients/google-drive/database/folder.js
@@ -1,9 +1,4 @@
-const { promisify } = require("util");
-
-// Redis client setup
-const client = require("models/client");
-const hgetAsync = promisify(client.hget).bind(client);
-const hscanAsync = promisify(client.hscan).bind(client);
+const client = require("models/client-new");
 
 const PREFIX = require("./prefix");
 
@@ -12,7 +7,7 @@ function folder(folderId) {
   if (!folderId) {
     throw new Error("Folder ID is required");
   }
-  
+
   // Redis keys
   this.key = `${PREFIX}${folderId}:folder`; // ID ↔ Path mapping
   this.reverseKey = `${PREFIX}${folderId}:path`; // Path ↔ ID mapping
@@ -30,25 +25,25 @@ function folder(folderId) {
 
     const multi = client.multi(); // Start a Redis transaction
 
-    const previousPath = await hgetAsync(this.key, id);
+    const previousPath = await client.hGet(this.key, id);
     if (previousPath && previousPath !== path) {
       // Remove the old reverse mapping for the previous path
-      multi.hdel(this.reverseKey, previousPath);
+      multi.hDel(this.reverseKey, previousPath);
     }
 
-    const previousId = await hgetAsync(this.reverseKey, path);
+    const previousId = await client.hGet(this.reverseKey, path);
     if (previousId && previousId !== id) {
       // Remove the old mapping for the previous ID
-      multi.hdel(this.key, previousId);
+      multi.hDel(this.key, previousId);
     }
 
     // Add the new ID ↔ Path mapping
-    multi.hset(this.key, id, path);
-    multi.hset(this.reverseKey, path, id);
+    multi.hSet(this.key, id, path);
+    multi.hSet(this.reverseKey, path, id);
 
     // Update metadata if provided
     if (metadata && Object.keys(metadata).length > 0) {
-      multi.hset(this.metadataKey, id, JSON.stringify(metadata));
+      multi.hSet(this.metadataKey, id, JSON.stringify(metadata));
     }
 
     // Execute the transaction
@@ -58,18 +53,18 @@ function folder(folderId) {
   // Get the path for a given ID
   this.get = async (id) => {
     if (!id) return null;
-    return await hgetAsync(this.key, id);
+    return await client.hGet(this.key, id);
   };
 
   // Get the ID for a given path
   this.getByPath = async (path) => {
     if (!path) return null;
-    return await hgetAsync(this.reverseKey, path);
+    return await client.hGet(this.reverseKey, path);
   };
 
   // Get metadata for a given ID
   this.getMetadata = async (id) => {
-    const metadata = await hgetAsync(this.metadataKey, id);
+    const metadata = await client.hGet(this.metadataKey, id);
     return metadata ? JSON.parse(metadata) : null;
   };
 
@@ -100,10 +95,10 @@ function folder(folderId) {
       const metadata = (await this.getMetadata(id)) || {}; // Default to empty metadata
 
       // Remove old reverse mapping and add new mappings in transaction
-      multi.hdel(this.reverseKey, from);
-      multi.hset(this.reverseKey, to, id);
-      multi.hset(this.key, id, to);
-      multi.hset(this.metadataKey, id, JSON.stringify(metadata));
+      multi.hDel(this.reverseKey, from);
+      multi.hSet(this.reverseKey, to, id);
+      multi.hSet(this.key, id, to);
+      multi.hSet(this.metadataKey, id, JSON.stringify(metadata));
 
       movedPaths.push({ from, to });
 
@@ -117,12 +112,12 @@ function folder(folderId) {
     let cursor = START_CURSOR;
 
     do {
-      const [nextCursor, results] = await hscanAsync(this.key, cursor);
+      const { cursor: nextCursor, tuples } = await client.hScan(this.key, cursor);
       cursor = nextCursor;
 
-      for (let i = 0; i < results.length; i += 2) {
-        const currentId = results[i];
-        const currentPath = results[i + 1];
+      for (const entry of tuples) {
+        const currentId = entry.field;
+        const currentPath = entry.value;
 
         // Check if the current path is affected by the move
         if (currentPath === from || currentPath.startsWith(`${from}/`)) {
@@ -130,10 +125,10 @@ function folder(folderId) {
           const metadata = (await this.getMetadata(currentId)) || {}; // Default to empty metadata
 
           // Queue all changes in the transaction
-          multi.hdel(this.reverseKey, currentPath); // Remove old reverse mapping
-          multi.hset(this.reverseKey, newPath, currentId); // Add new reverse mapping
-          multi.hset(this.key, currentId, newPath); // Update the path mapping
-          multi.hset(this.metadataKey, currentId, JSON.stringify(metadata)); // Update metadata
+          multi.hDel(this.reverseKey, currentPath); // Remove old reverse mapping
+          multi.hSet(this.reverseKey, newPath, currentId); // Add new reverse mapping
+          multi.hSet(this.key, currentId, newPath); // Update the path mapping
+          multi.hSet(this.metadataKey, currentId, JSON.stringify(metadata)); // Update metadata
 
           movedPaths.push({ from: currentPath, to: newPath });
         }
@@ -150,8 +145,8 @@ function folder(folderId) {
   // Remove a file or folder and its children
   this.remove = async (id) => {
     const from = await this.get(id);
-    
-    if (!from) { 
+
+    if (!from) {
       console.log("Warning: No file or folder found for ID: ", id);
       return [];
     }
@@ -164,12 +159,12 @@ function folder(folderId) {
     let cursor = START_CURSOR;
 
     do {
-      const [nextCursor, results] = await hscanAsync(this.key, cursor);
+      const { cursor: nextCursor, tuples } = await client.hScan(this.key, cursor);
       cursor = nextCursor;
 
-      for (let i = 0; i < results.length; i += 2) {
-        const currentId = results[i];
-        const currentPath = results[i + 1];
+      for (const entry of tuples) {
+        const currentId = entry.field;
+        const currentPath = entry.value;
 
         // Check if the current path is affected by the removal
         if (
@@ -177,9 +172,9 @@ function folder(folderId) {
           currentPath === from ||
           currentPath.startsWith(`${from}/`)
         ) {
-          multi.hdel(this.key, currentId); // Delete ID ↔ Path mapping
-          multi.hdel(this.reverseKey, currentPath); // Delete Path ↔ ID mapping
-          multi.hdel(this.metadataKey, currentId); // Delete metadata
+          multi.hDel(this.key, currentId); // Delete ID ↔ Path mapping
+          multi.hDel(this.reverseKey, currentPath); // Delete Path ↔ ID mapping
+          multi.hDel(this.metadataKey, currentId); // Delete metadata
           removedPaths.push(currentPath);
         }
       }
@@ -214,12 +209,12 @@ function folder(folderId) {
 
     do {
       // Scan the folder key
-      const [nextCursor, results] = await hscanAsync(this.key, cursor);
+      const { cursor: nextCursor, tuples } = await client.hScan(this.key, cursor);
       cursor = nextCursor;
 
-      for (let i = 0; i < results.length; i += 2) {
-        const id = results[i];
-        const path = results[i + 1];
+      for (const entry of tuples) {
+        const id = entry.field;
+        const path = entry.value;
 
         // Check if the path is an immediate child of the given directory
         if (
@@ -246,12 +241,12 @@ function folder(folderId) {
     let results = [];
 
     do {
-      const [nextCursor, entries] = await hscanAsync(this.key, cursor);
+      const { cursor: nextCursor, tuples } = await client.hScan(this.key, cursor);
       cursor = nextCursor;
 
-      for (let i = 0; i < entries.length; i += 2) {
-        const id = entries[i];
-        const path = entries[i + 1];
+      for (const entry of tuples) {
+        const id = entry.field;
+        const path = entry.value;
         const metadata = await this.getMetadata(id);
         results.push({ id, path, metadata });
       }

--- a/app/clients/google-drive/database/serviceAccount.js
+++ b/app/clients/google-drive/database/serviceAccount.js
@@ -1,13 +1,4 @@
-const { promisify } = require("util");
-
-// Redis client setup
-const client = require("models/client");
-const hsetAsync = promisify(client.hset).bind(client);
-const hgetallAsync = promisify(client.hgetall).bind(client);
-const delAsync = promisify(client.del).bind(client);
-const saddAsync = promisify(client.sadd).bind(client);
-const sremAsync = promisify(client.srem).bind(client);
-const smembersAsync = promisify(client.smembers).bind(client);
+const client = require("models/client-new");
 
 const PREFIX = require("./prefix");
 
@@ -33,21 +24,21 @@ const serviceAccount = {
     // Serialize each field of the data object and store it in the Redis hash
     for (const [field, value] of Object.entries(data)) {
       const serializedValue = JSON.stringify(value); // Serialize value
-      await hsetAsync(key, field, serializedValue);
+      await client.hSet(key, field, serializedValue);
     }
   
     // Track the service account in the global set
-    await saddAsync(globalSetKey, serviceAccountId);
+    await client.sAdd(globalSetKey, serviceAccountId);
   },
   
   async get(serviceAccountId) {
     const key = this._key(serviceAccountId);
   
     // Retrieve all fields from the hash
-    const result = await hgetallAsync(key);
+    const result = await client.hGetAll(key);
   
     // Return null if the key does not exist
-    if (!result) {
+    if (!result || !Object.keys(result).length) {
       return null;
     }
   
@@ -68,13 +59,13 @@ const serviceAccount = {
   async delete(serviceAccountId) {
     const key = this._key(serviceAccountId);
     const globalSetKey = this._globalSetKey();
-    await delAsync(key);
-    await sremAsync(globalSetKey, serviceAccountId); // Remove from global service accounts set
+    await client.del(key);
+    await client.sRem(globalSetKey, serviceAccountId); // Remove from global service accounts set
   },
 
   async list() {
     const globalSetKey = this._globalSetKey();
-    return await smembersAsync(globalSetKey); // Fetch all service accounts from the set
+    return await client.sMembers(globalSetKey); // Fetch all service accounts from the set
   },
 
 };

--- a/app/clients/google-drive/database/tests/blog.js
+++ b/app/clients/google-drive/database/tests/blog.js
@@ -1,23 +1,13 @@
 describe("google drive database.blog", function () {
   const database = require("clients/google-drive/database");
-  const client = require("models/client");
+  const client = require("models/client-new");
   const prefix = require("clients/google-drive/database/prefix");
 
   afterEach(async function () {
-    const keys = await new Promise((resolve, reject) => {
-      client.keys(`${prefix}*`, (err, keys) => {
-        if (err) reject(err);
-        else resolve(keys);
-      });
-    });
+    const keys = await client.keys(`${prefix}*`);
 
     if (keys.length) {
-      await new Promise((resolve, reject) => {
-        client.del(keys, (err) => {
-          if (err) reject(err);
-          else resolve();
-        });
-      });
+      await client.del(keys);
     }
   });
 
@@ -398,15 +388,10 @@ describe("google drive database.blog", function () {
     await database.blog.store(blogID, { foo: "bar", serviceAccountId: null });
 
     // Ensure no serviceAccountId set contains the blog
-    const keys = await new Promise((resolve, reject) => {
-      client.keys(`${prefix}serviceAccountId:*`, (err, keys) => {
-        if (err) reject(err);
-        else resolve(keys);
-      });
-    });
+    const keys = await client.keys(`${prefix}serviceAccountId:*`);
 
     for (const key of keys) {
-      const serviceAccountBlogs = await client.smembers(key);
+      const serviceAccountBlogs = await client.sMembers(key);
       expect(serviceAccountBlogs).not.toContain(blogID);
     }
 
@@ -436,6 +421,15 @@ describe("google drive database.blog", function () {
     });
 
     expect(updatedBlogIDs).toContain(blogID);
+  });
+
+
+
+  it("propagates client-new promise failures", async function () {
+    const error = new Error("boom");
+    spyOn(client, "hSet").and.returnValue(Promise.reject(error));
+
+    await expectAsync(database.blog.store("blog_failure", { foo: "bar" })).toBeRejectedWith(error);
   });
 
 });

--- a/app/clients/google-drive/database/tests/channel.js
+++ b/app/clients/google-drive/database/tests/channel.js
@@ -1,17 +1,16 @@
 describe("google drive database.channel", function () {
   const database = require("clients/google-drive/database");
-  const client = require("models/client");
+  const client = require("models/client-new");
   const prefix = require("clients/google-drive/database/prefix");
 
   const channel = database.channel;
 
   // Before each test, clear all Redis data with the matching prefix
-  afterEach(function (done) {
-    client.keys(`${prefix}*`, async function (err, keys) {
-      if (err) return done(err);
-      if (!keys.length) return done();
-      client.del(keys, done);
-    });
+  afterEach(async function () {
+    const keys = await client.keys(`${prefix}*`);
+    if (keys.length) {
+      await client.del(keys);
+    }
   });
 
   it("can create and retrieve a changes.watch channel", async function () {
@@ -372,4 +371,18 @@ describe("google drive database.channel", function () {
     );
     expect(result).toEqual(expected);
   });
+
+
+  it("propagates client-new promise failures", async function () {
+    const error = new Error("boom");
+    spyOn(client, "hSet").and.returnValue(Promise.reject(error));
+
+    await expectAsync(channel.store("channel_failure", {
+      type: "changes.watch",
+      serviceAccountId: "service_account_1",
+      resourceId: "resource_failure",
+      url: "https://example.com",
+    })).toBeRejectedWith(error);
+  });
+
 });

--- a/app/clients/google-drive/database/tests/folder.js
+++ b/app/clients/google-drive/database/tests/folder.js
@@ -1,6 +1,6 @@
 describe("folder module", function () {
   const folderModule = require("clients/google-drive/database/folder");
-  const client = require("models/client");
+  const client = require("models/client-new");
   const prefix = require("clients/google-drive/database/prefix");
 
   let folder;
@@ -11,12 +11,11 @@ describe("folder module", function () {
   });
 
   // Clear Redis data after each test
-  afterEach(function (done) {
-    client.keys(`${prefix}*`, async function (err, keys) {
-      if (err) return done(err);
-      if (!keys.length) return done();
-      client.del(keys, done);
-    });
+  afterEach(async function () {
+    const keys = await client.keys(`${prefix}*`);
+    if (keys.length) {
+      await client.del(keys);
+    }
   });
 
   it("can set and get a mapping (ID → Path)", async function () {
@@ -395,7 +394,7 @@ describe("folder module", function () {
     const path = "/folder/file1.txt";
   
     // Corrupt metadata in Redis
-    await client.hset(`${prefix}test_folder:metadata`, id, "corrupted_metadata_string");
+    await client.hSet(`${prefix}test_folder:metadata`, id, "corrupted_metadata_string");
   
     try {
       await folder.getMetadata(id);
@@ -532,7 +531,7 @@ describe("folder module", function () {
     await folder.set(id2, path2);
   
     // Manually remove some Redis data
-    await client.hdel(`${prefix}test_folder:path`, path1);
+    await client.hDel(`${prefix}test_folder:path`, path1);
   
     await folder.reset();
   
@@ -740,4 +739,13 @@ describe("folder module", function () {
     const entriesLowerCase = await folder.readdir(basePath.toLowerCase());
     expect(entriesLowerCase).toEqual([]); // Should not match a case-sensitive path
   });
+
+
+  it("propagates client-new promise failures", async function () {
+    const error = new Error("boom");
+    spyOn(client, "hSet").and.returnValue(Promise.reject(error));
+
+    await expectAsync(folder.set("file_failure", "/folder/failure.txt")).toBeRejectedWith(error);
+  });
+
 });

--- a/app/clients/google-drive/database/tests/serviceAccount.js
+++ b/app/clients/google-drive/database/tests/serviceAccount.js
@@ -1,15 +1,14 @@
 describe("serviceAccount module", function () {
     const serviceAccount = require("clients/google-drive/database/serviceAccount");
-    const client = require("models/client");
+    const client = require("models/client-new");
     const prefix = require("clients/google-drive/database/prefix");
   
     // Before each test, clear all Redis data with the matching prefix
-    afterEach(function (done) {
-      client.keys(`${prefix}*`, async function (err, keys) {
-        if (err) return done(err);
-        if (!keys.length) return done();
-        client.del(keys, done);
-      });
+    afterEach(async function () {
+      const keys = await client.keys(`${prefix}*`);
+      if (keys.length) {
+        await client.del(keys);
+      }
     });
   
     it("can store and retrieve a service account", async function () {
@@ -83,4 +82,15 @@ describe("serviceAccount module", function () {
       const serviceAccounts = await serviceAccount.list();
       expect(serviceAccounts).not.toContain(nonExistentServiceAccountId);
     });
-  });
+  
+
+    it("propagates client-new promise failures", async function () {
+      const error = new Error("boom");
+      spyOn(client, "hSet").and.returnValue(Promise.reject(error));
+
+      await expectAsync(serviceAccount.store("service_account_failure", {
+        email: "service_account_failure@example.com",
+      })).toBeRejectedWith(error);
+    });
+
+});


### PR DESCRIPTION
### Motivation
- Move Google Drive database modules off callback-style `models/client` with `promisify` onto the promise-based `models/client-new` API and modern Redis method names. 
- Update call shapes (hash/set/key/scan/transaction) to the newer clients while preserving existing key names and data model composed via `PREFIX` helpers.

### Description
- Replaced `models/client` + `promisify` usage with `require('models/client-new')` in `blog`, `channel`, `folder`, and `serviceAccount` modules and updated calls to `client.hSet/hGet/hGetAll/hDel/hScan`, `client.sAdd/sRem/sMembers/sScan`, and `client.del`. 
- Updated `folder` to keep atomic operations via `multi().exec()` but using `client.multi()` and modern `hSet/hDel` etc, and converted hscan iterations to the new `hScan` return shape (`{ cursor, tuples }` with tuple field/value objects). 
- Adjusted `channel` iteration code to use `sScan` with the `{ cursor, members }` shape and normalized `get`/`getAll` return handling to return `null` for empty hashes. 
- Updated tests in `app/clients/google-drive/database/tests/*.js` to require `models/client-new`, use promise-style `client.keys`/`client.del` cleanup (removed callback wrappers), swapped legacy `client.hset/hdel/smembers` calls to modern method names, and added explicit tests that mock `client-new` methods to assert promise rejections are propagated.

### Testing
- Performed syntax checks with `node -c` on updated modules and test files which passed. 
- Attempted to run the test suite via the project test script (`npm test -- app/clients/google-drive/database/tests`) but the environment cannot run Docker, so the full automated test run failed with `docker: command not found`. 
- Added focused unit tests to each test file that mock `client-new` promise failures to validate error propagation; these files were updated and are syntax-checked in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2be265e44832980c7453d92b89bf0)