### PR TITLE
Fix list-ghosts to promisify Entry.get safely

### DIFF
--- a/app/sync/fix/list-ghosts.js
+++ b/app/sync/fix/list-ghosts.js
@@ -6,7 +6,9 @@ const { promisify } = require("util");
 var lists = ["all", "created", "entries", "drafts", "scheduled", "pages"];
 
 const pruneMissing = promisify(Entries.pruneMissing);
-const getEntry = promisify(Entry.get);
+const getEntry = promisify((blogID, id, callback) =>
+  Entry.get(blogID, id, (entry) => callback(null, entry))
+);
 const setEntry = promisify(Entry.set);
 
 function main(blog, callback) {

--- a/app/sync/fix/tests/list-ghosts.js
+++ b/app/sync/fix/tests/list-ghosts.js
@@ -1,0 +1,62 @@
+describe("sync/fix/list-ghosts", function () {
+  var Entry = require("models/entry");
+  var Entries = require("models/entries");
+  var client = require("models/client");
+  var fixListGhosts = require("../list-ghosts");
+
+  it("resolves missing entries without rejection and continues mismatch cleanup", function (done) {
+    spyOn(Entries, "pruneMissing").and.callFake(function (_blogID, callback) {
+      callback(null);
+    });
+
+    spyOn(client, "zRevRange").and.callFake(function (key) {
+      if (key === "blog:blog-id:entries") {
+        return Promise.resolve(["existing-id", "missing-id"]);
+      }
+
+      return Promise.resolve([]);
+    });
+
+    spyOn(client, "zRem").and.returnValue(Promise.resolve(1));
+
+    spyOn(Entry, "get").and.callFake(function (_blogID, id, callback) {
+      if (id === "existing-id") {
+        return callback({ id: "moved-id", title: "Moved" });
+      }
+
+      if (id === "missing-id") {
+        return callback(undefined);
+      }
+
+      return callback(undefined);
+    });
+
+    spyOn(Entry, "set").and.callFake(function (_blogID, id, entry, callback) {
+      expect(id).toBe("moved-id");
+      expect(entry.id).toBe("moved-id");
+      callback(null);
+    });
+
+    fixListGhosts({ id: "blog-id" }, function (err, report) {
+      expect(err).toBeNull();
+
+      expect(Entry.get.calls.allArgs()).toEqual([
+        ["blog-id", "existing-id", jasmine.any(Function)],
+        ["blog-id", "missing-id", jasmine.any(Function)],
+      ]);
+
+      expect(client.zRem.calls.allArgs()).toEqual([
+        ["blog:blog-id:entries", "existing-id"],
+        ["blog:blog-id:entries", "missing-id"],
+      ]);
+
+      expect(Entry.set.calls.count()).toBe(1);
+      expect(report).toEqual([
+        ["entries", "MISMATCH", "existing-id"],
+        ["entries", "MISMATCH", "missing-id"],
+      ]);
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- `Entry.get` uses a non-standard callback that returns the entry (no error-first argument), so `promisify(Entry.get)` can misbehave when an entry is missing; normalize it to an error-first signature to avoid rejected promises and preserve existing falsy-handling logic.

### Description
- Replace `const getEntry = promisify(Entry.get);` with `const getEntry = promisify((blogID, id, callback) => Entry.get(blogID, id, (entry) => callback(null, entry)));` in `app/sync/fix/list-ghosts.js` so `await getEntry(...)` resolves `undefined` for missing entries instead of rejecting.
- Leave `setEntry` and other promisified APIs unchanged.
- Add a focused unit test at `app/sync/fix/tests/list-ghosts.js` that asserts an existing entry resolves to an object, a missing entry resolves to `undefined`, and the cleanup loop continues and reports mismatches correctly.

### Testing
- Ran syntax checks with `node --check app/sync/fix/list-ghosts.js` and `node --check app/sync/fix/tests/list-ghosts.js`, both of which succeeded.
- Attempted `NODE_PATH=app npx jasmine app/sync/fix/tests/list-ghosts.js` but it failed in this environment due to missing Redis/runtime wiring and client setup required by the broader test harness.
- Attempted `npm test -- app/sync/fix/tests/list-ghosts.js` but it could not run here because the test runner requires `docker` which is unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a33924f14c8329a3146581591b01c8)