### PR TITLE
Fix duplicating a template whose name fills its id

### DIFF
--- a/app/dashboard/site/template/save/duplicate-template.js
+++ b/app/dashboard/site/template/save/duplicate-template.js
@@ -1,5 +1,33 @@
+const makeSlug = require("helper/makeSlug");
+const makeID = require("models/template/util/makeID");
 const createTemplate = require("./create-template");
 const { MAX_DEDUPLICATION_ATTEMPTS } = require("./constants");
+
+// Template.create derives a template's id from makeSlug(name).slice(0, 30)
+const MAX_SLUG_LENGTH = 30;
+
+// The id is what routing resolves a template by, and writeToFolder names the
+// template's directory after the stored slug, which readFromFolder then turns
+// back into an id. Let the two disagree and a locally edited copy can be read
+// back as the template it was copied from, so derive the slug from the id.
+const slugFor = (owner, name) =>
+  makeID(owner, name).split(":").slice(1).join(":");
+
+// Appending a counter to a name whose slug already fills those 30 characters
+// leaves them unchanged, so every attempt derives the same id and collides
+// again. Trim the base until the counter survives into the slug.
+const withCounter = (base, counter) => {
+  let trimmed = base;
+
+  while (
+    trimmed.length > 1 &&
+    makeSlug(`${trimmed} ${counter}`).length > MAX_SLUG_LENGTH
+  ) {
+    trimmed = trimmed.slice(0, -1).trim();
+  }
+
+  return `${trimmed} ${counter}`;
+};
 
 const COPY_NAME_PATTERN = /^(.*?)(?: copy(?: (\d+))?)$/;
 const COPY_SLUG_PATTERN = /^(.*?)(?:-copy(?:-(\d+))?)$/;
@@ -46,14 +74,13 @@ async function duplicateTemplate({ owner, template }) {
   }
 
   const { base: nameBase, counter: nameCounter } = parseCopyName(template.name);
-  const { base: slugBase, counter: slugCounter } = parseCopySlug(template.slug);
+  // Only the counter: the slug now follows whatever name we settle on
+  const { counter: slugCounter } = parseCopySlug(template.slug);
 
   const baseName = `${nameBase} copy`.trim();
-  const baseSlug = `${slugBase}-copy`;
 
   let deduplicationCounter = Math.max(nameCounter, slugCounter, 1);
   let attemptName = baseName;
-  let attemptSlug = baseSlug;
   let attempts = 0;
 
   while (attempts < MAX_DEDUPLICATION_ATTEMPTS) {
@@ -64,7 +91,7 @@ async function duplicateTemplate({ owner, template }) {
         isPublic: false,
         owner,
         name: attemptName,
-        slug: attemptSlug,
+        slug: slugFor(owner, attemptName),
         cloneFrom: template.id,
       });
     } catch (error) {
@@ -74,8 +101,7 @@ async function duplicateTemplate({ owner, template }) {
         attempts < MAX_DEDUPLICATION_ATTEMPTS
       ) {
         deduplicationCounter = Math.max(deduplicationCounter, 1) + 1;
-        attemptName = `${baseName} ${deduplicationCounter}`;
-        attemptSlug = `${baseSlug}-${deduplicationCounter}`;
+        attemptName = withCounter(baseName, deduplicationCounter);
         continue;
       }
 

--- a/app/dashboard/site/template/save/duplicate-template.js
+++ b/app/dashboard/site/template/save/duplicate-template.js
@@ -13,20 +13,25 @@ const MAX_SLUG_LENGTH = 30;
 const slugFor = (owner, name) =>
   makeID(owner, name).split(":").slice(1).join(":");
 
-// Appending a counter to a name whose slug already fills those 30 characters
-// leaves them unchanged, so every attempt derives the same id and collides
-// again. Trim the base until the counter survives into the slug.
-const withCounter = (base, counter) => {
-  let trimmed = base;
+// A name whose slug already fills those 30 characters leaves no room for
+// ' copy', so the copy derives the same id as the template it came from and
+// collides with it. Make room by trimming the name — but only the name, never
+// the suffix: trimming the whole thing would eat the word 'copy' first,
+// leaving a copy which does not say it is one and which parseCopyName can no
+// longer recognise when it is itself duplicated.
+const withCopySuffix = (nameBase, counter) => {
+  const suffix = counter > 1 ? ` copy ${counter}` : " copy";
+
+  let trimmed = nameBase.trim();
 
   while (
     trimmed.length > 1 &&
-    makeSlug(`${trimmed} ${counter}`).length > MAX_SLUG_LENGTH
+    makeSlug(`${trimmed}${suffix}`).length > MAX_SLUG_LENGTH
   ) {
     trimmed = trimmed.slice(0, -1).trim();
   }
 
-  return `${trimmed} ${counter}`;
+  return `${trimmed}${suffix}`.trim();
 };
 
 const COPY_NAME_PATTERN = /^(.*?)(?: copy(?: (\d+))?)$/;
@@ -77,10 +82,8 @@ async function duplicateTemplate({ owner, template }) {
   // Only the counter: the slug now follows whatever name we settle on
   const { counter: slugCounter } = parseCopySlug(template.slug);
 
-  const baseName = `${nameBase} copy`.trim();
-
   let deduplicationCounter = Math.max(nameCounter, slugCounter, 1);
-  let attemptName = baseName;
+  let attemptName = withCopySuffix(nameBase, 1);
   let attempts = 0;
 
   while (attempts < MAX_DEDUPLICATION_ATTEMPTS) {
@@ -101,7 +104,7 @@ async function duplicateTemplate({ owner, template }) {
         attempts < MAX_DEDUPLICATION_ATTEMPTS
       ) {
         deduplicationCounter = Math.max(deduplicationCounter, 1) + 1;
-        attemptName = withCounter(baseName, deduplicationCounter);
+        attemptName = withCopySuffix(nameBase, deduplicationCounter);
         continue;
       }
 

--- a/app/dashboard/site/template/tests/duplicate.js
+++ b/app/dashboard/site/template/tests/duplicate.js
@@ -23,6 +23,60 @@ describe("duplicate template route", function () {
     });
   });
 
+  describe("of a template whose name fills the id", function () {
+    // Template.create derives the id from makeSlug(name).slice(0, 30), so a
+    // name this long leaves no room for a counter
+    const longName = "My extremely long template name for testing";
+
+    beforeEach(function (done) {
+      const test = this;
+
+      Template.create(test.blog.id, longName, {}, function (err) {
+        if (err) return done.fail(err);
+
+        Template.getTemplateList(test.blog.id, function (err, templates) {
+          if (err) return done.fail(err);
+
+          test.longTemplate = templates.filter(function (template) {
+            return template.name === longName;
+          })[0];
+
+          done();
+        });
+      });
+    });
+
+    it("stores a slug which matches the id", async function () {
+      // writeToFolder names the template's directory after the stored slug
+      // and readFromFolder turns that name back into an id. If they disagree,
+      // enabling local editing on the copy can write it over the original.
+      const copy = await duplicateTemplate({
+        owner: this.blog.id,
+        template: this.longTemplate,
+      });
+
+      expect(copy.slug).toEqual(copy.id.split(":").slice(1).join(":"));
+    });
+
+    it("can be duplicated more than once", async function () {
+      const first = await duplicateTemplate({
+        owner: this.blog.id,
+        template: this.longTemplate,
+      });
+
+      // Without trimming the name, the counter falls outside the 30
+      // characters the id is cut to, so every retry derives the same id and
+      // duplication gives up after MAX_DEDUPLICATION_ATTEMPTS
+      const second = await duplicateTemplate({
+        owner: this.blog.id,
+        template: this.longTemplate,
+      });
+
+      expect(second.id).not.toEqual(first.id);
+      expect(second.slug).toEqual(second.id.split(":").slice(1).join(":"));
+    });
+  });
+
   it("deduplicates subsequent copies", async function () {
     const firstCopy = await duplicateTemplate({
       owner: this.blog.id,

--- a/app/dashboard/site/template/tests/duplicate.js
+++ b/app/dashboard/site/template/tests/duplicate.js
@@ -46,6 +46,36 @@ describe("duplicate template route", function () {
       });
     });
 
+    it("still says it is a copy", async function () {
+      // Room for ' copy' is made by trimming the name, never the suffix.
+      // Trimming the whole thing eats the word first, leaving a copy which
+      // does not say so and which parseCopyName cannot recognise later.
+      const copy = await duplicateTemplate({
+        owner: this.blog.id,
+        template: this.longTemplate,
+      });
+
+      expect(copy.name).toMatch(/ copy$/);
+      expect(copy.slug).toMatch(/-copy$/);
+
+      const second = await duplicateTemplate({
+        owner: this.blog.id,
+        template: this.longTemplate,
+      });
+
+      expect(second.name).toMatch(/ copy 2$/);
+      expect(second.slug).toMatch(/-copy-2$/);
+    });
+
+    it("does not collide with the template it came from", async function () {
+      const copy = await duplicateTemplate({
+        owner: this.blog.id,
+        template: this.longTemplate,
+      });
+
+      expect(copy.id).not.toEqual(this.longTemplate.id);
+    });
+
     it("stores a slug which matches the id", async function () {
       // writeToFolder names the template's directory after the stored slug
       // and readFromFolder turns that name back into an id. If they disagree,


### PR DESCRIPTION
Duplicating a template whose name is longer than about 30 slug characters **does not work at all** on master. It fails after 999 Redis round-trips with:

```
A template called My extremely long template name for testing copy 999 name already exists
```

## Cause

`Template.create` derives the id from `makeSlug(name).slice(0, 30)`. The truncation happens *before* the suffix has any effect, so the original, its copy, and every numbered retry all derive the same id:

```
original    blog_1:my-extremely-long-template-nam
copy        blog_1:my-extremely-long-template-nam
copy 2      blog_1:my-extremely-long-template-nam
```

The first attempt collides with the original, and each retry appends a counter that falls outside the 30 characters, so it collides again — 999 times.

## A second bug in the same place

`duplicate-template.js` also passed an explicit `slug`, which `Template.create` stores untruncated. For the same long names, the stored slug then disagrees with the id suffix.

That is not cosmetic. `writeToFolder` names the template's directory after the stored slug, and `readFromFolder` turns that directory name back into an id — cutting it to 30 characters again. So enabling local editing on such a copy can resolve to the template it was copied from and write the copy's `package.json` and views over the original.

## Fix

- Trim the base name until the counter survives into the derived slug, so each attempt asks for a genuinely different id.
- Derive the slug from the id rather than passing one, so the two cannot drift.

## Tests

Two specs in `app/dashboard/site/template/tests/duplicate.js`, both verified to fail on master — the first with the "copy 999" error above — and to pass with the fix. The existing `deduplicates subsequent copies` spec still passes unchanged, so ordinary names are unaffected.

Split out of #1637 so it can be reviewed and merged on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)