### PR TITLE
Use strict boolean assertions in template membership cleanup specs

### DIFF
--- a/app/models/blog/tests/remove.js
+++ b/app/models/blog/tests/remove.js
@@ -52,7 +52,7 @@ describe("Blog.remove", function () {
         client
           .sIsMember("template:public_templates", createdTemplate.id)
           .then(function (isMemberBeforeRemove) {
-            expect(isMemberBeforeRemove).toEqual(1);
+            expect(isMemberBeforeRemove).toBe(true);
 
             remove(test.blog.id, function (err) {
               if (err) return done.fail(err);

--- a/app/models/template/tests/drop.js
+++ b/app/models/template/tests/drop.js
@@ -97,7 +97,7 @@ describe("template", function () {
         client
           .sIsMember(key.blogTemplates(test.blog.id), test.template.id)
           .then(function (isMember) {
-            expect(isMember).toEqual(0);
+            expect(isMember).toBe(false);
             done();
           })
           .catch(done.fail);


### PR DESCRIPTION
### Motivation
- Enforce strict boolean checking for Redis set membership assertions to catch RESP-mode regressions and avoid numeric coercion hiding failures.

### Description
- Replace `expect(isMemberBeforeRemove).toEqual(1);` with `expect(isMemberBeforeRemove).toBe(true);` in `app/models/blog/tests/remove.js` and replace `expect(isMember).toEqual(0);` with `expect(isMember).toBe(false);` in `app/models/template/tests/drop.js`.

### Testing
- Ran `npm test -- app/models/blog/tests/remove.js app/models/template/tests/drop.js` but the test invocation could not complete here because `./scripts/tests/invoke.sh` requires `docker` which is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a339408a648329b45245d567dd3aad)