### PR TITLE
Log Redis client-side cache stats from every application process

### DIFF
--- a/app/scheduler/index.js
+++ b/app/scheduler/index.js
@@ -14,9 +14,6 @@ const exec = require("child_process").exec;
 const zombies = require("./zombies");
 const checkCardTesters = require("./check-card-testers");
 const subscriptionLifecycleJob = require("./subscription-lifecycle");
-const redisClient = require("models/client");
-const getClientSideCacheStats =
-  require("models/redis").getClientSideCacheStats;
 
 // If any disk has less than 2GB of space, we should notify the admin
 const MINIMUM_DISK_SPACE_IN_K = 2 * 1024 * 1024;
@@ -29,44 +26,6 @@ let NOTIFIED_LOW_DISK_SPACE = false;
 module.exports = function () {
   // Log useful system information, once per minute
   scheduler.scheduleJob("* * * * *", function () {
-    // These metrics are cumulative for this process's Redis cache lifetime.
-    // Reading them does not reset the cache's counters.
-    try {
-      const cacheStats = getClientSideCacheStats(redisClient);
-
-      if (!cacheStats) {
-        console.error(
-          clfdate(),
-          "[STATS]",
-          "redis_cache_stats_error=cache_unavailable"
-        );
-      } else {
-        console.log(
-          clfdate(),
-          "[STATS]",
-          "redis_cache_hitCount=" + cacheStats.hitCount,
-          "redis_cache_missCount=" + cacheStats.missCount,
-          "redis_cache_hitRate=" + cacheStats.hitRate(),
-          "redis_cache_requestCount=" + cacheStats.requestCount(),
-          "redis_cache_loadSuccessCount=" + cacheStats.loadSuccessCount,
-          "redis_cache_loadFailureCount=" + cacheStats.loadFailureCount,
-          "redis_cache_totalLoadTime=" + cacheStats.totalLoadTime,
-          "redis_cache_evictionCount=" + cacheStats.evictionCount,
-          "redis_cache_missRate=" + cacheStats.missRate(),
-          "redis_cache_loadCount=" + cacheStats.loadCount(),
-          "redis_cache_loadFailureRate=" + cacheStats.loadFailureRate(),
-          "redis_cache_averageLoadPenalty=" + cacheStats.averageLoadPenalty()
-        );
-      }
-    } catch (err) {
-      console.error(
-        clfdate(),
-        "[STATS]",
-        "redis_cache_stats_error=metric_access_failed",
-        "error=" + JSON.stringify(err && err.message ? err.message : String(err))
-      );
-    }
-
     // Detect any zombie processes
     zombies(function (err) {
       if (err) throw err;

--- a/app/scheduler/redis-cache-stats.js
+++ b/app/scheduler/redis-cache-stats.js
@@ -1,0 +1,44 @@
+const clfdate = require("helper/clfdate");
+const redisClient = require("models/client");
+const getClientSideCacheStats =
+  require("models/redis").getClientSideCacheStats;
+
+module.exports = function () {
+  // These metrics are cumulative for this process's Redis cache lifetime.
+  // Reading them does not reset the cache's counters.
+  try {
+    const cacheStats = getClientSideCacheStats(redisClient);
+
+    if (!cacheStats) {
+      console.error(
+        clfdate(),
+        "[STATS]",
+        "redis_cache_stats_error=cache_unavailable"
+      );
+    } else {
+      console.log(
+        clfdate(),
+        "[STATS]",
+        "redis_cache_hitCount=" + cacheStats.hitCount,
+        "redis_cache_missCount=" + cacheStats.missCount,
+        "redis_cache_hitRate=" + cacheStats.hitRate(),
+        "redis_cache_requestCount=" + cacheStats.requestCount(),
+        "redis_cache_loadSuccessCount=" + cacheStats.loadSuccessCount,
+        "redis_cache_loadFailureCount=" + cacheStats.loadFailureCount,
+        "redis_cache_totalLoadTime=" + cacheStats.totalLoadTime,
+        "redis_cache_evictionCount=" + cacheStats.evictionCount,
+        "redis_cache_missRate=" + cacheStats.missRate(),
+        "redis_cache_loadCount=" + cacheStats.loadCount(),
+        "redis_cache_loadFailureRate=" + cacheStats.loadFailureRate(),
+        "redis_cache_averageLoadPenalty=" + cacheStats.averageLoadPenalty()
+      );
+    }
+  } catch (err) {
+    console.error(
+      clfdate(),
+      "[STATS]",
+      "redis_cache_stats_error=metric_access_failed",
+      "error=" + JSON.stringify(err && err.message ? err.message : String(err))
+    );
+  }
+};

--- a/app/setup.js
+++ b/app/setup.js
@@ -9,6 +9,7 @@ const folders = require("./templates/folders");
 const async = require("async");
 const clfdate = require("helper/clfdate");
 const scheduler = require("./scheduler");
+const logRedisCacheStats = require("./scheduler/redis-cache-stats");
 const flush = require("documentation/tools/flush-cache");
 const configureLocalBlogs = require("./configure-local-blogs");
 const purgeCdnUrls = require("helper/purgeCdnUrls");
@@ -40,6 +41,14 @@ async function runPostListenTasks() {
     }
   } else {
     log("Skipping template build after listen (not master)");
+  }
+
+  try {
+    // Each application process owns an independent client-side Redis cache.
+    log("Starting Redis cache stats logging asynchronously");
+    setInterval(logRedisCacheStats, 60 * 1000);
+  } catch (err) {
+    logError("Failed to start Redis cache stats logging", err);
   }
 
   try {


### PR DESCRIPTION
### Motivation

- The previous implementation logged client-side Redis cache metrics only from the master-only scheduler, which under the production topology reported metrics for a single container and omitted most request-serving caches.
- Collecting cache metrics from every application process yields representative hit/miss rates and counters for each container's independent `BasicClientSideCache`.

### Description

- Extracted the Redis client-side cache metric collection into a new module `app/scheduler/redis-cache-stats.js` that preserves the existing cumulative counters and error reporting behavior.
- Removed the inline cache-stat logging from `app/scheduler/index.js` so the scheduler retains system checks but not the cache-metrics snippet.
- Start a one-minute interval in `runPostListenTasks` (`app/setup.js`) by requiring the new module and invoking `setInterval(logRedisCacheStats, 60 * 1000)` so every application process reports its own cache stats asynchronously.

### Testing

- Ran `git diff --check` with no issues reported.
- Ran `node --check` on `app/setup.js`, `app/scheduler/index.js`, and `app/scheduler/redis-cache-stats.js`, and all checks succeeded.
- Verified file diffs and formatting checks (`prettier` not installed in the environment) and confirmed no syntax errors via automated checks used above.
- Confirmed repository working tree state after changes with status checks (no outstanding syntax errors from automated checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c6d68240c8329ad583e8c34c01cf2)