### PR TITLE
Fix RESP3 scan cursor type checks to prevent infinite loops

### DIFF
--- a/app/clients/google-drive/database/channel.js
+++ b/app/clients/google-drive/database/channel.js
@@ -104,7 +104,7 @@ const channel = {
   // Iterate over all channels globally
   async iterate(callback) {
     const globalSetKey = this._globalSetKey();
-    let cursor = "0";
+    let cursor = 0;
     do {
       const { cursor: nextCursor, members: channelIds } = await client.sScan(globalSetKey, cursor);
       for (const channelId of channelIds) {
@@ -114,13 +114,13 @@ const channel = {
         }
       }
       cursor = nextCursor;
-    } while (cursor !== "0");
+    } while (cursor !== 0);
   },
 
   // Iterate over all channels associated with a serviceAccountId
   async iterateByServiceAccount(serviceAccountId, callback) {
     const serviceAccountKey = this._serviceAccountKey(serviceAccountId);
-    let cursor = "0";
+    let cursor = 0;
     do {
       const { cursor: nextCursor, members: channelIds } = await client.sScan(serviceAccountKey, cursor);
       for (const channelId of channelIds) {
@@ -130,13 +130,13 @@ const channel = {
         }
       }
       cursor = nextCursor;
-    } while (cursor !== "0");
+    } while (cursor !== 0);
   },
 
   // Iterate over all channels associated with a serviceAccountId and fileId
   async iterateByFile(serviceAccountId, fileId, callback) {
     const fileKey = this._fileKey(serviceAccountId, fileId);
-    let cursor = "0";
+    let cursor = 0;
     do {
       const { cursor: nextCursor, members: channelIds } = await client.sScan(fileKey, cursor);
       for (const channelId of channelIds) {
@@ -146,7 +146,7 @@ const channel = {
         }
       }
       cursor = nextCursor;
-    } while (cursor !== "0");
+    } while (cursor !== 0);
   },
 };
 

--- a/app/clients/google-drive/database/folder.js
+++ b/app/clients/google-drive/database/folder.js
@@ -112,7 +112,7 @@ function folder(folderId) {
     }
 
     // For folders, update all child paths
-    const START_CURSOR = "0";
+    const START_CURSOR = 0;
     let cursor = START_CURSOR;
 
     do {
@@ -159,7 +159,7 @@ function folder(folderId) {
     let removedPaths = [];
 
     // Scan and delete all affected paths
-    const START_CURSOR = "0";
+    const START_CURSOR = 0;
     let cursor = START_CURSOR;
 
     do {
@@ -207,7 +207,7 @@ function folder(folderId) {
     // Normalize the directory path to ensure it ends with a "/"
     const basePath = dir.endsWith("/") ? dir : dir + "/";
 
-    const START_CURSOR = "0";
+    const START_CURSOR = 0;
     let cursor = START_CURSOR;
     let entries = [];
 
@@ -240,7 +240,7 @@ function folder(folderId) {
 
   // List all files and folders with metadata
   this.listAll = async () => {
-    const START_CURSOR = "0";
+    const START_CURSOR = 0;
     let cursor = START_CURSOR;
     let results = [];
 

--- a/app/models/question/search.js
+++ b/app/models/question/search.js
@@ -101,7 +101,7 @@ const load = async (ids) => {
 module.exports = async ({ query, page = 1, page_size = PAGE_SIZE } = {}) => {
   const key = keys.all_questions;
   const questions = [];
-  let cursor = "0";
+  let cursor = 0;
 
   do {
     const result = await client.sScan(key, cursor);
@@ -119,7 +119,7 @@ module.exports = async ({ query, page = 1, page_size = PAGE_SIZE } = {}) => {
         });
       }
     });
-  } while (questions.length < page_size * page && cursor !== "0");
+  } while (questions.length < page_size * page && cursor !== 0);
 
   return sortAndPaginate(questions, page_size, page);
 };

--- a/app/models/redirects/check.js
+++ b/app/models/redirects/check.js
@@ -18,7 +18,7 @@ module.exports = function (blogID, input, callback) {
 
     (async function () {
       try {
-        var cursor = "0";
+        var cursor = 0;
 
         while (true) {
           // SORTED SET, precedence is important
@@ -29,7 +29,7 @@ module.exports = function (blogID, input, callback) {
           cursor = response.cursor;
           var matches = response.members || [];
 
-          if (!matches.length && cursor === "0") {
+          if (!matches.length && cursor === 0) {
             return callback();
           }
 
@@ -41,7 +41,7 @@ module.exports = function (blogID, input, callback) {
             }
           }
 
-          if (cursor === "0") {
+          if (cursor === 0) {
             return callback();
           }
         }


### PR DESCRIPTION
## Summary
- switch Redis scan cursors from string `"0"` sentinels to numeric `0` in scan loops impacted by RESP:3 responses
- update loop termination checks to use numeric strict comparisons (`=== 0` / `!== 0`)
- apply fixes in redirect regex scanning, question search pagination scan, and Google Drive database channel/folder iterators

## Files changed
- `app/models/redirects/check.js`
- `app/models/question/search.js`
- `app/clients/google-drive/database/channel.js`
- `app/clients/google-drive/database/folder.js`

## Validation
- static inspection of updated files and diff confirms all affected loops now compare numeric cursors

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a33809fb388329ad5d6668a645e9d6)