### PR TITLE
Migrate maintenance scripts to models/client-new

### DIFF
--- a/scripts/blog/purge-entry-database.js
+++ b/scripts/blog/purge-entry-database.js
@@ -1,7 +1,7 @@
 const colors = require("colors/safe");
 const getBlog = require("../get/blog");
 const redisKeys = require("../util/redisKeys");
-const client = require("models/client");
+const client = require("models/client-new");
 const getConfirmation = require("../util/getConfirmation");
 
 const ENTRY_LISTS = [
@@ -65,19 +65,20 @@ async function main(blog) {
     await new Promise((resolve, reject) => {
       const multi = client.multi();
       multi.del(keys);
-      multi.exec((err, results) => {
-        if (err) return reject(err);
-
-        const deleted = Array.isArray(results)
-          ? results.reduce((sum, value) => sum + (Array.isArray(value) ? value[1] : 0), 0)
-          : 0;
-        console.log(
-          colors.green(
-            `Deleted ${keys.length} keys for blog ${blog.id}. Redis removed ${deleted} keys.`
-          )
-        );
-        resolve();
-      });
+      multi
+        .exec()
+        .then((results) => {
+          const deleted = Array.isArray(results)
+            ? results.reduce((sum, value) => sum + (typeof value === "number" ? value : 0), 0)
+            : 0;
+          console.log(
+            colors.green(
+              `Deleted ${keys.length} keys for blog ${blog.id}. Redis removed ${deleted} keys.`
+            )
+          );
+          resolve();
+        })
+        .catch(reject);
     });
   } catch (err) {
     throw err;

--- a/scripts/db/migrate-rendered-output-to-disk.js
+++ b/scripts/db/migrate-rendered-output-to-disk.js
@@ -15,7 +15,7 @@
 const eachTemplate = require("../each/template");
 const getMetadata = require("models/template/getMetadata");
 const Blog = require("models/blog");
-const client = require("models/client");
+const client = require("models/client-new");
 const key = require("models/template/key");
 const redisKeys = require("../util/redisKeys");
 const { promisify } = require("util");
@@ -27,8 +27,12 @@ const config = require("config");
 const RENDERED_OUTPUT_BASE_DIR = path.join(config.data_directory, "cdn", "template");
 
 const getMetadataAsync = promisify(getMetadata);
-const getAsync = promisify(client.get).bind(client);
-const delAsync = promisify(client.del).bind(client);
+const getAsync = function (redisKey) {
+  return client.get(redisKey);
+};
+const delAsync = function (redisKey) {
+  return client.del(redisKey);
+};
 const blogSetAsync = promisify(Blog.set);
 
 function getRenderedOutputPath(hash, viewName) {

--- a/scripts/db/remove-legacy-tag-set-keys.js
+++ b/scripts/db/remove-legacy-tag-set-keys.js
@@ -1,5 +1,5 @@
 const colors = require("colors/safe");
-const client = require("models/client");
+const client = require("models/client-new");
 const redisKeys = require("../util/redisKeys");
 const getConfirmation = require("../util/getConfirmation");
 
@@ -65,18 +65,19 @@ async function removeLegacyTagSetKeys(blogID) {
     const batchDeleted = await new Promise((resolve, reject) => {
       const multi = client.multi();
       batchKeys.forEach((key) => multi.del(key));
-      multi.exec((err, results) => {
-        if (err) return reject(err);
+      multi
+        .exec()
+        .then((results) => {
+          const deleted = Array.isArray(results)
+            ? results.reduce(
+                (sum, value) => sum + (typeof value === "number" ? value : 0),
+                0
+              )
+            : 0;
 
-        const deleted = Array.isArray(results)
-          ? results.reduce(
-              (sum, value) => sum + (typeof value === "number" ? value : 0),
-              0
-            )
-          : 0;
-
-        resolve(deleted);
-      });
+          resolve(deleted);
+        })
+        .catch(reject);
     });
 
     totalDeleted += batchDeleted;

--- a/scripts/db/remove-metadata-model-keys.js
+++ b/scripts/db/remove-metadata-model-keys.js
@@ -3,9 +3,10 @@
 // return "blog:" + blogID + ":folder:" + pathNormalizer(path);
 
 const keys = require("../util/redisKeys");
-const client = require("models/client");
-const { promisify } = require("util");
-const del = promisify(client.del).bind(client);
+const client = require("models/client-new");
+const del = function (redisKey) {
+  return client.del(redisKey);
+};
 
 const main = async () => {
   const pattern = "blog:*:folder:*";

--- a/scripts/email/newsletter.js
+++ b/scripts/email/newsletter.js
@@ -1,7 +1,7 @@
 var send = require("helper/email").send;
 var letter = process.argv[2];
 var fs = require("fs");
-var client = require("models/client");
+var client = require("models/client-new");
 var async = require("async");
 
 if (!letter) {
@@ -51,7 +51,12 @@ function main(letter, callback) {
             if (err) return next(err);
 
             console.log(". Email sent to", email);
-            client.sadd("newsletter:letter:" + letter, email, next);
+            client
+              .sAdd("newsletter:letter:" + letter, email)
+              .then(function () {
+                next();
+              })
+              .catch(next);
           });
         },
         callback
@@ -61,15 +66,20 @@ function main(letter, callback) {
 }
 
 function getAllSubscribers(callback) {
-  client.smembers("newsletter:list", callback);
+  client
+    .sMembers("newsletter:list")
+    .then(function (emails) {
+      callback(null, emails);
+    })
+    .catch(callback);
 }
 
 function alreadySent(email, done) {
-  client.sismember("newsletter:letter:" + letter, email, function (
-    err,
-    member
-  ) {
-    if (member === 1) console.log("Email already sent to", email);
-    done(err, member === 0);
-  });
+  client
+    .sIsMember("newsletter:letter:" + letter, email)
+    .then(function (member) {
+      if (member) console.log("Email already sent to", email);
+      done(null, !member);
+    })
+    .catch(done);
 }

--- a/scripts/entry/wipe-image-and-thumbnail-cache.js
+++ b/scripts/entry/wipe-image-and-thumbnail-cache.js
@@ -1,5 +1,5 @@
 var get = require("../get/entry");
-var client = require("models/client");
+var client = require("models/client-new");
 var async = require("async");
 
 if (require.main === module) {
@@ -30,35 +30,45 @@ function imageCache(blog, entry, callback) {
 
   var set = "blog:" + blog.id + ":store:image-cache:everything";
 
-  client.smembers(set, function (err, keys) {
-    if (err) return callback(err);
-    async.each(
-      keys,
-      function (key, next) {
-        client.get(key, function (err, res) {
-          if (err) return next(err);
+  client
+    .sMembers(set)
+    .then(function (keys) {
+      async.each(
+        keys,
+        function (key, next) {
+          client
+            .get(key)
+            .then(function (res) {
+              if (!res) return next();
 
-          if (!res) return next();
+              try {
+                res = JSON.parse(res);
+              } catch (e) {
+                console.log(e.message);
+                return next();
+              }
 
-          try {
-            res = JSON.parse(res);
-          } catch (e) {
-            console.log(e.message);
-            return next();
-          }
+              if (entry.html.indexOf(res.src) === -1) return next();
 
-          if (entry.html.indexOf(res.src) === -1) return next();
+              var multi = client.multi();
 
-          var multi = client.multi();
+              console.log(res.src, "wiped");
 
-          console.log(res.src, "wiped");
-
-          multi.srem(set, key).del(key).exec(next);
-        });
+              multi
+                .sRem(set, key)
+                .del(key)
+                .exec()
+                .then(function () {
+                  next();
+                })
+                .catch(next);
+            })
+            .catch(next);
       },
-      callback
-    );
-  });
+        callback
+      );
+    })
+    .catch(callback);
 }
 
 function thumbnails(blog, entry, callback) {
@@ -66,33 +76,42 @@ function thumbnails(blog, entry, callback) {
 
   var set = "blog:" + blog.id + ":store:thumbnails:everything";
 
-  client.smembers(set, function (err, keys) {
-    if (err) return callback(err);
+  client
+    .sMembers(set)
+    .then(function (keys) {
+      async.each(
+        keys,
+        function (key, next) {
+          client
+            .get(key)
+            .then(function (res) {
+              try {
+                res = JSON.parse(res);
+                if (res.small.name !== entry.thumbnail.small.name) return next();
+              } catch (e) {
+                console.log("Error", key, e.message);
+                return next();
+              }
 
-    async.each(
-      keys,
-      function (key, next) {
-        client.get(key, function (err, res) {
-          if (err) return next(err);
+              var multi = client.multi();
 
-          try {
-            res = JSON.parse(res);
-            if (res.small.name !== entry.thumbnail.small.name) return next();
-          } catch (e) {
-            console.log("Error", key, e.message);
-            return next();
-          }
+              console.log(entry.thumbnail.small.url, "wiped");
 
-          var multi = client.multi();
-
-          console.log(entry.thumbnail.small.url, "wiped");
-
-          multi.srem(set, key).del(key).exec(next);
-        });
+              multi
+                .sRem(set, key)
+                .del(key)
+                .exec()
+                .then(function () {
+                  next();
+                })
+                .catch(next);
+            })
+            .catch(next);
       },
-      callback
-    );
-  });
+        callback
+      );
+    })
+    .catch(callback);
 }
 
 module.exports = main;

--- a/scripts/template/ensure-cdn-files-on-disk.js
+++ b/scripts/template/ensure-cdn-files-on-disk.js
@@ -2,15 +2,19 @@ const { promisify } = require("util");
 const path = require("path");
 const fs = require("fs-extra");
 const config = require("config");
-const client = require("models/client");
+const client = require("models/client-new");
 const key = require("models/template/key");
 const getMetadata = require("models/template/getMetadata");
 const updateCdnManifest = require("models/template/util/updateCdnManifest");
 
 const getMetadataAsync = promisify(getMetadata);
 const updateCdnManifestAsync = promisify(updateCdnManifest);
-const smembersAsync = promisify(client.smembers).bind(client);
-const hdelAsync = promisify(client.hdel).bind(client);
+const smembersAsync = function (redisKey) {
+  return client.sMembers(redisKey);
+};
+const hdelAsync = function (redisKey, field) {
+  return client.hDel(redisKey, field);
+};
 
 // Base directory for rendered output storage (same as in updateCdnManifest.js)
 const RENDERED_OUTPUT_BASE_DIR = path.join(config.data_directory, "cdn", "template");

--- a/scripts/user/cleanup-dangling-blog-ids.js
+++ b/scripts/user/cleanup-dangling-blog-ids.js
@@ -11,7 +11,7 @@ var getConfirmation = require("../util/getConfirmation");
 var User = require("models/user");
 var Blog = require("models/blog");
 var blogKey = require("models/blog/key");
-var client = require("models/client");
+var client = require("models/client-new");
 
 if (require.main === module)
   main(function (err) {
@@ -124,11 +124,12 @@ function cleanupDeadBlogIndexIDs(callback) {
 
           if (!ok) return callback(null, 0);
 
-          client.srem(blogKey.ids, deadIDs, function (err, removedCount) {
-            if (err) return callback(err);
-
-            callback(null, removedCount || 0);
-          });
+          client
+            .sRem(blogKey.ids, deadIDs)
+            .then(function (removedCount) {
+              callback(null, removedCount || 0);
+            })
+            .catch(callback);
         });
       }
     );

--- a/scripts/user/cleanup-dangling-users.js
+++ b/scripts/user/cleanup-dangling-users.js
@@ -14,7 +14,7 @@ var async = require("async");
 var colors = require("colors/safe");
 var User = require("models/user");
 var key = require("models/user/key");
-var client = require("models/client");
+var client = require("models/client-new");
 var getConfirmation = require("../util/getConfirmation");
 
 var argv = process.argv.slice(2);
@@ -85,17 +85,18 @@ function main(callback) {
         });
 
         function remove() {
-          client.srem(key.uids, dangling, function (err, removedCount) {
-            if (err) return callback(err);
+          client
+            .sRem(key.uids, dangling)
+            .then(function (removedCount) {
+              console.log(
+                colors.green(
+                  "Removed " + (removedCount || 0) + " dangling ID(s) from user index set."
+                )
+              );
 
-            console.log(
-              colors.green(
-                "Removed " + (removedCount || 0) + " dangling ID(s) from user index set."
-              )
-            );
-
-            callback();
-          });
+              callback();
+            })
+            .catch(callback);
         }
 
         if (YES_FLAG) return remove();


### PR DESCRIPTION
## Summary
- switch remaining script imports from `models/client` to `models/client-new`
- migrate script Redis calls that depended on legacy callback/command shims to the current promise-based API (`sMembers`, `sAdd`, `sIsMember`, `sRem`, `hDel`)
- update multi-command execution sites to use promise-based `multi().exec()` handling
- replace `promisify(client.<command>)` usages that are incompatible with the new client singleton with direct promise-returning helpers

## Files updated
- `scripts/email/newsletter.js`
- `scripts/template/ensure-cdn-files-on-disk.js`
- `scripts/entry/wipe-image-and-thumbnail-cache.js`
- `scripts/user/cleanup-dangling-blog-ids.js`
- `scripts/user/cleanup-dangling-users.js`
- `scripts/db/remove-legacy-tag-set-keys.js`
- `scripts/db/migrate-rendered-output-to-disk.js`
- `scripts/db/remove-metadata-model-keys.js`
- `scripts/blog/purge-entry-database.js`

## Validation
- syntax-checked all updated scripts with `node --check`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c0682270832987f050b543442ea0)