### PR TITLE
Don't crash the whole process when a template folder is caught mid-edit

### DIFF
--- a/app/templates/index.js
+++ b/app/templates/index.js
@@ -134,68 +134,83 @@ function build(directory, callback) {
     // package.json is optional
   }
 
-  id = TEMPLATES_OWNER + ":" + basename(directory);
-  name = templatePackage.name || capitalize(basename(directory));
-  description = templatePackage.description || "";
-  isPublic = templatePackage.isPublic !== false;
+  try {
+    id = TEMPLATES_OWNER + ":" + basename(directory);
+    name = templatePackage.name || capitalize(basename(directory));
+    description = templatePackage.description || "";
+    isPublic = templatePackage.isPublic !== false;
 
-  template = {
-    isPublic: isPublic,
-    description: description,
-    locals: templatePackage.locals,
-  };
-
-  // Set the default font for each template
-  if (template.locals.body_font !== undefined) {
-    template.locals.body_font = _.merge(
-      _.cloneDeep(DEFAULT_FONT),
-      template.locals.body_font
-    );
-  }
-
-  if (template.locals.font !== undefined) {
-    template.locals.font = _.merge(
-      _.cloneDeep(DEFAULT_FONT),
-      template.locals.font
-    );
-  }
-
-  if (template.locals.navigation_font !== undefined) {
-    template.locals.navigation_font = _.merge(
-      _.cloneDeep(DEFAULT_FONT),
-      template.locals.navigation_font
-    );
-  }
-
-  if (template.locals.syntax_highlighter !== undefined) {
-    template.locals.syntax_highlighter = {
-      ...HIGHLIGHTER_THEMES.find(
-        ({ id }) =>
-          id ===
-          (template.locals.syntax_highlighter.id || "stackoverflow-light")
-      ),
+    template = {
+      isPublic: isPublic,
+      description: description,
+      // templatePackage can be {} (missing/unreadable/mid-write
+      // package.json - see above, deliberately tolerated), so this
+      // can't just be templatePackage.locals: that's undefined in
+      // exactly that case, and every .locals.* read below would throw.
+      locals: templatePackage.locals || {},
     };
-  }
 
-  if (template.locals.coding_font !== undefined) {
-    template.locals.coding_font = _.merge(
-      _.cloneDeep(DEFAULT_MONO_FONT),
-      template.locals.coding_font
+    // Set the default font for each template
+    if (template.locals.body_font !== undefined) {
+      template.locals.body_font = _.merge(
+        _.cloneDeep(DEFAULT_FONT),
+        template.locals.body_font
+      );
+    }
+
+    if (template.locals.font !== undefined) {
+      template.locals.font = _.merge(
+        _.cloneDeep(DEFAULT_FONT),
+        template.locals.font
+      );
+    }
+
+    if (template.locals.navigation_font !== undefined) {
+      template.locals.navigation_font = _.merge(
+        _.cloneDeep(DEFAULT_FONT),
+        template.locals.navigation_font
+      );
+    }
+
+    if (template.locals.syntax_highlighter !== undefined) {
+      template.locals.syntax_highlighter = {
+        ...HIGHLIGHTER_THEMES.find(
+          ({ id }) =>
+            id ===
+            (template.locals.syntax_highlighter.id || "stackoverflow-light")
+        ),
+      };
+    }
+
+    if (template.locals.coding_font !== undefined) {
+      template.locals.coding_font = _.merge(
+        _.cloneDeep(DEFAULT_MONO_FONT),
+        template.locals.coding_font
+      );
+    }
+
+    if (template.locals.syntax_highlighter_font !== undefined) {
+      template.locals.syntax_highlighter_font = _.merge(
+        _.cloneDeep(DEFAULT_MONO_FONT),
+        template.locals.syntax_highlighter_font
+      );
+    }
+
+    snapshot = assembleTemplateSnapshot(
+      directory,
+      templatePackage,
+      template.locals
     );
+  } catch (e) {
+    // A template folder can be caught mid-edit (a save landing between
+    // chokidar's change event and a template being fully rewritten, a
+    // package.json briefly missing/malformed, etc). That's a build
+    // failure for this one template, not a reason to crash the whole
+    // process - log it and let the next file change in this folder
+    // trigger a fresh, hopefully-complete rebuild.
+    e.message = "Failed to build " + basename(directory) + ": " + e.message;
+    return callback(e);
   }
-
-  if (template.locals.syntax_highlighter_font !== undefined) {
-    template.locals.syntax_highlighter_font = _.merge(
-      _.cloneDeep(DEFAULT_MONO_FONT),
-      template.locals.syntax_highlighter_font
-    );
-  }
-
-  snapshot = assembleTemplateSnapshot(
-    directory,
-    templatePackage,
-    template.locals
-  );
 
   Template.getMetadata(id, function (metadataErr, storedMetadata) {
     if (metadataErr && metadataErr.code !== "ENOENT")


### PR DESCRIPTION
## Summary
Fixes a crash reported live during Notebook template development:

```
Warning: ENOENT .../app/templates/source/notebook/package.json
TypeError: Cannot read properties of undefined (reading 'body_font')
    at build (/usr/src/app/app/templates/index.js:149:23)
```

`build()`'s own fallback for a missing/unreadable `package.json` is `templatePackage = {}` (explicitly commented "package.json is optional"), but `template.locals` was then set directly to `templatePackage.locals` - `undefined` in exactly that case - and the very next line, `template.locals.body_font`, threw synchronously. That happened before `build()` ever reached its callback, so it crashed the entire Node process rather than failing just that one template's build.

The `watch()` queue (chokidar-driven, rebuilds a template folder on every file change while developing) already treats a `callback(err)` from `build()` as non-fatal - logs it and moves on, and the next file change in that folder triggers a fresh rebuild. So the fix is to make sure build() actually reaches that path instead of crashing first:

- `locals: templatePackage.locals || {}` - the direct cause.
- Wrapped the rest of `build()`'s synchronous body (locals/font normalization, snapshot assembly) in try/catch, routing any throw through the same `callback(err)` path. This covers the reported crash and similar ones from the same root cause (a template folder caught mid-edit - a save landing between chokidar's change event and the file being fully rewritten, a git checkout, an editor's write-then-rename, etc), not just the one line that happened to be hit this time.

No behavior change for a template that builds cleanly.

## Test plan
- [x] Reproduced directly: a temp template folder with no `package.json` at all, run through the real build path via `npm test app/templates/tests/index.js`. Before this fix that's exactly the crash above; after, the log shows the same `Warning: ENOENT .../package.json` line but the template builds successfully (empty locals) with its own passing "no broken links" spec, no crash.
- [x] `npm test app/templates/tests/index.js` - 20 specs, 0 failures (matches master's baseline count with the temp folder removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)