### PR TITLE
Test Git authorization across blog owners

### DIFF
--- a/app/clients/git/tests/authenticate.js
+++ b/app/clients/git/tests/authenticate.js
@@ -11,6 +11,38 @@ describe("git client authenticate", function () {
   var Git = require("simple-git");
   var http = require("http");
   var url = require("url");
+  var async = require("async");
+  var Blog = require("models/blog");
+  var User = require("models/user");
+  var dataDir = require("clients/git/dataDir");
+  var createRepository = require("clients/git/create");
+
+  var otherBlog;
+  var otherUser;
+
+  afterEach(function (done) {
+    async.series(
+      [
+        function (next) {
+          if (!otherBlog) return next();
+          fs.remove(dataDir + "/" + otherBlog.handle + ".git", next);
+        },
+        function (next) {
+          if (!otherBlog) return next();
+          Blog.remove(otherBlog.id, next);
+        },
+        function (next) {
+          if (!otherUser) return next();
+          User.remove(otherUser.uid, next);
+        },
+      ],
+      function (err) {
+        otherBlog = null;
+        otherUser = null;
+        done(err);
+      }
+    );
+  });
 
   it("rejects unauthenticated and noncanonical Git endpoints before Pushover", function (done) {
     var dataDir = require("clients/git/dataDir");
@@ -80,17 +112,45 @@ describe("git client authenticate", function () {
     var repoUrl = this.repoUrl;
     var tmp = this.tmp;
 
-    repoUrl = url.parse(repoUrl);
-    repoUrl.pathname = repoUrl.pathname.split(this.blog.handle).join("not_you");
-    repoUrl = url.format(repoUrl);
+    async.waterfall(
+      [
+        function (next) {
+          User.hashPassword("other-users-password", next);
+        },
+        function (passwordHash, next) {
+          User.create(
+            "other-git-user@example.com",
+            passwordHash,
+            {},
+            {},
+            next
+          );
+        },
+        function (user, next) {
+          otherUser = user;
+          Blog.create(user.uid, { handle: "othergitrepo" }, next);
+        },
+        function (blog, next) {
+          otherBlog = blog;
+          createRepository(blog, next);
+        },
+        function (next) {
+          repoUrl = url.parse(repoUrl);
+          repoUrl.pathname = repoUrl.pathname
+            .split(this.blog.handle)
+            .join(otherBlog.handle);
+          repoUrl = url.format(repoUrl);
 
-    Git(tmp)
-      .silent(true)
-      .clone(repoUrl, function (err) {
-        expect(err.message).toContain("401 Unauthorized");
+          Git(tmp).silent(true).clone(repoUrl, next);
+        }.bind(this),
+      ],
+      function (err) {
+        expect(err).not.toBe(null);
+        expect(err && err.message).toContain("401 Unauthorized");
         expect(fs.readdirSync(tmp)).toEqual([]);
         done();
-      });
+      }
+    );
   });
 
   it("prevents a user with invalid credentials from accessing someone else's repo", function (done) {


### PR DESCRIPTION
### Motivation

- Strengthen the Git authentication specs by verifying that valid credentials for one user do not allow access to another user's repository.

### Description

- Updated `app/clients/git/tests/authenticate.js` to create a second `User` and a second `Blog` with a lowercase alphanumeric handle and initialize its Git repository before attempting a clone.
- Constructed a clone URL that uses the second blog's canonical handle while keeping the first user's existing `email:token` credentials, and attempted the clone to assert the server rejects cross-owner access.
- Asserts that cloning returns `401 Unauthorized` and that no local clone is created in the temporary directory. 
- Added cleanup in an `afterEach` hook to remove the second blog's bare repo, the blog record, and the user record.

### Testing

- Ran `node --check app/clients/git/tests/authenticate.js` which passed static checks. 
- Ran `git diff --check` which returned no whitespace or diff issues. 
- Attempting `npm test -- app/clients/git/tests/authenticate.js` could not be executed in this environment because the test runner requires Docker, which is unavailable here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ade09a16883299a5afb4c4e865e99)