### PR TITLE
Remove stale cache references from app/blog/README

### DIFF
--- a/app/blog/README
+++ b/app/blog/README
@@ -68,7 +68,7 @@ The `render/` subdirectory implements the Mustache rendering engine used by `res
 
 Attaches `res.renderView(viewName, next, callback)` to the response. When called:
 
-1. Fetches the full view from `Template.getFullView()` via an in-process LRU cache (`full-view-cache.js`). The cache key includes `blogID`, `cacheID`, `templateID`, and `viewName`. A changed `blog.cacheID` invalidates all cached views for that blog.
+1. Fetches the full view directly from `Template.getFullView()` using the blog ID, template ID, and view name.
 2. Merges view-level locals, query parameters, template locals, and blog locals into `res.locals`.
 3. Calls `render/retrieve/index.js` to fetch any named locals declared as required by the view.
 4. Calls `render/load/index.js` to augment every entry object found in `res.locals`.
@@ -245,7 +245,7 @@ The `static/` directory contains global assets served to all blogs under paths s
 | `models/blog` | `vhosts.js`, `render/view.js` |
 | `models/entry` | `draft.js`, `entry.js`, `search.js`, `render/retrieve/tagged.js`, `render/load/augment.js` |
 | `models/entries` | `entries.js`, `draft.js`, `entry.js`, `random.js`, `render/retrieve/` |
-| `models/template` | `loadTemplate.js`, `view.js`, `render/full-view-cache.js`, `render/view.js` |
+| `models/template` | `loadTemplate.js`, `view.js`, `render/middleware.js`, `render/view.js` |
 | `models/tags` | `render/retrieve/all_tags.js`, `render/retrieve/tagged.js`, `render/retrieve/popular_tags.js`, `render/load/augment.js` |
 | `models/redirects` | `error.js` |
 | `models/user` | `robots.js` |
@@ -266,7 +266,6 @@ The `static/` directory contains global assets served to all blogs under paths s
 | `parse5` | HTML parsing for CDN link rewriting |
 | `cheerio` | HTML manipulation in `absolute_urls.js` and `encode_xml.js` |
 | `moment` / `moment-timezone` | Date formatting in augment and retrieve functions |
-| `lru-cache` | In-process LRU caches for full view and popular tags |
 | `lodash` | Utility functions in retrieve and augment |
 | `async` | Parallel/series async control |
 | `mime-types` | Content-Type detection in `assets.js` |
@@ -290,4 +289,4 @@ Integration tests live in `app/blog/tests/`. The shared test setup in `tests/uti
 
 Test files cover: archives, assets, CDN manifest, dates, draft rendering and SSE streaming, entries listing, entry rendering, error handling, robots.txt, routing edge cases, search, tagged pages, template rendering, domain verification, and vhost resolution logic.
 
-Render-specific tests live in `app/blog/render/tests/` and cover: full-view caching, locals rendering, main Mustache rendering, entry augmentation, and the complete middleware pipeline.
+Render-specific tests live in `app/blog/render/tests/` and cover: locals rendering, main Mustache rendering, entry augmentation, and the complete middleware pipeline.


### PR DESCRIPTION
### Motivation
- Remove outdated documentation that referenced a deleted in-process full-view LRU cache and the `lru-cache` package so the README accurately reflects the current rendering implementation and dependency map.

### Description
- Updated `app/blog/README` to state that `Template.getFullView()` is fetched directly, replaced the removed `render/full-view-cache.js` consumer with `render/middleware.js`, removed `lru-cache` from the external dependency list, and removed the obsolete "full-view caching" item from the render tests description.

### Testing
- Ran `git diff --check` which passed, searched `app/blog/README` with `rg -n 'full-view-cache|lru-cache|full-view caching'` which found no stale references, and verified the repository status showing the README change was committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c6d4eadb88329af1a764335a8060a)