### PR TITLE
Remove Commento plugin support

### DIFF
--- a/app/blog/README
+++ b/app/blog/README
@@ -166,7 +166,7 @@ Registers two routes:
 
 Resolves the request URL (decoded, lowercased, trimmed) via `Entry.getByUrl()`. Skips deleted, draft, or scheduled (unless `?scheduled` is set) entries. Loads adjacent entries via `Entries.adjacentTo()`. Issues a 301 redirect if the canonical URL differs from the request URL. Loads plugin HTML via `build/plugins` and attaches it as `res.locals.partials.pluginHTML`. Renders `entry.html`.
 
-Comments (Commento/Disqus plugins) are suppressed when entry metadata sets `Comments: No`, or for pages that do not explicitly set `Comments: Yes`.
+Comments (Disqus plugin) are suppressed when entry metadata sets `Comments: No`, or for pages that do not explicitly set `Comments: Yes`.
 
 ### `entries.js`
 

--- a/app/blog/entry.js
+++ b/app/blog/entry.js
@@ -47,7 +47,6 @@ module.exports = function (request, response, next) {
       commentsToggle === "no" ||
       (commentsToggle !== "yes" && entry.page)
     ) {
-      delete blog.plugins.commento;
       delete blog.plugins.disqus;
     }
 

--- a/app/blog/tests/pluginHTML.js
+++ b/app/blog/tests/pluginHTML.js
@@ -3,42 +3,6 @@ describe("pluginHTML", function () {
     require('./util/setup')();
     const config = require('config');
     
-    it("injects commento html", async function () {
-
-        // enable the commento plugin
-        const plugins = {...this.blog.plugins, commento: {enabled: true, options: {}}};
-        await this.blog.update({plugins})
-
-        await this.template({ "entry.html": "{{{entry.html}}} {{> pluginHTML}}" });
-        await this.write({path: '/a.txt', content: 'Link: /foo\n\nHello, world!'});        
-        await this.write({path: '/Pages/about.txt', content: 'Link: /about\n\nHello, page!'});        
-        await this.write({path: '/Drafts/test.txt', content: 'Hello, draft!'});        
-
-        const areThereComments = async (path) => {
-            const body = await this.text(path);
-            return body.includes('<script defer') && body.includes('src="https://cdn.commento.io/js/commento.js"');
-        }
-
-        expect(await areThereComments('/foo')).toBe(true, 'comments should appear on posts');
-
-        // but not on the preview subdomain
-        const res = await this.fetch(config.protocol + 'preview-of-my-local-on-' + this.blog.handle + '.' + config.host + '/foo');
-        const body = await res.text();
-        expect(body).not.toContain('src="https://cdn.commento.io/js/commento.js"');
-
-        expect(await areThereComments('/about')).toBe(false, 'comments should not appear on pages');
-        expect(await areThereComments('/draft/view/Drafts/test.txt')).toBe(false, 'comments should not appear on drafts');
-
-        // disable comments for the post
-        await this.write({path: '/a.txt', content: 'Link: /foo\nComments: No\n\nHello, world!'});
-        // enable comments for the page
-        await this.write({path: '/Pages/about.txt', content: 'Link: /about\nComments: Yes\n\nHello, world!'});
-
-        expect(await areThereComments('/about')).toBe(true, 'comments should appear on a pages with comments enabled');
-
-        expect(await areThereComments('/foo')).toBe(false, 'comments should not appear on posts with comments disabled');
-    });
-
     it("injects disqus html", async function () {
 
         // enable the disqus plugin
@@ -81,7 +45,7 @@ describe("pluginHTML", function () {
 
     it("normalizes comment metadata toggles", async function () {
 
-        const plugins = {...this.blog.plugins, commento: {enabled: true, options: {}}};
+        const plugins = {...this.blog.plugins, disqus: {enabled: true, options: {shortname: "test"}}};
         await this.blog.update({plugins})
 
         await this.template({ "entry.html": "{{{entry.html}}} {{> pluginHTML}}" });
@@ -92,7 +56,7 @@ describe("pluginHTML", function () {
 
         const areThereComments = async (path) => {
             const body = await this.text(path);
-            return body.includes('<script defer') && body.includes('src="https://cdn.commento.io/js/commento.js"');
+            return body.includes('<div id="disqus_thread"></div>') && body.includes('disqus.com/embed.js');
         }
 
         expect(await areThereComments('/post-no')).toBe(false, 'comments should not appear on posts with lowercase no');

--- a/app/build/README
+++ b/app/build/README
@@ -106,7 +106,6 @@ build/
 │   ├── mediaPreload/      Adds preload hints for media elements
 │   ├── linkScreenshot/    Generates screenshot thumbnails for links
 │   ├── analytics/         Injects analytics tracking code
-│   ├── commento/          Injects Commento comment threads
 │   └── disqus/            Injects Disqus comment threads
 ├── prepare/               Derives entry properties from HTML and metadata
 │   ├── index.js           Orchestrates all prepare steps; returns the enriched entry

--- a/app/build/plugins/commento/entry.html
+++ b/app/build/plugins/commento/entry.html
@@ -1,5 +1,0 @@
-<div id="commento"></div>
-<script defer
-  src="https://cdn.commento.io/js/commento.js"
-  data-page-id="{{{entry.url}}}">
-</script>

--- a/app/build/plugins/commento/form.html
+++ b/app/build/plugins/commento/form.html
@@ -1,1 +1,0 @@
-<p>Configure Commento to enable comments on your site</p>

--- a/app/build/plugins/commento/index.js
+++ b/app/build/plugins/commento/index.js
@@ -1,6 +1,0 @@
-module.exports = {
-  description: "Commento comments",
-  category: "external",
-  isDefault: false,
-  options: {},
-};

--- a/app/build/plugins/index.js
+++ b/app/build/plugins/index.js
@@ -24,7 +24,6 @@ var loaded = loadPlugins({
   autoImage: require("./autoImage"),
   bluesky: require("./bluesky"),
   codeHighlighting: require("./codeHighlighting"),
-  commento: require("./commento"),
   disqus: require("./disqus"),
   externalLinks: require("./externalLinks"),
   flickr: require("./flickr"),

--- a/app/views/developers/reference.yml
+++ b/app/views/developers/reference.yml
@@ -579,6 +579,6 @@
           description: Public JavaScript emitted by the plugin when available.
         - name: known keys
           type: array
-          description: "analytics, autoImage, bluesky, codeHighlighting, commento, disqus, externalLinks, flickr, image, imageCaption, injectTitle, katex, linebreaks, mediaPreload, linkScreenshot, titlecase, twitter, typeset, videoEmbeds, wikilinks, zoom"
+          description: "analytics, autoImage, bluesky, codeHighlighting, disqus, externalLinks, flickr, image, imageCaption, injectTitle, katex, linebreaks, mediaPreload, linkScreenshot, titlecase, twitter, typeset, videoEmbeds, wikilinks, zoom"
       example: |
         <style>{{{plugin.katex.css}}}</style>


### PR DESCRIPTION
### Motivation
- Remove Commento as a supported comment provider and stop emitting its assets and registration so the codebase only advertises/uses remaining comment plugins (Disqus).
- Keep Disqus behavior intact while ignoring legacy `blog.plugins.commento` settings so existing settings become no-ops.

### Description
- Deleted the Commento plugin module directory `app/build/plugins/commento/` and its files (`index.js`, `entry.html`, `form.html`).
- Removed the `commento` registration from the plugins loader in `app/build/plugins/index.js` so Commento is no longer loaded. 
- Removed the runtime cleanup line that deleted `blog.plugins.commento` in `app/blog/entry.js`, preserving Disqus suppression behavior. 
- Updated `app/blog/tests/pluginHTML.js` by removing the Commento-specific test and adapting the comment metadata-toggle test to exercise Disqus instead. 
- Updated developer/build/blog docs to remove Commento from `app/views/developers/reference.yml`, `app/build/README`, and changed the blog README wording to reference only Disqus; historical newsletter files mentioning Commento were left as archives.

### Testing
- Searched the repository for Commento references with `rg -n "commento|Commento|cdn.commento.io" .` and confirmed only intentional historical newsletter references remain (success).
- Loaded the plugins module with `NODE_PATH=app node -e "require('./app/build/plugins')"` which returned `plugins ok` indicating the loader resolves without the Commento plugin, though runtime Redis connections were refused in this environment (nonfatal warnings).
- Ran `git diff --check` to validate no whitespace/merge errors (success).
- Attempted to run the targeted test runner `npm test -- app/blog/tests/pluginHTML.js` but it could not execute in this environment because Docker is not available (blocked/failure to run tests here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3250ae0c848329aa67ba5605bda24a)