### PR TITLE
Handle setView Redis URL write rejections

### DIFF
--- a/app/models/template/setView.js
+++ b/app/models/template/setView.js
@@ -71,6 +71,11 @@ module.exports = function setView(templateID, updates, callback) {
 			// Look up previous state of view if applicable
 			getView(templateID, name, (err, view) => {
 				view = view || {};
+				let redisWriteChain = Promise.resolve();
+
+				const enqueueRedisWrite = (writeFn) => {
+					redisWriteChain = redisWriteChain.then(() => Promise.resolve().then(writeFn));
+				};
 
 				// Normalize legacy views' urlPatterns for short-circuit comparison
 				// This ensures legacy views with only view.url can properly short-circuit
@@ -109,19 +114,22 @@ module.exports = function setView(templateID, updates, callback) {
 
 					// Only update Redis if url is still defined (not deleted due to empty array)
 					if (updates.url !== undefined) {
-						client.set(key.url(templateID, updates.url), name);
+						enqueueRedisWrite(() =>
+							client.set(key.url(templateID, updates.url), name),
+						);
 
 						if (updates.url !== view.url) {
-							client.del(key.url(templateID, view.url));
+							enqueueRedisWrite(() => client.del(key.url(templateID, view.url)));
 						}
 					} else {
 						// If url was deleted (empty array), remove the old URL mapping
 						if (view.url) {
-							client.del(key.url(templateID, view.url));
+							enqueueRedisWrite(() => client.del(key.url(templateID, view.url)));
 						}
 					}
 				}
 
+				redisWriteChain.then(() => {
 				// SHORT-CIRCUIT: Check if content and other critical fields are unchanged
 				// This avoids expensive operations (parsing, dependency detection, Redis writes, CDN updates)
 				var contentUnchanged =
@@ -236,21 +244,26 @@ module.exports = function setView(templateID, updates, callback) {
 				if (updates.urlPatterns) {
 					// Store `urlPatterns` in Redis
 					const urlPatternsKey = key.urlPatterns(templateID);
-					client.hSet(
-						urlPatternsKey,
-						name,
-						JSON.stringify(updates.urlPatterns),
+					enqueueRedisWrite(() =>
+						client.hSet(
+							urlPatternsKey,
+							name,
+							JSON.stringify(updates.urlPatterns),
+						),
 					);
 				} else if (shouldRemoveUrlPatterns) {
 					// Delete urlPatterns from Redis if it was removed
 					const urlPatternsKey = key.urlPatterns(templateID);
-					client.hDel(urlPatternsKey, name);
+					enqueueRedisWrite(() => client.hDel(urlPatternsKey, name));
 				}
-				view.locals = view.locals || {};
-				view.retrieve = view.retrieve || {};
-				view.partials = view.partials || {};
 
-				var parseResult = parseTemplate(view.content);
+				redisWriteChain
+					.then(() => {
+						view.locals = view.locals || {};
+						view.retrieve = view.retrieve || {};
+						view.partials = view.partials || {};
+
+						var parseResult = parseTemplate(view.content);
 
 				// TO DO REMOVE THIS
 				if (type(view.partials, "array")) {
@@ -264,11 +277,11 @@ module.exports = function setView(templateID, updates, callback) {
 
 				extend(view.partials).and(parseResult.partials);
 
-				detectInfinitePartialDependency(
-					templateID,
-					view,
-					parseResult,
-					(infiniteError) => {
+						detectInfinitePartialDependency(
+						templateID,
+						view,
+						parseResult,
+						(infiniteError) => {
 						if (infiniteError) return callback(infiniteError);
 
 						// Merge parser-derived retrieve (e.g. {{title}}) into view.retrieve; do not overwrite user-provided retrieve (includeDraft, filters, etc.)
@@ -320,8 +333,11 @@ module.exports = function setView(templateID, updates, callback) {
 								});
 							})
 							.catch(callback);
-					},
-				);
+						},
+					);
+					})
+					.catch(callback);
+				}).catch(callback);
 			});
 		}).catch(callback);
 	});

--- a/app/models/template/tests/setView.js
+++ b/app/models/template/tests/setView.js
@@ -4,7 +4,8 @@ const { promisify } = require("util");
 describe("template", () => {
 	require("./setup")({ createTemplate: true });
 
-	const setView = promisify(require("../index").setView);
+	const setViewCallback = require("../index").setView;
+	const setView = promisify(setViewCallback);
 	const setMetadata = promisify(require("../index").setMetadata);
 	const getView = promisify(require("../index").getView);
 	const getMetadata = promisify(require("../index").getMetadata);
@@ -176,6 +177,24 @@ describe("template", () => {
 		} catch (err) {
 			expect(err instanceof Error).toBe(true);
 		}
+	});
+
+	it("forwards Redis url mapping failures to callback", function (done) {
+		const expectedError = new Error("redis set failed");
+		spyOn(client, "set").and.returnValue(Promise.reject(expectedError));
+
+		setViewCallback(
+			this.template.id,
+			{
+				name: "redis-error.html",
+				content: "hello",
+				url: "/redis-error",
+			},
+			(err) => {
+				expect(err).toBe(expectedError);
+				done();
+			},
+		);
 	});
 
 	it("updates the cache ID of the blog which owns a template after setting a view", async function () {


### PR DESCRIPTION
### Motivation
- Prevent unhandled promise rejections from fire-and-forget Redis calls in `setView()` by ensuring URL-related Redis writes are awaited and failures are forwarded to the `callback` so they short-circuit later logic.

### Description
- Replace fire-and-forget `client.set`/`client.del` calls for `url` with a queued promise chain driven by `redisWriteChain` and `enqueueRedisWrite` so each Redis operation is awaited and its rejection can be caught.
- Apply the same queued pattern to `urlPatterns` writes (`client.hSet`/`client.hDel`) so all URL-related writes participate in the same controlled async flow before parsing and saving the view.
- Wire `.catch(callback)` on the queued chain so any Redis write failure is forwarded to the original `callback(err)` and prevents proceeding with parse/save/CDN updates.
- Add a focused spec to `app/models/template/tests/setView.js` that spies on `client.set` to return a rejected promise and asserts the error is delivered to `setView`'s callback; also expose the callback-style `setView` alongside the promisified helper in the test file to invoke it directly.

### Testing
- Ran JavaScript syntax/type checks with `node --check app/models/template/setView.js` and `node --check app/models/template/tests/setView.js`, both succeeded.
- Attempted to run the test file via the project test runner (`./scripts/tests/invoke.sh app/models/template/tests/setView.js`), but the runner failed in this environment because `docker` is not available, so the full Jasmine execution could not be completed here.
- The new regression spec was added and is ready to run in CI / a developer environment with Docker available; it validates that Redis write rejections are forwarded to the `callback` as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a33957bcd88329b7e41ce495e8d841)