### PR TITLE
Update folder hScan usage for Redis v5 entries

### DIFF
--- a/app/clients/google-drive/database/folder.js
+++ b/app/clients/google-drive/database/folder.js
@@ -112,10 +112,10 @@ function folder(folderId) {
     let cursor = START_CURSOR;
 
     do {
-      const { cursor: nextCursor, tuples } = await client.hScan(this.key, cursor);
+      const { cursor: nextCursor, entries } = await client.hScan(this.key, cursor);
       cursor = nextCursor;
 
-      for (const entry of tuples) {
+      for (const entry of entries) {
         const currentId = entry.field;
         const currentPath = entry.value;
 
@@ -159,10 +159,10 @@ function folder(folderId) {
     let cursor = START_CURSOR;
 
     do {
-      const { cursor: nextCursor, tuples } = await client.hScan(this.key, cursor);
+      const { cursor: nextCursor, entries } = await client.hScan(this.key, cursor);
       cursor = nextCursor;
 
-      for (const entry of tuples) {
+      for (const entry of entries) {
         const currentId = entry.field;
         const currentPath = entry.value;
 
@@ -209,10 +209,10 @@ function folder(folderId) {
 
     do {
       // Scan the folder key
-      const { cursor: nextCursor, tuples } = await client.hScan(this.key, cursor);
+      const { cursor: nextCursor, entries: scannedEntries } = await client.hScan(this.key, cursor);
       cursor = nextCursor;
 
-      for (const entry of tuples) {
+      for (const entry of scannedEntries) {
         const id = entry.field;
         const path = entry.value;
 
@@ -241,10 +241,10 @@ function folder(folderId) {
     let results = [];
 
     do {
-      const { cursor: nextCursor, tuples } = await client.hScan(this.key, cursor);
+      const { cursor: nextCursor, entries } = await client.hScan(this.key, cursor);
       cursor = nextCursor;
 
-      for (const entry of tuples) {
+      for (const entry of entries) {
         const id = entry.field;
         const path = entry.value;
         const metadata = await this.getMetadata(id);


### PR DESCRIPTION
### Motivation
- The Redis v5 client returns an `entries` array from `hScan` instead of the older `tuples` shape, causing iteration errors in folder DB operations.
- Update the folder DB scan handling so nested `move` and `readdir` scenarios iterate correctly over the new response shape.

### Description
- Replaced `tuples` destructuring with `entries` for `client.hScan` in `app/clients/google-drive/database/folder.js` across the affected methods `move`, `remove`, `readdir`, and `listAll`.
- Updated loops to iterate over `entries` (using `entries` or `scannedEntries` where appropriate) and preserved access via `entry.field` and `entry.value` for ID/path extraction.
- Preserved existing transaction (`multi`) and metadata update logic so behavior is unchanged except for scan parsing.

### Testing
- Ran `node --check app/clients/google-drive/database/folder.js` which succeeded.
- Attempted to run folder DB tests with `./scripts/tests/invoke.sh app/clients/google-drive/database/tests/folder.js` but the test runner failed because `docker` is not available in this environment (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c3f8373c8329bf1c3d09935d9f2b)