### PR TITLE
Accept organization CNAME targets in domain verification

### DIFF
--- a/app/dashboard/site/domain/tests/index.js
+++ b/app/dashboard/site/domain/tests/index.js
@@ -194,6 +194,40 @@ describe("domain verifier", function () {
     }
   });
 
+  it("should return true for hostnames with CNAME record to an organizations subdomain", async () => {
+    const hostname = "organizations-cname.com";
+    const handle = "example";
+
+    resolver.resolveCname.and.returnValue(
+      Promise.resolve([`customer.organizations.${ourHost}`])
+    );
+    resolver.resolve4.and.returnValue(Promise.reject(new Error("ENOTFOUND")));
+    resolver.resolve6.and.returnValue(Promise.resolve([]));
+    dns.resolveNs.and.returnValue(
+      Promise.resolve(["ns1.organizations.com", "ns2.organizations.com"])
+    );
+
+    const result = await verify({ hostname, handle, ourIP, ourIPv6, ourHost });
+    expect(result).toBe(true);
+  });
+
+  it("should return true for hostnames with CNAME record to an organization subdomain", async () => {
+    const hostname = "organization-cname.com";
+    const handle = "example";
+
+    resolver.resolveCname.and.returnValue(
+      Promise.resolve([`customer.organization.${ourHost}`])
+    );
+    resolver.resolve4.and.returnValue(Promise.reject(new Error("ENOTFOUND")));
+    resolver.resolve6.and.returnValue(Promise.resolve([]));
+    dns.resolveNs.and.returnValue(
+      Promise.resolve(["ns1.organization.com", "ns2.organization.com"])
+    );
+
+    const result = await verify({ hostname, handle, ourIP, ourIPv6, ourHost });
+    expect(result).toBe(true);
+  });
+
   it("should return true for hostnames with correct handle verification", async () => {
     const hostname = "correct-handle.com";
     const handle = "example";

--- a/app/dashboard/site/domain/verify.js
+++ b/app/dashboard/site/domain/verify.js
@@ -35,6 +35,24 @@ const VERIFICATION_TIMEOUT_LABEL = Number.isInteger(VERIFICATION_TIMEOUT_SECONDS
     ? `${VERIFICATION_TIMEOUT_SECONDS} seconds`
     : `${VERIFICATION_TIMEOUT_SECONDS.toFixed(2)} seconds`;
 
+function normalizeHostname(hostname) {
+    if (!hostname || typeof hostname !== 'string') return '';
+    return hostname.toLowerCase().replace(/\.$/, '');
+}
+
+function isValidCNAMETarget(cnameHost, ourHost) {
+    const normalizedCNAMEHost = normalizeHostname(cnameHost);
+    const normalizedOurHost = normalizeHostname(ourHost);
+
+    if (!normalizedCNAMEHost || !normalizedOurHost) return false;
+    if (normalizedCNAMEHost === normalizedOurHost) return true;
+
+    return (
+        normalizedCNAMEHost.endsWith(`.organization.${normalizedOurHost}`) ||
+        normalizedCNAMEHost.endsWith(`.organizations.${normalizedOurHost}`)
+    );
+}
+
 async function validate({ hostname, handle, ourIP, ourIPv6, ourHost }) {
     
     const parsed = parse(hostname);
@@ -105,7 +123,7 @@ async function validate({ hostname, handle, ourIP, ourIPv6, ourHost }) {
     ]);
 
     if (cnameHost) {
-        if (cnameHost === ourHost) {
+        if (isValidCNAMETarget(cnameHost, ourHost)) {
             // CNAME matches our host, return success
             return true;
         } else {


### PR DESCRIPTION
### Motivation
- Domain verification currently only accepted an exact CNAME match to `config.host` and should also treat CNAMEs that point to organization subdomains like `*.organization.<host>` or `*.organizations.<host>` as valid.

### Description
- Added `normalizeHostname` and `isValidCNAMETarget` helpers to `app/dashboard/site/domain/verify.js` to normalize DNS names and validate CNAME targets.
- Updated `validate` to accept CNAME targets that equal `ourHost` or end with `.organization.<ourHost>` or `.organizations.<ourHost>` instead of only exact matches.
- Implemented hostname normalization to lowercase and strip a trailing dot before comparisons to make matching robust against DNS formatting.
- Added two tests in `app/dashboard/site/domain/tests/index.js` to assert that `customer.organization.<host>` and `customer.organizations.<host>` CNAME targets are accepted.

### Testing
- Added Jasmine tests in `app/dashboard/site/domain/tests/index.js` covering the new CNAME acceptance patterns; these tests were added to the test suite but were not executed to completion in this environment.
- Attempted to run `npm test -- app/dashboard/site/domain/tests/index.js` which failed due to the environment missing Docker (`docker: command not found`).
- Attempted to run `npx jasmine app/dashboard/site/domain/tests/index.js` which failed due to missing project container configuration (`Cannot find module 'config'`) in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64ead3e5483299665f68dc4522e2e)