### PR TITLE
Prevent prototype pollution in formJSON paths

### DIFF
--- a/app/helper/formJSON.js
+++ b/app/helper/formJSON.js
@@ -14,7 +14,7 @@ function formJSON(fields, model) {
 
   ensure(fields, "object").and(model, "object");
 
-  var obj = {};
+  var obj = Object.create(null);
 
   for (var i in fields) {
     // Sometimes there are multiple values
@@ -27,6 +27,10 @@ function formJSON(fields, model) {
     var terms = i.split("."),
       totalTerms = terms.length,
       val = fields[i];
+
+    // Reject the entire field before traversing or creating any of its path.
+    // These names can otherwise reach or modify JavaScript object prototypes.
+    if (terms.some(isDangerousPathSegment)) continue;
 
     var parent = obj,
       modelDef = model;
@@ -42,7 +46,7 @@ function formJSON(fields, model) {
         modelDef = false;
       }
 
-      parent[key] = parent[key] || {};
+      parent[key] = parent[key] || Object.create(null);
 
       // At the leaf node
       // final term in list of terms
@@ -122,6 +126,14 @@ function formJSON(fields, model) {
   ensure(obj, model);
 
   return obj;
+}
+
+function isDangerousPathSegment(segment) {
+  return (
+    segment === "__proto__" ||
+    segment === "constructor" ||
+    segment === "prototype"
+  );
 }
 
 function parseBool(string) {

--- a/app/helper/tests/formJSON.js
+++ b/app/helper/tests/formJSON.js
@@ -61,4 +61,31 @@ describe("formJSON ", function () {
 
     expect(formJSON(field2, model2)).toEqual(expected2);
   });
+
+  it("rejects fields containing prototype-polluting path segments", function () {
+    var dangerousSegments = ["__proto__", "constructor", "prototype"];
+    var injectedProperty = "formJSONPolluted";
+
+    dangerousSegments.forEach(function (segment) {
+      var fields = {
+        "ordinary.dotted": "safe",
+      };
+      fields["target." + segment + "." + injectedProperty] = "injected";
+
+      try {
+        var result = formJSON(fields, {
+          ordinary: { dotted: "string" },
+          target: "object",
+        });
+        var unrelated = {};
+
+        expect(Object.prototype[injectedProperty]).toBeUndefined();
+        expect(unrelated[injectedProperty]).toBeUndefined();
+        expect(result.ordinary.dotted).toBe("safe");
+        expect(result.target).toBeUndefined();
+      } finally {
+        delete Object.prototype[injectedProperty];
+      }
+    });
+  });
 });


### PR DESCRIPTION
### Motivation

- Prevent prototype pollution caused by dotted form field names that can reach inherited properties like `__proto__`, `constructor`, or `prototype` during path traversal and assignment.
- Ensure safe fields are still parsed while making parsed objects impossible to traverse via inherited properties.

### Description

- Construct the top-level result and any intermediate path objects with `Object.create(null)` so they have no prototype.
- Reject entire input fields up-front when any dotted path segment equals `__proto__`, `constructor`, or `prototype` by using a new `isDangerousPathSegment` check before traversing or creating the path.
- Replace default object creation for path nodes with `Object.create(null)` to avoid inherited-property traversal targets.
- Add a focused regression test that iterates the three dangerous segments, asserts `Object.prototype` and an unrelated plain object are not polluted, verifies a safe dotted field is still parsed, and defensively removes any tested prototype property in a `finally` block.

### Testing

- Ran `node_modules/.bin/jasmine app/helper/tests/formJSON.js` which executed 3 specs and reported `0 failures`.
- The new test confirms the three dangerous segments are rejected and that safe fields continue to be parsed correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a1a00bcd4832989ebda9bbf109ac7)