### PR TITLE
Preserve raw TeX across Pandoc math converters

### DIFF
--- a/app/build/converters/markdown/convert.js
+++ b/app/build/converters/markdown/convert.js
@@ -133,6 +133,13 @@ module.exports = function (blog, text, options, callback) {
 
     if (err) return callback(err);
 
+    // --katex guarantees that the text in Pandoc math spans is raw TeX.
+    // Preserve that provenance for the KaTeX rendering boundary.
+    result = result.replace(
+      /<span class="math (inline|display)">/g,
+      '<span class="math $1" data-math-source="tex">'
+    );
+
     debug("Pre-footnotes", result);
     time("footnotes");
     result = safely(footnotes, result);

--- a/app/build/converters/org/convert.js
+++ b/app/build/converters/org/convert.js
@@ -26,6 +26,9 @@ module.exports = function (blog, text, callback) {
     // we use our own highlighint library (hljs) later
     "--no-highlight",
 
+    // Emit span.math with raw TeX for the KaTeX plugin.
+    "--katex",
+
     "--email-obfuscation=none"
   ];
 
@@ -76,6 +79,11 @@ module.exports = function (blog, text, callback) {
       },
       false
     );
+
+    // Pandoc's --katex writer leaves the original TeX in these spans. Mark
+    // that provenance so the KaTeX plugin never interprets an arbitrary
+    // user-authored span.math as TeX.
+    $("span.math.inline, span.math.display").attr("data-math-source", "tex");
 
     // if there is a pre tag with class="yaml"
     // at the very start of the document then extract its contents,

--- a/app/build/converters/rtf/convert.js
+++ b/app/build/converters/rtf/convert.js
@@ -3,6 +3,10 @@ var time = require("helper/time");
 var config = require("config");
 var Pandoc = config.pandoc.bin;
 var debug = require("debug")("blot:converters:rtf");
+var cheerio = require("cheerio");
+var normalizeLiteralDollarMath = require(
+  "build/math/normalizeLiteralDollars"
+).normalizeLiteralDollarMath;
 
 module.exports = function (blog, text, callback) {
   var args = [
@@ -23,6 +27,11 @@ module.exports = function (blog, text, callback) {
 
     // we use our own highlighint library (hljs) later
     "--no-highlight",
+
+    // Keep this aligned with the other Pandoc converters. The RTF reader does
+    // not create Pandoc Math nodes from dollar-delimited TeX, so normalize its
+    // literal output below while the original TeX is still available.
+    "--katex",
 
     // such a dumb default feature... sorry john!
     "--email-obfuscation=none",
@@ -66,6 +75,10 @@ module.exports = function (blog, text, callback) {
     }
 
     if (err) return callback(err);
+
+    var $ = cheerio.load(result, { decodeEntities: false }, false);
+    normalizeLiteralDollarMath($);
+    result = $.html();
 
     debug("Final:", result);
     callback(null, result);

--- a/app/build/math/normalizeLiteralDollars.js
+++ b/app/build/math/normalizeLiteralDollars.js
@@ -5,7 +5,13 @@ const SKIP_TAGS = ["script", "style", "code", "pre"];
 
 function mathSpan(source, display) {
   const mode = display ? "display" : "inline";
-  return '<span class="math ' + mode + '">' + escapeHtml(source.trim()) + '</span>';
+  return (
+    '<span class="math ' +
+    mode +
+    '" data-math-source="tex">' +
+    escapeHtml(source.trim()) +
+    "</span>"
+  );
 }
 
 function isEscaped(text, index) {

--- a/app/build/plugins/katex/index.js
+++ b/app/build/plugins/katex/index.js
@@ -26,7 +26,9 @@ function renderTex(source, display) {
 }
 
 function renderPandocMath($) {
-  $("span.math.inline, span.math.display").each(function () {
+  $(
+    'span.math.inline[data-math-source="tex"], span.math.display[data-math-source="tex"]'
+  ).each(function () {
     const $span = $(this);
     if ($span.closest(SKIP_TAGS.join(",")).length) return;
 

--- a/app/build/plugins/katex/tests/converter-math-normalization.js
+++ b/app/build/plugins/katex/tests/converter-math-normalization.js
@@ -2,11 +2,15 @@ const fs = require("fs-extra");
 const LocalPath = require("helper/localPath");
 
 const markdownConvert = require("../../../converters/markdown/convert");
+const orgConvert = require("../../../converters/org/convert");
+const rtfConvert = require("../../../converters/rtf/convert");
 const htmlConverter = require("../../../converters/html");
 const gdocConverter = require("../../../converters/gdoc");
 const markdownWithoutPandoc = require(
   "../../../converters/markdown-without-pandoc"
 );
+const cheerio = require("cheerio");
+const { render } = require("../index");
 
 describe("converter math normalization", function () {
   const blog = {
@@ -37,20 +41,57 @@ describe("converter math normalization", function () {
     });
   }
 
+  function convertDirect(converter, text) {
+    return new Promise((resolve, reject) => {
+      converter(blog, text, (err, html) => {
+        if (err) return reject(err);
+        resolve(html);
+      });
+    });
+  }
+
+  function renderWithKatex(html) {
+    return new Promise((resolve, reject) => {
+      const $ = cheerio.load(html, { decodeEntities: false }, false);
+      render($, (err) => {
+        if (err) return reject(err);
+        resolve($.html());
+      });
+    });
+  }
+
+  const tex = "\\frac{1}{2}";
+
   const fixtures = [
     {
       name: "pandoc markdown",
-      inline: "Inline $a+b$ math",
-      display: "$$c=d$$",
+      inline: "Inline $\\frac{1}{2}$ math",
+      display: "$$\\frac{1}{2}$$",
       convert(content) {
         return convertMarkdown(content);
       },
     },
     {
+      name: "pandoc org",
+      inline: "Inline \\(\\frac{1}{2}\\) math",
+      display: "\\[\\frac{1}{2}\\]",
+      convert(content) {
+        return convertDirect(orgConvert, content);
+      },
+    },
+    {
+      name: "pandoc rtf",
+      inline: "{\\rtf1\\ansi Inline $\\\\frac\\{1\\}\\{2\\}$ math}",
+      display: "{\\rtf1\\ansi $$\\\\frac\\{1\\}\\{2\\}$$}",
+      convert(content) {
+        return convertDirect(rtfConvert, content);
+      },
+    },
+    {
       name: "html",
       path: "/math-normalization.html",
-      inline: "<p>Inline $a+b$ math</p>",
-      display: "<p>$$c=d$$</p>",
+      inline: "<p>Inline $\\frac{1}{2}$ math</p>",
+      display: "<p>$$\\frac{1}{2}$$</p>",
       convert() {
         return readWith(htmlConverter, this.path);
       },
@@ -58,8 +99,8 @@ describe("converter math normalization", function () {
     {
       name: "gdoc",
       path: "/math-normalization.gdoc",
-      inline: "<html><body><p>Inline $a+b$ math</p></body></html>",
-      display: "<html><body><p>$$<br>c=d<br>$$</p></body></html>",
+      inline: "<html><body><p>Inline $\\frac{1}{2}$ math</p></body></html>",
+      display: "<html><body><p>$$<br>\\frac{1}{2}<br>$$</p></body></html>",
       convert() {
         return readWith(gdocConverter, this.path);
       },
@@ -67,8 +108,8 @@ describe("converter math normalization", function () {
     {
       name: "markdown without pandoc",
       path: "/math-normalization.md",
-      inline: "Inline $a+b$ math",
-      display: "$$c=d$$",
+      inline: "Inline $\\frac{1}{2}$ math",
+      display: "$$\\frac{1}{2}$$",
       convert() {
         return readWith(markdownWithoutPandoc, this.path);
       },
@@ -76,12 +117,12 @@ describe("converter math normalization", function () {
   ];
 
   const cases = [
-    { mode: "inline", expected: '<span class="math inline">a+b</span>' },
-    { mode: "display", expected: '<span class="math display">c=d</span>' },
+    { mode: "inline", className: "inline" },
+    { mode: "display", className: "display" },
   ];
 
   fixtures.forEach((fixture) => {
-    cases.forEach(({ mode, expected }) => {
+    cases.forEach(({ mode, className }) => {
       it(
         fixture.name +
           " emits normalized " +
@@ -96,8 +137,23 @@ describe("converter math normalization", function () {
 
           const html = await fixture.convert.call(fixture, content);
 
-          expect(html).toContain(expected);
+          const $ = cheerio.load(html, { decodeEntities: false }, false);
+          const $math = $("span.math." + className);
+
+          expect($math.length).toBe(1);
+          expect($math.attr("data-math-source")).toBe("tex");
+          expect($math.text()).toBe(tex);
           expect(html).not.toContain('class="katex"');
+
+          const rendered = await renderWithKatex(html);
+          const renderedDocument = cheerio.load(
+            rendered,
+            { decodeEntities: false },
+            false
+          );
+          expect(
+            renderedDocument("annotation[encoding='application/x-tex']").text()
+          ).toBe(tex);
         }
       );
     });

--- a/app/build/plugins/katex/tests/normalize-literal-dollars.js
+++ b/app/build/plugins/katex/tests/normalize-literal-dollars.js
@@ -39,22 +39,22 @@ describe("literal dollar math normalization", function () {
 
   it("normalizes single-dollar inline math", function () {
     expect(normalizeMathInText("Inline $x$ math")).toBe(
-      'Inline <span class="math inline">x</span> math'
+      'Inline <span class="math inline" data-math-source="tex">x</span> math'
     );
   });
 
   it("normalizes double-dollar math with existing inline/display semantics", function () {
     expect(normalizeMathInText("Inline $$x$$ math")).toBe(
-      'Inline <span class="math inline">x</span> math'
+      'Inline <span class="math inline" data-math-source="tex">x</span> math'
     );
     expect(normalizeMathInText("$$x$$")).toBe(
-      '<span class="math display">x</span>'
+      '<span class="math display" data-math-source="tex">x</span>'
     );
   });
 
   it("normalizes adjacent single- and double-dollar math", function () {
     expect(normalizeMathInText("$x$ and $$y$$")).toBe(
-      '<span class="math inline">x</span> and <span class="math inline">y</span>'
+      '<span class="math inline" data-math-source="tex">x</span> and <span class="math inline" data-math-source="tex">y</span>'
     );
   });
 

--- a/app/build/plugins/katex/tests/pandoc-math.js
+++ b/app/build/plugins/katex/tests/pandoc-math.js
@@ -12,7 +12,7 @@ describe("katex pandoc math spans", function () {
 
   it("renders span.math.inline without markdown emphasis tags", function (done) {
     const input =
-      '<p>Inline <span class="math inline">a+b</span> math</p>';
+      '<p>Inline <span class="math inline" data-math-source="tex">a+b</span> math</p>';
 
     renderHtml(input, function (err, html) {
       if (err) return done.fail(err);
@@ -26,7 +26,7 @@ describe("katex pandoc math spans", function () {
   it("renders underscore-heavy display math without em tags", function (done) {
     const tex =
       "\\mathbf{v}_1^{\\text{cm}} = \\mathbf{v} - \\mathbf{v}_{\\text{cm}} = \\frac{\\mathbf{v}}{2}";
-    const input = `<p><span class="math display">${tex}</span></p>`;
+    const input = `<p><span class="math display" data-math-source="tex">${tex}</span></p>`;
 
     renderHtml(input, function (err, html) {
       if (err) return done.fail(err);
@@ -41,7 +41,7 @@ describe("katex pandoc math spans", function () {
 
   it("falls back to escaped inline TeX with inline delimiters", function (done) {
     const input =
-      '<p>Inline <span class="math inline">\\frac{&lt;img src=x onerror=alert(1)&gt;</span> math</p>';
+      '<p>Inline <span class="math inline" data-math-source="tex">\\frac{&lt;img src=x onerror=alert(1)&gt;</span> math</p>';
 
     renderHtml(input, function (err, html) {
       if (err) return done.fail(err);
@@ -54,7 +54,7 @@ describe("katex pandoc math spans", function () {
 
   it("falls back to escaped display TeX with display delimiters", function (done) {
     const input =
-      '<p><span class="math display">\\frac{&lt;script&gt;alert(1)&lt;/script&gt;</span></p>';
+      '<p><span class="math display" data-math-source="tex">\\frac{&lt;script&gt;alert(1)&lt;/script&gt;</span></p>';
 
     renderHtml(input, function (err, html) {
       if (err) return done.fail(err);
@@ -73,6 +73,17 @@ describe("katex pandoc math spans", function () {
       if (err) return done.fail(err);
       expect(html).not.toContain('class="katex"');
       expect(html).toContain('<span class="math inline">a+b</span>');
+      done();
+    });
+  });
+
+  it("leaves untrusted user-authored math spans untouched", function (done) {
+    const input = '<p><span class="math inline">not raw TeX</span></p>';
+
+    renderHtml(input, function (err, html) {
+      if (err) return done.fail(err);
+      expect(html).not.toContain('class="katex"');
+      expect(html).toContain('<span class="math inline">not raw TeX</span>');
       done();
     });
   });


### PR DESCRIPTION
### Motivation
- Ensure Org and RTF Pandoc conversions emit the same raw-TeX `span.math.inline` / `span.math.display` representation consumed by the KaTeX plugin, matching the Markdown converter's `--katex` semantics where supported.
- Preserve provenance of raw TeX so the KaTeX renderer only processes spans known to contain TeX and does not render arbitrary user-authored `span.math` content.
- Add converter and integration tests using a meaningful formula (`\\frac{1}{2}`) to guard against Pandoc flattening or Unicode substitution of TeX source.

### Description
- Add Pandoc `--katex` to the Org and RTF converter argument arrays so Pandoc emits math spans where available, and mark Pandoc-produced math spans with `data-math-source="tex"` in the Org and Markdown converters.
- Extend `app/build/math/normalizeLiteralDollars.js` so normalized dollar-math spans include `data-math-source="tex"` provenance.
- For RTF output, parse the Pandoc HTML with `cheerio` and run `normalizeLiteralDollarMath` before returning to convert dollar-delimited TeX into `span.math` while preserving original TeX.
- Restrict the KaTeX plugin (`renderPandocMath`) to only render spans explicitly labeled with `data-math-source="tex"` so untrusted user-authored spans are left untouched.
- Update tests: extend `app/build/plugins/katex/tests/converter-math-normalization.js` with Org and RTF conversion cases, use `\frac{1}{2}` for inline and display cases, assert that converter output contains a single `span.math` with `data-math-source="tex"` and the original TeX, and then pass that output through the KaTeX plugin to assert the resulting MathML annotation contains the original TeX; update `normalize-literal-dollars` and `pandoc-math` tests to reflect the provenance attribute and add a test ensuring untrusted spans are not rendered.

### Testing
- Ran the focused KaTeX-related specs with Pandoc present using `PATH=/tmp/pandoc-3.1.1/bin:$PATH NODE_PATH=app npx jasmine app/build/plugins/katex/tests/converter-math-normalization.js app/build/plugins/katex/tests/pandoc-math.js app/build/plugins/katex/tests/normalize-literal-dollars.js`, which completed with `29 specs, 0 failures`.
- Ran `git diff --check` to ensure no whitespace/diff issues.
- Attempting to invoke the full converter test suites directly (e.g. `app/build/converters/org/tests` and `app/build/converters/rtf/tests`) outside the repository test harness failed to initialize because those suites require the shared Jasmine test harness context (`this.blog`), so they were not run standalone.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68749d093c832988403e014be0e6c5)