### PR TITLE
Isolate one broken template view from breaking the whole build

### DIFF
--- a/app/templates/index.js
+++ b/app/templates/index.js
@@ -313,17 +313,7 @@ function assembleTemplateSnapshot(directory, templatePackage, locals) {
     var path = directory + "/" + entry;
     var viewFilename = basename(path);
 
-    // READMEs are documentation, not views: they're never routed and
-    // often contain prose examples of Mustache syntax (e.g. an unclosed
-    // "{{#foo}}" to illustrate what a tag looks like), which is exactly
-    // the kind of thing that fails Template.setView's Mustache parse
-    // check. Treating them as a real view for no benefit isn't worth
-    // that risk.
-    if (
-      viewFilename === "package.json" ||
-      viewFilename.slice(0, 1) === "." ||
-      /^readme(\.\w+)?$/i.test(viewFilename)
-    )
+    if (viewFilename === "package.json" || viewFilename.slice(0, 1) === ".")
       return;
 
     var viewName = viewFilename;

--- a/app/templates/index.js
+++ b/app/templates/index.js
@@ -236,19 +236,24 @@ function build(directory, callback) {
         Template.create(TEMPLATES_OWNER, name, template, function (err) {
           if (err) return callback(err);
 
-          buildViews(id, snapshot.definitions, function (err) {
-            if (err) return callback(err);
-
+          buildViews(id, snapshot.definitions, function (buildViewsErr) {
+            // Every valid view has already been persisted by buildViews
+            // regardless of buildViewsErr, so blogs using this template
+            // must still have their cache flushed to see them - a broken
+            // view elsewhere shouldn't leave the working views stuck
+            // behind a stale cache. We still propagate buildViewsErr to
+            // our own callback below, once that's done, so CI/dev logging
+            // of the underlying error is unaffected.
             emptyCacheForBlogsUsing(id, function (err) {
               if (err) return callback(err);
 
               if (!isPublic || config.environment !== "development")
-                return callback();
+                return callback(buildViewsErr);
 
               // in development, we want to reset any versions of the template
               // otherwise it seems local changes are not reflected
-              removeOldVersionFromTestBlogs(id, function (err) {
-                callback();
+              removeOldVersionFromTestBlogs(id, function () {
+                callback(buildViewsErr);
               });
             });
           });
@@ -260,14 +265,15 @@ function build(directory, callback) {
 
 function buildViews(id, definitions, callback) {
   var views = Object.keys(definitions || {}).sort();
-  var errors = [];
+  var errors = {};
 
   // One view failing to build (e.g. invalid Mustache) must not prevent
   // every other view from building too - alphabetically-later views
   // would otherwise never get rebuilt after Template.drop() wiped the
   // previous, working set. So we always call next() and collect errors
-  // instead, then report them via the final callback once every view
-  // has had a chance to build.
+  // instead, keyed by view name (same shape readFromFolder.js uses for
+  // its own metadata.errors), then persist them once every view has had
+  // a chance to build.
   async.eachSeries(
     views,
     function (name, next) {
@@ -281,7 +287,7 @@ function buildViews(id, definitions, callback) {
           errorView.content = err.toString();
           Template.setView(id, errorView, function () {});
           if (path) err.message += " in " + path;
-          errors.push(err);
+          errors[name] = err.message;
         }
 
         next();
@@ -289,17 +295,25 @@ function buildViews(id, definitions, callback) {
     },
     function (err) {
       if (err) return callback(err);
-      if (!errors.length) return callback();
 
-      callback(
-        new Error(
-          errors.length +
-            " view" +
-            (errors.length === 1 ? "" : "s") +
-            " failed to build: " +
-            errors.map((e) => e.message).join("; ")
-        )
-      );
+      // Always write errors, even when empty, so a previously-broken
+      // view's error is cleared once it's fixed rather than lingering.
+      Template.setMetadata(id, { errors }, function (metadataErr) {
+        if (metadataErr) return callback(metadataErr);
+
+        var names = Object.keys(errors);
+        if (!names.length) return callback();
+
+        callback(
+          new Error(
+            names.length +
+              " view" +
+              (names.length === 1 ? "" : "s") +
+              " failed to build: " +
+              names.map((name) => name + ": " + errors[name]).join("; ")
+          )
+        );
+      });
     }
   );
 }

--- a/app/templates/index.js
+++ b/app/templates/index.js
@@ -260,7 +260,14 @@ function build(directory, callback) {
 
 function buildViews(id, definitions, callback) {
   var views = Object.keys(definitions || {}).sort();
+  var errors = [];
 
+  // One view failing to build (e.g. invalid Mustache) must not prevent
+  // every other view from building too - alphabetically-later views
+  // would otherwise never get rebuilt after Template.drop() wiped the
+  // previous, working set. So we always call next() and collect errors
+  // instead, then report them via the final callback once every view
+  // has had a chance to build.
   async.eachSeries(
     views,
     function (name, next) {
@@ -274,13 +281,26 @@ function buildViews(id, definitions, callback) {
           errorView.content = err.toString();
           Template.setView(id, errorView, function () {});
           if (path) err.message += " in " + path;
-          return next(err);
+          errors.push(err);
         }
 
         next();
       });
     },
-    callback
+    function (err) {
+      if (err) return callback(err);
+      if (!errors.length) return callback();
+
+      callback(
+        new Error(
+          errors.length +
+            " view" +
+            (errors.length === 1 ? "" : "s") +
+            " failed to build: " +
+            errors.map((e) => e.message).join("; ")
+        )
+      );
+    }
   );
 }
 
@@ -293,7 +313,17 @@ function assembleTemplateSnapshot(directory, templatePackage, locals) {
     var path = directory + "/" + entry;
     var viewFilename = basename(path);
 
-    if (viewFilename === "package.json" || viewFilename.slice(0, 1) === ".")
+    // READMEs are documentation, not views: they're never routed and
+    // often contain prose examples of Mustache syntax (e.g. an unclosed
+    // "{{#foo}}" to illustrate what a tag looks like), which is exactly
+    // the kind of thing that fails Template.setView's Mustache parse
+    // check. Treating them as a real view for no benefit isn't worth
+    // that risk.
+    if (
+      viewFilename === "package.json" ||
+      viewFilename.slice(0, 1) === "." ||
+      /^readme(\.\w+)?$/i.test(viewFilename)
+    )
       return;
 
     var viewName = viewFilename;


### PR DESCRIPTION
## Summary
- `buildViews()` in `app/templates/index.js` stopped its `async.eachSeries` loop the instant any single view failed `Template.setView` (e.g. invalid Mustache syntax). Since views build alphabetically and `Template.drop()` already wiped the previous, working template first, one broken view meant every alphabetically-later view (e.g. `entries.html`, `style.css`) never got rebuilt at all - not just left with an error.
- Concretely reproduced with the new `notebook` template: a documentation-only `README` contained a prose example of an unclosed `{{#foo}}`-style Mustache tag, which failed the syntax check `Template.setView` runs on every file. Because `README` sorts before the real views, the build died there and the template was left with almost nothing.
- Fix: `buildViews` now always continues to the next view. Two follow-on gaps found in review, both now fixed too:
  - `build()` skipped `emptyCacheForBlogsUsing` whenever `buildViews` reported an error, even though every valid view had already been persisted - so blogs using the template would keep serving a stale cached render of the working views until something else flushed it. Cache flushing (and the dev-only test-blog reset) now always runs; the build error is still propagated to `build()`'s own callback afterward, so CI/dev logging of a genuine problem is unaffected.
  - Per-view errors were only ever transient (thrown/logged), never persisted anywhere. `buildViews` now writes them to the template's metadata via `Template.setMetadata`, keyed by view name - same shape `readFromFolder.js` already uses for local-editing templates - unconditionally, so a previously-broken view's error is cleared once it's fixed rather than lingering.

## Test plan
- [x] `npm test app/templates/tests/index.js` - 20/21 pass; the 1 failure (`notebook` links to `/feed.rss` instead of its configured `/feeds/posts/default`) is a pre-existing, unrelated content bug in that template, not caused by this change.
- [x] 100% statement/branch/function coverage on `app/templates/index.js` per the test run.
- [x] Manually confirmed with a deliberately-broken README: every other view still builds and gets served; only the broken view records an error.

## Note for reviewer
Persisting `errors` means `loadTemplate.js`'s existing preview gate (`if (req.preview && metadata.errors && ...)`) now also applies to these `SITE`-owned templates for the first time - visiting `preview-of-X-on-Y...` for a template with a genuine error will show the blocking `template-error.html` page for every route, same as it already does for local-editing templates. Production traffic is unaffected either way, since cache-flushing now always runs regardless. Flagging in case that preview behavior (block everything vs. only the affected route) is worth reconsidering as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)