### PR TITLE
Fix pruneMissing to remove all missing entry IDs

### DIFF
--- a/app/models/entries/index.js
+++ b/app/models/entries/index.js
@@ -238,7 +238,7 @@ module.exports = (function () {
               if (!missing.length) return nextList();
 
               redis
-                .zRem.apply(redis, [key].concat(missing))
+                .zRem(key, missing)
                 .then(function () {
                   nextList();
                 })

--- a/app/models/entries/tests.js
+++ b/app/models/entries/tests.js
@@ -223,17 +223,23 @@ describe("entries", function () {
   });
 
   describe("pruneMissing", function () {
-    it("removes orphaned IDs from entry lists", async function () {
+    it("removes all orphaned IDs from entry lists", async function () {
       const blogID = this.blog.id;
       const path = "/prune-entry.txt";
-      const ghostID = "/ghost-entry";
+      const ghostIDs = ["/ghost-entry-1", "/ghost-entry-2"];
       const listKey = `blog:${blogID}:entries`;
 
       await new Promise((resolve, reject) => {
         Entry.set(blogID, path, buildEntry(path), (err) => (err ? reject(err) : resolve()));
       });
 
-      await redis.zAdd(listKey, { score: Date.now(), value: ghostID });
+      await redis.zAdd(
+        listKey,
+        ghostIDs.map((ghostID, index) => ({
+          score: Date.now() + index,
+          value: ghostID,
+        }))
+      );
 
       await new Promise((resolve, reject) => {
         Entries.pruneMissing(blogID, (err) => (err ? reject(err) : resolve()));
@@ -241,7 +247,9 @@ describe("entries", function () {
 
       const members = await redis.zRange(listKey, 0, -1);
       expect(members).toContain(path);
-      expect(members).not.toContain(ghostID);
+      ghostIDs.forEach((ghostID) => {
+        expect(members).not.toContain(ghostID);
+      });
     });
   });
 


### PR DESCRIPTION
### Motivation

- Ensure `pruneMissing` removes all orphaned IDs from Redis sorted sets when multiple missing IDs are present by using the Redis client API correctly.

### Description

- Replace `redis.zRem.apply(redis, [key].concat(missing))` with `redis.zRem(key, missing)` in `pruneMissing` while preserving the existing Promise flow and callback behavior (`.then(nextList)` / `.catch(nextList(err))`).
- Expand the `pruneMissing` test to insert multiple ghost IDs and verify each missing ID is removed, not just the first.
- Searched the repository for other `.zRem.apply` occurrences and found no additional instances to normalize.

### Testing

- Ran a repository search for `zRem.apply` (no occurrences remaining after the change). 
- Attempted to run the entry tests with `npm test -- app/models/entries/tests.js`, but the test runner failed in this environment because `docker` is not available, so the test could not be executed here; the new test was added to the test suite nonetheless.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3390d778483299d33a3f5aa73a018)