### PR TITLE
Allow http.rb user agent in OpenResty bot map

### DIFF
--- a/config/openresty/conf/server.conf
+++ b/config/openresty/conf/server.conf
@@ -16,7 +16,8 @@ http {
         # Scraper libraries and automation tools
         ~*(?i)(axios|wget|okhttp|jsdom|phantomjs|selenium|webdriver) 1;
         ~*(?i)(playwright|puppeteer|cypress|watir|mechanize) 1;
-        ~*(?i)(aoihttp|Faraday|Go-http-client|hackney|http.rb|python-httpx|python-requests|Python-urllib) 1;
+        # Allow http.rb because Mastodon/OpenGraph preview fetchers may use it.
+        ~*(?i)(aoihttp|Faraday|Go-http-client|hackney|python-httpx|python-requests|Python-urllib) 1;
         
         # AI and specialized bots
         ~*(?i)(anthropic-ai|Timpibot|ClaudeBot|Claude-Web|^AIBOT|^BunnySlippers|^Cegbfeieh|^CheeseBot) 1;


### PR DESCRIPTION
### Motivation
- Prevent legitimate Ruby HTTP clients (such as Mastodon/OpenGraph preview fetchers) from being flagged as bad bots by removing `http.rb` from the `$bad_bot` User-Agent map in `config/openresty/conf/server.conf`.

### Description
- Removed `http.rb` from the scraper-library regex under the `# bots` section in `config/openresty/conf/server.conf` and added a brief comment explaining that `http.rb` is allowed because Mastodon/OpenGraph preview fetchers may use it.

### Testing
- Verified the change with `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c3264252c8329948d9d6ffa771d54)