### PR TITLE
Fix sync progress bar resetting to 0% on re-render

### DIFF
--- a/app/views/js/sync_status.js
+++ b/app/views/js/sync_status.js
@@ -8,6 +8,7 @@ var timerId = null;
 var pendingWhileHidden = false;
 var evtSource = null;
 var shouldReload = false;
+var lastRawMessage = null;
 var PROGRESS_MESSAGE_RE = /^\((\d+)\/(\d+)\)\s*(.*)$/;
 
 function q(sel) {
@@ -60,8 +61,18 @@ function renderSyncStatusMessage(message) {
   if (!statusText) return;
 
   if (typeof message === "undefined") {
-    message = statusText.innerText || "";
+    // Re-apply the last raw status we were given. We must not read it back
+    // from statusText.innerText, because the render below replaces that with
+    // the shortened text (the "(current/total)" progress prefix stripped).
+    // Re-parsing the shortened text would report no progress and reset the
+    // bar to 0% on every subsequent no-argument render.
+    message =
+      lastRawMessage !== null ? lastRawMessage : statusText.innerText || "";
   }
+
+  // Remember the raw, unshortened status so later no-argument renders can
+  // recover the progress prefix.
+  lastRawMessage = message;
 
   var parsed = parseSyncStatusMessage(message);
   var visibleMessage = shortenSyncingFilename(parsed.text);


### PR DESCRIPTION
Fixes the sync progress bar (git / Google Drive client setup) resetting to 0% almost immediately after it appears.

**Cause:** `renderSyncStatusMessage()` in `app/views/js/sync_status.js` defaults its `message` to `statusText.innerText` when called with no argument — which is what the re-render paths do (the initial render, and after each folder reload). But the render then overwrites that element with the *shortened* text, which drops the `(current/total)` prefix that is the only source of the percentage. The next no-argument render therefore parses a prefix-less string, sees no progress, and sets the bar back to `0%`. So the bar flashes to its real value once and then empties.

**Fix:** cache the last raw status message at module scope and default to that instead of re-reading the already-shortened DOM text. Explicit (SSE) updates and non-progress messages ("Synced", etc.) are unaffected.

The `sortTable is not defined` error visible around the same code is a separate, harmless red herring — that call is already wrapped in a `try/catch` that only logs, so it isn't what breaks the bar.

I verified the fix by replaying the render logic: with the patch, repeated no-argument renders hold the bar at its real percentage, SSE updates still move it, and a non-progress message still clears it. I was not able to run it in a live browser against a full Blot stack, so a quick manual check during a real sync would be worth doing.
