### PR TITLE
Allow curl User-Agent through default OpenResty bot filter

### DIFF
--- a/config/openresty/conf/server.conf
+++ b/config/openresty/conf/server.conf
@@ -16,7 +16,7 @@ http {
         # Scraper libraries and automation tools
         ~*(?i)(axios|wget|okhttp|jsdom|phantomjs|headless|selenium|webdriver) 1;
         ~*(?i)(playwright|puppeteer|cypress|watir|mechanize) 1;
-        ~*(?i)(aoihttp|curl|Faraday|Go-http-client|hackney|http.rb|python-httpx|python-requests|Python-urllib) 1;
+        ~*(?i)(aoihttp|Faraday|Go-http-client|hackney|http.rb|python-httpx|python-requests|Python-urllib) 1;
         
         # AI and specialized bots
         ~*(?i)(anthropic-ai|Timpibot|ClaudeBot|Claude-Web|^AIBOT|^BunnySlippers|^Cegbfeieh|^CheeseBot) 1;


### PR DESCRIPTION
### Motivation
- Stop treating the `curl` User-Agent as a blocked scraper by default so legitimate `curl` requests are not denied while preserving existing bot protections.

### Description
- Removed `curl` from the scraper libraries regex in the `$bad_bot` map inside `config/openresty/conf/server.conf` and left all other bot signatures unchanged, and kept `config/openresty/conf/restrict-bot-uas.conf` unchanged so it still enforces `if ($bad_bot = 1) { return 403; }`.

### Testing
- Confirmed the change with a targeted replacement and inspected the diff and the files using `sed`/`nl`/`git diff`, and committed the update; all inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4f6e6c1883298c948ffb5bf71e08)