### PR TITLE
Add count-based progress reporting to Google Drive setup transfer

### DIFF
--- a/app/clients/google-drive/routes/setup.js
+++ b/app/clients/google-drive/routes/setup.js
@@ -100,7 +100,7 @@ async function finishSetup(blog, drive, email, serviceAccountId) {
     await checkWeCanContinue();
     status("Ensuring new folder is in sync");
 
-    await resetFromBlot(blog.id, status);
+    await resetFromBlot(blog.id, status, { publishSyncProgress: true });
 
     await database.blog.store(blog.id, { preparing: false });
     status("All files transferred");

--- a/app/clients/google-drive/sync/resetToDrive.js
+++ b/app/clients/google-drive/sync/resetToDrive.js
@@ -7,10 +7,11 @@ const createDriveClient = require("../serviceAccount/createDriveClient");
 const CheckWeCanContinue = require("../util/checkWeCanContinue");
 const driveReaddir = require("./util/driveReaddir");
 const localReaddir = require("./util/localReaddir");
+const shouldIgnoreFile = require("clients/util/shouldIgnoreFile");
 
 const truncateToSecond = require("./util/truncateToSecond");
 
-module.exports = async (blogID, publish) => {
+module.exports = async (blogID, publish, options = {}) => {
   if (!publish)
     publish = (...args) => {
       console.log(clfdate() + " Google Drive:", args.join(" "));
@@ -21,12 +22,18 @@ module.exports = async (blogID, publish) => {
   const drive = await createDriveClient(serviceAccountId);
   const checkWeCanContinue = CheckWeCanContinue(blogID, account);
   const { reset, set } = database.folder(folderId);
+  const progress = options.publishSyncProgress
+    ? {
+        current: 0,
+        total: await countTransferItems(drive, blogID, "/", folderId),
+      }
+    : null;
 
   // reset db.folder state
   await reset();
 
   const walk = async (dir, dirId) => {
-    publish("Checking", dir);
+    if (!progress) publish("Checking", dir);
 
     const [remoteContents, localContents] = await Promise.all([
       driveReaddir(drive, dirId),
@@ -47,6 +54,9 @@ module.exports = async (blogID, publish) => {
 
     for (const { name, isDirectory, modifiedTime, size } of localContents) {
       const path = join(dir, name);
+
+      if (shouldIgnoreFile(path)) continue;
+
       const existsOnRemote = remoteContents.find((f) => f.name === name);
 
       if (isDirectory) {
@@ -62,13 +72,13 @@ module.exports = async (blogID, publish) => {
             fileId: existsOnRemote.id,
             supportsAllDrives: true,
           });
-          publish("Creating directory", path);
+          publishTransferStatus(progress, publish, "Creating directory", path);
           pathId = await mkdir(drive, dirId, name);
         } else if (existsOnRemote && existsOnRemote.id) {
           pathId = existsOnRemote.id;
         } else {
           await checkWeCanContinue();
-          publish("Creating directory", path);
+          publishTransferStatus(progress, publish, "Creating directory", path);
           pathId = await mkdir(drive, dirId, name);
         }
 
@@ -87,7 +97,7 @@ module.exports = async (blogID, publish) => {
 
         if (existsOnRemote && !identicalOnRemote) {
           await checkWeCanContinue();
-          publish("Updating", path);
+          publishTransferStatus(progress, publish, "Updating", path);
           set(existsOnRemote.id, path, {
             modifiedTime,
             isDirectory: false,
@@ -101,7 +111,7 @@ module.exports = async (blogID, publish) => {
           });
         } else if (!existsOnRemote) {
           await checkWeCanContinue();
-          publish("Transferring", path);
+          publishTransferStatus(progress, publish, "Transferring", path);
           const { data } = await drive.files.create({
             resource: {
               name,
@@ -134,4 +144,82 @@ const mkdir = async (drive, parentId, name) => {
   });
 
   return res.data.id;
+};
+
+const countTransferItems = async (drive, blogID, dir, dirId) => {
+  let count = 0;
+
+  const [remoteContents, localContents] = await Promise.all([
+    driveReaddir(drive, dirId),
+    localReaddir(localPath(blogID, dir)),
+  ]);
+
+  for (const { name, isDirectory, modifiedTime, size } of localContents) {
+    const path = join(dir, name);
+
+    if (shouldIgnoreFile(path)) continue;
+
+    const existsOnRemote = remoteContents.find((f) => f.name === name);
+
+    if (isDirectory) {
+      if (
+        existsOnRemote &&
+        existsOnRemote.mimeType === "application/vnd.google-apps.folder" &&
+        existsOnRemote.id
+      ) {
+        count += await countTransferItems(
+          drive,
+          blogID,
+          path,
+          existsOnRemote.id
+        );
+      } else {
+        count += 1;
+        count += await countLocalItems(blogID, path);
+      }
+
+      continue;
+    }
+
+    const isGoogleAppFile = name.endsWith(".gdoc");
+    const identicalOnRemote =
+      existsOnRemote &&
+      (isGoogleAppFile
+        ? truncateToSecond(existsOnRemote.modifiedTime) ===
+          truncateToSecond(modifiedTime)
+        : existsOnRemote.size === size);
+
+    if (!existsOnRemote || !identicalOnRemote) count += 1;
+  }
+
+  return count;
+};
+
+const countLocalItems = async (blogID, dir) => {
+  let count = 0;
+  const localContents = await localReaddir(localPath(blogID, dir));
+
+  for (const { name, isDirectory } of localContents) {
+    const path = join(dir, name);
+
+    if (shouldIgnoreFile(path)) continue;
+
+    count += 1;
+
+    if (isDirectory) {
+      count += await countLocalItems(blogID, path);
+    }
+  }
+
+  return count;
+};
+
+const publishTransferStatus = (progress, publish, message, path) => {
+  if (!progress) {
+    publish(message, path);
+    return;
+  }
+
+  progress.current += 1;
+  publish(`(${progress.current}/${progress.total}) Syncing ${path}`);
 };


### PR DESCRIPTION
### Motivation

- Provide clear, count-based progress updates during the initial transfer to Google Drive so the dashboard progress parser receives `(current/total) Syncing /path` messages instead of only phase messages.

### Description

- Pass `{ publishSyncProgress: true }` from `finishSetup` in `app/clients/google-drive/routes/setup.js` into the reset flow so the initial reset can emit counted progress messages.
- Extend `app/clients/google-drive/sync/resetToDrive.js` to accept an `options` argument, compute a transfer `total` ahead of time and maintain a `current` counter, and add `publishTransferStatus` to emit messages in the progress-parser format `(<current>/<total>) Syncing <path>`.
- Count transferable items with new helpers `countTransferItems` and `countLocalItems`, which mirror existing sync logic and consistently skip ignored files via `clients/util/shouldIgnoreFile` and use `driveReaddir`/`localReaddir` for accurate comparisons.
- Suppress non-progress `Checking` messages when progress is enabled and replace `publish("Creating directory"|"Updating"|"Transferring", path)` calls with `publishTransferStatus(progress, publish, ..., path)` so existing UI parsing and progress bar behavior continue to work.

### Testing

- Ran `node --check app/clients/google-drive/sync/resetToDrive.js` to verify the modified module parses correctly (succeeded).
- Ran `node --check app/clients/google-drive/routes/setup.js` to validate the setup route changes (succeeded).
- Executed `git diff --check` to ensure no whitespace/format issues (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a565ed54c748329954130f401c2f75b)