### PR TITLE
Add Blogger import views, dashboard entry, icon and documentation

### DIFF
--- a/app/views/dashboard/import/blogger.html
+++ b/app/views/dashboard/import/blogger.html
@@ -2,7 +2,8 @@
 
 <div style="border:1px solid var(--border-color);border-radius: var(--border-radius);padding:20px">
   <h1>Blogger import</h1>
-  <p style="max-width: 600px">The importer turns a Blogger export XML file into an archive containing Markdown files and downloaded assets.</p>
+  <p style="max-width: 600px">In Blogger, open <strong>Settings</strong>, scroll to <strong>Manage blog</strong>, choose <strong>Back up content</strong>, then select <strong>Download</strong> to obtain your blog's XML export.</p>
+  <p style="max-width: 600px">The importer turns this XML file into an archive (.zip) containing Markdown files. It preserves published posts and pages, their original URLs and publication dates, and labels, and downloads images and linked PDF files alongside the Markdown.</p>
   <br>
 
   <form method="POST" enctype="multipart/form-data" action="{{{importBase}}}/blogger">

--- a/app/views/dashboard/import/index.html
+++ b/app/views/dashboard/import/index.html
@@ -92,6 +92,7 @@
 
 <ul class="imports">
   <li><a href="{{{importBase}}}/wordpress"><img width="100" height="100" src="/images/configure/wordpress.png"> <span class="a">Wordpress</span></a></li>
+  <li><a href="{{{importBase}}}/blogger"><img width="100" height="100" src="/images/configure/blogger.svg"> <span class="a">Blogger</span></a></li>
   <li><a href="{{{importBase}}}/are.na"><img width="250" height="149" src="/images/configure/are.na.png">  <span class="a">Are.na</span></a></li>
 </ul>
 

--- a/app/views/how/configure/import.html
+++ b/app/views/how/configure/import.html
@@ -4,12 +4,13 @@
    import sites from the following platforms:</p>
 <ul>
   <li>Wordpress</li>
+  <li>Blogger</li>
   <li>Squarespace</li>
   <li>Are.na</li>
 </ul>
 
 <p>
-  The importer generates a folder of <a href="/how/posts/markdown">Markdown</a> and <a href="/how/files/images">image</a> files which you can drag into your site's folder. The importer will preserve the URLs of your posts and the dates they were published.
+  The importer generates a ZIP archive containing <a href="/how/posts/markdown">Markdown</a> and <a href="/how/files/images">image</a> files. Download and extract the ZIP, then place its contents into your Blot folder. The importer will preserve the URLs of your posts and the dates they were published.
 </p>
 
 <h2>Transferring your domain</h2>

--- a/app/views/images/configure/blogger.svg
+++ b/app/views/images/configure/blogger.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-labelledby="title">
+  <title>Blogger</title>
+  <rect width="100" height="100" rx="18" fill="#f57d00"/>
+  <path fill="#fff" d="M28 24h27c12 0 21 9 21 21v5h4v15c0 7-6 13-13 13H38c-10 0-18-8-18-18V32c0-4 4-8 8-8Zm10 15v11h17a5.5 5.5 0 0 0 0-11H38Zm0 25h27v-9H38v9Z"/>
+</svg>


### PR DESCRIPTION
### Motivation
- Provide a dashboard UI and documentation so users can import Blogger blogs into Blot using the same workflow as other importers.
- Explain how to obtain a Blogger XML backup and what the importer preserves so users know what to expect from the import output.

### Description
- Added the Blogger dashboard view at `app/views/dashboard/import/blogger.html` which uses a multipart form with an input named `exportUpload`, includes the `_csrf` token via `{{csrftoken}}`, and posts to `{{{importBase}}}/blogger`.
- Added a Blogger entry to the imports list in `app/views/dashboard/import/index.html` linking to `{{{importBase}}}/blogger` and referencing a repository-native SVG at `/images/configure/blogger.svg`.
- Added the accessible SVG icon at `app/views/images/configure/blogger.svg` and updated documentation at `app/views/how/configure/import.html` to list Blogger and instruct users to download/extract the resulting ZIP and place its contents into their Blot folder.

### Testing
- Ran `NODE_PATH=app npx jasmine app/dashboard/site/import/sources/blogger/tests/index.js` and the Blogger import tests completed with 2 specs and 0 failures.
- Executed a Node assertion script that programmatically verified the form uses `enctype="multipart/form-data"`, contains an input named `exportUpload`, includes the CSRF token `{{csrftoken}}`, posts to `{{{importBase}}}/blogger`, the dashboard list contains a Blogger link, and the how-page lists Blogger and ZIP instructions; the script succeeded.
- Ran `git diff --check` to validate whitespace/format issues and it reported no problems.
- Attempted a `curl` request to the local server and a Puppeteer screenshot run for visual verification, but these failed due to the local Blot server not running and missing system libraries in the environment respectively (environment warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71b384ea588329b400d814f1b1e37c)