### PR TITLE
Add progress parsing and rendering for sync status

### DIFF
--- a/app/clients/git/create.js
+++ b/app/clients/git/create.js
@@ -160,8 +160,7 @@ async function createRepository(blog, folder) {
     await liveRepo.addRemote("origin", bareDirectory);
 
     report(folder, "Adding existing folder to live repository");
-    const progress = { filesAdded: 0 };
-    await addFolder(folder, liveRepo, bareRepo, progress);
+    await addFolder(folder, liveRepo, bareRepo);
   } finally {
     await Promise.all([
       unsetTemporaryGitGc(bareRepo),
@@ -220,13 +219,14 @@ function report(folder, message, logMessage = message) {
   folder.status(message);
 }
 
-async function addFolder(folder, liveRepo, bareRepo, progress) {
-  async function walk(dir) {
-    const entries = (await fs.readdir(dir, { withFileTypes: true }))
-      .filter((entry) => !shouldIgnoreFile(entry.name))
-      .sort((a, b) => a.name.localeCompare(b.name));
+async function addFolder(folder, liveRepo, bareRepo) {
+  const progress = { filesAdded: 0, totalFiles: 0 };
 
-    if (!entries.length && dir === folder.path) {
+  try {
+    const files = await collectFiles(folder.path);
+    progress.totalFiles = files.length;
+
+    if (!files.length) {
       console.log(
         clfdate() + " Git: addFolder: folder is empty, creating initial commit"
       );
@@ -234,22 +234,36 @@ async function addFolder(folder, liveRepo, bareRepo, progress) {
       return handleEmptyFolder(folder, liveRepo);
     }
 
+    for (const [index, filePath] of files.entries()) {
+      await addFile(folder, liveRepo, bareRepo, progress, filePath, index + 1);
+    }
+  } catch (err) {
+    throw new Error("Error while adding files to repository: " + err.message);
+  }
+}
+
+async function collectFiles(rootDirectory) {
+  const files = [];
+
+  async function walk(dir) {
+    const entries = (await fs.readdir(dir, { withFileTypes: true }))
+      .filter((entry) => !shouldIgnoreFile(entry.name))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
     for (const entry of entries) {
       const filePath = path.join(dir, entry.name);
 
       if (entry.isDirectory()) {
         await walk(filePath);
       } else if (entry.isFile()) {
-        await addFile(folder, liveRepo, bareRepo, progress, filePath);
+        files.push(filePath);
       }
     }
   }
 
-  try {
-    await walk(folder.path);
-  } catch (err) {
-    throw new Error("Error while adding files to repository: " + err.message);
-  }
+  await walk(rootDirectory);
+
+  return files;
 }
 
 async function handleEmptyFolder(folder, liveRepo) {
@@ -261,7 +275,14 @@ async function handleEmptyFolder(folder, liveRepo) {
   folder.status("Created initial commit in empty repository");
 }
 
-async function addFile(folder, liveRepo, bareRepo, progress, filePath) {
+async function addFile(
+  folder,
+  liveRepo,
+  bareRepo,
+  progress,
+  filePath,
+  currentFileIndex
+) {
   const relativePath = path.relative(folder.path, filePath);
   const untilGc =
     GC_INTERVAL - (progress.filesAdded % GC_INTERVAL || GC_INTERVAL);
@@ -275,7 +296,14 @@ async function addFile(folder, liveRepo, bareRepo, progress, filePath) {
       " successful files until gc)"
   );
 
-  folder.status("Adding " + relativePath + " to repository");
+  folder.status(
+    "(" +
+      currentFileIndex +
+      "/" +
+      progress.totalFiles +
+      ") Syncing /" +
+      relativePath
+  );
 
   try {
     await liveRepo.add(filePath);

--- a/app/clients/git/create.js
+++ b/app/clients/git/create.js
@@ -10,8 +10,6 @@ const shouldIgnoreFile = require("clients/util/shouldIgnoreFile");
 const path = require("path");
 
 const GC_INTERVAL = 100;
-const COMMIT_BATCH_SIZE = 25;
-const PUSH_COMMIT_BATCH_SIZE = 5;
 const COMMIT_RETRY_DELAYS_MS = [1000, 2000, 3000];
 
 // We apply this configuration because there is a bug with git version 2.54.0 
@@ -44,11 +42,7 @@ async function createEmptyCommit(repo, message) {
   await repo.commit(message, { "--allow-empty": true });
 }
 
-async function pushMaster(repo, folder, message) {
-  if (folder) {
-    folder.status(message || "Pushing commits to repository");
-  }
-
+async function pushMaster(repo) {
   await repo.push(["-u", "origin", "master"]);
 }
 
@@ -81,18 +75,17 @@ async function unsetTemporaryGitGc(repo) {
   });
 }
 
-async function commitBatchWithRetries(repo, folder, label, message) {
+async function commitFileWithRetries(repo, relativePath) {
   for (let attempt = 0; ; attempt++) {
     try {
-      folder.status("Committing " + label + " to repository");
-      await repo.raw(["commit", "--allow-empty", "-m", message]);
+      await repo.raw(["commit", "--allow-empty", "-m", "Add file"]);
       if (attempt > 0) {
         console.log(
           clfdate() +
             " Git: create: commit succeeded on attempt " +
             (attempt + 1) +
             " " +
-            label
+            relativePath
         );
       }
       return;
@@ -112,7 +105,7 @@ async function commitBatchWithRetries(repo, folder, label, message) {
           " in " +
           delayMs +
           "ms " +
-          label +
+          relativePath +
           " err=" +
           err.message
       );
@@ -167,7 +160,7 @@ async function createRepository(blog, folder) {
     await liveRepo.addRemote("origin", bareDirectory);
 
     report(folder, "Adding existing folder to live repository");
-    const progress = { filesAdded: 0, pendingFiles: [], unpushedCommits: 0 };
+    const progress = { filesAdded: 0 };
     await addFolder(folder, liveRepo, bareRepo, progress);
   } finally {
     await Promise.all([
@@ -227,14 +220,13 @@ function report(folder, message, logMessage = message) {
   folder.status(message);
 }
 
-async function addFolder(folder, liveRepo, bareRepo) {
-  const progress = { filesAdded: 0, totalFiles: 0 };
+async function addFolder(folder, liveRepo, bareRepo, progress) {
+  async function walk(dir) {
+    const entries = (await fs.readdir(dir, { withFileTypes: true }))
+      .filter((entry) => !shouldIgnoreFile(entry.name))
+      .sort((a, b) => a.name.localeCompare(b.name));
 
-  try {
-    const files = await collectFiles(folder.path);
-    progress.totalFiles = files.length;
-
-    if (!files.length) {
+    if (!entries.length && dir === folder.path) {
       console.log(
         clfdate() + " Git: addFolder: folder is empty, creating initial commit"
       );
@@ -242,45 +234,19 @@ async function addFolder(folder, liveRepo, bareRepo) {
       return handleEmptyFolder(folder, liveRepo);
     }
 
-    for (const [index, filePath] of files.entries()) {
-      await addFile(folder, liveRepo, bareRepo, progress, filePath, index + 1);
-    }
-  } catch (err) {
-    throw new Error("Error while adding files to repository: " + err.message);
-  }
-}
-
-async function collectFiles(rootDirectory) {
-  const files = [];
-
-  async function walk(dir) {
-    const entries = (await fs.readdir(dir, { withFileTypes: true }))
-      .filter((entry) => !shouldIgnoreFile(entry.name))
-      .sort((a, b) => a.name.localeCompare(b.name));
-
     for (const entry of entries) {
       const filePath = path.join(dir, entry.name);
 
       if (entry.isDirectory()) {
         await walk(filePath);
       } else if (entry.isFile()) {
-        await stageFile(folder, liveRepo, bareRepo, progress, filePath);
-
-        if (progress.pendingFiles.length >= COMMIT_BATCH_SIZE) {
-          await commitPendingFiles(folder, liveRepo, progress);
-          await pushIfNeeded(folder, liveRepo, progress);
-        }
+        await addFile(folder, liveRepo, bareRepo, progress, filePath);
       }
     }
   }
 
   try {
     await walk(folder.path);
-    await commitPendingFiles(folder, liveRepo, progress);
-
-    if (progress.unpushedCommits > 0) {
-      await pushPendingCommits(folder, liveRepo, progress);
-    }
   } catch (err) {
     throw new Error("Error while adding files to repository: " + err.message);
   }
@@ -290,12 +256,12 @@ async function handleEmptyFolder(folder, liveRepo) {
   folder.status("Initial commit to repository");
 
   await createEmptyCommit(liveRepo, "Initial commit");
-  await pushMaster(liveRepo, folder, "Pushing initial commit to repository");
+  await pushMaster(liveRepo);
 
   folder.status("Created initial commit in empty repository");
 }
 
-async function stageFile(folder, liveRepo, bareRepo, progress, filePath) {
+async function addFile(folder, liveRepo, bareRepo, progress, filePath) {
   const relativePath = path.relative(folder.path, filePath);
   const untilGc =
     GC_INTERVAL - (progress.filesAdded % GC_INTERVAL || GC_INTERVAL);
@@ -309,14 +275,7 @@ async function stageFile(folder, liveRepo, bareRepo, progress, filePath) {
       " successful files until gc)"
   );
 
-  folder.status(
-    "(" +
-      currentFileIndex +
-      "/" +
-      progress.totalFiles +
-      ") Syncing /" +
-      relativePath
-  );
+  folder.status("Adding " + relativePath + " to repository");
 
   try {
     await liveRepo.add(filePath);
@@ -327,54 +286,29 @@ async function stageFile(folder, liveRepo, bareRepo, progress, filePath) {
     throw err;
   }
 
-  progress.pendingFiles.push(relativePath);
+  try {
+    await commitFileWithRetries(liveRepo, relativePath);
+  } catch (err) {
+    console.log(
+      "Failed to commit file " +
+        relativePath +
+        " to repository: " +
+        err.message
+    );
+    throw err;
+  }
+
+  try {
+    await pushMaster(liveRepo);
+  } catch (err) {
+    console.log(
+      "Failed to push file " + relativePath + " to repository: " + err.message
+    );
+    throw err;
+  }
+
   progress.filesAdded++;
 
-  await gcIfNeeded(folder, liveRepo, bareRepo, progress);
-}
-
-async function commitPendingFiles(folder, liveRepo, progress) {
-  const batchSize = progress.pendingFiles.length;
-
-  if (!batchSize) return;
-
-  const label = batchSize === 1 ? progress.pendingFiles[0] : batchSize + " files";
-  const message = batchSize === 1 ? "Add files" : "Add " + batchSize + " files";
-
-  try {
-    await commitBatchWithRetries(liveRepo, folder, label, message);
-  } catch (err) {
-    console.log("Failed to commit " + label + " to repository: " + err.message);
-    throw err;
-  }
-
-  progress.pendingFiles = [];
-  progress.unpushedCommits++;
-}
-
-async function pushIfNeeded(folder, liveRepo, progress) {
-  if (progress.unpushedCommits >= PUSH_COMMIT_BATCH_SIZE) {
-    await pushPendingCommits(folder, liveRepo, progress);
-  }
-}
-
-async function pushPendingCommits(folder, liveRepo, progress) {
-  const label =
-    progress.unpushedCommits === 1
-      ? "1 commit"
-      : progress.unpushedCommits + " commits";
-
-  try {
-    await pushMaster(liveRepo, folder, "Pushing " + label + " to repository");
-  } catch (err) {
-    console.log("Failed to push commits to repository: " + err.message);
-    throw err;
-  }
-
-  progress.unpushedCommits = 0;
-}
-
-async function gcIfNeeded(folder, liveRepo, bareRepo, progress) {
   if (progress.filesAdded % GC_INTERVAL === 0) {
     folder.status("Cleaning up and optimizing the repository after adding " + progress.filesAdded + " files...");
     console.log(

--- a/app/clients/git/create.js
+++ b/app/clients/git/create.js
@@ -10,6 +10,8 @@ const shouldIgnoreFile = require("clients/util/shouldIgnoreFile");
 const path = require("path");
 
 const GC_INTERVAL = 100;
+const COMMIT_BATCH_SIZE = 25;
+const PUSH_COMMIT_BATCH_SIZE = 5;
 const COMMIT_RETRY_DELAYS_MS = [1000, 2000, 3000];
 
 // We apply this configuration because there is a bug with git version 2.54.0 
@@ -42,7 +44,11 @@ async function createEmptyCommit(repo, message) {
   await repo.commit(message, { "--allow-empty": true });
 }
 
-async function pushMaster(repo) {
+async function pushMaster(repo, folder, message) {
+  if (folder) {
+    folder.status(message || "Pushing commits to repository");
+  }
+
   await repo.push(["-u", "origin", "master"]);
 }
 
@@ -75,17 +81,18 @@ async function unsetTemporaryGitGc(repo) {
   });
 }
 
-async function commitFileWithRetries(repo, relativePath) {
+async function commitBatchWithRetries(repo, folder, label, message) {
   for (let attempt = 0; ; attempt++) {
     try {
-      await repo.raw(["commit", "--allow-empty", "-m", "Add file"]);
+      folder.status("Committing " + label + " to repository");
+      await repo.raw(["commit", "--allow-empty", "-m", message]);
       if (attempt > 0) {
         console.log(
           clfdate() +
             " Git: create: commit succeeded on attempt " +
             (attempt + 1) +
             " " +
-            relativePath
+            label
         );
       }
       return;
@@ -105,7 +112,7 @@ async function commitFileWithRetries(repo, relativePath) {
           " in " +
           delayMs +
           "ms " +
-          relativePath +
+          label +
           " err=" +
           err.message
       );
@@ -160,7 +167,7 @@ async function createRepository(blog, folder) {
     await liveRepo.addRemote("origin", bareDirectory);
 
     report(folder, "Adding existing folder to live repository");
-    const progress = { filesAdded: 0 };
+    const progress = { filesAdded: 0, pendingFiles: [], unpushedCommits: 0 };
     await addFolder(folder, liveRepo, bareRepo, progress);
   } finally {
     await Promise.all([
@@ -240,13 +247,23 @@ async function addFolder(folder, liveRepo, bareRepo, progress) {
       if (entry.isDirectory()) {
         await walk(filePath);
       } else if (entry.isFile()) {
-        await addFile(folder, liveRepo, bareRepo, progress, filePath);
+        await stageFile(folder, liveRepo, bareRepo, progress, filePath);
+
+        if (progress.pendingFiles.length >= COMMIT_BATCH_SIZE) {
+          await commitPendingFiles(folder, liveRepo, progress);
+          await pushIfNeeded(folder, liveRepo, progress);
+        }
       }
     }
   }
 
   try {
     await walk(folder.path);
+    await commitPendingFiles(folder, liveRepo, progress);
+
+    if (progress.unpushedCommits > 0) {
+      await pushPendingCommits(folder, liveRepo, progress);
+    }
   } catch (err) {
     throw new Error("Error while adding files to repository: " + err.message);
   }
@@ -256,12 +273,12 @@ async function handleEmptyFolder(folder, liveRepo) {
   folder.status("Initial commit to repository");
 
   await createEmptyCommit(liveRepo, "Initial commit");
-  await pushMaster(liveRepo);
+  await pushMaster(liveRepo, folder, "Pushing initial commit to repository");
 
   folder.status("Created initial commit in empty repository");
 }
 
-async function addFile(folder, liveRepo, bareRepo, progress, filePath) {
+async function stageFile(folder, liveRepo, bareRepo, progress, filePath) {
   const relativePath = path.relative(folder.path, filePath);
   const untilGc =
     GC_INTERVAL - (progress.filesAdded % GC_INTERVAL || GC_INTERVAL);
@@ -286,29 +303,54 @@ async function addFile(folder, liveRepo, bareRepo, progress, filePath) {
     throw err;
   }
 
-  try {
-    await commitFileWithRetries(liveRepo, relativePath);
-  } catch (err) {
-    console.log(
-      "Failed to commit file " +
-        relativePath +
-        " to repository: " +
-        err.message
-    );
-    throw err;
-  }
-
-  try {
-    await pushMaster(liveRepo);
-  } catch (err) {
-    console.log(
-      "Failed to push file " + relativePath + " to repository: " + err.message
-    );
-    throw err;
-  }
-
+  progress.pendingFiles.push(relativePath);
   progress.filesAdded++;
 
+  await gcIfNeeded(folder, liveRepo, bareRepo, progress);
+}
+
+async function commitPendingFiles(folder, liveRepo, progress) {
+  const batchSize = progress.pendingFiles.length;
+
+  if (!batchSize) return;
+
+  const label = batchSize === 1 ? progress.pendingFiles[0] : batchSize + " files";
+  const message = batchSize === 1 ? "Add files" : "Add " + batchSize + " files";
+
+  try {
+    await commitBatchWithRetries(liveRepo, folder, label, message);
+  } catch (err) {
+    console.log("Failed to commit " + label + " to repository: " + err.message);
+    throw err;
+  }
+
+  progress.pendingFiles = [];
+  progress.unpushedCommits++;
+}
+
+async function pushIfNeeded(folder, liveRepo, progress) {
+  if (progress.unpushedCommits >= PUSH_COMMIT_BATCH_SIZE) {
+    await pushPendingCommits(folder, liveRepo, progress);
+  }
+}
+
+async function pushPendingCommits(folder, liveRepo, progress) {
+  const label =
+    progress.unpushedCommits === 1
+      ? "1 commit"
+      : progress.unpushedCommits + " commits";
+
+  try {
+    await pushMaster(liveRepo, folder, "Pushing " + label + " to repository");
+  } catch (err) {
+    console.log("Failed to push commits to repository: " + err.message);
+    throw err;
+  }
+
+  progress.unpushedCommits = 0;
+}
+
+async function gcIfNeeded(folder, liveRepo, bareRepo, progress) {
   if (progress.filesAdded % GC_INTERVAL === 0) {
     folder.status("Cleaning up and optimizing the repository after adding " + progress.filesAdded + " files...");
     console.log(

--- a/app/views/dashboard/clients/disconnect-line.html
+++ b/app/views/dashboard/clients/disconnect-line.html
@@ -1,7 +1,7 @@
 
 <a class="line" href="{{{dashboardBase}}}/client/activity" style="flex-wrap: nowrap;">
   <span class="label"  style="flex-shrink: 0;">Status</span>
-  <span class="center" style="height:1.5em;overflow: hidden;text-wrap: nowrap;">  
+  <span class="center sync-status-center">
     {{> sync-status}}
   </span>
 </a>

--- a/app/views/dashboard/clients/sync-status.html
+++ b/app/views/dashboard/clients/sync-status.html
@@ -10,5 +10,10 @@
             <span class="loading"></span>
         </span>
     </span>
-    <span class="sync-status-text">{{blog.status.message}}</span>
+    <span class="sync-status-body">
+        <span class="sync-status-text">{{blog.status.message}}</span>
+        <span class="sync-status-progress">
+            <span class="sync-status-progress-bar"></span>
+        </span>
+    </span>
 </span>

--- a/app/views/dashboard/dashboard.css
+++ b/app/views/dashboard/dashboard.css
@@ -18,6 +18,14 @@
   width: 100%;
 }
 
+.sync-status.has-progress .sync-status-body {
+  flex: 1 1 auto;
+}
+
+.sync-status.has-progress .sync-status-body {
+  flex: 1 1 auto;
+}
+
 .sync-status-progress {
   display: none;
   width: 100%;

--- a/app/views/dashboard/dashboard.css
+++ b/app/views/dashboard/dashboard.css
@@ -34,6 +34,17 @@
   transition: width 350ms ease-out;
 }
 
+.sync-status-center {
+  height: 1.5em;
+  overflow: hidden;
+  text-wrap: nowrap;
+}
+
+.sync-status-center:has(.sync-status.has-progress) {
+  height: auto;
+  overflow: visible;
+}
+
 .sites-list-container {
   min-height: calc(100vh - 7.8rem);
   display: flex;
@@ -462,5 +473,4 @@ line-height: 48px;
   color: var(--success-text-color);
   background: var(--success-background-color);
 }
-
 

--- a/app/views/dashboard/dashboard.css
+++ b/app/views/dashboard/dashboard.css
@@ -1,3 +1,39 @@
+.sync-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.sync-status-body {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.sync-status-progress {
+  display: none;
+  width: 100%;
+  min-width: 8rem;
+  height: 0.35rem;
+  overflow: hidden;
+  background: var(--border-color);
+  border-radius: var(--border-radius);
+}
+
+.sync-status.has-progress .sync-status-progress {
+  display: block;
+}
+
+.sync-status-progress-bar {
+  display: block;
+  width: 0%;
+  height: 100%;
+  background: var(--accent-color);
+  border-radius: var(--border-radius);
+  transition: width 350ms ease-out;
+}
+
 .sites-list-container {
   min-height: calc(100vh - 7.8rem);
   display: flex;

--- a/app/views/dashboard/dashboard.css
+++ b/app/views/dashboard/dashboard.css
@@ -4,11 +4,18 @@
   gap: 0.25rem;
 }
 
+.sync-status.has-progress {
+  flex: 1 1 auto;
+  width: 100%;
+}
+
 .sync-status-body {
   display: inline-flex;
   flex-direction: column;
+  flex: 1 1 auto;
   gap: 0.25rem;
   min-width: 0;
+  width: 100%;
 }
 
 .sync-status-progress {
@@ -41,8 +48,11 @@
 }
 
 .sync-status-center:has(.sync-status.has-progress) {
+  flex: 1 1 auto;
   height: auto;
+  min-width: 0;
   overflow: visible;
+  width: 100%;
 }
 
 .sites-list-container {
@@ -473,4 +483,3 @@ line-height: 48px;
   color: var(--success-text-color);
   background: var(--success-background-color);
 }
-

--- a/app/views/dashboard/folder/folder.css
+++ b/app/views/dashboard/folder/folder.css
@@ -49,6 +49,11 @@
     overflow: hidden;
   }
 
+  .sync-status.has-progress {
+    height: auto;
+    overflow: visible;
+  }
+
   .folder-corner {
     position: absolute;
     top: 5px;

--- a/app/views/dashboard/folder/folder.css
+++ b/app/views/dashboard/folder/folder.css
@@ -50,8 +50,10 @@
   }
 
   .sync-status.has-progress {
+    display: flex;
     height: auto;
     overflow: visible;
+    width: 100%;
   }
 
   .folder-corner {

--- a/app/views/dashboard/folder/folder.css
+++ b/app/views/dashboard/folder/folder.css
@@ -44,8 +44,11 @@
   }
 
   .sync-status {
+    align-items: center;
+    display: flex;
+    gap: 0.25rem;
     height: 1.5em;
-    display: block;
+    min-width: 0;
     overflow: hidden;
   }
 
@@ -54,6 +57,16 @@
     height: auto;
     overflow: visible;
     width: 100%;
+  }
+
+  .sync-status .sync-status-body {
+    min-width: 0;
+  }
+
+  .sync-status .sync-status-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .folder-corner {

--- a/app/views/js/sync_status.js
+++ b/app/views/js/sync_status.js
@@ -226,6 +226,5 @@ window.addEventListener("beforeunload", function () {
 
 // First attach on initial load
 document.addEventListener("DOMContentLoaded", function () {
-  renderSyncStatusMessage();
   attachSSE();
 });

--- a/app/views/js/sync_status.js
+++ b/app/views/js/sync_status.js
@@ -8,14 +8,84 @@ var timerId = null;
 var pendingWhileHidden = false;
 var evtSource = null;
 var shouldReload = false;
+var PROGRESS_MESSAGE_RE = /^\((\d+)\/(\d+)\)\s*(.*)$/;
 
 function q(sel) {
   return document.querySelector(sel);
 }
 
+function parseSyncStatusMessage(message) {
+  var match = (message || "").match(PROGRESS_MESSAGE_RE);
+
+  if (!match) {
+    return {
+      hasProgress: false,
+      text: message || "",
+      current: 0,
+      total: 0,
+      percent: 0,
+    };
+  }
+
+  var current = parseInt(match[1], 10);
+  var total = parseInt(match[2], 10);
+  var percent = total > 0 ? (current / total) * 100 : 0;
+
+  percent = Math.max(0, Math.min(100, percent));
+
+  return {
+    hasProgress: true,
+    text: match[3] || "",
+    current: current,
+    total: total,
+    percent: percent,
+  };
+}
+
+function shortenSyncingFilename(message) {
+  if (message.startsWith("Syncing /")) {
+    var path = message.slice("Syncing ".length);
+    var filename = path.split("/").pop();
+    return "Syncing " + filename;
+  }
+
+  return message;
+}
+
+function renderSyncStatusMessage(message) {
+  var statusContainer = q(".sync-status");
+  if (!statusContainer) return;
+
+  var statusText = q(".sync-status-text");
+  if (!statusText) return;
+
+  if (typeof message === "undefined") {
+    message = statusText.innerText || "";
+  }
+
+  var parsed = parseSyncStatusMessage(message);
+  var visibleMessage = shortenSyncingFilename(parsed.text);
+  var progressBar = q(".sync-status-progress-bar");
+
+  statusText.innerText = visibleMessage;
+
+  if (parsed.hasProgress) {
+    statusContainer.classList.add("has-progress");
+    if (progressBar) progressBar.style.width = parsed.percent + "%";
+  } else {
+    statusContainer.classList.remove("has-progress");
+    if (progressBar) progressBar.style.width = "0%";
+  }
+
+  updateContainerClass();
+}
+
 function updateContainerClass() {
   var statusContainer = q(".sync-status");
-  var statusText = q(".sync-status-text").innerText || "";
+  var statusTextElement = q(".sync-status-text");
+  var statusText = statusTextElement ? statusTextElement.innerText || "" : "";
+
+  if (!statusContainer) return;
 
   if (statusText.startsWith("Synced")) {
     statusContainer.classList.remove("syncing", "error");
@@ -99,7 +169,7 @@ function loadFolder(callback) {
               console.error(e);
             }
             try {
-              updateContainerClass();
+              renderSyncStatusMessage();
             } catch (e) {
               console.error(e);
             }
@@ -120,7 +190,7 @@ function attachSSE() {
   var statusContainer = q(".sync-status");
   if (!statusContainer) return;
 
-  updateContainerClass();
+  renderSyncStatusMessage();
 
   var syncStatusURL = statusContainer.getAttribute("data-sync-status-url");
   if (!syncStatusURL) {
@@ -134,17 +204,7 @@ function attachSSE() {
   evtSource.onmessage = function (event) {
     var message = event.data || "";
 
-    if (message.startsWith("Syncing /")) {
-      var path = message.slice("Syncing ".length);
-      var filename = path.split("/").pop();
-      message = "Syncing " + filename;
-    }
-
-    var sc = q(".sync-status-text");
-    if (sc) {
-      sc.innerHTML = message;
-      updateContainerClass();
-    }
+    renderSyncStatusMessage(message);
 
     if (q(".live-updates")) {
       scheduleLoad();
@@ -166,5 +226,6 @@ window.addEventListener("beforeunload", function () {
 
 // First attach on initial load
 document.addEventListener("DOMContentLoaded", function () {
+  renderSyncStatusMessage();
   attachSSE();
 });


### PR DESCRIPTION
### Motivation
- The sync-status partial needs to show in-progress progress for long-running syncs and surface a visual progress bar when the server sends prefixed progress messages. 
- Client-side code should parse progress-prefixed messages, render text safely, and toggle a progress UI without changing existing visual behavior.

### Description
- Wrap the existing `.sync-status-text` in a new `.sync-status-body` and add hidden `.sync-status-progress` / `.sync-status-progress-bar` markup in `app/views/dashboard/clients/sync-status.html`.
- Add CSS rules in `app/views/dashboard/dashboard.css` for `.sync-status`, `.sync-status-body`, `.sync-status-progress`, `.sync-status.has-progress`, and `.sync-status-progress-bar` using `var(--border-color)`, `var(--accent-color)`, `var(--border-radius)` and `transition: width 350ms ease-out` for animated width changes.
- Add a progress parser and renderer in `app/views/js/sync_status.js` that recognizes the regex `^
(\d+)/(\d+)\)\s*(.*)$` as `PROGRESS_MESSAGE_RE` and returns `{hasProgress, text, current, total, percent}`.
- Implement `renderSyncStatusMessage(message)` which strips the numeric prefix, applies the existing `Syncing /` filename-shortening to the parsed visible text, updates `.sync-status-text` via `innerText`, toggles the `.sync-status.has-progress` class, updates `.sync-status-progress-bar.style.width`, and resets/hides the bar when no prefix is present.
- Replace raw `innerHTML` assignment in the SSE `onmessage` handler to call `renderSyncStatusMessage(message)`, and call `renderSyncStatusMessage()` after `.live-updates` HTML replacement and during initial `DOMContentLoaded` setup so server-rendered progress messages are converted immediately.

### Testing
- Ran `node --check app/views/js/sync_status.js` to validate the modified JavaScript syntax, and it succeeded.
- Ran `git diff --check` to validate whitespace/patch issues, and it succeeded.
- No new automated tests were added for this change as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54e99c6a90832989695a9b9d92ceba)