### PR TITLE
Migrate sync/fix Redis usage to models/client-new API

### DIFF
--- a/app/sync/fix/entries-path-index.js
+++ b/app/sync/fix/entries-path-index.js
@@ -1,11 +1,11 @@
-const client = require("models/client");
+const client = require("models/client-new");
 const pathIndex = require("models/entries/pathIndex");
 
 module.exports = function entriesPathIndex(blog, callback) {
   const entriesKey = "blog:" + blog.id + ":entries";
   const lexKey = pathIndex.lexKey(blog.id);
 
-  Promise.all([client.zcard(entriesKey), client.zcard(lexKey)])
+  Promise.all([client.zCard(entriesKey), client.zCard(lexKey)])
     .then(function ([entriesCountResult, lexCountResult]) {
       const entriesCount = parseInt(entriesCountResult, 10) || 0;
       const lexCount = parseInt(lexCountResult, 10) || 0;

--- a/app/sync/fix/list-ghosts.js
+++ b/app/sync/fix/list-ghosts.js
@@ -1,6 +1,6 @@
 const Entry = require("models/entry");
 const Entries = require("models/entries");
-const client = require("models/client");
+const client = require("models/client-new");
 const { promisify } = require("util");
 
 var lists = ["all", "created", "entries", "drafts", "scheduled", "pages"];
@@ -17,14 +17,14 @@ function main(blog, callback) {
 
     for (const list of lists) {
       const key = "blog:" + blog.id + ":" + list;
-      const ids = await client.zrevrange(key, 0, -1);
+      const ids = await client.zRevRange(key, 0, -1);
 
       for (const id of ids) {
         const entry = await getEntry(blog.id, id);
         if (entry && entry.id === id) continue;
 
         report.push([list, "MISMATCH", id]);
-        await client.zrem(key, id);
+        await client.zRem(key, id);
 
         if (entry) await setEntry(blog.id, entry.id, entry);
       }

--- a/app/sync/fix/tag-ghosts.js
+++ b/app/sync/fix/tag-ghosts.js
@@ -1,7 +1,7 @@
 var Tags = require("models/tags");
 var Entry = require("models/entry");
 var async = require("async");
-var client = require("models/client");
+var client = require("models/client-new");
 
 module.exports = function main(blog, callback) {
   const report = [];
@@ -17,7 +17,7 @@ module.exports = function main(blog, callback) {
           if (!entryIDs.length) {
             report.push(["EMPTY TAG", tag]);
             const multi = client.multi();
-            multi.srem(Tags.key.all(blog.id), tag.slug);
+            multi.sRem(Tags.key.all(blog.id), tag.slug);
             multi.del(tagKey);
             return multi.exec(next);
           }
@@ -29,7 +29,7 @@ module.exports = function main(blog, callback) {
                 if (!entry) {
                   report.push(["MISSING", entryID]);
                   const multi = client.multi();
-                  multi.zrem(tagKey, entryID);
+                  multi.zRem(tagKey, entryID);
                   return multi.exec(next);
                 }
 
@@ -45,8 +45,8 @@ module.exports = function main(blog, callback) {
                 }
 
                 multi.rename(entryKeyForIncorrectID, entryKeyForCorrectID);
-                multi.zrem(tagKey, entryID);
-                multi.zadd(tagKey, score, entry.id);
+                multi.zRem(tagKey, entryID);
+                multi.zAdd(tagKey, { score: score, value: entry.id });
                 multi.exec(function (err) {
                   if (err) return next(err);
                   Entry.set(blog.id, entry.id, entry, next);

--- a/app/sync/fix/tests/entries-path-index.js
+++ b/app/sync/fix/tests/entries-path-index.js
@@ -1,10 +1,10 @@
 describe("sync/fix/entries-path-index", function () {
-  var client = require("models/client");
+  var client = require("models/client-new");
   var pathIndex = require("models/entries/pathIndex");
   var fixEntriesPathIndex = require("../entries-path-index");
 
   it("does nothing when entry count and path index count match", function (done) {
-    var zcard = spyOn(client, "zcard").and.returnValues(
+    var zcard = spyOn(client, "zCard").and.returnValues(
       Promise.resolve("2"),
       Promise.resolve("2")
     );
@@ -20,7 +20,7 @@ describe("sync/fix/entries-path-index", function () {
   });
 
   it("backfills the index when counts do not match", function (done) {
-    spyOn(client, "zcard").and.returnValues(
+    spyOn(client, "zCard").and.returnValues(
       Promise.resolve("5"),
       Promise.resolve("3")
     );
@@ -40,10 +40,29 @@ describe("sync/fix/entries-path-index", function () {
     });
   });
 
+
+  it("returns errors from backfill when counts do not match", function (done) {
+    var backfillError = new Error("backfill exploded");
+
+    spyOn(client, "zCard").and.returnValues(
+      Promise.resolve("5"),
+      Promise.resolve("3")
+    );
+    spyOn(pathIndex, "backfillIndex").and.callFake(function (_blogID, callback) {
+      callback(backfillError);
+    });
+
+    fixEntriesPathIndex({ id: "blog-id" }, function (err, changes) {
+      expect(err).toBe(backfillError);
+      expect(changes).toBeUndefined();
+      done();
+    });
+  });
+
   it("returns errors from the initial redis query", function (done) {
     var redisError = new Error("redis exploded");
 
-    spyOn(client, "zcard").and.returnValues(
+    spyOn(client, "zCard").and.returnValues(
       Promise.reject(redisError),
       Promise.resolve("2")
     );

--- a/app/sync/fix/tests/tag-ghosts.js
+++ b/app/sync/fix/tests/tag-ghosts.js
@@ -1,0 +1,37 @@
+describe("sync/fix/tag-ghosts", function () {
+  var Tags = require("models/tags");
+  var Entry = require("models/entry");
+  var client = require("models/client-new");
+  var fixTagGhosts = require("../tag-ghosts");
+
+  it("propagates transaction rejections for empty-tag cleanup", function (done) {
+    var execError = new Error("exec exploded");
+
+    spyOn(Tags, "list").and.callFake(function (_blogID, callback) {
+      callback(null, [{ slug: "ghost-tag" }]);
+    });
+    spyOn(Tags, "get").and.callFake(function (_blogID, _slug, callback) {
+      callback(null, []);
+    });
+    spyOn(Entry, "get");
+
+    var multi = {
+      sRem: jasmine.createSpy("sRem"),
+      del: jasmine.createSpy("del"),
+      exec: jasmine.createSpy("exec").and.callFake(function (callback) {
+        callback(execError);
+      }),
+    };
+
+    spyOn(client, "multi").and.returnValue(multi);
+
+    fixTagGhosts({ id: "blog-id" }, function (err, report) {
+      expect(err).toBe(execError);
+      expect(report).toBeUndefined();
+      expect(client.multi).toHaveBeenCalled();
+      expect(multi.sRem).toHaveBeenCalled();
+      expect(multi.del).toHaveBeenCalled();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Modernize Redis usage in the `app/sync/fix` utilities to the project-wide `models/client-new` promise-based API and keep transactional atomicity where required.
- Ensure commands use the camelCase client-new names and argument shapes so code and tests align with the shared Redis client contract.

### Description
- Replaced `require("models/client")` with `require("models/client-new")` in `entries-path-index.js`, `list-ghosts.js`, and `tag-ghosts.js` and updated usages accordingly.
- Replaced command names: `zcard` -> `zCard`, `zrevrange` -> `zRevRange`, `zrem` -> `zRem`, and converted `zadd` calls to `zAdd(key, { score, value })` where used while preserving write ordering and `multi().exec()` boundaries in `tag-ghosts.js`.
- Kept existing callback APIs and report payload shapes unchanged so public behavior is preserved.
- Updated tests to reference `models/client-new`, switched spies from `zcard` to `zCard`, and added two negative-path assertions: a backfill error propagation test in `entries-path-index` and a `multi().exec()` rejection propagation test for `tag-ghosts`.

### Testing
- Ran syntax/type checks with `node --check` for `app/sync/fix/entries-path-index.js`, `app/sync/fix/list-ghosts.js`, `app/sync/fix/tag-ghosts.js`, and the two new/updated test files, which succeeded.
- Attempted to run tests via the project test harness and `jasmine`, but local runs in this environment failed due to missing runtime Redis/test setup (errors: `MODULE_NOT_FOUND` for modules without `NODE_PATH` and `ECONNREFUSED` / `TypeError: client.connect is not a function` when `models/client-new` attempted to initialize a real Redis connection), so full integration test execution could not complete here.
- Added unit tests for the negative paths and updated spies; these tests are included in the repo and will run in CI or a developer environment with Redis/test containers available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c2b5838883298e7b329c2416f82c)