### PR TITLE
Batch repository create commits

### DIFF
--- a/app/clients/git/create.js
+++ b/app/clients/git/create.js
@@ -10,6 +10,8 @@ const shouldIgnoreFile = require("clients/util/shouldIgnoreFile");
 const path = require("path");
 
 const GC_INTERVAL = 100;
+const COMMIT_BATCH_SIZE = 25;
+const PUSH_COMMIT_BATCH_SIZE = 5;
 const COMMIT_RETRY_DELAYS_MS = [1000, 2000, 3000];
 
 // We apply this configuration because there is a bug with git version 2.54.0 
@@ -75,17 +77,17 @@ async function unsetTemporaryGitGc(repo) {
   });
 }
 
-async function commitFileWithRetries(repo, relativePath) {
+async function commitBatchWithRetries(repo, label, message) {
   for (let attempt = 0; ; attempt++) {
     try {
-      await repo.raw(["commit", "--allow-empty", "-m", "Add file"]);
+      await repo.raw(["commit", "--allow-empty", "-m", message]);
       if (attempt > 0) {
         console.log(
           clfdate() +
             " Git: create: commit succeeded on attempt " +
             (attempt + 1) +
             " " +
-            relativePath
+            label
         );
       }
       return;
@@ -105,7 +107,7 @@ async function commitFileWithRetries(repo, relativePath) {
           " in " +
           delayMs +
           "ms " +
-          relativePath +
+          label +
           " err=" +
           err.message
       );
@@ -160,7 +162,7 @@ async function createRepository(blog, folder) {
     await liveRepo.addRemote("origin", bareDirectory);
 
     report(folder, "Adding existing folder to live repository");
-    const progress = { filesAdded: 0 };
+    const progress = { filesAdded: 0, pendingFiles: [], unpushedCommits: 0 };
     await addFolder(folder, liveRepo, bareRepo, progress);
   } finally {
     await Promise.all([
@@ -240,13 +242,23 @@ async function addFolder(folder, liveRepo, bareRepo, progress) {
       if (entry.isDirectory()) {
         await walk(filePath);
       } else if (entry.isFile()) {
-        await addFile(folder, liveRepo, bareRepo, progress, filePath);
+        await stageFile(folder, liveRepo, bareRepo, progress, filePath);
+
+        if (progress.pendingFiles.length >= COMMIT_BATCH_SIZE) {
+          await commitPendingFiles(liveRepo, progress);
+          await pushIfNeeded(liveRepo, progress);
+        }
       }
     }
   }
 
   try {
     await walk(folder.path);
+    await commitPendingFiles(liveRepo, progress);
+
+    if (progress.unpushedCommits > 0) {
+      await pushPendingCommits(liveRepo, progress);
+    }
   } catch (err) {
     throw new Error("Error while adding files to repository: " + err.message);
   }
@@ -261,7 +273,7 @@ async function handleEmptyFolder(folder, liveRepo) {
   folder.status("Created initial commit in empty repository");
 }
 
-async function addFile(folder, liveRepo, bareRepo, progress, filePath) {
+async function stageFile(folder, liveRepo, bareRepo, progress, filePath) {
   const relativePath = path.relative(folder.path, filePath);
   const untilGc =
     GC_INTERVAL - (progress.filesAdded % GC_INTERVAL || GC_INTERVAL);
@@ -286,29 +298,49 @@ async function addFile(folder, liveRepo, bareRepo, progress, filePath) {
     throw err;
   }
 
+  progress.pendingFiles.push(relativePath);
+  progress.filesAdded++;
+
+  await gcIfNeeded(folder, liveRepo, bareRepo, progress);
+}
+
+async function commitPendingFiles(liveRepo, progress) {
+  const batchSize = progress.pendingFiles.length;
+
+  if (!batchSize) return;
+
+  const label = batchSize === 1 ? progress.pendingFiles[0] : batchSize + " files";
+  const message = batchSize === 1 ? "Add files" : "Add " + batchSize + " files";
+
   try {
-    await commitFileWithRetries(liveRepo, relativePath);
+    await commitBatchWithRetries(liveRepo, label, message);
   } catch (err) {
-    console.log(
-      "Failed to commit file " +
-        relativePath +
-        " to repository: " +
-        err.message
-    );
+    console.log("Failed to commit " + label + " to repository: " + err.message);
     throw err;
   }
 
+  progress.pendingFiles = [];
+  progress.unpushedCommits++;
+}
+
+async function pushIfNeeded(liveRepo, progress) {
+  if (progress.unpushedCommits >= PUSH_COMMIT_BATCH_SIZE) {
+    await pushPendingCommits(liveRepo, progress);
+  }
+}
+
+async function pushPendingCommits(liveRepo, progress) {
   try {
     await pushMaster(liveRepo);
   } catch (err) {
-    console.log(
-      "Failed to push file " + relativePath + " to repository: " + err.message
-    );
+    console.log("Failed to push commits to repository: " + err.message);
     throw err;
   }
 
-  progress.filesAdded++;
+  progress.unpushedCommits = 0;
+}
 
+async function gcIfNeeded(folder, liveRepo, bareRepo, progress) {
   if (progress.filesAdded % GC_INTERVAL === 0) {
     folder.status("Cleaning up and optimizing the repository after adding " + progress.filesAdded + " files...");
     console.log(

--- a/app/clients/git/create.js
+++ b/app/clients/git/create.js
@@ -44,7 +44,11 @@ async function createEmptyCommit(repo, message) {
   await repo.commit(message, { "--allow-empty": true });
 }
 
-async function pushMaster(repo) {
+async function pushMaster(repo, folder, message) {
+  if (folder) {
+    folder.status(message || "Pushing commits to repository");
+  }
+
   await repo.push(["-u", "origin", "master"]);
 }
 
@@ -77,9 +81,10 @@ async function unsetTemporaryGitGc(repo) {
   });
 }
 
-async function commitBatchWithRetries(repo, label, message) {
+async function commitBatchWithRetries(repo, folder, label, message) {
   for (let attempt = 0; ; attempt++) {
     try {
+      folder.status("Committing " + label + " to repository");
       await repo.raw(["commit", "--allow-empty", "-m", message]);
       if (attempt > 0) {
         console.log(
@@ -245,8 +250,8 @@ async function addFolder(folder, liveRepo, bareRepo, progress) {
         await stageFile(folder, liveRepo, bareRepo, progress, filePath);
 
         if (progress.pendingFiles.length >= COMMIT_BATCH_SIZE) {
-          await commitPendingFiles(liveRepo, progress);
-          await pushIfNeeded(liveRepo, progress);
+          await commitPendingFiles(folder, liveRepo, progress);
+          await pushIfNeeded(folder, liveRepo, progress);
         }
       }
     }
@@ -254,10 +259,10 @@ async function addFolder(folder, liveRepo, bareRepo, progress) {
 
   try {
     await walk(folder.path);
-    await commitPendingFiles(liveRepo, progress);
+    await commitPendingFiles(folder, liveRepo, progress);
 
     if (progress.unpushedCommits > 0) {
-      await pushPendingCommits(liveRepo, progress);
+      await pushPendingCommits(folder, liveRepo, progress);
     }
   } catch (err) {
     throw new Error("Error while adding files to repository: " + err.message);
@@ -268,7 +273,7 @@ async function handleEmptyFolder(folder, liveRepo) {
   folder.status("Initial commit to repository");
 
   await createEmptyCommit(liveRepo, "Initial commit");
-  await pushMaster(liveRepo);
+  await pushMaster(liveRepo, folder, "Pushing initial commit to repository");
 
   folder.status("Created initial commit in empty repository");
 }
@@ -304,7 +309,7 @@ async function stageFile(folder, liveRepo, bareRepo, progress, filePath) {
   await gcIfNeeded(folder, liveRepo, bareRepo, progress);
 }
 
-async function commitPendingFiles(liveRepo, progress) {
+async function commitPendingFiles(folder, liveRepo, progress) {
   const batchSize = progress.pendingFiles.length;
 
   if (!batchSize) return;
@@ -313,7 +318,7 @@ async function commitPendingFiles(liveRepo, progress) {
   const message = batchSize === 1 ? "Add files" : "Add " + batchSize + " files";
 
   try {
-    await commitBatchWithRetries(liveRepo, label, message);
+    await commitBatchWithRetries(liveRepo, folder, label, message);
   } catch (err) {
     console.log("Failed to commit " + label + " to repository: " + err.message);
     throw err;
@@ -323,15 +328,20 @@ async function commitPendingFiles(liveRepo, progress) {
   progress.unpushedCommits++;
 }
 
-async function pushIfNeeded(liveRepo, progress) {
+async function pushIfNeeded(folder, liveRepo, progress) {
   if (progress.unpushedCommits >= PUSH_COMMIT_BATCH_SIZE) {
-    await pushPendingCommits(liveRepo, progress);
+    await pushPendingCommits(folder, liveRepo, progress);
   }
 }
 
-async function pushPendingCommits(liveRepo, progress) {
+async function pushPendingCommits(folder, liveRepo, progress) {
+  const label =
+    progress.unpushedCommits === 1
+      ? "1 commit"
+      : progress.unpushedCommits + " commits";
+
   try {
-    await pushMaster(liveRepo);
+    await pushMaster(liveRepo, folder, "Pushing " + label + " to repository");
   } catch (err) {
     console.log("Failed to push commits to repository: " + err.message);
     throw err;


### PR DESCRIPTION
### Motivation
- Reduce the number of individual commits and pushes when importing large folders to improve performance and limit remote operations. 
- Preserve existing per-file status updates so the UI still shows progress while processing large folders. 
- Keep the existing manual git GC behavior tied to total files processed to avoid parallel GC issues.

### Description
- Add `COMMIT_BATCH_SIZE = 25` and `PUSH_COMMIT_BATCH_SIZE = 5` constants and keep `GC_INTERVAL = 100` unchanged. 
- Replace the single-file commit flow with staged batching by introducing `stageFile()` that calls `liveRepo.add(filePath)`, records `progress.pendingFiles`, and updates `progress.filesAdded`. 
- Introduce `commitBatchWithRetries(repo, label, message)` (refactor of the previous retry logic) and `commitPendingFiles()` to commit pending staged files with retry semantics and batch-aware messages. 
- Track `progress.unpushedCommits`, push with `pushMaster()` only when it reaches `PUSH_COMMIT_BATCH_SIZE`, and flush remaining staged files and unpushed commits after the walk completes. 
- Preserve `handleEmptyFolder()` behavior and preserve GC logic by running `liveRepo.raw(['gc'])` and `bareRepo.raw(['gc'])` every `GC_INTERVAL` files.

### Testing
- Ran a syntax check with `node -c app/clients/git/create.js`, which succeeded. 
- Ran `git diff --check` to validate the workspace changes, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54e7f5c0688329bca48f0d311ebafc)