### PR TITLE
Migrate iCloud database to models/client-new and native Redis promises

### DIFF
--- a/app/clients/icloud/database.js
+++ b/app/clients/icloud/database.js
@@ -1,14 +1,4 @@
-const { promisify } = require("util");
-
-// Redis client setup
-const client = require("models/client");
-
-const hsetAsync = promisify(client.hset).bind(client);
-const hgetallAsync = promisify(client.hgetall).bind(client);
-const delAsync = promisify(client.del).bind(client);
-const saddAsync = promisify(client.sadd).bind(client);
-const sremAsync = promisify(client.srem).bind(client);
-const smembersAsync = promisify(client.smembers).bind(client);
+const client = require("models/client-new");
 
 const PREFIX = 'blot:clients:icloud-drive:'
 
@@ -33,18 +23,18 @@ module.exports = {
     // Serialize and save fields
     for (const [field, value] of Object.entries(data)) {
       const serializedValue = JSON.stringify(value);
-      await hsetAsync(key, field, serializedValue);
+      await client.hSet(key, field, serializedValue);
     }
 
     // Add blog ID to the global set
-    await saddAsync(this._globalSetKey(), blogID);
+    await client.sAdd(this._globalSetKey(), blogID);
   },
 
   async get(blogID) {
     const key = this._key(blogID);
-    const result = await hgetallAsync(key);
+    const result = await client.hGetAll(key);
 
-    if (!result) {
+    if (!result || !Object.keys(result).length) {
       return null;
     }
 
@@ -64,14 +54,14 @@ module.exports = {
     const key = this._key(blogID);
 
     // Remove the Redis hash
-    await delAsync(key);
+    await client.del(key);
 
     // Remove blog ID from the global set
-    await sremAsync(this._globalSetKey(), blogID);
+    await client.sRem(this._globalSetKey(), blogID);
   },
 
   async list() {
-    return await smembersAsync(this._globalSetKey());
+    return await client.sMembers(this._globalSetKey());
   },
 
   async iterate(callback) {

--- a/app/clients/icloud/tests/database.js
+++ b/app/clients/icloud/tests/database.js
@@ -1,0 +1,51 @@
+const client = require("models/client-new");
+const database = require("clients/icloud/database");
+
+describe("icloud database", function () {
+  global.test.blog();
+
+  afterEach(async function () {
+    await database.delete(this.blog.id);
+  });
+
+  it("returns null when no hash exists", async function () {
+    const result = await database.get(this.blog.id);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty hash responses", async function () {
+    spyOn(client, "hGetAll").and.resolveTo({});
+
+    const result = await database.get(this.blog.id);
+
+    expect(result).toBeNull();
+  });
+
+  it("tracks global set membership across store and delete", async function () {
+    const data = {
+      setupComplete: true,
+      sharingLink: "https://example.com/shared",
+      transferState: { active: false },
+    };
+
+    await database.store(this.blog.id, data);
+
+    const stored = await database.get(this.blog.id);
+    expect(stored).toEqual(data);
+
+    const listedAfterStore = await database.list();
+    expect(listedAfterStore).toContain(this.blog.id);
+
+    const globalMembers = await client.sMembers(database._globalSetKey());
+    expect(globalMembers).toContain(this.blog.id);
+
+    await database.delete(this.blog.id);
+
+    const listedAfterDelete = await database.list();
+    expect(listedAfterDelete).not.toContain(this.blog.id);
+
+    const globalMembersAfterDelete = await client.sMembers(database._globalSetKey());
+    expect(globalMembersAfterDelete).not.toContain(this.blog.id);
+  });
+});


### PR DESCRIPTION
### Motivation
- Modernize the iCloud client to use the shared `models/client-new` Redis client and its native promise API instead of wrapped callbacks.
- Remove fragile `util.promisify` wrappers and align Redis calls with the `redis` client used elsewhere to simplify code and reduce boilerplate.
- Preserve existing serialization semantics and method contracts while ensuring empty-hash responses are treated as `null`.

### Description
- Replaced the client import with `require("models/client-new")` in `app/clients/icloud/database.js` and removed all `util.promisify` usage.
- Migrated Redis calls to native promise methods: `hset` -> `hSet`, `hgetall` -> `hGetAll`, `sadd` -> `sAdd`, `srem` -> `sRem`, and `smembers` -> `sMembers`.
- Kept JSON behavior unchanged by still `JSON.stringify`-ing values on `store` and `JSON.parse`-ing on `get` with a fallback to raw value.
- Adjusted `get` to return `null` when `hGetAll` returns no keys (empty object) to preserve null semantics; preserved `store`, `get`, `delete`, `list`, and `iterate` method shapes.
- Added tests at `app/clients/icloud/tests/database.js` that cover no-hash (`null`) behavior, empty-hash handling, and global set membership across `store` and `delete`.

### Testing
- Added `app/clients/icloud/tests/database.js` with automated cases for empty-hash/null handling and global set membership, and those tests are included in the repo.
- Ran JavaScript syntax checks via `node -c` on `app/clients/icloud/database.js` and the new test file, which passed.
- Attempted to run the new test via `npm test -- app/clients/icloud/tests/database.js`, but the test harness was blocked in this environment because `docker` is not available, so the full Jasmine run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c2a9958083299ecf1352171eb96e)