### PR TITLE
Validate template ownership before install

### DIFF
--- a/app/dashboard/site/template/index.js
+++ b/app/dashboard/site/template/index.js
@@ -67,7 +67,22 @@ TemplateEditor.route("/:templateSlug/install")
   })
   .post(function (req, res, next) {
     var templateID = req.body.template;
-    if (!templateID) return next(new Error("No template ID"));
+    if (typeof templateID !== "string") {
+      const err = new TypeError("Invalid template ID");
+      err.status = 400;
+      return next(err);
+    }
+
+    const ownerPrefix = `${req.blog.id}:`;
+    if (
+      !templateID.startsWith("SITE:") &&
+      !templateID.startsWith(ownerPrefix)
+    ) {
+      const err = new Error("No permission to install template");
+      err.status = 403;
+      return next(err);
+    }
+
     var updates = { template: templateID };
     Blog.set(req.blog.id, updates, function (err) {
       if (err) return next(err);

--- a/app/dashboard/site/template/tests/install.js
+++ b/app/dashboard/site/template/tests/install.js
@@ -75,7 +75,6 @@ describe("install template route", function () {
   it("rejects an existing template owned by a different blog", async function () {
     const blog = this.blogs[0];
     const otherBlog = this.blogs[1];
-    const originalTemplate = blog.template;
     const otherTemplate = await new Promise(function (resolve, reject) {
       Template.create(otherBlog.id, "Existing template", {}, function (
         err,
@@ -85,6 +84,14 @@ describe("install template route", function () {
         resolve(template);
       });
     });
+
+    const originalTemplate = await new Promise(function (resolve, reject) {
+      Blog.get({ id: blog.id }, function (err, value) {
+        if (err) return reject(err);
+        resolve(value.template);
+      });
+    });
+    Blog.set.calls.reset();
 
     const result = await runInstall(blog, otherTemplate.id);
 
@@ -109,6 +116,8 @@ describe("install template route", function () {
     ];
 
     const expectedStatuses = [400, 403];
+
+    Blog.set.calls.reset();
 
     for (let index = 0; index < malformedValues.length; index++) {
       const value = malformedValues[index];

--- a/app/dashboard/site/template/tests/install.js
+++ b/app/dashboard/site/template/tests/install.js
@@ -1,0 +1,122 @@
+describe("install template route", function () {
+  global.test.blogs(2);
+
+  const Blog = require("models/blog");
+  const Template = require("models/template");
+  const router = require("../index");
+
+  const installHandler = router.stack
+    .find(function (layer) {
+      return layer.route && layer.route.path === "/:templateSlug/install";
+    })
+    .route.stack.find(function (layer) {
+      return layer.method === "post";
+    }).handle;
+
+  function runInstall(blog, templateID) {
+    return new Promise(function (resolve) {
+      const req = {
+        blog: blog,
+        body: { template: templateID },
+        params: { templateSlug: "installed-template" },
+      };
+      const res = { message: jasmine.createSpy("message") };
+
+      installHandler(req, res, function (err) {
+        resolve({ err: err, res: res });
+      });
+
+      if (res.message.calls.any()) resolve({ res: res });
+    });
+  }
+
+  beforeEach(function () {
+    spyOn(Blog, "set").and.callFake(function (_blogID, _updates, callback) {
+      callback();
+    });
+    spyOn(Template, "removeEnabledFromAllTemplates").and.callFake(function (
+      _blogID,
+      callback
+    ) {
+      callback();
+    });
+  });
+
+  it("installs a template owned by the requesting blog", async function () {
+    const blog = this.blogs[0];
+    const templateID = `${blog.id}:owned-template`;
+
+    const result = await runInstall(blog, templateID);
+
+    expect(result.err).toBeUndefined();
+    expect(Blog.set).toHaveBeenCalledWith(
+      blog.id,
+      { template: templateID },
+      jasmine.any(Function)
+    );
+    expect(result.res.message).toHaveBeenCalled();
+  });
+
+  it("installs a shared SITE template", async function () {
+    const blog = this.blogs[0];
+    const templateID = "SITE:shared-template";
+
+    const result = await runInstall(blog, templateID);
+
+    expect(result.err).toBeUndefined();
+    expect(Blog.set).toHaveBeenCalledWith(
+      blog.id,
+      { template: templateID },
+      jasmine.any(Function)
+    );
+    expect(result.res.message).toHaveBeenCalled();
+  });
+
+  it("rejects an existing template owned by a different blog", async function () {
+    const blog = this.blogs[0];
+    const otherBlog = this.blogs[1];
+    const originalTemplate = blog.template;
+    const otherTemplate = await new Promise(function (resolve, reject) {
+      Template.create(otherBlog.id, "Existing template", {}, function (
+        err,
+        template
+      ) {
+        if (err) return reject(err);
+        resolve(template);
+      });
+    });
+
+    const result = await runInstall(blog, otherTemplate.id);
+
+    expect(result.err).toEqual(jasmine.any(Error));
+    expect(result.err.status).toBe(403);
+    expect(Blog.set).not.toHaveBeenCalled();
+
+    const storedBlog = await new Promise(function (resolve, reject) {
+      Blog.get({ id: blog.id }, function (err, value) {
+        if (err) return reject(err);
+        resolve(value);
+      });
+    });
+    expect(storedBlog.template).toBe(originalTemplate);
+  });
+
+  it("rejects malformed and partially matching owner prefixes", async function () {
+    const blog = this.blogs[0];
+    const malformedValues = [
+      { id: "not-a-string" },
+      `${blog.id}another-blog:template`,
+    ];
+
+    const expectedStatuses = [400, 403];
+
+    for (let index = 0; index < malformedValues.length; index++) {
+      const value = malformedValues[index];
+      const result = await runInstall(blog, value);
+      expect(result.err).toEqual(jasmine.any(Error));
+      expect(result.err.status).toBe(expectedStatuses[index]);
+    }
+
+    expect(Blog.set).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent sites from installing templates they do not own by validating `req.body.template` at the route layer before calling `Blog.set`.
- Ensure the owner prefix check is exact (includes the colon) so a partially matching blog ID cannot be used to bypass permission checks.
- Preserve the existing shared-template forking behavior handled in `app/models/blog/set.js`.

### Description

- Require `req.body.template` to be a string and return a 400 validation error for non-string values in `app/dashboard/site/template/index.js` (install POST handler).
- Allow installation only when the template ID starts with the exact `SITE:` prefix or the exact owner prefix `${req.blog.id}:`, returning a 403 permission error otherwise.
- Added focused route-level tests at `app/dashboard/site/template/tests/install.js` that verify installing a blog-owned template, installing a shared `SITE:` template, rejecting an existing template owned by a different blog while preserving the requesting blog’s stored template, and rejecting malformed/non-string or partially matching owner-prefix values.
- Left shared-template forking behavior in `app/models/blog/set.js` unchanged.

### Testing

- Ran syntax checks with `node --check app/dashboard/site/template/index.js` and `node --check app/dashboard/site/template/tests/install.js`, which succeeded.
- Ran repository check `git diff --check`, which reported no issues.
- Attempted to run the Jasmine test runner via `npm test -- app/dashboard/site/template/tests/install.js`, but the test launcher requires Docker and the environment does not have Docker installed, so the test harness could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7adf5359608329955640516e8faa7a)