### PR TITLE
Migrate Redis client usage to models/client-new and handle publish rejections

### DIFF
--- a/app/clients/dropbox/routes/dashboard.js
+++ b/app/clients/dropbox/routes/dashboard.js
@@ -9,7 +9,7 @@ const join = require("path").join;
 const moment = require("moment");
 const { Dropbox } = require("dropbox");
 const views = __dirname + "/../views/";
-const client = require("models/client");
+const client = require("models/client-new");
 const Blog = require("models/blog");
 
 dashboard.use(function loadDropboxAccount (req, res, next) {
@@ -218,10 +218,12 @@ dashboard.post("/disconnect", function (req, res, next) {
     return res.redirect(res.locals.dashboardBase + "/client");
   }
 
-  client.publish(
-    "sync:status:" + req.blog.id,
-    "Attempting to disconnect from Dropbox"
-  );
+  client
+    .publish(
+      "sync:status:" + req.blog.id,
+      "Attempting to disconnect from Dropbox"
+    )
+    .catch((err) => console.error("failed to publish dropbox disconnect status", err));
   delete req.session.dropbox;
   disconnect(req.blog.id, next);
 });

--- a/app/dashboard/site/folder/folder.js
+++ b/app/dashboard/site/folder/folder.js
@@ -3,7 +3,7 @@ const path = require("path");
 const alphanum = require("helper/alphanum");
 const localPath = require("helper/localPath");
 const Stat = require("./stat");
-const client = require("models/client");
+const client = require("models/client-new");
 const pathNormalize = require("helper/pathNormalizer");
 
 async function getContents(blog, dir) {
@@ -27,7 +27,16 @@ async function getContents(blog, dir) {
       )
         .then((res) => {
           if (!res || !res.length) return resolve([]);
-          resolve(filtered.filter((_, index) => res[index] === 1));
+          resolve(
+            filtered.filter((_, index) => {
+              const exists = res[index];
+              return (
+                exists === 1 ||
+                exists === "1" ||
+                exists === true
+              );
+            })
+          );
         })
         .catch(() => {
           resolve([]);

--- a/app/dashboard/site/import/init.js
+++ b/app/dashboard/site/import/init.js
@@ -1,6 +1,6 @@
 const fs = require("fs-extra");
 const tempDir = require("helper/tempDir")();
-const client = require("models/client");
+const client = require("models/client-new");
 const { join } = require("path");
 const archiver = require("archiver");
 
@@ -47,10 +47,12 @@ module.exports = ({ blogID, label }) => {
   function status(message) {
     console.log("reporting status", message);
     // should write to disk somehow
-    client.publish(
-      "import:status:" + blogID,
-      JSON.stringify({ status: message, importID })
-    );
+    client
+      .publish(
+        "import:status:" + blogID,
+        JSON.stringify({ status: message, importID })
+      )
+      .catch((err) => console.error("failed to publish import status", err));
     fs.outputFile(lastStatus, message);
   }
 

--- a/app/sync/messenger.js
+++ b/app/sync/messenger.js
@@ -1,4 +1,4 @@
-const client = require("models/client");
+const client = require("models/client-new");
 const clfdate = require("helper/clfdate");
 const uuid = require("uuid/v4");
 const Blog = require("models/blog");
@@ -21,7 +21,9 @@ module.exports = (blog) => {
 
     Blog.setStatus(blog.id, { message, syncID });
     log(message);
-    client.publish("sync:status:" + blog.id, message);
+    client
+      .publish("sync:status:" + blog.id, message)
+      .catch((err) => log("failed to publish sync status", err.message));
   };
   return {
     log,


### PR DESCRIPTION
### Motivation
- Move legacy `models/client` usages to the new promise-based `models/client-new` shared Redis client to follow the migration guidance and avoid callback-only semantics.
- Avoid unhandled promise rejections for fire-and-forget publish calls in publish-only paths so background status updates do not crash the process.
- Preserve existing user-visible behavior such as status message contents and folder-entry detection semantics during the migration.

### Description
- Swapped `require("models/client")` to `require("models/client-new")` in `app/sync/messenger.js`, `app/dashboard/site/import/init.js`, `app/clients/dropbox/routes/dashboard.js`, and `app/dashboard/site/folder/folder.js`.
- Added explicit rejection handling for publish-only calls by appending `.catch(...)` in `app/sync/messenger.js`, `app/dashboard/site/import/init.js`, and `app/clients/dropbox/routes/dashboard.js` to prevent unhandled promise rejections while retaining the same status messages.
- Updated `app/dashboard/site/folder/folder.js` to handle different `exists` return types from the new client by accepting `1`, `"1"`, or `true` when deciding whether a folder item is an entry, preserving folder-entry flag behavior.
- Did not change user-visible status text or CDN/fallback logic; only internal client usage and error handling were adjusted.

### Testing
- Ran `node --check app/sync/messenger.js` and it succeeded.
- Ran `node --check app/dashboard/site/import/init.js` and it succeeded.
- Ran `node --check app/clients/dropbox/routes/dashboard.js` and it succeeded.
- Ran `node --check app/dashboard/site/folder/folder.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c2b18a848329a9a6484d8424c56f)