### PR TITLE
Refactor newsletter routes to async Redis client-new API

### DIFF
--- a/app/documentation/news.js
+++ b/app/documentation/news.js
@@ -6,7 +6,7 @@ const { marked } = require("marked");
 var parse = require("body-parser").urlencoded({ extended: false });
 var uuid = require("uuid/v4");
 var config = require("config");
-var client = require("models/client");
+var client = require("models/client-new");
 var gitCommits = require("./tools/git-commits").middleware;
 var listKey = "newsletter:list";
 var moment = require("moment");
@@ -102,120 +102,129 @@ news.param("guid", function (req, res, next) {
   next();
 });
 
-news.post("/cancel", parse, function (req, res, next) {
-  var cancel, email, locals;
-  var guid = uuid();
+news.post("/cancel", parse, async function (req, res, next) {
+  try {
+    var cancel, email, locals;
+    var guid = uuid();
 
-  if (!req.body || !req.body.email) {
-    return next(new Error("No email"));
-  }
+    if (!req.body || !req.body.email) {
+      throw new Error("No email");
+    }
 
-  email = req.body.email.trim().toLowerCase();
-  guid = guid.split("-").join("");
-  guid = encodeURIComponent(guid);
-  cancel = cancellationLink(guid);
-  locals = { email: email, cancel: cancel };
+    email = req.body.email.trim().toLowerCase();
+    guid = guid.split("-").join("");
+    guid = encodeURIComponent(guid);
+    cancel = cancellationLink(guid);
+    locals = { email: email, cancel: cancel };
 
-  client.sismember(listKey, email, function (err, stat) {
-    if (err || !stat) return next(err || new Error("No subscription found"));
+    var stat = await client.sIsMember(listKey, email);
+    if (!stat) throw new Error("No subscription found");
 
-    client.setex(cancellationKey(guid), TTL, email, function (err) {
-      if (err) return next(err);
+    await client.setEx(cancellationKey(guid), TTL, email);
 
+    await new Promise(function (resolve, reject) {
       Email.NEWSLETTER_CANCELLATION_CONFIRMATION(null, locals, function (err) {
-        if (err) return next(err);
-
-        res.redirect("/news/cancel?email=" + email);
+        if (err) return reject(err);
+        return resolve();
       });
     });
-  });
-});
 
-news.get("/cancel/:guid", function (req, res, next) {
-  var guid = decodeURIComponent(req.params.guid);
-
-  client.get(cancellationKey(guid), function (err, email) {
-    if (err || !email) return next(err || new Error("No email"));
-
-    client.srem(listKey, email, function (err, removed) {
-      if (err) return next(err);
-
-      var locals = { email: email };
-
-      res.locals.title = "Cancelled";
-      res.locals.email = email;
-
-      if (removed) {
-        Email.NEWSLETTER_CANCELLATION_CONFIRMED(null, locals, function () {
-          // Email confirmation sent
-        });
-      }
-
-      res.locals.title = "Cancelled";
-      res.render("news/cancelled");
-    });
-  });
-});
-
-news.get("/confirm/:guid", function (req, res, next) {
-  var guid = decodeURIComponent(req.params.guid);
-
-  client.get(confirmationKey(guid), function (err, email) {
-    if (err || !email) return next(err || new Error("No email"));
-
-    client.sadd(listKey, email, function (err, added) {
-      if (err) return next(err);
-
-      var locals = {
-        email: email,
-        cancel: "https://" + config.host + "/news/cancel"
-      };
-
-      res.locals.title = "Confirmed";
-      res.locals.email = email;
-
-      // The first time the user clicks the confirmation
-      // link we send out a confirmation email, subsequent
-      // clicks they just see the confirmation page.
-      if (added) {
-        Email.NEWSLETTER_SUBSCRIPTION_CONFIRMED(null, locals, function () {
-          // Email confirmation sent
-        });
-      }
-
-      res.redirect(req.baseUrl + "/confirmed");
-    });
-  });
-});
-
-news.post("/sign-up", parse, function (req, res, next) {
-  var confirm, email, locals;
-  var guid = uuid();
-
-  if (!req.body && !req.body.contact_gfhkj) {
-    return next(new Error("No email"));
+    res.redirect("/news/cancel?email=" + email);
+  } catch (err) {
+    next(err);
   }
+});
 
-  // honeypot fields
-  if (req.body.email || req.body.name) {
-    return next(new Error("Honeypot triggered"));
+news.get("/cancel/:guid", async function (req, res, next) {
+  try {
+    var guid = decodeURIComponent(req.params.guid);
+    var email = await client.get(cancellationKey(guid));
+
+    if (!email) throw new Error("No email");
+
+    var removed = await client.sRem(listKey, email);
+    var locals = { email: email };
+
+    res.locals.title = "Cancelled";
+    res.locals.email = email;
+
+    if (removed) {
+      Email.NEWSLETTER_CANCELLATION_CONFIRMED(null, locals, function () {
+        // Email confirmation sent
+      });
+    }
+
+    res.locals.title = "Cancelled";
+    res.render("news/cancelled");
+  } catch (err) {
+    next(err);
   }
+});
 
-  email = req.body.contact_gfhkj.trim().toLowerCase();
-  guid = guid.split("-").join("");
-  guid = encodeURIComponent(guid);
-  confirm = confirmationLink(guid);
-  locals = { email: email, confirm: confirm };
+news.get("/confirm/:guid", async function (req, res, next) {
+  try {
+    var guid = decodeURIComponent(req.params.guid);
+    var email = await client.get(confirmationKey(guid));
 
-  client.setex(confirmationKey(guid), TTL, email, function (err) {
-    if (err) return next(err);
+    if (!email) throw new Error("No email");
 
-    Email.NEWSLETTER_SUBSCRIPTION_CONFIRMATION(null, locals, function (err) {
-      if (err) return next(err);
+    var added = await client.sAdd(listKey, email);
+    var locals = {
+      email: email,
+      cancel: "https://" + config.host + "/news/cancel"
+    };
 
-      res.redirect("/news/sign-up?email=" + email);
+    res.locals.title = "Confirmed";
+    res.locals.email = email;
+
+    // The first time the user clicks the confirmation
+    // link we send out a confirmation email, subsequent
+    // clicks they just see the confirmation page.
+    if (added) {
+      Email.NEWSLETTER_SUBSCRIPTION_CONFIRMED(null, locals, function () {
+        // Email confirmation sent
+      });
+    }
+
+    res.redirect(req.baseUrl + "/confirmed");
+  } catch (err) {
+    next(err);
+  }
+});
+
+news.post("/sign-up", parse, async function (req, res, next) {
+  try {
+    var confirm, email, locals;
+    var guid = uuid();
+
+    if (!req.body || !req.body.contact_gfhkj) {
+      throw new Error("No email");
+    }
+
+    // honeypot fields
+    if (req.body.email || req.body.name) {
+      throw new Error("Honeypot triggered");
+    }
+
+    email = req.body.contact_gfhkj.trim().toLowerCase();
+    guid = guid.split("-").join("");
+    guid = encodeURIComponent(guid);
+    confirm = confirmationLink(guid);
+    locals = { email: email, confirm: confirm };
+
+    await client.setEx(confirmationKey(guid), TTL, email);
+
+    await new Promise(function (resolve, reject) {
+      Email.NEWSLETTER_SUBSCRIPTION_CONFIRMATION(null, locals, function (err) {
+        if (err) return reject(err);
+        return resolve();
+      });
     });
-  });
+
+    res.redirect("/news/sign-up?email=" + email);
+  } catch (err) {
+    next(err);
+  }
 });
 
 function loadToDo (req, res, next) {

--- a/app/documentation/tests/news.js
+++ b/app/documentation/tests/news.js
@@ -1,0 +1,200 @@
+const Express = require("express");
+
+const newsPath = require.resolve("../news");
+
+const setModuleMock = (moduleName, exportsValue, touched) => {
+  const resolved = require.resolve(moduleName);
+  touched.push({ resolved, previous: require.cache[resolved] });
+  require.cache[resolved] = {
+    id: resolved,
+    filename: resolved,
+    loaded: true,
+    exports: exportsValue,
+  };
+};
+
+const restoreModuleMocks = (touched) => {
+  touched.reverse().forEach(({ resolved, previous }) => {
+    if (previous) {
+      require.cache[resolved] = previous;
+    } else {
+      delete require.cache[resolved];
+    }
+  });
+};
+
+describe("documentation news routes", function () {
+  let touched;
+  let client;
+  let Email;
+  let server;
+  const origin = "http://localhost:8928";
+
+  beforeEach(function (done) {
+    touched = [];
+
+    client = {
+      sIsMember: jasmine.createSpy("sIsMember").and.returnValue(Promise.resolve(1)),
+      setEx: jasmine.createSpy("setEx").and.returnValue(Promise.resolve("OK")),
+      get: jasmine.createSpy("get").and.returnValue(Promise.resolve("reader@example.com")),
+      sRem: jasmine.createSpy("sRem").and.returnValue(Promise.resolve(1)),
+      sAdd: jasmine.createSpy("sAdd").and.returnValue(Promise.resolve(1)),
+    };
+
+    Email = {
+      NEWSLETTER_CANCELLATION_CONFIRMATION: jasmine
+        .createSpy("NEWSLETTER_CANCELLATION_CONFIRMATION")
+        .and.callFake((_, __, callback) => callback()),
+      NEWSLETTER_CANCELLATION_CONFIRMED: jasmine
+        .createSpy("NEWSLETTER_CANCELLATION_CONFIRMED")
+        .and.callFake((_, __, callback) => callback()),
+      NEWSLETTER_SUBSCRIPTION_CONFIRMATION: jasmine
+        .createSpy("NEWSLETTER_SUBSCRIPTION_CONFIRMATION")
+        .and.callFake((_, __, callback) => callback()),
+      NEWSLETTER_SUBSCRIPTION_CONFIRMED: jasmine
+        .createSpy("NEWSLETTER_SUBSCRIPTION_CONFIRMED")
+        .and.callFake((_, __, callback) => callback()),
+    };
+
+    setModuleMock("models/client-new", client, touched);
+    setModuleMock("helper/email", Email, touched);
+    setModuleMock("uuid/v4", () => "123e4567-e89b-12d3-a456-426614174000", touched);
+    setModuleMock("../tools/git-commits", { middleware: (req, res, next) => next() }, touched);
+
+    delete require.cache[newsPath];
+
+    const app = Express();
+
+    app.use((req, res, next) => {
+      res.locals.breadcrumbs = ["news", "guid"];
+      res.render = function (_view) {
+        this.status(200).send("rendered");
+      };
+      next();
+    });
+
+    app.use("/news", require("../news"));
+
+    app.use((err, req, res, next) => {
+      res.status(500).send(err.message);
+    });
+
+    server = app.listen(8928, done);
+  });
+
+  afterEach(function (done) {
+    delete require.cache[newsPath];
+    restoreModuleMocks(touched);
+    server.close(done);
+  });
+
+  it("POST /news/sign-up redirects and stores confirmation key for 1 day", async function () {
+    const response = await fetch(origin + "/news/sign-up", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "contact_gfhkj=Reader%40Example.com",
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/news/sign-up?email=reader@example.com");
+    expect(client.setEx).toHaveBeenCalledWith(
+      "newsletter:confirm:123e4567e89b12d3a456426614174000",
+      60 * 60 * 24,
+      "reader@example.com"
+    );
+    expect(Email.NEWSLETTER_SUBSCRIPTION_CONFIRMATION).toHaveBeenCalled();
+  });
+
+  it("POST /news/sign-up fails when contact email is missing", async function () {
+    const response = await fetch(origin + "/news/sign-up", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "",
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(500);
+    expect(client.setEx).not.toHaveBeenCalled();
+  });
+
+  it("POST /news/cancel redirects and sends cancellation confirmation", async function () {
+    const response = await fetch(origin + "/news/cancel", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "email=Reader%40Example.com",
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/news/cancel?email=reader@example.com");
+    expect(client.sIsMember).toHaveBeenCalledWith("newsletter:list", "reader@example.com");
+    expect(client.setEx).toHaveBeenCalledWith(
+      "newsletter:cancel:123e4567e89b12d3a456426614174000",
+      60 * 60 * 24,
+      "reader@example.com"
+    );
+    expect(Email.NEWSLETTER_CANCELLATION_CONFIRMATION).toHaveBeenCalled();
+  });
+
+  it("POST /news/cancel fails when email is missing", async function () {
+    const response = await fetch(origin + "/news/cancel", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "",
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(500);
+    expect(client.sIsMember).not.toHaveBeenCalled();
+  });
+
+  it("GET /news/confirm/:guid redirects and only sends confirmation email when added", async function () {
+    client.sAdd.and.returnValue(Promise.resolve(1));
+
+    const response = await fetch(origin + "/news/confirm/abc-guid", {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/news/confirmed");
+    expect(client.get).toHaveBeenCalledWith("newsletter:confirm:abc-guid");
+    expect(client.sAdd).toHaveBeenCalledWith("newsletter:list", "reader@example.com");
+    expect(Email.NEWSLETTER_SUBSCRIPTION_CONFIRMED).toHaveBeenCalled();
+  });
+
+  it("GET /news/confirm/:guid fails when guid lookup has no email", async function () {
+    client.get.and.returnValue(Promise.resolve(null));
+
+    const response = await fetch(origin + "/news/confirm/missing-guid", {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(500);
+    expect(client.sAdd).not.toHaveBeenCalled();
+  });
+
+  it("GET /news/cancel/:guid renders cancelled and only sends email when removed", async function () {
+    client.sRem.and.returnValue(Promise.resolve(1));
+
+    const response = await fetch(origin + "/news/cancel/abc-guid", {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(200);
+    expect(client.get).toHaveBeenCalledWith("newsletter:cancel:abc-guid");
+    expect(client.sRem).toHaveBeenCalledWith("newsletter:list", "reader@example.com");
+    expect(Email.NEWSLETTER_CANCELLATION_CONFIRMED).toHaveBeenCalled();
+  });
+
+  it("GET /news/cancel/:guid fails when guid lookup has no email", async function () {
+    client.get.and.returnValue(Promise.resolve(null));
+
+    const response = await fetch(origin + "/news/cancel/missing-guid", {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(500);
+    expect(client.sRem).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation
- Migrate newsletter code to use the new promise-based Redis client so model code uses the shared modern API surface.
- Convert callback-based Redis calls and route handlers to async/await with centralized error propagation to simplify control flow and error handling.
- Add focused route tests for success and failure paths to verify behavior and preserve existing UX (redirects/email triggers).

### Description
- Replaced `require("models/client")` with `require("models/client-new")` and migrated Redis calls to the promise-based methods `sIsMember`, `setEx`, `get`, `sRem`, and `sAdd`.
- Refactored the route handlers `POST /cancel`, `GET /cancel/:guid`, `GET /confirm/:guid`, and `POST /sign-up` to async handlers using `try/catch` and `next(err)` on failures, preserving all original redirects and response paths.
- Kept all existing conditional email triggers (checks on `added`/`removed`) intact and preserved exact TTL behavior using `setEx` with `60 * 60 * 24` seconds (1 day).
- Added `app/documentation/tests/news.js` with assertions on redirects, TTL/value passed to `setEx`, and conditional email-send invocation for success and missing-guid/missing-email failure cases.

### Testing
- Added and ran the new spec `app/documentation/tests/news.js` via `NODE_PATH=app npx jasmine app/documentation/tests/news.js`, which executed 8 specs with 0 failures.
- Attempting to run `npm test -- app/documentation/tests/news.js` in this environment failed because Docker is not available, but the direct Jasmine run (with `NODE_PATH=app`) validated the behavior.
- The test file covers success and failure for `POST /news/sign-up`, `POST /news/cancel`, `GET /news/confirm/:guid`, and `GET /news/cancel/:guid`, and asserts Redis call arguments and email calls as described.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c2b63610832982427ec3b5f641f4)