### PR TITLE
Preserve Entry instance prototypes in posts cache

### DIFF
--- a/app/blog/render/retrieve/posts.js
+++ b/app/blog/render/retrieve/posts.js
@@ -1,4 +1,5 @@
 const Entry = require("models/entry");
+const EntryInstance = require("models/entry/instance");
 const entriesModel = require("models/entries");
 const LRUCache = require("lru-cache").LRUCache;
 const fetchTaggedEntries = require("./helpers/fetchTaggedEntries");
@@ -13,7 +14,7 @@ function cloneDeep(value) {
   }
 
   if (value && typeof value === "object") {
-    const clone = {};
+    const clone = value instanceof EntryInstance ? new EntryInstance() : {};
 
     Object.keys(value).forEach((key) => {
       clone[key] = cloneDeep(value[key]);

--- a/app/blog/render/retrieve/tests/posts.js
+++ b/app/blog/render/retrieve/tests/posts.js
@@ -140,6 +140,33 @@ describe("posts", function () {
     expect(text.trim()).toEqual("One");
   });
 
+
+  it("augments tags on posts across cached requests", async function () {
+    await this.write({
+      path: "/paris.txt",
+      content: "Title: Paris\nTags: Paris\n\nBonjour",
+    });
+
+    await this.template(
+      {
+        "foo.html": `{{#posts}}{{#tags}}{{name}}|{{slug}}|{{first}}|{{last}}{{/tags}}{{/posts}}`,
+      },
+      {
+        views: {
+          "foo.html": {
+            url: "/foo",
+          },
+        },
+      }
+    );
+
+    const first = await this.get("/foo");
+    expect((await first.text()).trim()).toEqual("Paris|paris|true|true");
+
+    const second = await this.get("/foo");
+    expect((await second.text()).trim()).toEqual("Paris|paris|true|true");
+  });
+
   describe("rejects invalid page numbers", function () {
     const cases = [
       ["zero", "/page/0"],


### PR DESCRIPTION
### Motivation
- Ensure values returned to templates from the posts retriever keep `models/entry/instance` prototypes so `app/blog/render/load/eachEntry.js` can discover and augment entries correctly.
- Prevent cached payload cloning from turning `Entry` instances into plain objects which breaks tag augmentation and adjacent-entry augmentation.

### Description
- Special-case the deep clone to preserve `Entry` instances by importing `models/entry/instance` and creating new `EntryInstance` objects when cloning entries in `app/blog/render/retrieve/posts.js`.
- Keep pagination and other payload parts safely cloned and frozen while ensuring entries satisfy `entry instanceof Entry` when returned to callers.
- Add a regression test `app/blog/render/retrieve/tests/posts.js` that creates a post with `Tags: Paris` and renders the `{{#posts}}{{#tags}}{{name}}|{{slug}}|{{first}}|{{last}}{{/tags}}{{/posts}}` view twice to cover both the initial and cached retrieval paths.

### Testing
- Syntax check: `node -c app/blog/render/retrieve/posts.js` succeeded. 
- Syntax check: `node -c app/blog/render/retrieve/tests/posts.js` succeeded. 
- Full test run `npm test -- app/blog/render/retrieve/tests/posts.js` was attempted but blocked because Docker is not available in the environment, so the container-based test runner could not run the integration tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f66630e3483299ead35dbd0b897ba)