### PR TITLE
Fix literal dollar traversal after DOM replacements

### DIFF
--- a/app/build/math/normalizeLiteralDollars.js
+++ b/app/build/math/normalizeLiteralDollars.js
@@ -260,7 +260,7 @@ function replaceDisplayRange($, range) {
 function eachTextNode(node, cb) {
   if (!node || !node.children) return;
 
-  node.children.forEach((child) => {
+  node.children.slice().forEach((child) => {
     if (child.type === "text") {
       cb(child);
       return;

--- a/app/build/plugins/katex/tests/normalize-literal-dollars.js
+++ b/app/build/plugins/katex/tests/normalize-literal-dollars.js
@@ -25,6 +25,20 @@ describe("literal dollar math normalization", function () {
     });
   });
 
+  it("normalizes math in original siblings after an expanding replacement", function (done) {
+    const input = "<p>First $x$ then <em>$y$</em><strong>after</strong></p>";
+
+    normalizeAndRender(input, function (err, html) {
+      if (err) return done.fail(err);
+      const $ = cheerio.load(html, { decodeEntities: false }, false);
+      expect($(".katex").length).toBe(2);
+      expect(html).not.toContain("$x$");
+      expect(html).not.toContain("$y$");
+      expect($("strong").text()).toBe("after");
+      done();
+    });
+  });
+
   it("leaves literal $$ untouched during the KaTeX render phase", function (done) {
     const $ = cheerio.load("<p>Inline $$a+b$$ math</p>", { decodeEntities: false }, false);
 


### PR DESCRIPTION
### Motivation
- The `eachTextNode` iterator previously walked the live `node.children` array so callbacks that replaced text nodes could mutate the children and cause original sibling nodes to be skipped; iterating a snapshot prevents this while keeping recursive traversal and `SKIP_TAGS` behavior.

### Description
- Change `eachTextNode` to iterate over `node.children.slice()` in `app/build/math/normalizeLiteralDollars.js` and add a regression test in `app/build/plugins/katex/tests/normalize-literal-dollars.js` that normalizes and renders `<p>First $x$ then <em>$y$</em><strong>after</strong></p>` and asserts both expressions are rendered and no literal `$x$`/`$y$` remain.

### Testing
- Ran `NODE_PATH=app ./node_modules/.bin/jasmine app/build/plugins/katex/tests/normalize-literal-dollars.js`, which executed 20 specs with 0 failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70eaaf62c48329ad1248ebd4dee9e7)