### PR TITLE
Preserve HTML metadata before Cheerio serialization

### DIFF
--- a/app/build/converters/html/index.js
+++ b/app/build/converters/html/index.js
@@ -3,6 +3,7 @@ var ensure = require("helper/ensure");
 var LocalPath = require("helper/localPath");
 var extname = require("path").extname;
 var cheerio = require("cheerio");
+var Metadata = require("build/metadata");
 var normalizeLiteralDollarMath = require("build/math/normalizeLiteralDollars").normalizeLiteralDollarMath;
 
 function is(path) {
@@ -25,10 +26,16 @@ function read(blog, path, callback) {
     fs.readFile(localPath, "utf-8", function (err, contents) {
       if (err) return callback(err);
 
-      var $ = cheerio.load(contents, { decodeEntities: false }, false);
+      // Metadata must be extracted from the source, rather than from Cheerio's
+      // serialization. In particular, serialization can encode characters in
+      // metadata values (such as "&"), changing both the value and its slug.
+      var parsed = Metadata(contents);
+      var $ = cheerio.load(parsed.html, { decodeEntities: false }, false);
       normalizeLiteralDollarMath($);
 
-      return callback(null, $.html(), stat);
+      return callback(null, $.html(), stat, {
+        preExtractedMetadata: parsed.metadata
+      });
     });
   });
 }

--- a/app/build/converters/html/tests/fixtures/bare-metadata.html
+++ b/app/build/converters/html/tests/fixtures/bare-metadata.html
@@ -1,0 +1,4 @@
+Title: Rock & Roll
+Custom: 1 < 2 &copy; 3 > 2
+
+<DIV CLASS="body">Body &amp; entity<BR></DIV>

--- a/app/build/converters/html/tests/fixtures/yaml-metadata.html
+++ b/app/build/converters/html/tests/fixtures/yaml-metadata.html
@@ -1,0 +1,5 @@
+---
+Title: Rock & Roll
+Custom: "1 < 2 &copy; 3 > 2"
+---
+<DIV CLASS="body">Body &amp; entity<BR></DIV>

--- a/app/build/converters/html/tests/index.js
+++ b/app/build/converters/html/tests/index.js
@@ -1,0 +1,32 @@
+const build = require("../../../index");
+const fs = require("fs-extra");
+const path = require("path");
+
+describe("html converter metadata", function () {
+  global.test.blog();
+
+  ["bare-metadata.html", "yaml-metadata.html"].forEach(function (fixture) {
+    it("preserves metadata before converting " + fixture, function (done) {
+      const entryPath = "/" + fixture;
+      const source = path.join(__dirname, "fixtures", fixture);
+
+      fs.copySync(source, this.blogDirectory + entryPath);
+
+      build(this.blog, entryPath, function (err, entry) {
+        if (err) return done.fail(err);
+
+        expect(entry.metadata.Title).toBe("Rock & Roll");
+        expect(entry.metadata.Custom).toBe("1 < 2 &copy; 3 > 2");
+        expect(entry.slug).toBe("rock-roll");
+
+        expect(entry.html).not.toContain("Title: Rock");
+        expect(entry.html).not.toContain("Custom:");
+        expect(entry.html).not.toContain("---");
+        expect(entry.html).toContain(
+          '<div class="body">Body &amp; entity<br></div>'
+        );
+        done();
+      });
+    });
+  });
+});

--- a/app/build/single.js
+++ b/app/build/single.js
@@ -24,14 +24,20 @@ module.exports = function (blog, path, callback) {
 
         var parsed, metadata, dependencies;
 
-        // Now we extract any metadata from the file
-        // This modifies the 'contents' if it succeeds
-        try {
-          parsed = Metadata(html);
-          metadata = parsed.metadata;
-          html = parsed.html;
-        } catch (err) {
-          return callback(err);
+        // Some converters need to extract metadata before converting the body.
+        // Use those original values directly instead of reparsing converted HTML.
+        if (extras && extras.preExtractedMetadata) {
+          metadata = extras.preExtractedMetadata;
+        } else {
+          // Now we extract any metadata from the file
+          // This modifies the 'contents' if it succeeds
+          try {
+            parsed = Metadata(html);
+            metadata = parsed.metadata;
+            html = parsed.html;
+          } catch (err) {
+            return callback(err);
+          }
         }
 
         // We have to compute the dependencies before


### PR DESCRIPTION
### Motivation
- HTML files can contain leading bare metadata or YAML front matter whose values (e.g. `Title: Rock & Roll`) must be preserved exactly and not altered by DOM serialization entity-encoding.  
- Metadata must be extracted from the original source prior to Cheerio processing so `makeSlug` and other metadata-driven behavior see the original values.  
- Do not globally decode serialized HTML entities because that can change intentional body markup.

### Description
- Update `app/build/converters/html/index.js` to call `Metadata(contents)` and pass `parsed.html` to `cheerio.load`, run `normalizeLiteralDollarMath` on the loaded body, and return `extras.preExtractedMetadata` containing the parsed metadata.  
- Update `app/build/single.js` to prefer `extras.preExtractedMetadata` (if present) instead of reparsing the converter output, and to fall back to `Metadata(html)` for other converters.  
- Add real-file fixtures `app/build/converters/html/tests/fixtures/bare-metadata.html` and `yaml-metadata.html` covering both bare metadata and YAML front matter with entity-sensitive values.  
- Add full-build regression test `app/build/converters/html/tests/index.js` asserting exact metadata preservation (e.g. `Title: Rock & Roll` and a `Custom` value containing `<`/`>`/`&copy;`), that the metadata prefix is removed from `entry.html`, and that `entry.slug` becomes `rock-roll`.

### Testing
- `node --check app/build/converters/html/index.js` succeeded.  
- `node --check app/build/single.js` succeeded.  
- `node --check app/build/converters/html/tests/index.js` succeeded.  
- `git diff --check` succeeded.  
- Manual verification using `NODE_PATH=app node` and `Metadata` confirmed both fixtures yield `{"Title":"Rock & Roll","Custom":"1 < 2 &copy; 3 > 2"}` and that body HTML remains properly serialized.  
- Attempted to run the test suite with `./scripts/tests/invoke.sh app/build/converters/html/tests` but the containerized test runner could not run because Docker is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70ea7fec6c8329b6230cb77884baff)