### PR TITLE
Require callout marker to be first visible content in blockquote

### DIFF
--- a/app/build/plugins/obsidianCallouts/index.js
+++ b/app/build/plugins/obsidianCallouts/index.js
@@ -1,4 +1,5 @@
 const SKIP_SELECTOR = "script,style,pre,code";
+const VISIBLE_LEADING_SELECTOR = "img,video,audio,iframe,object,embed";
 
 const TYPE_ALIASES = {
   note: "note",
@@ -50,15 +51,26 @@ function meaningfulChildren($blockquote) {
 
 function firstTextNode(node) {
   if (!node) return null;
-  if (node.type === "text") return node;
+
+  if (node.type === "text") {
+    return /\S/.test(node.data || "") ? node : null;
+  }
+
   if (node.type !== "tag") return null;
-  if (SKIP_SELECTOR.split(",").indexOf((node.name || "").toLowerCase()) !== -1) return null;
+
+  const tagName = (node.name || "").toLowerCase();
+
+  if (SKIP_SELECTOR.split(",").indexOf(tagName) !== -1) return null;
+  if (VISIBLE_LEADING_SELECTOR.split(",").indexOf(tagName) !== -1) return false;
+
   let child = node.children && node.children[0];
   while (child) {
     const found = firstTextNode(child);
+    if (found === false) return false;
     if (found) return found;
     child = child.next;
   }
+
   return null;
 }
 

--- a/app/build/plugins/obsidianCallouts/tests/examples/markdown-callouts.md
+++ b/app/build/plugins/obsidianCallouts/tests/examples/markdown-callouts.md
@@ -41,3 +41,9 @@
 
 <pre><code>&gt; [!warning]
 &gt; Pre should not change.</code></pre>
+
+> ![x](y)[!note]
+> Image before marker should remain quoted.
+
+>    [!note]
+> Leading whitespace still works.

--- a/app/build/plugins/obsidianCallouts/tests/examples/markdown-callouts.md.html
+++ b/app/build/plugins/obsidianCallouts/tests/examples/markdown-callouts.md.html
@@ -16,4 +16,8 @@
 &gt; Code should not change.
 </code></pre>
 <pre><code>&gt; [!warning]
-&gt; Pre should not change.</code></pre>
+&gt; Pre should not change.</code></pre><blockquote>
+<p><img src="y" alt="x">[!note]
+Image before marker should remain quoted.</p>
+</blockquote>
+<div class="callout" data-callout="note" data-callout-original="note"><div class="callout-title"><span class="callout-icon" aria-hidden="true"></span><span class="callout-title-inner">Note</span></div><div class="callout-content"><p>Leading whitespace still works.</p></div></div>


### PR DESCRIPTION
### Motivation
- Prevent callout markers from being detected when visible non-text content (images/media/iframes/embeds/links) appears before the marker in a blockquote's first meaningful content path while preserving existing skip rules and leading-whitespace acceptance.

### Description
- Add `VISIBLE_LEADING_SELECTOR = "img,video,audio,iframe,object,embed"` and update `firstTextNode(node)` to treat visible leading elements as rejection candidates (return `false`) and to ignore whitespace-only text nodes by only returning text nodes with `\S`.
- Preserve skip behavior for `script`, `style`, `pre`, and `code` via `SKIP_SELECTOR` and propagate the rejection (`false`) up the tree so `transformBlockquote()` only proceeds when the first meaningful content path yields a valid text node starting with the marker.
- Keep the `transformBlockquote()` flow using `firstTextNode(children[0])` so markers are only accepted at the start of the first meaningful content path.
- Add regression fixtures under `app/build/plugins/obsidianCallouts/tests/examples/` for a media-before-marker case and a leading-whitespace case, and update the expected HTML fixtures accordingly.

### Testing
- Ran a headless smoke test using `node` + `cheerio` to exercise common cases (markdown image-before-marker, markdown leading-whitespace marker, HTML marker-first, HTML image-before-marker) and confirmed the plugin leaves an image-before-marker as a normal `<blockquote>` while still converting markers after leading whitespace; this succeeded.
- Attempted to run the full plugin test harness via `npm test -- app/build/plugins/obsidianCallouts/tests/index.js` but it failed in this environment because Docker is not available (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a733c87e15483299330f0b4e5263fa7)