### PR TITLE
Report file-level progress during Dropbox setup uploads

### DIFF
--- a/app/clients/dropbox/sync/reset-from-blot.js
+++ b/app/clients/dropbox/sync/reset-from-blot.js
@@ -326,14 +326,23 @@ const countFilesToUpload = async (
     );
 
     if (localItem.is_directory) {
-      total += await countFilesToUpload(
-        blogID,
-        client,
-        dropboxRoot,
-        localRoot,
-        signal,
-        path
-      );
+      if (remoteCounterpart && remoteCounterpart.is_directory) {
+        total += await countFilesToUpload(
+          blogID,
+          client,
+          dropboxRoot,
+          localRoot,
+          signal,
+          path
+        );
+      } else {
+        total += await countLocalFilesToUpload(
+          blogID,
+          localRoot,
+          signal,
+          path
+        );
+      }
       continue;
     }
 
@@ -341,6 +350,32 @@ const countFilesToUpload = async (
       !remoteCounterpart ||
       remoteCounterpart.content_hash !== localItem.content_hash
     ) {
+      total += 1;
+    }
+  }
+
+  return total;
+};
+
+const countLocalFilesToUpload = async (blogID, localRoot, signal, dir) => {
+  abortIfRequested(signal);
+
+  const localContents = await localReaddir(blogID, localRoot, dir, signal);
+
+  abortIfRequested(signal);
+
+  let total = 0;
+
+  for (const localItem of localContents) {
+    abortIfRequested(signal);
+
+    const path = join(dir, localItem.name);
+
+    if (isDotfileOrDotfolder(path)) continue;
+
+    if (localItem.is_directory) {
+      total += await countLocalFilesToUpload(blogID, localRoot, signal, path);
+    } else {
       total += 1;
     }
   }

--- a/app/clients/dropbox/sync/reset-from-blot.js
+++ b/app/clients/dropbox/sync/reset-from-blot.js
@@ -88,6 +88,15 @@ async function resetFromBlot(blogID, publish, signal) {
 
   abortIfRequested(signal);
 
+  const uploadProgress = await createUploadProgressTracker(
+    blogID,
+    client,
+    dropboxRoot,
+    localRoot,
+    signal,
+    publish
+  );
+
   const walk = async (dir) => {
     abortIfRequested(signal);
 
@@ -160,7 +169,7 @@ async function resetFromBlot(blogID, publish, signal) {
           remoteCounterpart.content_hash === localItem.content_hash;
 
         if (remoteCounterpart && !identicalOnRemote) {
-          publish("Transferring", path);
+          uploadProgress.publish(path);
           try {
             abortIfRequested(signal);
             await upload(
@@ -173,7 +182,7 @@ async function resetFromBlot(blogID, publish, signal) {
             publish("Failed to transfer", path);
           }
         } else if (!remoteCounterpart) {
-          publish("Transferring", path);
+          uploadProgress.publish(path);
           try {
             abortIfRequested(signal);
             await upload(
@@ -247,6 +256,97 @@ async function resetFromBlot(blogID, publish, signal) {
 //     }
 //   }
 // }
+
+const createUploadProgressTracker = async (
+  blogID,
+  client,
+  dropboxRoot,
+  localRoot,
+  signal,
+  publish
+) => {
+  let current = 0;
+  const total = await countFilesToUpload(
+    blogID,
+    client,
+    dropboxRoot,
+    localRoot,
+    signal
+  );
+
+  abortIfRequested(signal);
+
+  return {
+    publish(path) {
+      abortIfRequested(signal);
+
+      current += 1;
+
+      if (total > 0) {
+        publishProgress(publish, current, total, path);
+      }
+    },
+  };
+};
+
+const publishProgress = (publish, current, total, path) => {
+  const displayPath = path.startsWith("/") ? path : join("/", path);
+
+  publish(`(${current}/${total}) Syncing ${displayPath}`);
+};
+
+const countFilesToUpload = async (
+  blogID,
+  client,
+  dropboxRoot,
+  localRoot,
+  signal,
+  dir = "/"
+) => {
+  abortIfRequested(signal);
+
+  const [remoteContents, localContents] = await Promise.all([
+    remoteReaddir(client, join(dropboxRoot, dir), signal),
+    localReaddir(blogID, localRoot, dir, signal),
+  ]);
+
+  abortIfRequested(signal);
+
+  let total = 0;
+
+  for (const localItem of localContents) {
+    abortIfRequested(signal);
+
+    const path = join(dir, localItem.name);
+
+    if (isDotfileOrDotfolder(path)) continue;
+
+    const remoteCounterpart = remoteContents.find(
+      (remoteItem) => remoteItem.name === localItem.name
+    );
+
+    if (localItem.is_directory) {
+      total += await countFilesToUpload(
+        blogID,
+        client,
+        dropboxRoot,
+        localRoot,
+        signal,
+        path
+      );
+      continue;
+    }
+
+    if (
+      !remoteCounterpart ||
+      remoteCounterpart.content_hash !== localItem.content_hash
+    ) {
+      total += 1;
+    }
+  }
+
+  return total;
+};
 
 const localReaddir = async (blogID, localRoot, dir, signal) => {
   abortIfRequested(signal);


### PR DESCRIPTION
### Motivation
- Provide file-level progress during the Dropbox initial setup so the UI `status-line` shows per-file progress instead of only folder-level messages.
- Use the same progress parser format consumed by the client (`(current/total) Syncing /relative/path`) so the existing `app/views/js/sync_status.js` picks up updates automatically.
- Preserve existing abort handling and the current ignore rules when counting and publishing progress.

### Description
- Added a file-counting phase and progress tracker to `app/clients/dropbox/sync/reset-from-blot.js` that computes the total number of files to upload before starting the main walk using `countFilesToUpload` and `createUploadProgressTracker`.
- Replaced the per-file `publish("Transferring", path)` calls with `uploadProgress.publish(path)`, which emits messages in the parser format like `(${current}/${total}) Syncing /path` via the existing `publish` callback (passed through from `folder.status`).
- The counting logic uses the same ignore rules (`isDotfileOrDotfolder`) and compares remote `content_hash` to avoid counting unchanged files.
- All counting and publish operations check the provided `signal` via `abortIfRequested(signal)` so progress reporting stops cleanly if setup is aborted.

### Testing
- Ran `node --check app/clients/dropbox/sync/reset-from-blot.js` to validate syntax and it succeeded.
- Ran `git diff --check` to ensure no whitespace/patch problems and it succeeded.
- Verified that existing `signal`-based abort checks remain in place by ensuring `abortIfRequested(signal)` is called during counting and publishing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a565ee094648329b882f2152051ec1c)