### PR TITLE
Use `hasPassword` for password set access

### DIFF
--- a/app/dashboard/account/password.js
+++ b/app/dashboard/account/password.js
@@ -50,7 +50,7 @@ function requireTokenOrLackOfPassword(req, res, next) {
     return next();
   }
 
-  if (!req.user.passwordHash) {
+  if (!req.user.hasPassword) {
     return next();
   }
 


### PR DESCRIPTION
### Motivation
- Replace the removed `req.user.passwordHash` check with `req.user.hasPassword` so access to `/password/set` is correctly allowed for accounts without a password while keeping the existing reset-token exception.

### Description
- Update `requireTokenOrLackOfPassword` in `app/dashboard/account/password.js` to test `req.user.hasPassword` instead of `req.user.passwordHash`, preserving the `req.session.passwordSetToken` exception and the redirect to `/` when neither condition is met.

### Testing
- Ran `node --check app/dashboard/account/password.js` and `git diff --check`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a199c55808329a738607d4e24481c)