### PR TITLE
Add safe asynchronous Blogger dashboard imports

### DIFF
--- a/app/dashboard/site/import/index.js
+++ b/app/dashboard/site/import/index.js
@@ -82,5 +82,6 @@ Import.post("/delete/:importID", async function (req, res) {
 
 Import.use(require("./sources/arena/router"));
 Import.use(require("./sources/wordpress/router"));
+Import.use(require("./sources/blogger/router"));
 
 module.exports = Import;

--- a/app/dashboard/site/import/sources/blogger/router.js
+++ b/app/dashboard/site/import/sources/blogger/router.js
@@ -1,0 +1,108 @@
+const express = require("express");
+const fs = require("fs-extra");
+const { basename, extname, join } = require("path");
+
+const init = require("dashboard/site/import/init");
+const blogger = require("./index");
+
+const Importer = express.Router();
+const MAX_IDENTIFIER_LENGTH = 120;
+
+function identifierFor(filename) {
+  const identifier = basename(String(filename || "").replace(/\\/g, "/"))
+    .replace(/[\u0000-\u001f\u007f]/g, "")
+    .trim()
+    .slice(0, MAX_IDENTIFIER_LENGTH);
+
+  return identifier && identifier !== "." && identifier !== ".."
+    ? identifier
+    : "Blogger export";
+}
+
+function isXML(upload) {
+  const contentType = String(
+    upload.headers && upload.headers["content-type"]
+      ? upload.headers["content-type"]
+      : upload.mimetype || ""
+  )
+    .split(";", 1)[0]
+    .trim()
+    .toLowerCase();
+
+  return (
+    extname(upload.originalFilename || "").toLowerCase() === ".xml" ||
+    contentType === "application/xml" ||
+    contentType === "text/xml" ||
+    contentType.endsWith("+xml")
+  );
+}
+
+function errorMessage(error) {
+  const message = error && error.message ? error.message : String(error);
+  return (
+    message.replace(/[\r\n]+/g, " ").replace(/\s+/g, " ").trim() ||
+    "Blogger import failed"
+  ).slice(0, 300);
+}
+
+Importer.route("/blogger")
+  .get(function (req, res) {
+    res.locals.breadcrumbs.add("Blogger", "blogger");
+    res.render("dashboard/import/blogger");
+  })
+  .post(function (req, res) {
+    const upload =
+      req.files &&
+      Array.isArray(req.files.exportUpload) &&
+      req.files.exportUpload[0];
+
+    if (!upload || !upload.path) {
+      return res.message(
+        req.baseUrl,
+        new Error("Please select a Blogger XML export file.")
+      );
+    }
+
+    if (!isXML(upload)) {
+      fs.remove(upload.path).catch(() => {});
+      return res.message(
+        req.baseUrl,
+        new Error("Please upload an XML file exported from Blogger.")
+      );
+    }
+
+    const job = init({ blogID: req.blog.id, label: "Blogger" });
+    res.message(req.baseUrl, "Began import");
+
+    // Start after the response has been handed back to Express. The converter's
+    // promise resolves only after its Markdown and asset-writing pipeline ends.
+    setImmediate(async () => {
+      try {
+        await fs.outputFile(
+          join(job.importDirectory, "identifier.txt"),
+          identifierFor(upload.originalFilename),
+          "utf8"
+        );
+        await blogger(upload.path, job.outputDirectory, job.status);
+        await job.finish();
+      } catch (error) {
+        await fs
+          .outputFile(
+            join(job.importDirectory, "error.txt"),
+            errorMessage(error),
+            "utf8"
+          )
+          .catch((writeError) =>
+            console.error("Failed to record import error", writeError)
+          );
+      } finally {
+        await fs
+          .remove(upload.path)
+          .catch((removeError) =>
+            console.error("Failed to remove Blogger upload", removeError)
+          );
+      }
+    });
+  });
+
+module.exports = Importer;

--- a/app/views/dashboard/import/blogger.html
+++ b/app/views/dashboard/import/blogger.html
@@ -1,0 +1,20 @@
+{{> close-button}}
+
+<div style="border:1px solid var(--border-color);border-radius: var(--border-radius);padding:20px">
+  <h1>Blogger import</h1>
+  <p style="max-width: 600px">The importer turns a Blogger export XML file into an archive containing Markdown files and downloaded assets.</p>
+  <br>
+
+  <form method="POST" enctype="multipart/form-data" action="{{{importBase}}}/blogger">
+    <input type="hidden" name="_csrf" value="{{csrftoken}}">
+    <label style="border-radius:4px;border:1px solid rgba(0,0,0,0.05);display:block;padding:11px 20px;margin-bottom:6px;cursor:pointer;box-sizing:border-box;">
+      <span style="margin-top:0;color:rgb(158, 154, 152);font-size:14px;display:inline;margin-right:10px">Select XML file: </span>
+      <input type="file" id="exportUpload" name="exportUpload" accept=".xml,application/xml,text/xml" required style="display:inline;margin:0;cursor:pointer;">
+    </label>
+
+    <div class="buttons">
+      <button type="submit">Upload XML file</button>
+      <a href="{{{importBase}}}">Cancel</a>
+    </div>
+  </form>
+</div>


### PR DESCRIPTION
### Motivation

- Provide a Blogger import flow in the dashboard so users can upload Blogger XML exports and convert them into Markdown archives. 
- Prevent server errors caused by missing or invalid uploads by validating `req.files` and the uploaded file before dereferencing properties. 
- Run the potentially long-running conversion asynchronously while relaying progress and ensuring final archive completion and cleanup.

### Description

- Add `app/dashboard/site/import/sources/blogger/router.js` implementing `GET /blogger` (renders the upload form) and `POST /blogger` (validates upload presence and XML content-type/extension, returns user-facing errors when invalid). 
- Sanitize and bound the uploaded filename using `identifierFor(...)`, write it to `identifier.txt`, and initialize the background job via `init({ blogID, label: "Blogger" })`. 
- Invoke the Blogger converter asynchronously (via `setImmediate`), relay progress through the provided `status` function, await `finish()` only after conversion and asset writing complete, and write a concise `error.txt` on both synchronous and asynchronous failures. 
- Ensure temporary uploaded input is removed in a `finally` block after success or failure, register the router in `app/dashboard/site/import/index.js`, and add the view `app/views/dashboard/import/blogger.html` for the upload form. 

### Testing

- Ran `NODE_PATH=app npx jasmine app/dashboard/site/import/sources/blogger/tests/index.js`, which executed the Blogger importer tests (2 specs) and passed. 
- Ran `node --check app/dashboard/site/import/sources/blogger/router.js` to validate syntax, which passed. 
- Ran `git diff --check` to surface whitespace/format issues, which passed with no errors. 
- Attempted to generate a screenshot of the new form with Puppeteer, but Chromium failed to launch due to a missing system library (`libatk-1.0.so.0`), so visual verification was not captured in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71b12a932c8329859da37d0816939f)