### PR TITLE
Refactor math normalization and KaTeX rendering phases

### DIFF
--- a/app/build/converters/gdoc/index.js
+++ b/app/build/converters/gdoc/index.js
@@ -12,6 +12,7 @@ const footnotes = require("./footnotes");
 const linebreaks = require("./linebreaks");
 const processImages = require("./images");
 const cleanupSpans = require("./cleanup-spans");
+const { normalizeLiteralDollarMath } = require("build/math/normalizeLiteralDollars");
 
 function textWithLineBreaks($, node) {
   const clonedNode = $(node).clone();
@@ -220,6 +221,7 @@ async function read(blog, path, callback) {
     // transform code tables before final serialization
     convertCodeTables($);
 
+    normalizeLiteralDollarMath($);
 
     let html = $("body").html();
 

--- a/app/build/converters/html/index.js
+++ b/app/build/converters/html/index.js
@@ -2,6 +2,8 @@ var fs = require("fs");
 var ensure = require("helper/ensure");
 var LocalPath = require("helper/localPath");
 var extname = require("path").extname;
+var cheerio = require("cheerio");
+var normalizeLiteralDollarMath = require("build/math/normalizeLiteralDollars").normalizeLiteralDollarMath;
 
 function is(path) {
   return [".html", ".htm"].indexOf(extname(path).toLowerCase()) > -1;
@@ -23,7 +25,10 @@ function read(blog, path, callback) {
     fs.readFile(localPath, "utf-8", function (err, contents) {
       if (err) return callback(err);
 
-      return callback(null, contents, stat);
+      var $ = cheerio.load(contents, { decodeEntities: false }, false);
+      normalizeLiteralDollarMath($);
+
+      return callback(null, $.html(), stat);
     });
   });
 }

--- a/app/build/converters/markdown-without-pandoc.js
+++ b/app/build/converters/markdown-without-pandoc.js
@@ -5,6 +5,8 @@ const fs = require("fs-extra");
 const { marked } = require("marked");
 const extname = require("path").extname;
 const localPath = require("helper/localPath");
+const cheerio = require("cheerio");
+const { normalizeLiteralDollarMath } = require("build/math/normalizeLiteralDollars");
 
 module.exports = {
   read: function (blog, path, callback) {
@@ -12,9 +14,10 @@ module.exports = {
 
     const text = fs.readFileSync(path, "utf-8");
     const stat = fs.statSync(path);
-    const html = marked.parse(text);
+    const $ = cheerio.load(marked.parse(text), { decodeEntities: false }, false);
+    normalizeLiteralDollarMath($);
 
-    callback(null, html, stat);
+    callback(null, $.html(), stat);
   },
   is: function is (path) {
     return (

--- a/app/build/math/normalizeLiteralDollars.js
+++ b/app/build/math/normalizeLiteralDollars.js
@@ -1,0 +1,87 @@
+const escapeHtml = require("escape-html");
+
+const delimiter = "$$";
+const SKIP_TAGS = ["script", "style", "code", "pre"];
+
+function mathSpan(source, display) {
+  const mode = display ? "display" : "inline";
+  return '<span class="math ' + mode + '">' + escapeHtml(source.trim()) + '</span>';
+}
+
+function normalizeMathInText(text) {
+  if (!text || text.indexOf(delimiter) === -1) return text;
+
+  const tokens = text.split(delimiter);
+  if (tokens.length < 3) return text;
+
+  let remainder = "";
+
+  if (tokens.length % 2 === 0) {
+    remainder = delimiter + tokens.pop();
+  }
+
+  for (let i = 1; i < tokens.length; i += 2) {
+    const source = tokens[i];
+    const display =
+      /^\s*\n/.test(source) ||
+      (/^\s*$/.test(tokens[i - 1]) && /^\s*$/.test(tokens[i + 1] || ""));
+
+    tokens[i] = mathSpan(source, display);
+  }
+
+  return tokens
+    .map((token, index) => (index % 2 === 0 ? escapeHtml(token) : token))
+    .join("") + escapeHtml(remainder);
+}
+
+function textWithLineBreaks($, node) {
+  const clone = $(node).clone();
+  clone.find("br").replaceWith("\n");
+  return clone.text();
+}
+
+function canFlattenLinebreakParagraph(node) {
+  if (!node || !node.children) return false;
+
+  return node.children.every((child) => child.type === "text" || child.name === "br");
+}
+
+function eachTextNode(node, cb) {
+  if (!node || !node.children) return;
+
+  node.children.forEach((child) => {
+    if (child.type === "text") {
+      cb(child);
+      return;
+    }
+
+    if (SKIP_TAGS.includes(child.name)) return;
+
+    eachTextNode(child, cb);
+  });
+}
+
+function normalizeLiteralDollarMath($) {
+  $("p").each(function () {
+    const $p = $(this);
+    if ($p.html().indexOf(delimiter) === -1 || $p.find("br").length === 0) return;
+    if (!canFlattenLinebreakParagraph(this)) return;
+
+    $p.text(textWithLineBreaks($, this));
+  });
+
+  const rootNode = $("body")[0] || $.root()[0];
+
+  eachTextNode(rootNode, (textNode) => {
+    const converted = normalizeMathInText(textNode.data);
+
+    if (converted !== textNode.data) {
+      $(textNode).replaceWith(converted);
+    }
+  });
+}
+
+module.exports = {
+  normalizeLiteralDollarMath,
+  normalizeMathInText,
+};

--- a/app/build/plugins/katex/index.js
+++ b/app/build/plugins/katex/index.js
@@ -3,30 +3,6 @@ const katex = require("katex");
 const delimiter = "$$";
 const SKIP_TAGS = ["script", "style", "code", "pre"];
 
-function convertMathInText(text) {
-  if (!text || text.indexOf(delimiter) === -1) return text;
-
-  const tokens = text.split(delimiter);
-  if (tokens.length < 3) return text;
-
-  let remainder = "";
-
-  if (tokens.length % 2 === 0) {
-    remainder = delimiter + tokens.pop();
-  }
-
-  for (let i = 1; i < tokens.length; i += 2) {
-    const source = tokens[i];
-    const display =
-      /^\s*\n/.test(source) ||
-      (/^\s*$/.test(tokens[i - 1]) && /^\s*$/.test(tokens[i + 1] || ""));
-
-    tokens[i] = renderTex(source, display);
-  }
-
-  return tokens.join("") + remainder;
-}
-
 function renderTex(source, display) {
   const original = source;
 
@@ -37,33 +13,6 @@ function renderTex(source, display) {
   } catch (error) {
     return delimiter + original + delimiter;
   }
-}
-
-function textWithLineBreaks($, node) {
-  const clone = $(node).clone();
-  clone.find("br").replaceWith("\n");
-  return clone.text();
-}
-
-function canFlattenLinebreakParagraph(node) {
-  if (!node || !node.children) return false;
-
-  return node.children.every((child) => child.type === "text" || child.name === "br");
-}
-
-function eachTextNode(node, cb) {
-  if (!node || !node.children) return;
-
-  node.children.forEach((child) => {
-    if (child.type === "text") {
-      cb(child);
-      return;
-    }
-
-    if (SKIP_TAGS.includes(child.name)) return;
-
-    eachTextNode(child, cb);
-  });
 }
 
 function renderPandocMath($) {
@@ -79,25 +28,9 @@ function renderPandocMath($) {
 }
 
 function render($, callback) {
+  if (!$ || typeof $ !== "function") return callback(null);
+
   renderPandocMath($);
-
-  $("p").each(function () {
-    const $p = $(this);
-    if ($p.html().indexOf(delimiter) === -1 || $p.find("br").length === 0) return;
-    if (!canFlattenLinebreakParagraph(this)) return;
-
-    $p.text(textWithLineBreaks($, this));
-  });
-
-  const rootNode = $("body")[0] || $.root()[0];
-
-  eachTextNode(rootNode, (textNode) => {
-    const converted = convertMathInText(textNode.data);
-
-    if (converted !== textNode.data) {
-      $(textNode).replaceWith(converted);
-    }
-  });
 
   callback(null);
 }

--- a/app/build/plugins/katex/tests/normalize-literal-dollars.js
+++ b/app/build/plugins/katex/tests/normalize-literal-dollars.js
@@ -1,0 +1,35 @@
+const cheerio = require("cheerio");
+const { normalizeLiteralDollarMath } = require("../../../math/normalizeLiteralDollars");
+const { render } = require("../index");
+
+describe("literal dollar math normalization", function () {
+  function normalizeAndRender(html, callback) {
+    const $ = cheerio.load(html, { decodeEntities: false }, false);
+    normalizeLiteralDollarMath($);
+    render($, function (err) {
+      if (err) return callback(err);
+      callback(null, $.html());
+    });
+  }
+
+  it("normalizes literal $$ before KaTeX rendering", function (done) {
+    normalizeAndRender("<p>Inline $$a+b$$ math</p>", function (err, html) {
+      if (err) return done.fail(err);
+      expect(html).toContain('class="katex"');
+      expect(html).not.toContain("$$a+b$$");
+      done();
+    });
+  });
+
+  it("leaves literal $$ untouched during the KaTeX render phase", function (done) {
+    const $ = cheerio.load("<p>Inline $$a+b$$ math</p>", { decodeEntities: false }, false);
+
+    render($, function (err) {
+      if (err) return done.fail(err);
+      const html = $.html();
+      expect(html).not.toContain('class="katex"');
+      expect(html).toContain("$$a+b$$");
+      done();
+    });
+  });
+});

--- a/app/build/plugins/katex/tests/pandoc-math.js
+++ b/app/build/plugins/katex/tests/pandoc-math.js
@@ -38,15 +38,4 @@ describe("katex pandoc math spans", function () {
       done();
     });
   });
-
-  it("still renders literal $$ for non-pandoc html", function (done) {
-    const input = "<p>Inline $$a+b$$ math</p>";
-
-    renderHtml(input, function (err, html) {
-      if (err) return done.fail(err);
-      expect(html).toContain('class="katex"');
-      expect(html).not.toContain("$$a+b$$");
-      done();
-    });
-  });
 });


### PR DESCRIPTION
### Motivation
- Separate converter-specific normalization of literal `$$...$$` math from the KaTeX rendering step so converters produce normalized `span.math.inline` / `span.math.display` nodes and the plugin only renders those nodes.
- Make literal-dollar support reusable and explicit in converters that need it, and simplify the KaTeX plugin to a focused, safer render step.

### Description
- Extracted the literal `$$...$$` scanner into `app/build/math/normalizeLiteralDollars.js`, which converts literal-dollar math into `span.math.inline` / `span.math.display` while preserving skip-tag behavior for `script`, `style`, `code`, and `pre`.
- Updated converter outputs to run normalization before final serialization in `app/build/converters/html/index.js`, `app/build/converters/gdoc/index.js`, and `app/build/converters/markdown-without-pandoc.js`.
- Simplified the KaTeX plugin at `app/build/plugins/katex/index.js` to perform only `renderPandocMath()` with a minimal safety check and removed the inline literal-dollar scanning from the plugin.
- Added focused tests `app/build/plugins/katex/tests/normalize-literal-dollars.js` and adjusted existing Pandoc-span tests to validate the new two-phase behavior.

### Testing
- Static syntax checks: `NODE_PATH=app node -c` on the modified files passed without syntax errors.
- Unit tests: ran Jasmine specs with `NODE_PATH=app npx jasmine app/build/plugins/katex/tests/pandoc-math.js app/build/plugins/katex/tests/normalize-literal-dollars.js` which completed with `4 specs, 0 failures`.
- Attempted full `npm test -- --grep "katex|literal dollar"` but it is blocked in this environment because `docker` is not available; other local checks and focused Jasmine tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e7c7042c08329a23681abfd53c4d6)