### PR TITLE
Preserve paragraph line breaks when normalizing literal math

### DIFF
--- a/app/build/math/normalizeLiteralDollars.js
+++ b/app/build/math/normalizeLiteralDollars.js
@@ -180,16 +180,81 @@ function normalizeMathInText(text) {
     .join("");
 }
 
-function textWithLineBreaks($, node) {
-  const clone = $(node).clone();
-  clone.find("br").replaceWith("\n");
-  return clone.text();
-}
-
 function canFlattenLinebreakParagraph(node) {
   if (!node || !node.children) return false;
 
   return node.children.every((child) => child.type === "text" || child.name === "br");
+}
+
+// Find display math without first flattening the paragraph. Flattening is
+// tempting here, but it destroys every <br> in the paragraph even when the
+// dollars do not form a display expression.
+function displayMathRanges(node) {
+  let text = "";
+  const textNodes = [];
+
+  node.children.forEach((child) => {
+    if (child.type === "text") {
+      textNodes.push({
+        node: child,
+        start: text.length,
+        end: text.length + child.data.length,
+      });
+      text += child.data;
+    } else if (child.name === "br") {
+      text += "\n";
+    }
+  });
+
+  const lines = [];
+  let start = 0;
+  for (let i = 0; i <= text.length; i += 1) {
+    if (i === text.length || text[i] === "\n") {
+      lines.push({ start, end: i, value: text.slice(start, i) });
+      start = i + 1;
+    }
+  }
+
+  const ranges = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    if (!/^\s*\$\$\s*$/.test(lines[i].value)) continue;
+
+    for (let close = i + 1; close < lines.length; close += 1) {
+      if (!/^\s*\$\$\s*$/.test(lines[close].value)) continue;
+
+      const source = text.slice(lines[i].end + 1, lines[close].start);
+      if (source.trim()) {
+        ranges.push({
+          start: lines[i].start,
+          end: lines[close].end,
+          source,
+          textNodes,
+        });
+        i = close;
+      }
+      break;
+    }
+  }
+
+  return ranges;
+}
+
+function replaceDisplayRange($, range) {
+  const affected = range.textNodes.filter(
+    (entry) => entry.end > range.start && entry.start < range.end
+  );
+  if (!affected.length) return;
+
+  const first = affected[0];
+  // The opening delimiter occupies its whole visual line, so replacing its
+  // text node cannot consume any surrounding content.
+  $(first.node).replaceWith(mathSpan(range.source, true));
+
+  affected.slice(1).forEach((entry) => {
+    const from = Math.max(range.start, entry.start) - entry.start;
+    const to = Math.min(range.end, entry.end) - entry.start;
+    entry.node.data = entry.node.data.slice(0, from) + entry.node.data.slice(to);
+  });
 }
 
 function eachTextNode(node, cb) {
@@ -213,7 +278,9 @@ function normalizeLiteralDollarMath($) {
     if ($p.html().indexOf("$$") === -1 || $p.find("br").length === 0) return;
     if (!canFlattenLinebreakParagraph(this)) return;
 
-    $p.text(textWithLineBreaks($, this));
+    displayMathRanges(this)
+      .reverse()
+      .forEach((range) => replaceDisplayRange($, range));
   });
 
   const rootNode = $("body")[0] || $.root()[0];

--- a/app/build/plugins/katex/tests/normalize-literal-dollars.js
+++ b/app/build/plugins/katex/tests/normalize-literal-dollars.js
@@ -133,4 +133,59 @@ describe("literal dollar math normalization", function () {
       '<span class="math display">x+y</span>'
     );
   });
+
+  it("keeps the line break after inline double-dollar math", function (done) {
+    normalizeAndRender("<p>$$x$$<br>next</p>", function (err, html) {
+      if (err) return done.fail(err);
+      const $ = cheerio.load(html, { decodeEntities: false }, false);
+      expect($(".katex").length).toBe(1);
+      expect($(".katex-display").length).toBe(0);
+      expect($("br").length).toBe(1);
+      expect($("p").text()).toContain("next");
+      done();
+    });
+  });
+
+  it("does not consume line breaks for an unfinished delimiter", function (done) {
+    normalizeAndRender("<p>Unfinished $$x<br>next</p>", function (err, html) {
+      if (err) return done.fail(err);
+      const $ = cheerio.load(html, { decodeEntities: false }, false);
+      expect($(".katex").length).toBe(0);
+      expect($("br").length).toBe(1);
+      expect($("p").html()).toBe("Unfinished $$x<br>next");
+      done();
+    });
+  });
+
+  it(
+    "normalizes a bounded three-line display and preserves surrounding content",
+    function (done) {
+      const input = "<p>before<br>$$<br>x+y<br>$$<br>after</p>";
+      normalizeAndRender(input, function (err, html) {
+        if (err) return done.fail(err);
+        const $ = cheerio.load(html, { decodeEntities: false }, false);
+        // Display tokens mixed with other paragraph content render inline.
+        expect($(".katex").length).toBe(1);
+        expect($(".katex-display").length).toBe(0);
+        expect($("br").length).toBe(4);
+        expect($("p").text()).toContain("before");
+        expect($("p").text()).toContain("after");
+        done();
+      });
+    }
+  );
+
+  it("preserves unrelated line breaks around display math", function (done) {
+    const input = "<p>one<br>two<br>$$<br>z<br>$$<br>three<br>four</p>";
+    normalizeAndRender(input, function (err, html) {
+      if (err) return done.fail(err);
+      const $ = cheerio.load(html, { decodeEntities: false }, false);
+      expect($(".katex").length).toBe(1);
+      expect($(".katex-display").length).toBe(0);
+      expect($("br").length).toBe(6);
+      expect($("p").text()).toContain("onetwo");
+      expect($("p").text()).toContain("threefour");
+      done();
+    });
+  });
 });


### PR DESCRIPTION
### Motivation
- The prior paragraph-flattening approach replaced entire paragraphs that happened to contain `$$` and `<br>` nodes, destroying unrelated line breaks.
- Only valid multiline display math (a pair of `$$` each on its own visual line enclosing nonempty TeX) should be normalized.
- The change must preserve every existing `<br>` and surrounding paragraph content outside the matched display range.

### Description
- Replace the flatten-and-rewrite flow in `normalizeLiteralDollarMath` with a line-aware scanner `displayMathRanges` that constructs a non-mutating representation of paragraph text and `<br>` boundaries.
- Add `replaceDisplayRange` to replace only the matched bounded expression with `mathSpan(..., true)` while leaving all `<br>` nodes and unrelated text nodes intact.
- Remove `textWithLineBreaks` and the destructive paragraph flattening logic; ensure insertion/replacement does not consume surrounding content.
- Add regression tests in `app/build/plugins/katex/tests/normalize-literal-dollars.js` for `"<p>$$x$$<br>next</p>"`, `"<p>Unfinished $$x<br>next</p>"`, a three-line bounded display with surrounding content, and paragraphs with several unrelated `<br>` elements.

### Testing
- Ran `./node_modules/.bin/jasmine app/build/plugins/katex/tests/normalize-literal-dollars.js`, which reported `19 specs, 0 failures`.
- Ran `git diff --check` with no issues reported.
- Attempting the broader KaTeX test glob could not be executed in this environment due to an unresolved repository-specific module path (`helper/localPath`), so the full suite was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70a4300f808329ae9902a44d541a43)