### PR TITLE
Set system git pack settings in Dockerfile base stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,12 @@ RUN apk add --no-cache --update \
     ca-certificates \
     ttf-freefont
 
+# Configure git to handle lots of large binary files in memory-constrained environments.
+RUN git config --system pack.threads 1 \
+ && git config --system pack.windowMemory 32m \
+ && git config --system pack.deltaCacheSize 32m \
+ && git config --system pack.window 5
+
 # Use tini as the init process so simple-git child processes are reaped instead of becoming zombies.
 ENTRYPOINT ["/sbin/tini", "--"]
 


### PR DESCRIPTION
### Motivation
- Add system-level git pack settings in the `base` stage to help Git handle many large binary files in memory-constrained environments.

### Description
- Inserted a `RUN` configuring system git packing above the `ENTRYPOINT` in `Dockerfile` to limit memory use: `RUN git config --system pack.threads 1 && git config --system pack.windowMemory 32m && git config --system pack.deltaCacheSize 32m && git config --system pack.window 5`, and updated the adjacent comment to explain the intent.

### Testing
- Ran `git diff --check`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a520f3861b083298a296eb91dd3df98)