### PR TITLE
Validate raw Git endpoint paths

### DIFF
--- a/app/clients/git/routes.js
+++ b/app/clients/git/routes.js
@@ -103,18 +103,20 @@ dashboard.post("/disconnect", function (req, res, next) {
   disconnect(req.blog.id, next);
 });
 
-// Express leaves the portion after /end in req.url. Parse that raw value before
-// authentication so encoded separators and normalization cannot change which
-// repository is authorized. Blog handles are canonical lowercase alphanumerics
-// between 2 and 70 characters (the same shape stored by the blog model).
-var GIT_REQUEST = /^\/([a-z0-9]{2,70})\.git\/(?:info\/refs|HEAD|git-(?:upload|receive)-pack)(?:\?[^#]*)?$/;
+// Parse the literal /end prefix while this router can still see it. Mounting a
+// handler at /end first would let Express consume one optional slash, making
+// /end//handle.git indistinguishable from /end/handle.git. Blog handles are
+// canonical lowercase alphanumerics between 2 and 70 characters (the same
+// shape stored by the blog model).
+var GIT_REQUEST = /^\/end(\/([a-z0-9]{2,70})\.git\/(?:info\/refs|HEAD|git-(?:upload|receive)-pack)(?:\?[^#]*)?)$/;
 
 function parseGitRequest(req, res, next) {
   var match = GIT_REQUEST.exec(req.url);
 
   if (!match) return res.sendStatus(404);
 
-  req.gitHandle = match[1];
+  req.url = match[1];
+  req.gitHandle = match[2];
   next();
 }
 
@@ -131,6 +133,7 @@ function redirectRenamedGitHandle(req, res, next) {
         "://" +
         req.get("host") +
         req.baseUrl +
+        "/end" +
         "/" +
         blog.handle +
         ".git" +
@@ -245,7 +248,7 @@ repos.on("push", function (push) {
 // We need to pause then resume for some strange reason. See Pushover issue #30.
 // Keep req.url untouched: Pushover uses the canonical repository path parsed
 // and authenticated above to select the repository.
-site.use("/end", parseGitRequest, redirectRenamedGitHandle, authenticate, function (req, res) {
+site.use(parseGitRequest, redirectRenamedGitHandle, authenticate, function (req, res) {
   function endResponse() {
     if (res && !res.headersSent && !res.finished && !res.writableEnded) {
       try {

--- a/app/clients/git/tests/authenticate.js
+++ b/app/clients/git/tests/authenticate.js
@@ -12,28 +12,49 @@ describe("git client authenticate", function () {
   var http = require("http");
   var url = require("url");
 
-  it("rejects unauthenticated and noncanonical Git endpoints before Pushover", function (done) {
+  function expectRejectedBeforePushover(context, path, done, repository) {
     var dataDir = require("clients/git/dataDir");
+    var repos = require("clients/git/routes").repos;
+    var handleSpy = spyOn(repos, "handle").and.callThrough();
+    var req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: context.server.port,
+        path: path,
+      },
+      function (res) {
+        res.resume();
+        res.on("end", function () {
+          expect(res.statusCode).toBe(404, path);
+          expect(handleSpy).not.toHaveBeenCalled();
+          if (repository) {
+            expect(fs.existsSync(dataDir + "/" + repository + ".git")).toBe(
+              false,
+              path
+            );
+          }
+          done();
+        });
+      }
+    );
+
+    req.on("error", done.fail);
+    req.end();
+  }
+
+  it("rejects unauthenticated canonical Git endpoints before Pushover", function (done) {
     var repos = require("clients/git/routes").repos;
     var handle = this.blog.handle;
     var handleSpy = spyOn(repos, "handle").and.callThrough();
-    var requests = [
-      { path: "/clients/git/end/" + handle + ".git/info/refs?service=git-upload-pack", status: 401 },
-      { path: "/clients/git/end/" + handle + ".git/git-receive-pack", method: "POST", status: 401 },
-      { path: "/clients/git/end//" + handle + ".git/info/refs", status: 404 },
-      { path: "/clients/git/end/./" + handle + ".git/info/refs", status: 404 },
-      { path: "/clients/git/end/%2f" + handle + ".git/info/refs", status: 404 },
-      { path: "/clients/git/end/../" + handle + ".git/info/refs", status: 404 },
-      { path: "/clients/git/end/prefix/" + handle + ".git/info/refs", status: 404 },
-      { path: "/clients/git/end/" + handle + ".git/../info/refs", status: 404 },
+    var paths = [
+      "/clients/git/end/" + handle + ".git/info/refs?service=git-upload-pack",
+      "/clients/git/end/" + handle + ".git/git-receive-pack",
     ];
 
     function next() {
-      var request = requests.shift();
-
-      if (!request) {
+      var path = paths.shift();
+      if (!path) {
         expect(handleSpy).not.toHaveBeenCalled();
-        expect(fs.existsSync(dataDir + "/prefix.git")).toBe(false);
         return done();
       }
 
@@ -41,13 +62,12 @@ describe("git client authenticate", function () {
         {
           hostname: "127.0.0.1",
           port: this.server.port,
-          method: request.method || "GET",
-          path: request.path,
+          path: path,
         },
         function (res) {
           res.resume();
           res.on("end", function () {
-            expect(res.statusCode).toBe(request.status);
+            expect(res.statusCode).toBe(401, path);
             next.call(this);
           }.bind(this));
         }.bind(this)
@@ -58,6 +78,65 @@ describe("git client authenticate", function () {
     }
 
     next.call(this);
+  });
+
+  it("rejects a doubled slash immediately after /end without creating a repository", function (done) {
+    expectRejectedBeforePushover(
+      this,
+      "/clients/git/end//doubleslash.git/info/refs",
+      done,
+      "doubleslash"
+    );
+  });
+
+  it("rejects a doubled slash within the repository endpoint without creating a repository", function (done) {
+    expectRejectedBeforePushover(
+      this,
+      "/clients/git/end/doubleslash.git//info/refs",
+      done,
+      "doubleslash"
+    );
+  });
+
+  it("rejects dot segments in front of the repository", function (done) {
+    expectRejectedBeforePushover(
+      this,
+      "/clients/git/end/./" + this.blog.handle + ".git/info/refs",
+      done
+    );
+  });
+
+  it("rejects encoded separators", function (done) {
+    expectRejectedBeforePushover(
+      this,
+      "/clients/git/end/%2f" + this.blog.handle + ".git/info/refs",
+      done
+    );
+  });
+
+  it("rejects traversal in front of the repository", function (done) {
+    expectRejectedBeforePushover(
+      this,
+      "/clients/git/end/../" + this.blog.handle + ".git/info/refs",
+      done
+    );
+  });
+
+  it("rejects extra path prefixes", function (done) {
+    expectRejectedBeforePushover(
+      this,
+      "/clients/git/end/prefix/" + this.blog.handle + ".git/info/refs",
+      done,
+      "prefix"
+    );
+  });
+
+  it("rejects traversal within the repository endpoint", function (done) {
+    expectRejectedBeforePushover(
+      this,
+      "/clients/git/end/" + this.blog.handle + ".git/../info/refs",
+      done
+    );
   });
 
   it("allows a user with good credentials to clone a repo", function (done) {


### PR DESCRIPTION
### Motivation

- Prevent Express from collapsing doubled separators by validating the literal `/end` prefix against the untouched router-level `req.url` so malformed repository paths are rejected before Express mounts or normalization can change them.
- Ensure only the three smart-HTTP Git endpoint forms and canonical lowercase alphanumeric handles are accepted, and preserve the canonical `/<handle>.git/...` value passed to Pushover.
- Keep a single logical `/end` handler chain ordered as: raw-path validation and handle extraction, renamed-handle redirect, authentication, then `repos.handle(req, res)`.

### Description

- Replace the previous handle regex with `GIT_REQUEST` anchored to the literal `/end` and capturing the exact post-`/end` repository path and the canonical handle, then make `parseGitRequest` set `req.url` to the captured canonical `/<handle>.git/...` and expose `req.gitHandle`.
- Invoke the shared middleware chain at the router level with `site.use(parseGitRequest, redirectRenamedGitHandle, authenticate, ...)` so Express cannot consume an optional slash first, and include the `/end` prefix when constructing renamed-handle redirects while preserving trailing path and query suffixes.
- Update `redirectRenamedGitHandle` to preserve the original endpoint suffix and to prepend the `/end` prefix in the redirect target.
- Refactor `app/clients/git/tests/authenticate.js` to replace the table-driven malformed-path assertions with an `expectRejectedBeforePushover` helper and individual test cases, adding explicit assertions that doubled slashes both immediately after `/end` and within the repository path return `404`, never call `repos.handle`, and do not create repositories; preserve coverage for dot segments, encoded separators, traversal, and extra prefixes.

### Testing

- Ran syntax checks with `node --check app/clients/git/routes.js` and `node --check app/clients/git/tests/authenticate.js`, which passed.
- Ran repository checks with `git diff --check` which passed with no whitespace errors.
- Attempted to run the file-level test harness via `./scripts/tests/invoke.sh app/clients/git/tests/authenticate.js` but the environment lacks Docker (`docker: command not found`), so the integration tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ade14c960832986f8968d90da9cfe)