### PR TITLE
Use raw metadata values for setMetadata control flow

### DIFF
--- a/app/models/template/setMetadata.js
+++ b/app/models/template/setMetadata.js
@@ -38,17 +38,20 @@ module.exports = function setMetadata(id, updates, callback) {
       console.log("error injecting locals:", e);
     }
 
+    var isPublic = metadata.isPublic === true || metadata.isPublic === "true";
+    var owner = metadata.owner;
+
     metadata = serializeRedisHashValues(serialize(metadata, metadataModel));
 
     (async function () {
       try {
-        if (metadata.isPublic) {
+        if (isPublic) {
           await client.sAdd(key.publicTemplates(), id);
         } else {
           await client.sRem(key.publicTemplates(), id);
         }
 
-        await client.sAdd(key.blogTemplates(metadata.owner), id);
+        await client.sAdd(key.blogTemplates(owner), id);
         await client.hSet(key.metadata(id), metadata);
 
         if (!changes) {
@@ -58,7 +61,7 @@ module.exports = function setMetadata(id, updates, callback) {
           });
         }
 
-        var shouldBumpCache = !(metadata.isPublic || metadata.owner === "SITE");
+        var shouldBumpCache = !(isPublic || owner === "SITE");
         var regenerateManifest = function () {
           updateCdnManifest(id, function (manifestErr) {
             if (manifestErr) return callback(manifestErr);
@@ -68,7 +71,7 @@ module.exports = function setMetadata(id, updates, callback) {
 
         if (!shouldBumpCache) return regenerateManifest();
 
-        Blog.set(metadata.owner, { cacheID: Date.now() }, function (cacheErr) {
+        Blog.set(owner, { cacheID: Date.now() }, function (cacheErr) {
           if (cacheErr) return callback(cacheErr);
           regenerateManifest();
         });

--- a/app/models/template/tests/setMetadata.js
+++ b/app/models/template/tests/setMetadata.js
@@ -1,4 +1,8 @@
 const { promisify } = require("util");
+const client = require("models/client");
+const Blog = require("models/blog");
+const key = require("../key");
+
 describe("template", function () {
   require("./setup")({ createTemplate: true });
 
@@ -19,6 +23,22 @@ describe("template", function () {
     await setMetadata(this.template.id, updates);
     const blog = await getBlog({ id: this.template.owner });
     expect(blog.cacheID).not.toEqual(initialCacheID);
+  });
+
+  it("uses raw isPublic/owner values for set membership and cache bump decisions", async function () {
+    await setMetadata(this.template.id, { isPublic: true });
+
+    const sRemSpy = spyOn(client, "sRem").and.callThrough();
+    const blogSetSpy = spyOn(Blog, "set").and.callThrough();
+
+    await setMetadata(this.template.id, {
+      isPublic: false,
+      description: "Template should remain private",
+    });
+
+    expect(sRemSpy).toHaveBeenCalledWith(key.publicTemplates(), this.template.id);
+    expect(blogSetSpy).toHaveBeenCalled();
+    expect(blogSetSpy.calls.mostRecent().args[0]).toEqual(this.blog.id);
   });
 
   it("it will inject the font styles when you simply supply an id", async function () {


### PR DESCRIPTION
### Motivation
- Prevent control-flow from depending on serialized string values by using raw `metadata` fields for decisions before calling the serializers.
- Ensure public membership, blog set membership, and cache-bump logic use boolean semantics (not string truthiness) so private/public behavior and cache invalidation are correct.

### Description
- Capture raw values with `var isPublic = metadata.isPublic === true || metadata.isPublic === "true";` and `var owner = metadata.owner;` immediately before serialization in `app/models/template/setMetadata.js`.
- Keep Redis hash serialization and `client.hSet(key.metadata(id), metadata)` unchanged and call `serialize(...)` / `serializeRedisHashValues(...)` as before.
- Switch downstream control flow to use `isPublic` and `owner` for public set membership (`sAdd`/`sRem`), `client.sAdd(key.blogTemplates(...), id)`, the `shouldBumpCache` calculation, and the `Blog.set(...)` call.
- Add a focused unit test in `app/models/template/tests/setMetadata.js` that exercises `isPublic: false` behavior and asserts `sRem(key.publicTemplates(), id)` is called and the cache-bump path (`Blog.set`) is invoked for non-`SITE` owners.

### Testing
- Added/updated the unit test file `app/models/template/tests/setMetadata.js` to cover the boolean semantics and set membership behavior.
- Attempted to run the focused test via `./scripts/tests/invoke.sh app/models/template/tests/setMetadata.js` but test execution failed in this environment due to missing Docker (`docker: command not found`), so automated tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a338fa0a0c83299072b6d5963e23d5)