### PR TITLE
Handle ignoredFiles add/drop Redis failures via callback

### DIFF
--- a/app/models/ignoredFiles/index.js
+++ b/app/models/ignoredFiles/index.js
@@ -30,7 +30,7 @@ module.exports = (function () {
         await redis.hSet(ignoredFilesKey(blogID), path, reason);
         callback();
       } catch (err) {
-        throw err;
+        callback(err);
       }
     })();
   }
@@ -45,7 +45,7 @@ module.exports = (function () {
         await redis.hDel(ignoredFilesKey(blogID), path);
         callback();
       } catch (err) {
-        throw err;
+        callback(err);
       }
     })();
   }


### PR DESCRIPTION
### Motivation
- Ensure Redis errors in `add` and `drop` are reported via the module's callback convention instead of throwing, preventing unhandled rejections and matching nearby methods (`get`, `flush`, `getStatus`, and `isIt`).

### Description
- Replace `throw err` with `callback(err)` in `add(blogID, path, reason, callback)` and `drop(blogID, path, callback)` in `app/models/ignoredFiles/index.js`, preserving the existing `callback()` success behavior.

### Testing
- Ran `node --check app/models/ignoredFiles/index.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3394a2a7c8329990db683b5882846)