### PR TITLE
Extract KaTeX sources before Pandoc and render placeholders in plugin

### DIFF
--- a/app/build/converters/markdown/convert.js
+++ b/app/build/converters/markdown/convert.js
@@ -1,6 +1,7 @@
 var spawn = require("child_process").spawn;
 var indentation = require("./indentation");
 var footnotes = require("./footnotes");
+var extractMathSources = require("../../plugins/katex/source").extractMathSources;
 var time = require("helper/time");
 var config = require("config");
 var Pandoc = config.pandoc.bin;
@@ -158,6 +159,9 @@ module.exports = function (blog, text, options, callback) {
   // for the contents of an HTML tag. This preserves
   // indentation in text! More discussion of this issue:
   // https://github.com/jgm/pandoc/issues/1841
+  debug("Pre-katex-source", text);
+  text = safely(extractMathSources, text);
+
   debug("Pre-indentation", text);
   time("indentation");
   text = safely(indentation, text);

--- a/app/build/plugins/katex/index.js
+++ b/app/build/plugins/katex/index.js
@@ -66,7 +66,16 @@ function eachTextNode(node, cb) {
   });
 }
 
+function renderSourcePlaceholders($) {
+  $(".blot-katex-source").each(function () {
+    const source = $(this).text();
+    const display = $(this).attr("data-display") === "true";
+    $(this).replaceWith(renderTex(source, display));
+  });
+}
+
 function render($, callback) {
+  renderSourcePlaceholders($);
   $("p").each(function () {
     const $p = $(this);
     if ($p.html().indexOf(delimiter) === -1 || $p.find("br").length === 0) return;

--- a/app/build/plugins/katex/source.js
+++ b/app/build/plugins/katex/source.js
@@ -1,0 +1,71 @@
+const delimiter = "$$";
+
+function extractMathSources(input) {
+  if (!input || input.indexOf(delimiter) === -1) return input;
+
+  let output = "";
+  let position = 0;
+
+  while (position < input.length) {
+    const start = input.indexOf(delimiter, position);
+
+    if (start === -1) {
+      output += input.slice(position);
+      break;
+    }
+
+    const end = input.indexOf(delimiter, start + delimiter.length);
+
+    if (end === -1) {
+      output += input.slice(position);
+      break;
+    }
+
+    const sourceStart = start + delimiter.length;
+    const source = input.slice(sourceStart, end);
+    const afterEnd = end + delimiter.length;
+    const display = isDisplayMath(input, start, sourceStart, afterEnd);
+
+    output += input.slice(position, start);
+    output += placeholder(source, display);
+    position = afterEnd;
+  }
+
+  return output;
+}
+
+function placeholder(source, display) {
+  const escaped = escapeHtml(source);
+
+  if (display) {
+    return '<pre class="blot-katex-source" data-display="true">' + escaped + "</pre>";
+  }
+
+  return '<span class="blot-katex-source" data-display="false">' + escaped + "</span>";
+}
+
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function isDisplayMath(input, start, sourceStart, afterEnd) {
+  if (input[sourceStart] === "\n" || input[sourceStart] === "\r") return true;
+
+  return isOwnLineBefore(input, start) && isOwnLineAfter(input, afterEnd);
+}
+
+function isOwnLineBefore(input, start) {
+  const lineStart = input.lastIndexOf("\n", start - 1) + 1;
+  return /^\s*$/.test(input.slice(lineStart, start));
+}
+
+function isOwnLineAfter(input, afterEnd) {
+  let lineEnd = input.indexOf("\n", afterEnd);
+  if (lineEnd === -1) lineEnd = input.length;
+  return /^\s*$/.test(input.slice(afterEnd, lineEnd));
+}
+
+module.exports = { extractMathSources };


### PR DESCRIPTION
### Motivation
- Ensure KaTeX TeX sources are preserved across Pandoc conversion by replacing balanced `$$...$$` with Pandoc-safe HTML placeholders containing only the raw TeX (no `$$`), so the KaTeX plugin can render them reliably after conversion.
- Avoid restoring literal `$$...$$` after Pandoc and keep the existing `-tex_math_dollars` Pandoc extension to prevent Pandoc from interfering with math handling.

### Description
- Added a reusable helper `extractMathSources(input)` in `app/build/plugins/katex/source.js` that finds balanced `$$...$$`, leaves unmatched `$$` untouched, stores only the TeX source (no delimiters), HTML-escapes `&`, `<`, and `>`, and emits inline placeholders `<span class="blot-katex-source" data-display="false">...</span>` or display placeholders `<pre class="blot-katex-source" data-display="true">...</pre>` depending on block shape.
- Wired the helper into `app/build/converters/markdown/convert.js` so extraction runs before the indentation pass and before writing to `pandoc.stdin` via `text = safely(extractMathSources, text);`.
- Updated the KaTeX plugin in `app/build/plugins/katex/index.js` to render preserved placeholders directly with a new `renderSourcePlaceholders($)` step that replaces `.blot-katex-source` elements with `katex.renderToString` output based on the element body and `data-display` attribute, rather than restoring `$$`-delimited text.
- Kept the existing `-tex_math_dollars` Pandoc extension active so Pandoc will not produce its own math output.

### Testing
- Ran inline Node assertions that exercise `extractMathSources` behavior for inline, display, and unmatched cases; these assertions passed (`node - <<'NODE' ... NODE`).
- Performed syntax checks with `node -c` on `app/build/plugins/katex/source.js`, `app/build/converters/markdown/convert.js`, and `app/build/plugins/katex/index.js`, all of which succeeded.
- Attempted to run the plugin integration test script (`./scripts/tests/invoke.sh app/build/plugins/katex`) but it could not complete in this environment because Docker is not available (test runner requires Docker).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a2d5ad580832996bb1dc6b0862fcf)