### PR TITLE
Publish failed Blogger import status

### DIFF
--- a/app/dashboard/site/import/sources/blogger/router.js
+++ b/app/dashboard/site/import/sources/blogger/router.js
@@ -99,12 +99,11 @@ Importer.route("/blogger")
         });
         await job.finish();
       } catch (error) {
+        const message = errorMessage(error);
+
         await fs
-          .outputFile(
-            join(job.importDirectory, "error.txt"),
-            errorMessage(error),
-            "utf8"
-          )
+          .outputFile(join(job.importDirectory, "error.txt"), message, "utf8")
+          .then(() => job.status("Failed"))
           .catch((writeError) =>
             console.error("Failed to record import error", writeError)
           );

--- a/app/views/js/dashboard-import.js
+++ b/app/views/js/dashboard-import.js
@@ -57,6 +57,10 @@ function renderImportStatuses() {
   });
 }
 
+function isTerminalImportStatus(status) {
+  return status === "Finished" || status === "Failed";
+}
+
 if (importContainer && (liveUpdatesContainer || importStatusContainer)) {
   const ReconnectingEventSource = require("./reconnecting-event-source.js");
 
@@ -82,7 +86,7 @@ if (importContainer && (liveUpdatesContainer || importStatusContainer)) {
       statusNode.removeAttribute("data-text");
       renderImportStatus(statusNode, status);
 
-      if (status === "Finished") {
+      if (isTerminalImportStatus(status)) {
         refreshFolder();
       }
     };


### PR DESCRIPTION
### Motivation

- Ensure the dashboard's SSE listener receives a terminal update when a Blogger import fails so the import UI refreshes.
- Use the same sanitized `errorMessage(error)` text written to `error.txt` (or a stable terminal string) when publishing the terminal status.

### Description

- In `app/dashboard/site/import/sources/blogger/router.js` capture the sanitized message with `errorMessage(error)`, write it to `error.txt`, and then publish a terminal `job.status("Failed")` only after the error file is successfully recorded.
- In `app/views/js/dashboard-import.js` add an `isTerminalImportStatus` helper and update the SSE handler so terminal statuses (`"Finished"` or `"Failed"`) call `refreshFolder()`.
- Retain existing error logging when writing the error file fails.

### Testing

- Ran `node --check app/dashboard/site/import/sources/blogger/router.js` and `node --check app/views/js/dashboard-import.js`, both succeeded.
- Ran `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72f7f4ceb88329a37ad98470ea84a3)