### PR TITLE
Add script-level Redis helper and migrate scripts to use dedicated redis-new clients

### DIFF
--- a/scripts/blog/purge-entry-database.js
+++ b/scripts/blog/purge-entry-database.js
@@ -1,7 +1,7 @@
 const colors = require("colors/safe");
 const getBlog = require("../get/blog");
 const redisKeys = require("../util/redisKeys");
-const client = require("models/client");
+const createRedisClient = require("../util/createRedisClient");
 const getConfirmation = require("../util/getConfirmation");
 
 const ENTRY_LISTS = [
@@ -14,7 +14,7 @@ const ENTRY_LISTS = [
   "deleted",
 ];
 
-async function collectKeys(blog) {
+async function collectKeys(blog, client) {
   const blogPrefix = `blog:${blog.id}:`;
   const patterns = [
     ...ENTRY_LISTS.map((list) => `${blogPrefix}${list}`),
@@ -31,69 +31,64 @@ async function collectKeys(blog) {
   const keys = new Set();
 
   for (const pattern of patterns) {
-    await redisKeys(pattern, async (key) => {
-      if (key.startsWith(blogPrefix)) {
-        keys.add(key);
-      }
-    });
+    await redisKeys(
+      pattern,
+      async (key) => {
+        if (key.startsWith(blogPrefix)) keys.add(key);
+      },
+      client
+    );
   }
 
   return Array.from(keys);
 }
 
-async function main(blog) {
-  try {
-    const keys = await collectKeys(blog);
+async function main(blog, client) {
+  const keys = await collectKeys(blog, client);
 
-    if (!keys.length) {
-      console.log(colors.yellow("No keys to delete."));
-      return;
-    }
-
-    console.log(colors.cyan("Found the following keys:"));
-    console.log(JSON.stringify(keys, null, 2));
-
-    const confirmed = await getConfirmation(
-      `Delete ${keys.length} keys`
-    );
-
-    if (!confirmed) {
-      console.log(colors.yellow("Aborted without deleting any keys."));
-      return;
-    }
-
-    await new Promise((resolve, reject) => {
-      const multi = client.multi();
-      multi.del(keys);
-      multi.exec((err, results) => {
-        if (err) return reject(err);
-
-        const deleted = Array.isArray(results)
-          ? results.reduce((sum, value) => sum + (Array.isArray(value) ? value[1] : 0), 0)
-          : 0;
-        console.log(
-          colors.green(
-            `Deleted ${keys.length} keys for blog ${blog.id}. Redis removed ${deleted} keys.`
-          )
-        );
-        resolve();
-      });
-    });
-  } catch (err) {
-    throw err;
+  if (!keys.length) {
+    console.log(colors.yellow("No keys to delete."));
+    return;
   }
+
+  console.log(colors.cyan("Found the following keys:"));
+  console.log(JSON.stringify(keys, null, 2));
+
+  const confirmed = await getConfirmation(`Delete ${keys.length} keys`);
+
+  if (!confirmed) {
+    console.log(colors.yellow("Aborted without deleting any keys."));
+    return;
+  }
+
+  const replies = await client.multi([["DEL", ...keys]]).exec();
+  const deleted = Array.isArray(replies)
+    ? replies.reduce((sum, value) => sum + (typeof value === "number" ? value : 0), 0)
+    : 0;
+
+  console.log(
+    colors.green(
+      `Deleted ${keys.length} keys for blog ${blog.id}. Redis removed ${deleted} keys.`
+    )
+  );
 }
 
 if (require.main === module) {
   getBlog(process.argv[2], function (err, user, blog) {
     if (err) throw err;
 
-    main(blog)
-      .then(() => process.exit())
-      .catch((error) => {
+    (async () => {
+      const { client, close } = await createRedisClient();
+      try {
+        await main(blog, client);
+        await close();
+        process.exit(0);
+      } catch (error) {
         console.error(colors.red("Error:", error.message));
+        await close();
         process.exit(1);
-      });
+      }
+    })();
   });
 }
 

--- a/scripts/blog/rebuild/wipe-search-index.js
+++ b/scripts/blog/rebuild/wipe-search-index.js
@@ -2,25 +2,29 @@ var colors = require("colors/safe");
 var get = require("../../get/blog");
 var Keys = require("../../db/keys");
 var keysToDelete = [];
-var client = require("client");
+var createRedisClient = require("../../util/createRedisClient");
 var getConfirmation = require("../util/getConfirmation");
 
 if (require.main === module) {
   get(process.argv[2], function (err, user, blog) {
     if (err) throw err;
 
-    main(blog, function (err) {
-      if (err) {
-        console.error(colors.red("Error:", err.message));
-        return process.exit(1);
-      }
-      process.exit();
-    });
+    (async function () {
+      var redis = await createRedisClient();
+      main(redis.client, blog, async function (err) {
+        if (err) {
+          console.error(colors.red("Error:", err.message));
+          await redis.close();
+          return process.exit(1);
+        }
+        await redis.close();
+        process.exit();
+      });
+    })();
   });
 }
 
-function main(blog, callback) {
-  var multi = client.multi();
+function main(client, blog, callback) {
   Keys(
     `blog:${blog.id}:search:*`,
     function (keys, next) {
@@ -28,20 +32,23 @@ function main(blog, callback) {
       next();
     },
     function (err) {
-      if (err) throw err;
+      if (err) return callback(err);
       if (!keysToDelete.length) {
         console.log("No keys to delete");
-        process.exit();
+        return callback();
       }
       console.log(JSON.stringify(keysToDelete, null, 2));
-      getConfirmation(
-        "Delete " + keysToDelete.length + " keys? (y/n)",
-        function (err, ok) {
-          if (!ok) return callback();
-          multi.del(keysToDelete);
-          multi.exec(callback);
-        }
-      );
+      getConfirmation("Delete " + keysToDelete.length + " keys? (y/n)", function (err, ok) {
+        if (err) return callback(err);
+        if (!ok) return callback();
+
+        client
+          .multi([["DEL", ...keysToDelete]])
+          .exec()
+          .then(function () {
+            callback();
+          }, callback);
+      });
     }
   );
 }

--- a/scripts/blog/reset-ssl-certificate-for-expired-domain.js
+++ b/scripts/blog/reset-ssl-certificate-for-expired-domain.js
@@ -2,7 +2,7 @@ const request = require("request");
 const fs = require("fs-extra");
 const CERT_DIR = "/etc/resty-auto-ssl/letsencrypt/certs";
 const get = require("../get/blog");
-const client = require("client");
+const createRedisClient = require("../util/createRedisClient");
 const exec = require("child_process").exec;
 const nginx = "/usr/local/openresty/bin/openresty";
 var getConfirmation = require("../util/getConfirmation");
@@ -13,45 +13,68 @@ var getConfirmation = require("../util/getConfirmation");
 if (!(process.getuid && process.getuid() === 0))
   throw new Error("This script must be run as root");
 
-get(process.argv[2], function (err, user, blog) {
-  const domain = blog.domain;
-
-  if (!domain) throw new Error("blog does not have a domain");
-
-  const secureURL = `https://${domain}`;
-  const startsWithWWW = domain.indexOf("www.") === 0;
-  const domainWithoutWWW = startsWithWWW ? domain.slice("www.".length) : domain;
-  const domainWithWWW = startsWithWWW ? domain : "www." + domain;
-
-  const certKeys = [
-    `ssl:${domainWithoutWWW}:latest`,
-    `ssl:${domainWithWWW}:latest`,
-  ];
-
-  const certDirs = [
-    `${CERT_DIR}/${domainWithWWW}`,
-    `${CERT_DIR}/${domainWithoutWWW}`,
-  ];
-
-  console.log("secureURL", secureURL);
-  console.log("domainWithWWW:", domainWithWWW);
-  console.log("domainWithoutWWW:", domainWithoutWWW);
-  console.log("Keys to drop:", certKeys);
-  console.log("Directories to remove:", certDirs);
-
-  getConfirmation("Proceed? (y/n)", function (err, ok) {
-    if (!ok) throw "Not ok!";
-
-    client.del(certKeys, function (err) {
-      if (err) throw err;
-
-      console.log("removed redis keys", certKeys);
-      console.log("You need to remove the directories manually");
-      certDirs.forEach((dir) => {
-        console.log("rm -rf", dir);
-      });
-      console.log("You need to restart nginx manually");
-      console.log("sudo", nginx, "-s reload");
+function confirm(message) {
+  return new Promise(function (resolve, reject) {
+    getConfirmation(message, function (err, ok) {
+      if (err) return reject(err);
+      resolve(ok);
     });
   });
-});
+}
+
+if (require.main === module) {
+  get(process.argv[2], function (err, user, blog) {
+    if (err) throw err;
+
+    (async () => {
+      const { client, close } = await createRedisClient();
+
+      try {
+        const domain = blog.domain;
+
+        if (!domain) throw new Error("blog does not have a domain");
+
+        const secureURL = `https://${domain}`;
+        const startsWithWWW = domain.indexOf("www.") === 0;
+        const domainWithoutWWW = startsWithWWW ? domain.slice("www.".length) : domain;
+        const domainWithWWW = startsWithWWW ? domain : "www." + domain;
+
+        const certKeys = [
+          `ssl:${domainWithoutWWW}:latest`,
+          `ssl:${domainWithWWW}:latest`,
+        ];
+
+        const certDirs = [
+          `${CERT_DIR}/${domainWithWWW}`,
+          `${CERT_DIR}/${domainWithoutWWW}`,
+        ];
+
+        console.log("secureURL", secureURL);
+        console.log("domainWithWWW:", domainWithWWW);
+        console.log("domainWithoutWWW:", domainWithoutWWW);
+        console.log("Keys to drop:", certKeys);
+        console.log("Directories to remove:", certDirs);
+
+        const ok = await confirm("Proceed? (y/n)");
+        if (!ok) throw new Error("Not ok!");
+
+        await client.del(certKeys);
+
+        console.log("removed redis keys", certKeys);
+        console.log("You need to remove the directories manually");
+        certDirs.forEach((dir) => {
+          console.log("rm -rf", dir);
+        });
+        console.log("You need to restart nginx manually");
+        console.log("sudo", nginx, "-s reload");
+
+        await close();
+        process.exit(0);
+      } catch (error) {
+        console.error(error);
+        await close();
+        process.exit(1);
+      }
+    })();
+  });
+}

--- a/scripts/db/migrate-rendered-output-to-disk.js
+++ b/scripts/db/migrate-rendered-output-to-disk.js
@@ -15,7 +15,7 @@
 const eachTemplate = require("../each/template");
 const getMetadata = require("models/template/getMetadata");
 const Blog = require("models/blog");
-const client = require("models/client");
+const createRedisClient = require("../util/createRedisClient");
 const key = require("models/template/key");
 const redisKeys = require("../util/redisKeys");
 const { promisify } = require("util");
@@ -27,8 +27,6 @@ const config = require("config");
 const RENDERED_OUTPUT_BASE_DIR = path.join(config.data_directory, "cdn", "template");
 
 const getMetadataAsync = promisify(getMetadata);
-const getAsync = promisify(client.get).bind(client);
-const delAsync = promisify(client.del).bind(client);
 const blogSetAsync = promisify(Blog.set);
 
 function getRenderedOutputPath(hash, viewName) {
@@ -58,14 +56,14 @@ async function readRenderedOutputFromDisk(hash, viewName) {
   return await fs.readFile(filePath, "utf8");
 }
 
-async function migrateHash(hash, viewName) {
+async function migrateHash(client, hash, viewName) {
   // Validate hash format (should be 32 hex characters)
   if (!/^[a-f0-9]{32}$/.test(hash)) {
     return false;
   }
 
   const redisKey = key.renderedOutput(hash);
-  const redisContent = await getAsync(redisKey);
+  const redisContent = await client.get(redisKey);
 
   if (redisContent == null) return false; // already migrated (null or undefined, but empty strings are valid)
 
@@ -78,7 +76,7 @@ async function migrateHash(hash, viewName) {
 
     if (diskContent === redisContent) {
       // Content matches, safe to delete from Redis
-      await delAsync(redisKey);
+      await client.del(redisKey);
       return false; // Already migrated, just cleaned up Redis
     } else {
       // Content differs, log warning but proceed with migration
@@ -99,12 +97,12 @@ async function migrateHash(hash, viewName) {
   }
 
   // Delete from Redis
-  await delAsync(redisKey);
+  await client.del(redisKey);
 
   return true; // Successfully migrated
 }
 
-async function migrate() {
+async function migrate(client) {
   console.log("Starting migration of rendered output from Redis to disk...");
   console.log("Iterating over all templates to find referenced hashes...\n");
 
@@ -152,7 +150,7 @@ async function migrate() {
             expectedHashes.add(hash);
 
             try {
-              const wasMigrated = await migrateHash(hash, viewName);
+              const wasMigrated = await migrateHash(client, hash, viewName);
               if (wasMigrated) {
                 migratedHashes++;
                 templateMigrated = true;
@@ -170,7 +168,9 @@ async function migrate() {
                 view: viewName,
                 hash: hash,
                 error: err.message,
-              });
+                },
+    client
+  );
             }
           }
 
@@ -191,7 +191,9 @@ async function migrate() {
                 template: template.id,
                 blog: blog.id,
                 error: `Failed to update cacheID: ${err.message}`,
-              });
+                },
+    client
+  );
             }
           }
 
@@ -253,8 +255,10 @@ async function migrate() {
   const remainingKeys = [];
   const unexpectedKeys = [];
   
-  await redisKeys("cdn:rendered:*", async (redisKey) => {
-    const hash = redisKey.replace("cdn:rendered:", "");
+  await redisKeys(
+    "cdn:rendered:*",
+    async (redisKey) => {
+      const hash = redisKey.replace("cdn:rendered:", "");
     
     if (expectedHashes.has(hash)) {
       // This hash should have been migrated but is still in Redis
@@ -282,7 +286,7 @@ async function migrate() {
     for (const hash of remainingKeys) {
       try {
         const redisKey = key.renderedOutput(hash);
-        const redisContent = await getAsync(redisKey);
+        const redisContent = await client.get(redisKey);
         if (redisContent === "") {
           // Find the viewName for this hash from the templates we processed
           // We need to search through templates to find which viewName this hash belongs to
@@ -313,7 +317,7 @@ async function migrate() {
     for (const hash of unexpectedKeys) {
       try {
         const redisKey = key.renderedOutput(hash);
-        await delAsync(redisKey);
+        await client.del(redisKey);
         orphanedPurged++;
         
         if (orphanedPurged % 100 === 0) {
@@ -350,14 +354,18 @@ async function migrate() {
 }
 
 if (require.main === module) {
-  migrate()
-    .then((exitCode) => {
+  (async () => {
+    const { client, close } = await createRedisClient();
+    try {
+      const exitCode = await migrate(client);
+      await close();
       process.exit(exitCode);
-    })
-    .catch((err) => {
+    } catch (err) {
       console.error("Migration failed:", err);
+      await close();
       process.exit(1);
-    });
+    }
+  })();
 }
 
 module.exports = migrate;

--- a/scripts/db/remove-legacy-tag-set-keys.js
+++ b/scripts/db/remove-legacy-tag-set-keys.js
@@ -1,37 +1,39 @@
 const colors = require("colors/safe");
-const client = require("models/client");
 const redisKeys = require("../util/redisKeys");
+const createRedisClient = require("../util/createRedisClient");
 const getConfirmation = require("../util/getConfirmation");
 
 const LEGACY_PATTERN = "blog:*:tags:entries:*";
 const KEY_FORMAT = /^blog:([^:]+):tags:entries:(.+)$/;
 const DELETE_BATCH_SIZE = 500;
 
-async function collectLegacyKeys(blogID) {
-  const pattern = blogID
-    ? `blog:${blogID}:tags:entries:*`
-    : LEGACY_PATTERN;
+async function collectLegacyKeys(blogID, client) {
+  const pattern = blogID ? `blog:${blogID}:tags:entries:*` : LEGACY_PATTERN;
 
   const keysByBlog = new Map();
 
-  await redisKeys(pattern, async (key) => {
-    if (!KEY_FORMAT.test(key)) return;
+  await redisKeys(
+    pattern,
+    async (key) => {
+      if (!KEY_FORMAT.test(key)) return;
 
-    const [, id] = key.match(KEY_FORMAT) || [];
+      const [, id] = key.match(KEY_FORMAT) || [];
 
-    if (!id) return;
+      if (!id) return;
 
-    if (blogID && id !== blogID) return;
+      if (blogID && id !== blogID) return;
 
-    if (!keysByBlog.has(id)) keysByBlog.set(id, []);
-    keysByBlog.get(id).push(key);
-  });
+      if (!keysByBlog.has(id)) keysByBlog.set(id, []);
+      keysByBlog.get(id).push(key);
+    },
+    client
+  );
 
   return keysByBlog;
 }
 
-async function removeLegacyTagSetKeys(blogID) {
-  const keysByBlog = await collectLegacyKeys(blogID);
+async function removeLegacyTagSetKeys(blogID, client) {
+  const keysByBlog = await collectLegacyKeys(blogID, client);
   const allKeys = Array.from(keysByBlog.values()).flat();
 
   if (!allKeys.length) {
@@ -41,15 +43,11 @@ async function removeLegacyTagSetKeys(blogID) {
 
   console.log(colors.cyan("Found legacy tag set keys:"));
   keysByBlog.forEach((keys, id) => {
-    console.log(
-      colors.yellow(`- blog:${id} (${keys.length} keys)`)
-    );
+    console.log(colors.yellow(`- blog:${id} (${keys.length} keys)`));
   });
 
   const confirmed = await getConfirmation(
-    `Delete ${allKeys.length} legacy tag set key${
-      allKeys.length === 1 ? "" : "s"
-    }?`
+    `Delete ${allKeys.length} legacy tag set key${allKeys.length === 1 ? "" : "s"}?`
   );
 
   if (!confirmed) {
@@ -61,32 +59,16 @@ async function removeLegacyTagSetKeys(blogID) {
 
   for (let i = 0; i < allKeys.length; i += DELETE_BATCH_SIZE) {
     const batchKeys = allKeys.slice(i, i + DELETE_BATCH_SIZE);
-
-    const batchDeleted = await new Promise((resolve, reject) => {
-      const multi = client.multi();
-      batchKeys.forEach((key) => multi.del(key));
-      multi.exec((err, results) => {
-        if (err) return reject(err);
-
-        const deleted = Array.isArray(results)
-          ? results.reduce(
-              (sum, value) => sum + (typeof value === "number" ? value : 0),
-              0
-            )
-          : 0;
-
-        resolve(deleted);
-      });
-    });
-
+    const replies = await client.multi(batchKeys.map((key) => ["DEL", key])).exec();
+    const batchDeleted = Array.isArray(replies)
+      ? replies.reduce((sum, value) => sum + (typeof value === "number" ? value : 0), 0)
+      : 0;
     totalDeleted += batchDeleted;
   }
 
   console.log(
     colors.green(
-      `Deleted ${allKeys.length} key${
-        allKeys.length === 1 ? "" : "s"
-      }. Redis removed ${totalDeleted} key${totalDeleted === 1 ? "" : "s"}.`
+      `Deleted ${allKeys.length} key${allKeys.length === 1 ? "" : "s"}. Redis removed ${totalDeleted} key${totalDeleted === 1 ? "" : "s"}.`
     )
   );
 }
@@ -94,12 +76,18 @@ async function removeLegacyTagSetKeys(blogID) {
 if (require.main === module) {
   const blogID = process.argv[2];
 
-  removeLegacyTagSetKeys(blogID)
-    .then(() => process.exit())
-    .catch((error) => {
+  (async () => {
+    const { client, close } = await createRedisClient();
+    try {
+      await removeLegacyTagSetKeys(blogID, client);
+      await close();
+      process.exit(0);
+    } catch (error) {
       console.error(colors.red("Error:", error.message));
+      await close();
       process.exit(1);
-    });
+    }
+  })();
 }
 
 module.exports = removeLegacyTagSetKeys;

--- a/scripts/db/remove-metadata-model-keys.js
+++ b/scripts/db/remove-metadata-model-keys.js
@@ -3,11 +3,9 @@
 // return "blog:" + blogID + ":folder:" + pathNormalizer(path);
 
 const keys = require("../util/redisKeys");
-const client = require("models/client");
-const { promisify } = require("util");
-const del = promisify(client.del).bind(client);
+const createRedisClient = require("../util/createRedisClient");
 
-const main = async () => {
+const main = async (client) => {
   const pattern = "blog:*:folder:*";
   await keys(pattern, async (key) => {
     // match alphanumieric characters and underscores between blog: and :folder
@@ -33,18 +31,22 @@ const main = async () => {
     }
 
     console.log("Deleting", key);
-    await del(key);
+    await client.del(key);
   });
 };
 
 if (require.main === module) {
-  main()
-    .then(() => {
+  (async () => {
+    const { client, close } = await createRedisClient();
+    try {
+      await main(client);
       console.log("Processed all keys");
+      await close();
       process.exit(0);
-    })
-    .catch((err) => {
+    } catch (err) {
       console.error(err);
+      await close();
       process.exit(1);
-    });
+    }
+  })();
 }

--- a/scripts/email/newsletter.js
+++ b/scripts/email/newsletter.js
@@ -1,7 +1,7 @@
 var send = require("helper/email").send;
 var letter = process.argv[2];
 var fs = require("fs");
-var client = require("models/client");
+var createRedisClient = require("../util/createRedisClient");
 var async = require("async");
 
 if (!letter) {
@@ -14,27 +14,37 @@ if (!letter) {
   process.exit();
 }
 
-main(letter, function (err) {
-  if (err) throw err;
+(async function () {
+  var redis = await createRedisClient();
+  main(redis.client, letter, async function (err) {
+    if (err) {
+      console.error(err);
+      await redis.close();
+      process.exit(1);
+    }
 
-  console.log("All emails delivered!");
-  process.exit();
-});
+    console.log("All emails delivered!");
+    await redis.close();
+    process.exit();
+  });
+})();
 
-function main(letter, callback) {
+function main(client, letter, callback) {
   var emailPath = __dirname + "/../../app/helper/email/newsletters/" + letter;
 
   if (!fs.statSync(emailPath).isFile())
     return callback(new Error("Not a file"));
 
-  getAllSubscribers(function (err, emails) {
+  getAllSubscribers(client, function (err, emails) {
     if (err) return callback(err);
 
     console.log(
       "Sending " + letter + " out to " + emails.length + " subscribers"
     );
 
-    async.filter(emails, alreadySent, function (err, emails) {
+    async.filter(emails, function (email, done) {
+      alreadySent(client, email, done);
+    }, function (err, emails) {
       if (err) return callback(err);
 
       // When we want to preview a newsletter before it goes out
@@ -60,11 +70,11 @@ function main(letter, callback) {
   });
 }
 
-function getAllSubscribers(callback) {
+function getAllSubscribers(client, callback) {
   client.smembers("newsletter:list", callback);
 }
 
-function alreadySent(email, done) {
+function alreadySent(client, email, done) {
   client.sismember("newsletter:letter:" + letter, email, function (
     err,
     member

--- a/scripts/entry/wipe-image-and-thumbnail-cache.js
+++ b/scripts/entry/wipe-image-and-thumbnail-cache.js
@@ -1,31 +1,39 @@
 var get = require("../get/entry");
-var client = require("models/client");
+var createRedisClient = require("../util/createRedisClient");
 var async = require("async");
 
 if (require.main === module) {
-  main(process.argv[2], function (err) {
-    if (err) throw err;
-    console.log("Done!");
-    process.exit();
-  });
+  (async function () {
+    var redis = await createRedisClient();
+    main(redis.client, process.argv[2], async function (err) {
+      if (err) {
+        console.error(err);
+        await redis.close();
+        process.exit(1);
+      }
+      console.log("Done!");
+      await redis.close();
+      process.exit();
+    });
+  })();
 }
 
-function main(url, callback) {
+function main(client, url, callback) {
   console.log("Looking up", url);
   get(url, function (err, user, blog, entry) {
     if (err) return callback(err);
 
     console.log("Wiping thumbnails for", entry.path);
-    thumbnails(blog, entry, function (err) {
+    thumbnails(client, blog, entry, function (err) {
       if (err) return callback(err);
 
       console.log("Wiping image cache for", entry.path);
-      imageCache(blog, entry, callback);
+      imageCache(client, blog, entry, callback);
     });
   });
 }
 
-function imageCache(blog, entry, callback) {
+function imageCache(client, blog, entry, callback) {
   if (!entry.thumbnail.small || !entry.thumbnail.small.name) return callback();
 
   var set = "blog:" + blog.id + ":store:image-cache:everything";
@@ -61,7 +69,7 @@ function imageCache(blog, entry, callback) {
   });
 }
 
-function thumbnails(blog, entry, callback) {
+function thumbnails(client, blog, entry, callback) {
   if (!entry.thumbnail.small || !entry.thumbnail.small.name) return callback();
 
   var set = "blog:" + blog.id + ":store:thumbnails:everything";

--- a/scripts/google-drive/delete-keys.js
+++ b/scripts/google-drive/delete-keys.js
@@ -1,43 +1,50 @@
-const keys = require("../db/keys");
-const client = require("client");
+const redisKeys = require("../util/redisKeys");
+const createRedisClient = require("../util/createRedisClient");
 
 const MATCH = "clients:google-drive:*";
 
-function main(callback) {
-
+async function main(client) {
   console.log("Searching '" + MATCH + "'");
 
-  keys(
+  const foundKeys = [];
+
+  await redisKeys(
     MATCH,
-    async (keys, next) => {
-        if (!keys.length) return next();
-
-        console.log();
-        console.log("Found", keys.length, "keys");
-
-        for (const key of keys) {
-
-            if (!key.startsWith("clients:google-drive:")) {
-                console.log("Skipping", key);
-                continue;
-            }
-
-            console.log("Deleting", key);
-            await client.del(key);
-        }
-
-        next();
+    async (key) => {
+      foundKeys.push(key);
     },
-    callback
+    client
   );
+
+  if (!foundKeys.length) return;
+
+  console.log();
+  console.log("Found", foundKeys.length, "keys");
+
+  for (const key of foundKeys) {
+    if (!key.startsWith("clients:google-drive:")) {
+      console.log("Skipping", key);
+      continue;
+    }
+
+    console.log("Deleting", key);
+    await client.del(key);
+  }
 }
 
 if (require.main === module) {
-  main(function (err) {
-    if (err) throw err;
-
-    console.log("Done!");
-    console.log();
-    process.exit();
-  });
+  (async () => {
+    const { client, close } = await createRedisClient();
+    try {
+      await main(client);
+      console.log("Done!");
+      console.log();
+      await close();
+      process.exit(0);
+    } catch (err) {
+      console.error(err);
+      await close();
+      process.exit(1);
+    }
+  })();
 }

--- a/scripts/template/ensure-cdn-files-on-disk.js
+++ b/scripts/template/ensure-cdn-files-on-disk.js
@@ -2,15 +2,13 @@ const { promisify } = require("util");
 const path = require("path");
 const fs = require("fs-extra");
 const config = require("config");
-const client = require("models/client");
+const createRedisClient = require("../util/createRedisClient");
 const key = require("models/template/key");
 const getMetadata = require("models/template/getMetadata");
 const updateCdnManifest = require("models/template/util/updateCdnManifest");
 
 const getMetadataAsync = promisify(getMetadata);
 const updateCdnManifestAsync = promisify(updateCdnManifest);
-const smembersAsync = promisify(client.smembers).bind(client);
-const hdelAsync = promisify(client.hdel).bind(client);
 
 // Base directory for rendered output storage (same as in updateCdnManifest.js)
 const RENDERED_OUTPUT_BASE_DIR = path.join(config.data_directory, "cdn", "template");
@@ -50,7 +48,7 @@ async function fileExistsOnDisk(hash, viewName) {
 /**
  * Process a single SITE template
  */
-async function processTemplate(templateID) {
+async function processTemplate(client, templateID) {
   try {
     const metadata = await getMetadataAsync(templateID);
     
@@ -97,7 +95,7 @@ async function processTemplate(templateID) {
       
       try {
         // Delete the 'cdn' field from the template metadata hash
-        await hdelAsync(key.metadata(templateID), "cdn");
+        await client.hDel(key.metadata(templateID), "cdn");
         console.log(`  ✓  Deleted CDN manifest for ${templateID}`);
       } catch (err) {
         console.error(`  ⚠️  Error deleting CDN manifest for ${templateID}:`, err);
@@ -127,16 +125,16 @@ async function processTemplate(templateID) {
 /**
  * Main function
  */
-async function main() {
+async function main(client) {
   console.log("Starting CDN file verification for SITE templates...\n");
 
   try {
     // Get all SITE templates
-    const siteTemplateIDs = await smembersAsync(key.blogTemplates("SITE"));
+    const siteTemplateIDs = await client.sMembers(key.blogTemplates("SITE"));
     
     if (!siteTemplateIDs || siteTemplateIDs.length === 0) {
       console.log("No SITE templates found.");
-      process.exit(0);
+      return;
     }
 
     console.log(`Found ${siteTemplateIDs.length} SITE template(s)\n`);
@@ -146,7 +144,7 @@ async function main() {
     // Process each template
     for (const templateID of siteTemplateIDs) {
       console.log(`Processing ${templateID}...`);
-      const result = await processTemplate(templateID);
+      const result = await processTemplate(client, templateID);
       results.push(result);
       console.log(); // Empty line for readability
     }
@@ -183,15 +181,24 @@ async function main() {
     }
 
     console.log("\nDone!");
-    process.exit(0);
   } catch (err) {
     console.error("Fatal error:", err);
-    process.exit(1);
+    throw err;
   }
 }
 
 if (require.main === module) {
-  main();
+  (async () => {
+    const { client, close } = await createRedisClient();
+    try {
+      await main(client);
+      await close();
+      process.exit(0);
+    } catch (err) {
+      await close();
+      process.exit(1);
+    }
+  })();
 }
 
 module.exports = main;

--- a/scripts/tests/index.js
+++ b/scripts/tests/index.js
@@ -1,7 +1,7 @@
 var Jasmine = require("jasmine");
 var jasmine = new Jasmine();
 var colors = require("colors");
-var client = require("models/client");
+var createRedisClient = require("../util/createRedisClient");
 var clfdate = require("helper/clfdate");
 var seedrandom = require("seedrandom");
 var async = require("async");
@@ -215,15 +215,23 @@ global.test = {
 };
 
 // get the number of keys in the database
-client.keys("*", function (err, keys) {
-  if (err) {
-    throw err;
-  }
-  if (keys.length === 0) {
-    // if there are no keys, we need to run the tests
-    jasmine.execute();
-  } else {
+(async function () {
+  const { client, close } = await createRedisClient();
+
+  try {
+    const keys = await client.keys("*");
+    if (keys.length === 0) {
+      await close();
+      // if there are no keys, we need to run the tests
+      jasmine.execute();
+      return;
+    }
+
+    await close();
     // if there are keys, we need to throw an error
     throw new Error("Database is not empty: " + keys.length + " keys found");
+  } catch (error) {
+    await close();
+    throw error;
   }
-});
+})();

--- a/scripts/user/cleanup-dangling-blog-ids.js
+++ b/scripts/user/cleanup-dangling-blog-ids.js
@@ -11,15 +11,23 @@ var getConfirmation = require("../util/getConfirmation");
 var User = require("models/user");
 var Blog = require("models/blog");
 var blogKey = require("models/blog/key");
-var client = require("models/client");
+var createRedisClient = require("../util/createRedisClient");
 
 if (require.main === module)
-  main(function (err) {
-    if (err) throw err;
-    process.exit();
-  });
+  (async function () {
+    var redis = await createRedisClient();
+    main(redis.client, async function (err) {
+      if (err) {
+        console.error(err);
+        await redis.close();
+        process.exit(1);
+      }
+      await redis.close();
+      process.exit();
+    });
+  })();
 
-function main(callback) {
+function main(client, callback) {
   var usersScanned = 0;
   var usersFixed = 0;
   var idsRemovedFromUsers = 0;
@@ -79,7 +87,7 @@ function main(callback) {
       console.log("Users fixed:", usersFixed);
       console.log("Dangling IDs removed from users:", idsRemovedFromUsers);
 
-      cleanupDeadBlogIndexIDs(function (err, indexRemoved) {
+      cleanupDeadBlogIndexIDs(client, function (err, indexRemoved) {
         if (err) return callback(err);
 
         console.log("\nSecond pass complete");
@@ -91,7 +99,7 @@ function main(callback) {
   );
 }
 
-function cleanupDeadBlogIndexIDs(callback) {
+function cleanupDeadBlogIndexIDs(client, callback) {
   Blog.getAllIDs(function (err, ids) {
     if (err) return callback(err);
 

--- a/scripts/user/cleanup-dangling-users.js
+++ b/scripts/user/cleanup-dangling-users.js
@@ -14,7 +14,7 @@ var async = require("async");
 var colors = require("colors/safe");
 var User = require("models/user");
 var key = require("models/user/key");
-var client = require("models/client");
+var createRedisClient = require("../util/createRedisClient");
 var getConfirmation = require("../util/getConfirmation");
 
 var argv = process.argv.slice(2);
@@ -27,10 +27,18 @@ if (HELP_FLAG) {
 }
 
 if (require.main === module)
-  main(function (err) {
-    if (err) throw err;
-    process.exit();
-  });
+  (async function () {
+    var redis = await createRedisClient();
+    main(redis.client, async function (err) {
+      if (err) {
+        console.error(err);
+        await redis.close();
+        process.exit(1);
+      }
+      await redis.close();
+      process.exit();
+    });
+  })();
 
 function printUsage() {
   console.log("Usage: node scripts/user/cleanup-dangling-users.js [--yes]");
@@ -40,7 +48,7 @@ function printUsage() {
   console.log("  -h, --help  show this help output");
 }
 
-function main(callback) {
+function main(client, callback) {
   User.getAllIds(function (err, uids) {
     if (err) return callback(err);
 

--- a/scripts/util/createRedisClient.js
+++ b/scripts/util/createRedisClient.js
@@ -1,0 +1,22 @@
+const createClient = require("models/redis-new");
+
+module.exports = async function createRedisClient() {
+  const client = createClient();
+  await client.connect();
+
+  let closed = false;
+
+  return {
+    client,
+    async close() {
+      if (closed) return;
+      closed = true;
+
+      try {
+        await client.quit();
+      } catch (error) {
+        client.disconnect();
+      }
+    },
+  };
+};

--- a/scripts/util/redisKeys.js
+++ b/scripts/util/redisKeys.js
@@ -1,22 +1,26 @@
-const { promisify } = require("util");
-const redis = require("models/redis");
-const client = new redis();
+const createRedisClient = require("./createRedisClient");
 
-const scan = promisify(client.scan.bind(client));
+async function redisKeys(pattern, iterator, redisClient) {
+  let ownClient = null;
+  let client = redisClient;
 
-async function redisKeys(pattern, iterator) {
+  if (!client) {
+    ownClient = await createRedisClient();
+    client = ownClient.client;
+  }
+
   let cursor = "0";
   let complete = false;
 
-  while (!complete) {
-    try {
-      const [nextCursor, results] = await scan(
-        cursor,
-        "match",
-        pattern,
-        "count",
-        1000
-      );
+  try {
+    while (!complete) {
+      const reply = await client.scan(cursor, {
+        MATCH: pattern,
+        COUNT: 1000,
+      });
+
+      const nextCursor = String(reply.cursor);
+      const results = Array.isArray(reply.keys) ? reply.keys : [];
       cursor = nextCursor;
 
       for (const result of results) {
@@ -24,8 +28,10 @@ async function redisKeys(pattern, iterator) {
       }
 
       complete = cursor === "0";
-    } catch (err) {
-      throw err;
+    }
+  } finally {
+    if (ownClient) {
+      await ownClient.close();
     }
   }
 }


### PR DESCRIPTION
### Motivation

- Provide a simple script-scoped Redis helper that creates a dedicated `models/redis-new` client so scripts can control connect/close lifecycles instead of using the shared singleton. 
- Prevent leaked connections and mixed callback/await patterns across many maintenance scripts by standardizing how scripts scan and mutate Redis keys.

### Description

- Added `scripts/util/createRedisClient.js` which returns a dedicated `models/redis-new` client and exposes an idempotent `close()` that `quit()`s with a `disconnect()` fallback. 
- Reworked `scripts/util/redisKeys.js` to accept an injected client (or create/close its own temporary client) and to use the Redis v4-style `SCAN` reply shape safely. 
- Migrated multiple scripts to use the new helper: entry, email, db, template, user, blog and tests scripts now create a dedicated client at startup, pass the client into internal functions, and ensure `close()` is called on both success and fatal/error paths. 
- Kept transactional behavior where used by preserving `multi().exec()` semantics and converted only the outer lifecycle/callback boundaries to async/await; also refactored `scripts/google-drive/delete-keys.js` to avoid mixed callback/await style by using a fully async scan+delete flow.

### Testing

- Ran a syntax/parse check across changed files with `node --check` for the modified scripts (including `scripts/util/createRedisClient.js`, `scripts/util/redisKeys.js`, and all updated script entrypoints), and the check completed successfully. 
- Verified `redisKeys` and create/close code paths by ensuring scripts that scan keys now create/close clients in `finally` paths (static analysis during the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2be2846c08329ad59cc6f3c0b71ed)