### PR TITLE
Use execFile for Pandoc and add tests protecting against shell substitutions

### DIFF
--- a/app/build/converters/docx/index.js
+++ b/app/build/converters/docx/index.js
@@ -3,7 +3,7 @@ var ensure = require("helper/ensure");
 var LocalPath = require("helper/localPath");
 var makeUid = require("helper/makeUid");
 var extname = require("path").extname;
-var exec = require("child_process").exec;
+var execFile = require("child_process").execFile;
 var cheerio = require("cheerio");
 var Metadata = require("build/metadata");
 var extend = require("helper/extend");
@@ -41,9 +41,9 @@ function read (blog, path, callback) {
       if (err) return callback(err);
 
       var args = [
-        '"' + localPath + '"',
+        localPath,
         "-o",
-        '"' + outPath + '"',
+        outPath,
         "--extract-media=" + assetDir,
         "-f",
         "docx",
@@ -56,12 +56,13 @@ function read (blog, path, callback) {
         // memory in corner cases
         "+RTS",
         "-M" + config.pandoc.maxmemory,
-        " -RTS"
-      ].join(" ");
+        "-RTS"
+      ];
 
       var startTime = Date.now();
-      exec(
-        Pandoc + " " + args,
+      execFile(
+        Pandoc,
+        args,
         { timeout: config.pandoc.timeout },
         function (err, stdout, stderr) {
           if (err) {

--- a/app/build/converters/docx/tests/index.js
+++ b/app/build/converters/docx/tests/index.js
@@ -23,4 +23,25 @@ describe("docx converter", function () {
       });
     });
   });
+
+  it("does not execute shell substitutions in filenames", function (done) {
+    const test = this;
+    const name = "paragraph$(touch docx-shell-substitution).docx";
+    const path = "/" + name;
+    const marker = process.cwd() + "/docx-shell-substitution";
+    const expected = fs.readFileSync(
+      __dirname + "/paragraph.docx.html",
+      "utf8"
+    );
+
+    fs.removeSync(marker);
+    fs.copySync(__dirname + "/paragraph.docx", test.blogDirectory + path);
+
+    docx.read(test.blog, path, function (err, result) {
+      if (err) return done.fail(err);
+      expect(result).toEqual(expected);
+      expect(fs.existsSync(marker)).toBe(false);
+      done();
+    });
+  });
 });

--- a/app/build/converters/odt/index.js
+++ b/app/build/converters/odt/index.js
@@ -3,7 +3,7 @@ var ensure = require("helper/ensure");
 var makeUid = require("helper/makeUid");
 var LocalPath = require("helper/localPath");
 var extname = require("path").extname;
-var exec = require("child_process").exec;
+var execFile = require("child_process").execFile;
 var cheerio = require("cheerio");
 var Metadata = require("build/metadata");
 var extend = require("helper/extend");
@@ -40,9 +40,9 @@ function read (blog, path, callback) {
       if (err) return callback(err);
 
       var args = [
-        '"' + localPath + '"',
+        localPath,
         "-o",
-        '"' + outPath + '"',
+        outPath,
         "--extract-media=" + assetDir,
         "-f",
         "odt",
@@ -54,12 +54,13 @@ function read (blog, path, callback) {
         // memory in corner cases
         "+RTS",
         "-M" + config.pandoc.maxmemory,
-        " -RTS"
-      ].join(" ");
+        "-RTS"
+      ];
 
       var startTime = Date.now();
-      exec(
-        Pandoc + " " + args,
+      execFile(
+        Pandoc,
+        args,
         { timeout: config.pandoc.timeout },
         function (err, stdout, stderr) {
           if (err) {

--- a/app/build/converters/odt/tests/index.js
+++ b/app/build/converters/odt/tests/index.js
@@ -24,4 +24,25 @@ describe("odt converter", function () {
       });
     });
   });
+
+  it("does not execute shell substitutions in filenames", function (done) {
+    const test = this;
+    const name = "paragraph$(touch odt-shell-substitution).odt";
+    const path = "/" + name;
+    const marker = process.cwd() + "/odt-shell-substitution";
+    const expected = fs.readFileSync(
+      __dirname + "/paragraph.odt.html",
+      "utf8"
+    );
+
+    fs.removeSync(marker);
+    fs.copySync(__dirname + "/paragraph.odt", test.blogDirectory + path);
+
+    odt.read(test.blog, path, function (err, result) {
+      if (err) return done.fail(err);
+      expect(result).toEqual(expected);
+      expect(fs.existsSync(marker)).toBe(false);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
### Motivation
- Prevent shell interpretation of input/output paths when invoking Pandoc to avoid command injection via filenames.
- Add regression tests that exercise filenames containing shell-substitution characters to ensure such filenames are treated as data and not executed.

### Description
- Replace `child_process.exec` with `child_process.execFile` in `app/build/converters/docx/index.js` and `app/build/converters/odt/index.js` so Pandoc is invoked with a discrete argument array instead of a shell command string. 
- Pass `localPath` and `outPath` as unquoted array elements and change the final RTS argument from `" -RTS"` to `"-RTS"` in the argument arrays. 
- Update the converters to call `execFile(Pandoc, args, { timeout: ... }, callback)` and preserve existing timeout/error handling and HTML post-processing. 
- Add tests in `app/build/converters/docx/tests/index.js` and `app/build/converters/odt/tests/index.js` that copy a file using a filename containing `$(...)`, run the converter, assert the HTML output matches the expected fixture, and assert that no marker file was created (verifying no shell substitution was executed).

### Testing
- Ran `node --check` for `app/build/converters/docx/index.js`, `app/build/converters/odt/index.js`, and the modified test files, which succeeded. 
- Ran `git diff --check` which reported no whitespace or diff issues. 
- Attempted to run the project test harness via `./scripts/tests/invoke.sh` for the docx tests but the environment lacks `docker`, so the full test run could not be executed here; the added unit tests are present and will run in CI where Docker is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a19ba369c8329958d9babc2088ff5)