### PR TITLE
Report what is wrong with an invalid package.json

### DIFF
--- a/app/models/template/readFromFolder.js
+++ b/app/models/template/readFromFolder.js
@@ -187,7 +187,9 @@ function improveJSONErrorMessage (err, contents) {
     const linePosition = lines[lineNumber - 1].length;
     return `${messageWithoutLocation} at position ${linePosition} on line ${lineNumber}`;
   } catch (e) {
-    return e.message;
+    // We could not rewrite the message, so report the original rather than
+    // the failure to rewrite it
+    return err.message;
   }
 }
 
@@ -204,7 +206,9 @@ function improveMustacheErrorMessage (err, contents) {
     const linePosition = lines[lineNumber - 1].length;
     return `${messageWithoutLocation} at position ${linePosition} on line ${lineNumber}`;
   } catch (e) {
-    return e.message;
+    // We could not rewrite the message, so report the original rather than
+    // the failure to rewrite it
+    return err.message;
   }
 }
 

--- a/app/models/template/tests/readFromFolder.js
+++ b/app/models/template/tests/readFromFolder.js
@@ -31,6 +31,22 @@ describe("template", function () {
     });
   });
 
+  it("explains what is wrong with an invalid package.json", function (done) {
+    fs.outputFileSync(this.tmp + "/package.json", '{\n  "name": "Example",\n}');
+
+    readFromFolder(this.blog.id, this.tmp, function (err, template) {
+      if (err) return done.fail(err);
+
+      var message = template.errors["package.json"];
+
+      // The message has to describe the file, not our own failure to
+      // rewrite the parse error
+      expect(message).not.toContain("Cannot read properties");
+      expect(message.toLowerCase()).toContain("json");
+      done();
+    });
+  });
+
   it("ignores view files which are too large", function (done) {
     // 3mb of random data should exceed the limit of 2.5mb
     fs.writeFileSync(


### PR DESCRIPTION
A locally edited template with a malformed `package.json` currently shows this on its preview subdomain:

```
Cannot read properties of undefined (reading '1')
```

That is our own error, not the file's. This is [TODO:352](https://github.com/davidmerfield/blot/blob/master/TODO#L352) — the one about telling Jason.

## Cause

`improveJSONErrorMessage` rewrites a parse error to carry a line number by matching `at position (\d+)$` — anchored to the end of the message. Newer V8 appends `(line N column M)` of its own:

```
Expected double-quoted property name in JSON at position 23 (line 3 column 1)
```

So the match fails, `found[1]` throws, and the `catch` returns *that* TypeError's message rather than the parse error. `improveMustacheErrorMessage` has the same shape, though its pattern still matches today.

## Fix

Both fall back to the original error instead of the rewrite failure. On current Node the JSON error already carries the line and column, so the user gets strictly more than the rewrite was trying to add.

## Test

`app/models/template/tests/readFromFolder.js` gains a spec writing an invalid `package.json` and asserting the recorded error describes the JSON rather than containing "Cannot read properties". Verified it fails on master with exactly the message above, and passes with the fix.

Split out of #1637 so it can be reviewed and merged on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)