### PR TITLE
Secure downloader: block non-public addresses, pin DNS, and handle redirects manually

### DIFF
--- a/app/helper/transformer/download/index.js
+++ b/app/helper/transformer/download/index.js
@@ -1,6 +1,8 @@
 const fetch = require("node-fetch");
 const fs = require("fs").promises;
 const { createWriteStream } = require("fs");
+const http = require("http");
+const https = require("https");
 const ensure = require("helper/ensure");
 const UID = require("helper/makeUid");
 const callOnce = require("helper/callOnce");
@@ -13,117 +15,104 @@ const IF_NONE_MATCH = "If-None-Match";
 const IF_MODIFIED_SINCE = "If-Modified-Since";
 const LAST_MODIFIED = "last-modified";
 const CACHE_CONTROL = "cache-control";
-
 const MAX_REDIRECTS = 5;
-const TIMEOUT = 5000; // 5s
-
-const debug = function () {}; // console.log || noop for debugging
+const TIMEOUT = 5000;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const debug = function () {};
 
 module.exports = function (url, headers, callback) {
-  // Verify the url has a host, and protocol
   if (invalid(url)) return callback(new Error("Invalid URL " + url));
-
-  // Sometimes these are null for new urls...
   headers = headers || {};
-
   ensure(url, "string").and(headers, "object").and(callback, "function");
-
-  // The expire date is greater than now!
-  // We don't need to download anything.
   if (isFresh(headers)) return callback(null, null, headers);
-
   callback = callOnce(callback);
 
   const path = tempDir + UID(6) + "-" + nameFrom(url);
-  const file = createWriteStream(path);
-
-  const options = {
-    headers: {
-      "User-Agent": "node-fetch",
-      ...(headers.etag && { [IF_NONE_MATCH]: headers.etag }),
-      ...(headers[LAST_MODIFIED] && {
-        [IF_MODIFIED_SINCE]: headers[LAST_MODIFIED]
-      })
-    },
-    redirect: "follow",
-    follow: MAX_REDIRECTS,
-    timeout: TIMEOUT
+  const requestHeaders = {
+    "User-Agent": "node-fetch",
+    ...(headers.etag && { [IF_NONE_MATCH]: headers.etag }),
+    ...(headers[LAST_MODIFIED] && { [IF_MODIFIED_SINCE]: headers[LAST_MODIFIED] })
   };
 
-  debug("Downloading", url, "to", path, "with fetch headers:");
-  debug(print(options.headers));
-
-  fetch(url, options)
-    .then(res => {
-      debug("Received response:");
-
+  download(url, requestHeaders)
+    .then(async res => {
       const cacheControl = res.headers.get(CACHE_CONTROL);
       const lastModified = res.headers.get(LAST_MODIFIED);
       const expires = res.headers.get("expires");
       const etag = res.headers.get("etag");
-
       headers[LAST_MODIFIED] = lastModified || headers[LAST_MODIFIED] || "";
       headers.etag = etag || headers.etag || "";
-      headers.expires =
-        tidy.date(expires) ||
-        tidy.expire(cacheControl) ||
-        headers.expires ||
-        "";
+      headers.expires = tidy.date(expires) || tidy.expire(cacheControl) || headers.expires || "";
       headers.url = headers.url || url;
 
-      if (res.status === 304) {
-        debug("  it has 304 unchanged status");
-        file.end(); // close the file stream as we won't write anything to it
-        return { status: 304, headers };
-      }
+      if (res.status === 304) return { status: 304, headers };
+      if (!res.ok) throw new Error(res.status);
 
-      if (!res.ok) {
-        debug("  it has a bad status code:", res.status);
-        throw new Error(res.status);
-      }
-
-      debug("  updated latest response headers for status", res.status);
-      res.body.pipe(file); // start piping the response body to the file
-
-      return new Promise((resolve, reject) => {
-        file.on("finish", () => resolve({ status: res.status, path, headers }));
+      const file = createWriteStream(path);
+      res.body.pipe(file);
+      await new Promise((resolve, reject) => {
+        file.on("finish", resolve);
         file.on("error", reject);
+        res.body.on("error", reject);
       });
+      return { status: res.status, path, headers };
     })
     .then(result => {
-      if (!result) return;
-
       if (result.status === 304) {
-        debug("Calling back with cached headers for 304 response:");
-        debug(print(result.headers));
-        fs.unlink(path).catch(() => {});
         callback(null, null, result.headers);
-        return;
+      } else {
+        callback(null, result.path, result.headers);
       }
-
-      debug("Calling back with path", result.path, "and res headers:");
-      debug(print(result.headers));
-      callback(null, result.path, result.headers);
     })
     .catch(err => {
       debug("Download error:", err);
-      file.close();
       fs.unlink(path).catch(() => {});
       callback(err);
     });
 };
 
-function isFresh (existing) {
-  return (
-    existing &&
-    existing.url &&
-    existing.expires &&
-    new Date(existing.expires) > new Date()
-  );
+async function download (initialUrl, initialHeaders) {
+  let current = new URL(initialUrl);
+  let requestHeaders = initialHeaders;
+
+  for (let redirects = 0; ; redirects++) {
+    const addresses = await invalid.resolvePublic(current.hostname);
+    // Pin lookup to one member of the fully validated DNS answer. node-fetch still
+    // uses the URL hostname for Host, TLS SNI, and certificate verification.
+    const selected = addresses[0];
+    const Agent = current.protocol === "https:" ? https.Agent : http.Agent;
+    const agent = new Agent({
+      lookup: (hostname, options, callback) => callback(null, selected.address, selected.family)
+    });
+    let res;
+    try {
+      res = await fetch(current.toString(), {
+        headers: requestHeaders,
+        redirect: "manual",
+        timeout: TIMEOUT,
+        agent
+      });
+    } catch (err) {
+      agent.destroy();
+      throw err;
+    }
+    if (!REDIRECT_STATUSES.has(res.status) || !res.headers.get("location")) return res;
+    res.body.resume();
+    if (redirects >= MAX_REDIRECTS) throw new Error("Maximum redirects exceeded");
+
+    const next = new URL(res.headers.get("location"), current);
+    if (invalid(next.toString())) throw new Error("Invalid redirect URL " + next);
+    if (next.origin !== current.origin) {
+      // Conditional validators can expose private resource state and are only
+      // meaningful to the origin that issued them.
+      requestHeaders = { "User-Agent": requestHeaders["User-Agent"] };
+    }
+    current = next;
+  }
 }
 
-function print (obj) {
-  return Object.entries(obj)
-    .map(([key, value]) => `  ${key}: "${value}"`)
-    .join("\n");
+function isFresh (existing) {
+  return existing && existing.url && existing.expires && new Date(existing.expires) > new Date();
 }
+
+module.exports.MAX_REDIRECTS = MAX_REDIRECTS;

--- a/app/helper/transformer/download/invalid.js
+++ b/app/helper/transformer/download/invalid.js
@@ -1,22 +1,107 @@
-var protocols = ["http:", "https:"];
-var Url = require("url");
+const dns = require("dns");
+const net = require("net");
 
-function invalid(url) {
-  var parsed;
+const protocols = ["http:", "https:"];
+
+function invalid (url) {
+  let parsed;
 
   try {
-    parsed = Url.parse(url);
+    parsed = new URL(url);
   } catch (e) {
     return new Error("Could not parse " + url);
   }
 
-  if (!parsed.host || !parsed.protocol)
+  if (!parsed.hostname || !parsed.protocol) {
     return new Error("Has no host or protocol " + url);
+  }
 
-  if (protocols.indexOf(parsed.protocol) === -1)
+  if (!protocols.includes(parsed.protocol)) {
     return new Error("Has unsupported protocol " + url);
+  }
 
   return false;
 }
 
+async function resolvePublic (hostname) {
+  hostname = hostname.replace(/^\[|\]$/g, "");
+  const family = net.isIP(hostname);
+  const addresses = family
+    ? [{ address: hostname, family }]
+    : await dns.promises.lookup(hostname, { all: true, verbatim: true });
+
+  if (!addresses.length) throw new Error("Hostname resolved to no addresses");
+
+  for (const result of addresses) {
+    if (!isPublicAddress(result.address)) {
+      throw new Error("Refusing to connect to non-public address " + result.address);
+    }
+  }
+
+  return addresses;
+}
+
+function isPublicAddress (address) {
+  const family = net.isIP(address);
+  if (family === 4) return isPublicIPv4(address);
+  if (family === 6) return isPublicIPv6(address);
+  return false;
+}
+
+function isPublicIPv4 (address) {
+  const octets = address.split(".").map(Number);
+  if (octets.length !== 4 || octets.some(n => n < 0 || n > 255)) return false;
+  const value = octets.reduce((result, octet) => (result * 256) + octet, 0);
+  const inRange = (base, bits) => {
+    const start = base.split(".").map(Number).reduce((r, n) => (r * 256) + n, 0);
+    return Math.floor(value / Math.pow(2, 32 - bits)) === Math.floor(start / Math.pow(2, 32 - bits));
+  };
+
+  return ![
+    ["0.0.0.0", 8], ["10.0.0.0", 8], ["100.64.0.0", 10],
+    ["127.0.0.0", 8], ["169.254.0.0", 16], ["172.16.0.0", 12],
+    ["192.0.0.0", 24], ["192.0.2.0", 24], ["192.168.0.0", 16],
+    ["198.18.0.0", 15], ["198.51.100.0", 24], ["203.0.113.0", 24],
+    ["224.0.0.0", 4], ["240.0.0.0", 4]
+  ].some(([base, bits]) => inRange(base, bits));
+}
+
+function isPublicIPv6 (address) {
+  const bytes = ipv6Bytes(address);
+  if (!bytes) return false;
+  const prefix = (expected, bits) => {
+    const full = Math.floor(bits / 8);
+    const remainder = bits % 8;
+    for (let i = 0; i < full; i++) if (bytes[i] !== expected[i]) return false;
+    return !remainder || (bytes[full] >> (8 - remainder)) === (expected[full] >> (8 - remainder));
+  };
+
+  // Only global-unicast space is eligible, with IANA special-purpose ranges removed.
+  if (!prefix([0x20], 3)) return false;
+  if (prefix([0x20, 0x01, 0x00], 23)) return false;
+  if (prefix([0x20, 0x01, 0x0d, 0xb8], 32)) return false;
+  if (prefix([0x3f, 0xff], 20)) return false;
+  return true;
+}
+
+function ipv6Bytes (address) {
+  address = address.split("%")[0].toLowerCase();
+  // IPv4-mapped IPv6 destinations are rejected in their entirety.
+  if (address.includes(".")) return null;
+  const halves = address.split("::");
+  if (halves.length > 2) return null;
+  const left = halves[0] ? halves[0].split(":") : [];
+  const right = halves[1] ? halves[1].split(":") : [];
+  const missing = 8 - left.length - right.length;
+  if ((halves.length === 1 && missing !== 0) || missing < 0) return null;
+  const groups = left.concat(Array(missing).fill("0"), right);
+  if (groups.length !== 8 || groups.some(group => !/^[0-9a-f]{1,4}$/.test(group))) return null;
+  return groups.flatMap(group => {
+    const value = parseInt(group, 16);
+    return [value >> 8, value & 255];
+  });
+}
+
 module.exports = invalid;
+module.exports.resolvePublic = resolvePublic;
+module.exports.isPublicAddress = isPublicAddress;

--- a/app/helper/transformer/download/tests/index.js
+++ b/app/helper/transformer/download/tests/index.js
@@ -1,0 +1,73 @@
+const dns = require("dns");
+const fs = require("fs").promises;
+const nock = require("nock");
+const download = require("..");
+
+describe("secure image downloader", function () {
+  const publicAddress = { address: "93.184.216.34", family: 4 };
+
+  beforeEach(function () {
+    spyOn(dns.promises, "lookup").and.callFake(async hostname => {
+      if (hostname === "private.test") return [{ address: "10.0.0.4", family: 4 }];
+      return [publicAddress];
+    });
+  });
+
+  afterEach(function () {
+    nock.cleanAll();
+  });
+
+  function get (url, headers) {
+    return new Promise(resolve => {
+      download(url, headers || {}, (error, path, responseHeaders) => {
+        resolve({ error, path, headers: responseHeaders });
+      });
+    });
+  }
+
+  it("rejects direct private IPv4 and IPv6 destinations", async function () {
+    expect((await get("http://127.0.0.1/image.png")).error).toBeTruthy();
+    expect((await get("http://[fd00::1]/image.png")).error).toBeTruthy();
+  });
+
+  it("rejects hostnames whose DNS answers include a private address", async function () {
+    expect((await get("http://private.test/image.png")).error.message).toContain("non-public");
+  });
+
+  it("rejects IPv4-mapped IPv6 destinations", async function () {
+    expect((await get("http://[::ffff:127.0.0.1]/image.png")).error).toBeTruthy();
+  });
+
+  it("validates a redirect destination before requesting it", async function () {
+    nock("http://public.test").get("/start").reply(302, "", { Location: "http://private.test/image.png" });
+    const result = await get("http://public.test/start");
+    expect(result.error.message).toContain("non-public");
+  });
+
+  it("follows relative redirects and allows a public destination", async function () {
+    nock("http://public.test").get("/start").reply(302, "", { Location: "/image.png" });
+    nock("http://public.test").get("/image.png").reply(200, "image");
+    const result = await get("http://public.test/start");
+    expect(result.error).toBeNull();
+    expect(await fs.readFile(result.path, "utf8")).toBe("image");
+    await fs.unlink(result.path);
+  });
+
+  it("enforces the redirect limit", async function () {
+    const scope = nock("http://public.test");
+    for (let i = 0; i <= download.MAX_REDIRECTS; i++) {
+      scope.get("/" + i).reply(302, "", { Location: "/" + (i + 1) });
+    }
+    expect((await get("http://public.test/0")).error.message).toContain("Maximum redirects");
+  });
+
+  it("does not forward validators to an unrelated origin", async function () {
+    nock("http://public.test").get("/start").matchHeader("if-none-match", "secret").reply(302, "", {
+      Location: "http://other.test/image.png"
+    });
+    nock("http://other.test").get("/image.png").matchHeader("if-none-match", value => value === undefined).reply(200, "image");
+    const result = await get("http://public.test/start", { etag: "secret" });
+    expect(result.error).toBeNull();
+    await fs.unlink(result.path);
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent the remote image downloader from connecting to loopback, private, link-local, unspecified, multicast, reserved/documentation, IPv4-mapped IPv6, and cloud metadata destinations.
- Protect against DNS rebinding by resolving hostnames before connecting and binding the TCP connection to a validated address while preserving the original hostname for `Host` and TLS SNI/certificate checks.
- Eliminate implicit redirect following to ensure each redirect hop is validated and sensitive headers are not leaked to unrelated origins.

### Description

- Replaced simple URL checks with stricter parsing and added address classification utilities in `app/helper/transformer/download/invalid.js`, exporting `resolvePublic` and `isPublicAddress` to validate IPv4 and IPv6 addresses and reject disallowed ranges.
- Updated `app/helper/transformer/download/index.js` to resolve the target hostname via `invalid.resolvePublic()` before connecting and to pin connections by creating an `http(s).Agent` with a custom `lookup` that returns a validated address while keeping the URL hostname for `Host`/SNI.
- Switched fetch redirect handling to `redirect:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a1a4e15308329a6cb0eb4aa50cfc0)