### PR TITLE
Fix pruneMissing removal of multiple missing entry IDs

### DIFF
--- a/app/models/entries/index.js
+++ b/app/models/entries/index.js
@@ -238,7 +238,7 @@ module.exports = (function () {
               if (!missing.length) return nextList();
 
               redis
-                .zRem.apply(redis, [key].concat(missing))
+                .zRem(key, missing)
                 .then(function () {
                   nextList();
                 })

--- a/app/models/entries/tests.js
+++ b/app/models/entries/tests.js
@@ -223,17 +223,20 @@ describe("entries", function () {
   });
 
   describe("pruneMissing", function () {
-    it("removes orphaned IDs from entry lists", async function () {
+    it("removes all orphaned IDs from entry lists", async function () {
       const blogID = this.blog.id;
       const path = "/prune-entry.txt";
-      const ghostID = "/ghost-entry";
+      const ghostIDs = ["/ghost-entry-1", "/ghost-entry-2", "/ghost-entry-3"];
       const listKey = `blog:${blogID}:entries`;
 
       await new Promise((resolve, reject) => {
         Entry.set(blogID, path, buildEntry(path), (err) => (err ? reject(err) : resolve()));
       });
 
-      await redis.zAdd(listKey, { score: Date.now(), value: ghostID });
+      await redis.zAdd(
+        listKey,
+        ghostIDs.map((ghostID, index) => ({ score: Date.now() + index, value: ghostID }))
+      );
 
       await new Promise((resolve, reject) => {
         Entries.pruneMissing(blogID, (err) => (err ? reject(err) : resolve()));
@@ -241,7 +244,10 @@ describe("entries", function () {
 
       const members = await redis.zRange(listKey, 0, -1);
       expect(members).toContain(path);
-      expect(members).not.toContain(ghostID);
+
+      ghostIDs.forEach((ghostID) => {
+        expect(members).not.toContain(ghostID);
+      });
     });
   });
 


### PR DESCRIPTION
### Motivation
- Ensure `Entries.pruneMissing` removes all orphaned IDs from Redis sorted sets when multiple missing IDs are found rather than potentially only removing a single ID. 
- Replace the old `.apply` invocation pattern with a direct `zRem` call that accepts the key and array of members for clarity and correctness.

### Description
- Replaced `redis.zRem.apply(redis, [key].concat(missing))` with `redis.zRem(key, missing)` in `app/models/entries/index.js` while preserving the existing `.then/.catch` control flow. 
- Expanded the `pruneMissing` test in `app/models/entries/tests.js` to seed multiple ghost IDs and assert each missing ID is removed from the sorted set. 
- Verified there are no other `zRem.apply` usages in the repository that require the same migration.

### Testing
- Added/updated unit test `app/models/entries/tests.js` that covers multiple missing IDs removal and asserts all ghost IDs are pruned. 
- Attempted to run the test file with `npm test -- app/models/entries/tests.js`, but the test harness failed in this environment because the project test runner shells out to `docker`, which is not available, so the test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3391a99d88329889a296c121f7077)