### PR TITLE
Handle RESP3 `SETNX` collision retries in user creation

### DIFF
--- a/app/models/user/create.js
+++ b/app/models/user/create.js
@@ -63,7 +63,7 @@ module.exports = function create (
       var results = await multi.exec();
 
       // Retry if generated ID was in use
-      if (results && results[1] === 0)
+      if (results && (results[1] === false || results[1] === 0))
         return create(email, passwordHash, subscription, paypal, callback);
 
       // Schedule a notifcation email for their subscription renewal

--- a/app/models/user/tests/create.js
+++ b/app/models/user/tests/create.js
@@ -26,4 +26,49 @@ describe("user", function () {
       }
     );
   });
+
+  it("retries creation when SETNX reports collision with false", function (done) {
+    var create = require("models/user/create");
+    var client = require("models/client");
+
+    var execCalls = 0;
+
+    spyOn(client, "multi").and.callFake(function () {
+      var commands = [];
+
+      return {
+        sAdd: function () {
+          commands.push("sAdd");
+          return this;
+        },
+        setNX: function () {
+          commands.push("setNX");
+          return this;
+        },
+        set: function () {
+          commands.push("set");
+          return this;
+        },
+        exec: async function () {
+          execCalls += 1;
+
+          if (execCalls === 1) return [1, false, "OK", "OK"];
+          return [1, true, "OK", "OK"];
+        }
+      };
+    });
+
+    create(
+      "retry-false@gmail.com",
+      "hash",
+      {},
+      {},
+      function (err, user) {
+        expect(err).toBe(null);
+        expect(user).toEqual(jasmine.any(Object));
+        expect(execCalls).toBe(2);
+        done();
+      }
+    );
+  });
 });


### PR DESCRIPTION
### Motivation
- Redis RESP3 returns a boolean `false` for failed `SETNX` whereas RESP2 returned `0`, so the user creation flow must treat either form as an ID collision to retry ID generation.
- Ensure the create flow continues to retry on collisions while preserving the existing recursive retry behavior.

### Description
- Change collision check in `app/models/user/create.js` from `results[1] === 0` to `results[1] === false || results[1] === 0` so RESP3 `false` and RESP2 `0` are both treated as collisions.
- Keep the recursive retry call `return create(email, passwordHash, subscription, paypal, callback);` unchanged.
- Add a test `app/models/user/tests/create.js` that stubs `client.multi()`/`exec()` to return `[..., false, ...]` on the first call and a successful response on the second, and asserts the create flow retried (`exec` called twice) and succeeded.

### Testing
- Added an automated Jasmine test `app/models/user/tests/create.js` which simulates `multi.exec()` returning `false` on the first attempt and verifies the retry occurs and succeeds.
- Attempted to run `npm test -- app/models/user/tests/create.js` in the current environment, but the test runner invocation failed due to missing Docker (`docker: command not found`), so the new test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3392ffb60832985fb9272beb9be03)