### PR TITLE
Import: stage downloaded assets in temp dirs and refactor writer to allocate final paths and move assets

### DIFF
--- a/app/dashboard/site/import/helper/asset_directory.js
+++ b/app/dashboard/site/import/helper/asset_directory.js
@@ -1,0 +1,13 @@
+var fs = require("fs-extra");
+var os = require("os");
+var path = require("path");
+
+// Assets are staged outside the output tree. This keeps their directories from
+// influencing final path allocation before the entry itself is written.
+module.exports = function assetDirectory(entry) {
+  if (!entry.asset_directory) {
+    entry.asset_directory = fs.mkdtempSync(path.join(os.tmpdir(), "blot-import-"));
+  }
+
+  return entry.asset_directory;
+};

--- a/app/dashboard/site/import/helper/download_audio.js
+++ b/app/dashboard/site/import/helper/download_audio.js
@@ -4,6 +4,7 @@ var parse = require("url").parse;
 var download = require("download");
 var each_el = require("./each_el");
 var fs = require("fs-extra");
+var assetDirectory = require("./asset_directory");
 
 module.exports = function download_pdfs(post, callback) {
   var $ = cheerio.load(post.html, { decodeEntities: false });
@@ -25,7 +26,7 @@ module.exports = function download_pdfs(post, callback) {
 
       download(href)
         .then(function (data) {
-          fs.outputFile(post.path + "/" + name, data, function (err) {
+          fs.outputFile(assetDirectory(post) + "/" + name, data, function (err) {
             if (err) return next();
 
             $(el).attr("src", name);

--- a/app/dashboard/site/import/helper/download_images.js
+++ b/app/dashboard/site/import/helper/download_images.js
@@ -5,6 +5,7 @@ var each_el = require("./each_el");
 var fs = require("fs-extra");
 var sharp = require("sharp");
 var callOnce = require("helper/callOnce");
+var assetDirectory = require("./asset_directory");
 
 // Consider using this algorithm to determine best part of alt tag or caption to use
 // as the file's name:
@@ -62,7 +63,7 @@ function download(url, _callback) {
     });
 }
 
-function download_thumbnail(post, path, callback) {
+function download_thumbnail(post, callback) {
   if (!post || !post.metadata || !post.metadata.thumbnail) return callback();
 
   var thumbnail = post.metadata.thumbnail;
@@ -79,7 +80,7 @@ function download_thumbnail(post, path, callback) {
     if (format && !name.toLowerCase().endsWith(format.toLowerCase()))
       name = name + "." + format;
 
-    fs.outputFile(path + "/" + name, data, function (err) {
+    fs.outputFile(assetDirectory(post) + "/" + name, data, function (err) {
       if (err) return callback(err);
       callback(null, name);
     });
@@ -90,7 +91,8 @@ module.exports = function download_images(post, callback) {
   var changes = false;
   var $ = cheerio.load(post.html, { decodeEntities: false });
 
-  download_thumbnail(post, post.path, function (err, thumbnail) {
+  // The directory is created lazily only if a download succeeds.
+  download_thumbnail(post, function (err, thumbnail) {
     if (!err && thumbnail) {
       changes = true;
       post.metadata.thumbnail = thumbnail;
@@ -116,7 +118,7 @@ module.exports = function download_images(post, callback) {
           if (format && !name.toLowerCase().endsWith(format.toLowerCase()))
             name = name + "." + format;
 
-          fs.outputFile(post.path + "/" + name, data, function (err) {
+          fs.outputFile(assetDirectory(post) + "/" + name, data, function (err) {
             if (err) return next();
             changes = true;
 

--- a/app/dashboard/site/import/helper/download_pdfs.js
+++ b/app/dashboard/site/import/helper/download_pdfs.js
@@ -4,6 +4,7 @@ var parse = require("url").parse;
 var each_el = require("./each_el");
 var fs = require("fs-extra");
 var callOnce = require("helper/callOnce");
+var assetDirectory = require("./asset_directory");
 
 var TIMEOUT = 5 * 1000; // 10s
 
@@ -93,7 +94,7 @@ module.exports = function download_pdfs(post, callback) {
           return next();
         }
 
-        fs.outputFile(post.path + "/" + name, data, function (err) {
+        fs.outputFile(assetDirectory(post) + "/" + name, data, function (err) {
           if (err) return next();
 
           if ($(el).text() === href) {

--- a/app/dashboard/site/import/helper/process.js
+++ b/app/dashboard/site/import/helper/process.js
@@ -4,6 +4,9 @@ const fs = require("fs-extra");
 module.exports = (output_directory, posts, options = {}) => {
   if (!options.preserve_output_directory) fs.emptyDirSync(output_directory);
 
+  const determinePath = require("./determine_path")(output_directory);
+  const write = require("./write").createWriter();
+
   async.eachSeries(
     posts,
     (post, next) => {
@@ -11,13 +14,13 @@ module.exports = (output_directory, posts, options = {}) => {
         [
           // gets the waterfall flowing...
           (callback) => callback(null, post),
-          require("./determine_path")(output_directory),
+          determinePath,
           require("./download_audio"),
           require("./download_pdfs"),
           require("./download_images"),
           require("./convert_to_markdown"),
           require("./insert_metadata"),
-          require("./write"),
+          write,
         ],
         next
       );

--- a/app/dashboard/site/import/helper/tests/write.js
+++ b/app/dashboard/site/import/helper/tests/write.js
@@ -1,0 +1,82 @@
+var fs = require("fs-extra");
+var os = require("os");
+var path = require("path");
+var determinePath = require("../determine_path");
+var createWriter = require("../write").createWriter;
+
+describe("import writer path allocation", function () {
+  var output;
+
+  beforeEach(function () {
+    output = fs.mkdtempSync(path.join(os.tmpdir(), "import-writer-"));
+  });
+
+  afterEach(function () {
+    fs.removeSync(output);
+  });
+
+  function writeAll(entries, done) {
+    var determine = determinePath(output);
+    var write = createWriter();
+    var index = 0;
+
+    function next(err) {
+      if (err) return done.fail(err);
+      if (index === entries.length) return done();
+      var entry = entries[index++];
+      entry.content = entry.content || "body";
+      determine(entry, function (err) {
+        if (err) return next(err);
+        write(entry, next);
+      });
+    }
+
+    next();
+  }
+
+  it("deduplicates titles which collide after punctuation normalization", function (done) {
+    writeAll([{ title: "Hello!" }, { title: "Hello?" }], function () {
+      expect(fs.existsSync(path.join(output, "Undated", "Hello.txt"))).toBe(true);
+      expect(fs.existsSync(path.join(output, "Undated", "Hello-2.txt"))).toBe(true);
+      done();
+    });
+  });
+
+  it("deduplicates names which collide after 150-character truncation", function (done) {
+    var prefix = "a".repeat(150);
+    writeAll([{ title: prefix + "x" }, { title: prefix + "y" }], function () {
+      expect(fs.existsSync(path.join(output, "Undated", prefix + ".txt"))).toBe(true);
+      expect(fs.existsSync(path.join(output, "Undated", prefix.slice(0, 148) + "-2.txt"))).toBe(true);
+      done();
+    });
+  });
+
+  it("keeps suffixes visible within the filename limit", function (done) {
+    var entries = [];
+    for (var i = 0; i < 10; i++) entries.push({ title: "x".repeat(160) });
+    writeAll(entries, function () {
+      expect(fs.existsSync(path.join(output, "Undated", "x".repeat(147) + "-10.txt"))).toBe(true);
+      done();
+    });
+  });
+
+  it("allows identical names in different destination directories", function (done) {
+    writeAll([{ title: "Same", page: true }, { title: "Same", draft: true }], function () {
+      expect(fs.existsSync(path.join(output, "Pages", "Same.txt"))).toBe(true);
+      expect(fs.existsSync(path.join(output, "Drafts", "Same.txt"))).toBe(true);
+      done();
+    });
+  });
+
+  it("moves staged assets beside the final post.txt", function (done) {
+    var assets = fs.mkdtempSync(path.join(os.tmpdir(), "import-assets-"));
+    fs.writeFileSync(path.join(assets, "_image.png"), "image");
+    writeAll([{ title: "With asset", asset_directory: assets }], function () {
+      var destination = path.join(output, "Undated", "With-asset");
+      expect(fs.readFileSync(path.join(destination, "_image.png"), "utf8")).toBe("image");
+      expect(fs.existsSync(path.join(destination, "post.txt"))).toBe(true);
+      expect(fs.existsSync(assets)).toBe(false);
+      done();
+    });
+  });
+});

--- a/app/dashboard/site/import/helper/write.js
+++ b/app/dashboard/site/import/helper/write.js
@@ -1,28 +1,88 @@
 var fs = require("fs-extra");
+var path = require("path");
 
-module.exports = function (post, callback) {
-  var atime, mtime;
+var MAX_NAME_LENGTH = 150;
 
-  let path = post.path;
+function createWriter() {
+  var reserved = new Set();
 
-  if (fs.existsSync(path) && fs.statSync(path).isDirectory()) {
-    path += "/post.txt";
-  } else {
-    path += ".txt";
-  }
+  return function write(post, callback) {
+    var basePath = allocate(post, reserved);
+    var hasAssets = Boolean(
+      post.asset_directory && fs.existsSync(post.asset_directory)
+    );
+    var finalPath = hasAssets ? path.join(basePath, "post.txt") : basePath + ".txt";
 
-  // Remove leading and trailing whitespace
-  post.content = post.content.trim();
+    post.path = basePath;
+    post.content = post.content.trim();
 
-  fs.outputFile(path, post.content, function (err) {
-    if (err) return callback(err);
-
-    atime = Date.now();
-    mtime = post.updated || post.created || post.dateStamp || Date.now();
-
-    fs.utimes(path, atime, mtime, function (err) {
+    moveAssets(post.asset_directory, basePath, function (err) {
       if (err) return callback(err);
-      callback(null);
+
+      fs.outputFile(finalPath, post.content, function (err) {
+        if (err) return callback(err);
+
+        var atime = Date.now();
+        var mtime = post.updated || post.created || post.dateStamp || Date.now();
+        fs.utimes(finalPath, atime, mtime, function (err) {
+          if (err) return callback(err);
+          callback(null);
+        });
+      });
+    });
+  };
+}
+
+function allocate(post, reserved) {
+  var originalPath = post.path;
+  var originalName = path.basename(originalPath);
+  var directory = path.dirname(originalPath);
+  var hasAssets = Boolean(
+    post.asset_directory && fs.existsSync(post.asset_directory)
+  );
+  var number = 1;
+
+  while (true) {
+    var suffix = number === 1 ? "" : "-" + number;
+    var name = originalName.slice(0, MAX_NAME_LENGTH - suffix.length) + suffix;
+    var candidate = path.join(directory, name);
+    var finalPath = hasAssets ? path.join(candidate, "post.txt") : candidate + ".txt";
+    var key = path.normalize(finalPath);
+
+    if (!reserved.has(key) && !fs.existsSync(finalPath)) {
+      reserved.add(key);
+      return candidate;
+    }
+
+    number += 1;
+  }
+}
+
+function moveAssets(source, destination, callback) {
+  if (!source || !fs.existsSync(source)) return callback();
+
+  fs.ensureDir(destination, function (err) {
+    if (err) return callback(err);
+    fs.readdir(source, function (err, names) {
+      if (err) return callback(err);
+      var remaining = names.length;
+      if (!remaining) return fs.remove(source, callback);
+      var failed;
+      names.forEach(function (name) {
+        fs.move(path.join(source, name), path.join(destination, name), function (moveErr) {
+          if (failed) return;
+          if (moveErr) {
+            failed = true;
+            return callback(moveErr);
+          }
+          if (!--remaining) fs.remove(source, callback);
+        });
+      });
     });
   });
-};
+}
+
+// Retain the single-entry middleware API for callers outside the batch import.
+var write = createWriter();
+module.exports = write;
+module.exports.createWriter = createWriter;

--- a/app/dashboard/site/import/sources/wordpress/index.js
+++ b/app/dashboard/site/import/sources/wordpress/index.js
@@ -3,6 +3,7 @@ var async = require("async");
 var parseXML = require("xml2js").parseString;
 var colors = require("colors/safe");
 var Item = require("./item");
+var helper = require("dashboard/site/import/helper");
 
 if (require.main === module) {
   var options = {};
@@ -52,12 +53,10 @@ function main(sourceFile, outputDirectory, status, options, callback) {
 
       try {
         var channel = result.rss.channel[0];
-        console.log('HERE with channel', channel);
         var title = channel && channel.title && channel.title[0];
         var link = channel && channel.link && channel.link[0];
         var exportVersion = channel && channel["wp:wxr_version"] && channel["wp:wxr_version"][0];
         
-        console.log(title);
         console.log(colors.dim("Site URL:"), link);
         console.log(
           colors.dim("Export Version"),
@@ -85,25 +84,28 @@ function main(sourceFile, outputDirectory, status, options, callback) {
 
         var totalItems = items.length;
       } catch (e) {
-        console.log("HERE with err", e);
         return callback(new Error("Invalid XML"));
       }
+
+      // Final destinations are allocated only after downloads have established
+      // whether an entry needs a directory-backed post.txt representation.
+      var write = helper.write.createWriter();
 
       async.eachOfSeries(
         items,
         function (item, index, done) {
           status(
             "Processing " +
-              (++index + " of " + totalItems) +
+              (index + 1 + " of " + totalItems) +
               " " +
               item.title[0].trim()
           );
           console.log(
-            colors.dim(++index + "/" + totalItems),
+            colors.dim(index + 1 + "/" + totalItems),
             item.title[0].trim()
           );
           injectAttachedThumbnail(item, channel.item);
-          Item(item, outputDirectory, done);
+          Item(item, outputDirectory, write, done);
         },
         callback
       );

--- a/app/dashboard/site/import/sources/wordpress/item/index.js
+++ b/app/dashboard/site/import/sources/wordpress/item/index.js
@@ -3,7 +3,12 @@ var helper = require("dashboard/site/import/helper");
 var extract_entry = require("./extract_entry");
 var tidy = require("./tidy");
 
-module.exports = function (item, output_directory, callback) {
+module.exports = function (item, output_directory, write, callback) {
+  // Keep compatibility with callers which process a single item directly.
+  if (!callback) {
+    callback = write;
+    write = helper.write;
+  }
   // Filter out items which should not become posts or pages
   if (
     item["wp:post_type"][0] === "nav_menu_item" ||
@@ -22,7 +27,7 @@ module.exports = function (item, output_directory, callback) {
       helper.download_images,
       helper.convert_to_markdown,
       helper.insert_metadata,
-      helper.write,
+      write,
     ],
     function (err, result) {
       if (err) console.error(err);

--- a/app/dashboard/site/import/sources/wordpress/tests/path_collisions.js
+++ b/app/dashboard/site/import/sources/wordpress/tests/path_collisions.js
@@ -1,0 +1,35 @@
+var fs = require("fs-extra");
+var os = require("os");
+var path = require("path");
+var importWordpress = require("../index");
+
+describe("wordpress import path collisions", function () {
+  it("preserves both colliding entries in distinct files", function (done) {
+    var directory = fs.mkdtempSync(path.join(os.tmpdir(), "wordpress-import-"));
+    var source = path.join(directory, "export.xml");
+    var output = path.join(directory, "output");
+    var item = function (title, content) {
+      return "<item><title>" + title + "</title>" +
+        "<link>https://example.com/post</link>" +
+        "<pubDate>Tue, 04 Aug 2020 12:00:00 GMT</pubDate>" +
+        "<content:encoded><![CDATA[<p>" + content + "</p>]]></content:encoded>" +
+        "<wp:status>publish</wp:status><wp:post_type>post</wp:post_type></item>";
+    };
+    var xml = "<?xml version=\"1.0\"?><rss xmlns:wp=\"http://wordpress.org/export/1.2/\" " +
+      "xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel>" +
+      "<title>Test</title><link>https://example.com</link><wp:wxr_version>1.2</wp:wxr_version>" +
+      item("Collision!", "first body") + item("Collision?", "second body") +
+      "</channel></rss>";
+
+    fs.writeFileSync(source, xml);
+    importWordpress(source, output, function () {}, {}, function (err) {
+      if (err) return done.fail(err);
+      var first = fs.readFileSync(path.join(output, "2020", "08-04-Collision.txt"), "utf8");
+      var second = fs.readFileSync(path.join(output, "2020", "08-04-Collision-2.txt"), "utf8");
+      expect(first).toContain("first body");
+      expect(second).toContain("second body");
+      fs.removeSync(directory);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent downloaded assets from affecting final filename allocation by staging them outside the output tree until the final destination is determined.
- Improve path allocation and collision handling when writing imported posts, and support moving staged assets beside a `post.txt` when necessary.
- Reduce repeated creation of helper objects during batch imports by instantiating `determine_path` and a writer once per run.

### Description

- Added `helper/asset_directory.js` to lazily create a temporary staging directory for an entry via `fs.mkdtempSync` and return it from `assetDirectory(entry)`. 
- Updated `download_audio`, `download_images`, and `download_pdfs` to write downloaded assets into the staged asset directory using `assetDirectory(post)` instead of `post.path`.
- Modified `download_images` to lazily create thumbnails using the staged directory and adjusted the thumbnail helper signature accordingly.
- Refactored the writer into `helper/write.js` with `createWriter()` that performs deterministic path allocation with collision deduplication (max name length truncation and `-N` suffixing), reserves targets in-process to avoid races, and moves a staged asset directory beside the final `post.txt` when present; preserved the single-entry middleware API and exported `createWriter`.
- Changed `process.js` to instantiate `determine_path` and `write` once and reuse them across posts for efficiency.
- Updated WordPress import entry points to create and pass a writer into item processing (`sources/wordpress/index.js` and `sources/wordpress/item/index.js`), and adjusted index display to use `index + 1` for counters.
- Added unit tests for writer path allocation in `helper/tests/write.js` and a WordPress import path collision test in `sources/wordpress/tests/path_collisions.js`.

### Testing

- Ran the new helper writer unit tests (`app/dashboard/site/import/helper/tests/write.js`), which exercised name truncation, suffixing, directory-backed posts, and asset movement, and they passed.
- Ran the WordPress import path collision test (`app/dashboard/site/import/sources/wordpress/tests/path_collisions.js`) which verified both colliding entries are preserved with unique filenames, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71b704d1b883299dc5813d8dd9ccc1)