### PR TITLE
Distinguish deploy vs restart on server start emails and set release id in docker run

### DIFF
--- a/app/helper/email/admin/SERVER_START.txt
+++ b/app/helper/email/admin/SERVER_START.txt
@@ -1,4 +1,4 @@
-{{container}} server started
+{{container}} server {{event}}
 
 Log in to server and grep:
 

--- a/app/index.js
+++ b/app/index.js
@@ -1,8 +1,38 @@
 const config = require("config");
 const clfdate = require("helper/clfdate");
 const email = require("helper/email");
+const redis = require("models/client");
 const setup = require("./setup");
 const server = require("./server");
+
+const DEPLOYMENT_MARKER_EXPIRATION_SECONDS = 90 * 24 * 60 * 60;
+
+function releaseId() {
+  return process.env.BLOT_RELEASE_ID || process.env.GIT_SHA;
+}
+
+async function serverStartEvent() {
+  const id = releaseId();
+
+  if (!id) return "started";
+
+  const key = `server:start-notification:${config.container}:${id}`;
+
+  try {
+    // The deploy script passes the image commit hash as BLOT_RELEASE_ID; GIT_SHA
+    // is a fallback for other runtimes. Markers expire after 90 days to bound
+    // Redis key growth.
+    const result = await redis.set(key, "1", {
+      NX: true,
+      EX: DEPLOYMENT_MARKER_EXPIRATION_SECONDS,
+    });
+
+    return result === "OK" ? "deployed" : "restarted";
+  } catch (err) {
+    console.error(clfdate(), "Could not determine server start event", err);
+    return "started";
+  }
+}
 
 console.log(clfdate(), `Starting server env=${config.environment}`);
 setup(async (err) => {
@@ -29,6 +59,8 @@ setup(async (err) => {
     }
 
     // Send an email notification if the server starts or restarts
-    email.SERVER_START(null, { container: config.container });
+    serverStartEvent().then((event) =>
+      email.SERVER_START(null, { container: config.container, event })
+    );
   });
 });

--- a/scripts/deploy/util/generateDockerCommand.js
+++ b/scripts/deploy/util/generateDockerCommand.js
@@ -191,6 +191,7 @@ async function generateDockerCommand(container, platform, commitHash) {
     `-p ${portNum}:${INTERNAL_PORT}`,
     `--env-file ${ENV_FILE_ON_SERVER}`,
     `-e CONTAINER_NAME=${sanitizedName}`,
+    `-e BLOT_RELEASE_ID=${commitHash}`,
     // Configure the maximum memory usage for the node process
     `-e NODE_OPTIONS='--max-old-space-size=${oldSpaceSize}'`,
     // Mount the data directory on the host to the container


### PR DESCRIPTION
### Motivation
- Ensure server-start emails indicate whether the container was newly deployed or just restarted to reduce ambiguity and duplicate notifications.
- Persist a short-lived deployment marker so repeated restarts of the same image do not produce redundant "deployed" messages.
- Provide the deployment identifier to the runtime from the deploy command so the running process can detect deployments.

### Description
- Added a Redis-backed `serverStartEvent()` that uses `BLOT_RELEASE_ID` (or `GIT_SHA`) to set an NX key `server:start-notification:${container}:${id}` with a 90-day TTL and returns `deployed` or `restarted`, falling back to `started` on error. 
- Wired `serverStartEvent()` into the server startup flow and pass the resolved `event` to `email.SERVER_START` instead of always sending `started`. 
- Updated the `SERVER_START.txt` email template to use `{{event}}` in the subject line. 
- Updated the deploy helper `generateDockerCommand` to inject the `BLOT_RELEASE_ID` environment variable into the container image at run time and added related constants and error logging.

### Testing
- Ran the project's automated test suite with `npm test` and all tests completed successfully. 
- Ran the linter with `npm run lint` and no new lint errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5657854a8c8329a147102fed15cd2b)