### PR TITLE
Store Blogger alternate permalinks as relative paths

### DIFF
--- a/app/dashboard/site/import/sources/blogger/parse.js
+++ b/app/dashboard/site/import/sources/blogger/parse.js
@@ -49,8 +49,21 @@ function parseSiteHost(input) {
 // exports use blogger:filename with a path like /2020/01/post.html.
 function permalinkPath(permalink) {
   if (!permalink) return "";
+
+  const raw = String(permalink).trim();
+  if (!raw) return "";
+
   try {
-    return new URL(permalink, "https://blogger.invalid").pathname;
+    const url = new URL(raw, "https://blogger.invalid");
+    const query = new URLSearchParams(url.search);
+
+    // Blogger appends ?m=1 for mobile views; Blot metadata should store the
+    // canonical post path rather than a mobile-display variant. Preserve other
+    // query parameters because they may identify distinct pages.
+    query.delete("m");
+
+    const search = query.toString();
+    return (url.pathname || "/") + (search ? `?${search}` : "");
   } catch (err) {
     return "";
   }
@@ -118,7 +131,7 @@ function entryPermalink(atomEntry) {
   const alternate = (atomEntry.link || []).find(
     (link) => link && link.$ && link.$.rel === "alternate" && link.$.href
   );
-  if (alternate) return alternate.$.href;
+  if (alternate) return permalinkPath(alternate.$.href);
 
   const filename = value(atomEntry["blogger:filename"]).trim();
   return filename || undefined;

--- a/app/dashboard/site/import/sources/blogger/tests/index.js
+++ b/app/dashboard/site/import/sources/blogger/tests/index.js
@@ -29,9 +29,10 @@ describe("Blogger importer", function () {
     expect(entries[0].html).toContain(
       'href="https://example.blogspot.com/2020/01/hello-world.html"'
     );
-    expect(entries[0].permalink).toBe("https://example.blogspot.com/2020/01/shared.html");
+    expect(entries[0].permalink).toBe("/2020/01/shared.html");
     expect(entries[0].dateStamp).toBe(Date.parse("2020-01-02T03:04:05Z"));
     expect(entries[1].page).toBe(true);
+    expect(entries[2].permalink).toBe("/2020/01/shared.html");
     expect(entries[2].title).toBe("shared");
     expect(entries[2].slug).toBe("2020-01-shared-2");
     expect(entries[3].slug).toBe("a-☃-weird.name");
@@ -131,7 +132,7 @@ describe("Blogger importer", function () {
     const duplicate = path.join(output, "2020", "01-02-2020-01-shared-2.txt");
     const page = await fs.readFile(path.join(output, "Pages", "p-about.txt"), "utf8");
     expect(first).toContain("Tags: News, Two Words");
-    expect(first).toContain("Link: https://example.blogspot.com/2020/01/shared.html");
+    expect(first).toContain("Link: /2020/01/shared.html");
     expect(first).toContain("Hello **world**.");
     expect(first).toContain(
       "[other post](https://example.blogspot.com/2020/01/hello-world.html)"


### PR DESCRIPTION
### Motivation

- Ensure legacy Blogger `link[rel=alternate]` URLs are stored as relative permalink paths in Blot metadata so `Link:` entries do not include protocol/host fragments.
- Preserve meaningful query parameters while stripping Blogger mobile `m=1` variants so canonical post paths are recorded.
- Keep current Atom exports that use `blogger:filename` working as before and producing relative `Link:` values.

### Description

- Updated `permalinkPath(permalink)` in `app/dashboard/site/import/sources/blogger/parse.js` to normalize the input, parse with `new URL(...)`, remove the `m` query parameter, and return `url.pathname + (search ? `?${search}` : "")` so returned values are path-like and never contain `://`.
- Changed `entryPermalink(atomEntry)` to pass legacy `link[rel=alternate]` hrefs through `permalinkPath(...)` before returning them, ensuring alternate links become relative paths.
- Adjusted expectations in `app/dashboard/site/import/sources/blogger/tests/index.js` to assert legacy alternate permalinks and `Link:` metadata are relative (e.g. changed `https://example.blogspot.com/2020/01/shared.html` to `/2020/01/shared.html`) and to document handling of entries with `?m=1` query strings.

### Testing

- Attempted to run the repository test wrapper via `npm test -- app/dashboard/site/import/sources/blogger/tests`, but the wrapper failed because Docker is not available in the environment (`docker: command not found`).
- Ran the importer tests directly with Jasmine via a programmatic Node invocation (increasing the default timeout) and observed the suite complete successfully with `8 specs, 0 failures`.
- Executed the blogger import parse unit tests (the same `app/dashboard/site/import/sources/blogger/tests/index.js` specs) and validated the updated expectations for permalink/path handling passed under the direct Jasmine run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72f7c9ccdc8329be15f3c5f7bcc19b)