### PR TITLE
Revert "Remove in-process LRU caches for full view, popular tags, and posts"

### DIFF
--- a/app/blog/README
+++ b/app/blog/README
@@ -68,7 +68,7 @@ The `render/` subdirectory implements the Mustache rendering engine used by `res
 
 Attaches `res.renderView(viewName, next, callback)` to the response. When called:
 
-1. Fetches the full view directly from `Template.getFullView()` using the blog ID, template ID, and view name.
+1. Fetches the full view from `Template.getFullView()` via an in-process LRU cache (`full-view-cache.js`). The cache key includes `blogID`, `cacheID`, `templateID`, and `viewName`. A changed `blog.cacheID` invalidates all cached views for that blog.
 2. Merges view-level locals, query parameters, template locals, and blog locals into `res.locals`.
 3. Calls `render/retrieve/index.js` to fetch any named locals declared as required by the view.
 4. Calls `render/load/index.js` to augment every entry object found in `res.locals`.
@@ -108,7 +108,7 @@ Each file in this directory is a named retriever. The retrieve system (`render/r
 | `is` / `is_active` / `isActive` | `is.js`, `is_active.js` | Boolean helpers for conditional rendering. |
 | `latest_entry` / `latestEntry` | `latest_entry.js` | The most recently published entry. |
 | `plugin` | `plugin.js` | CSS and JS URLs for individually requested plugins. |
-| `popular_tags` | `popular_tags.js` | Tags fetched directly through `Tags.popular` on each invocation, formatted for rendering, sorted by entry count, and limited to 100. |
+| `popular_tags` | `popular_tags.js` | Tags sorted by entry count (top 100), cached with an LRU cache keyed by `blogID` and `cacheID`. |
 | `posts` | `posts.js` | A paginated page of entries, respecting template `sort_by`, `sort_order`, `page_size`, and `path_prefix` locals. |
 | `recent_entries` / `recentEntries` | `recent_entries.js` | A small list of recent entries (`Entries.getRecent`). |
 | `rgb` | `rgb.js` | Lambda that converts a CSS color value to an RGB component string (e.g. `255, 128, 0`) for use in `rgba()`. |
@@ -245,7 +245,7 @@ The `static/` directory contains global assets served to all blogs under paths s
 | `models/blog` | `vhosts.js`, `render/view.js` |
 | `models/entry` | `draft.js`, `entry.js`, `search.js`, `render/retrieve/tagged.js`, `render/load/augment.js` |
 | `models/entries` | `entries.js`, `draft.js`, `entry.js`, `random.js`, `render/retrieve/` |
-| `models/template` | `loadTemplate.js`, `view.js`, `render/middleware.js`, `render/view.js` |
+| `models/template` | `loadTemplate.js`, `view.js`, `render/full-view-cache.js`, `render/view.js` |
 | `models/tags` | `render/retrieve/all_tags.js`, `render/retrieve/tagged.js`, `render/retrieve/popular_tags.js`, `render/load/augment.js` |
 | `models/redirects` | `error.js` |
 | `models/user` | `robots.js` |
@@ -266,6 +266,7 @@ The `static/` directory contains global assets served to all blogs under paths s
 | `parse5` | HTML parsing for CDN link rewriting |
 | `cheerio` | HTML manipulation in `absolute_urls.js` and `encode_xml.js` |
 | `moment` / `moment-timezone` | Date formatting in augment and retrieve functions |
+| `lru-cache` | In-process LRU caches for full view and popular tags |
 | `lodash` | Utility functions in retrieve and augment |
 | `async` | Parallel/series async control |
 | `mime-types` | Content-Type detection in `assets.js` |
@@ -289,4 +290,4 @@ Integration tests live in `app/blog/tests/`. The shared test setup in `tests/uti
 
 Test files cover: archives, assets, CDN manifest, dates, draft rendering and SSE streaming, entries listing, entry rendering, error handling, robots.txt, routing edge cases, search, tagged pages, template rendering, domain verification, and vhost resolution logic.
 
-Render-specific tests live in `app/blog/render/tests/` and cover: locals rendering, main Mustache rendering, entry augmentation, and the complete middleware pipeline.
+Render-specific tests live in `app/blog/render/tests/` and cover: full-view caching, locals rendering, main Mustache rendering, entry augmentation, and the complete middleware pipeline.

--- a/app/blog/render/full-view-cache.js
+++ b/app/blog/render/full-view-cache.js
@@ -1,0 +1,80 @@
+var Template = require("models/template");
+var LRUCache = require("lru-cache").LRUCache;
+
+// This cache is safe because the key includes blog/template/view identity,
+// plus blog.cacheID which changes whenever render-relevant blog data changes.
+var fullViewCache = new LRUCache({
+  max: 1000,
+});
+
+function cloneDeep(value) {
+  if (Array.isArray(value)) {
+    return value.map(cloneDeep);
+  }
+
+  if (value && typeof value === "object") {
+    var clone = {};
+
+    Object.keys(value).forEach(function (key) {
+      clone[key] = cloneDeep(value[key]);
+    });
+
+    return clone;
+  }
+
+  return value;
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) {
+    return value;
+  }
+
+  Object.keys(value).forEach(function (key) {
+    deepFreeze(value[key]);
+  });
+
+  return Object.freeze(value);
+}
+
+function createCacheKey(blog, template, viewName) {
+  var blogID = blog && blog.id;
+  var cacheID = blog && blog.cacheID;
+  var templateID = template && template.id;
+
+  return JSON.stringify({
+    blogID: String(blogID),
+    cacheID: String(cacheID),
+    templateID: String(templateID),
+    viewName: String(viewName),
+  });
+}
+
+module.exports = function getCachedFullView(options, callback) {
+  var blog = options.blog;
+  var template = options.template;
+  var viewName = options.viewName;
+
+  var key = createCacheKey(blog, template, viewName);
+
+  if (fullViewCache.has(key)) {
+    return callback(null, cloneDeep(fullViewCache.get(key)));
+  }
+
+  Template.getFullView(blog.id, template.id, viewName, function (err, response) {
+    if (err) {
+      return callback(err);
+    }
+
+    var immutableCopy = deepFreeze(cloneDeep(response));
+
+    fullViewCache.set(key, immutableCopy);
+
+    return callback(null, cloneDeep(immutableCopy));
+  });
+};
+
+module.exports._createCacheKey = createCacheKey;
+module.exports._clear = function () {
+  fullViewCache.clear();
+};

--- a/app/blog/render/middleware.js
+++ b/app/blog/render/middleware.js
@@ -3,7 +3,7 @@ var loadView = require("./load");
 var renderLocals = require("./locals");
 var finalRender = require("./main");
 var retrieve = require("./retrieve");
-var Template = require("models/template");
+var getCachedFullView = require("./full-view-cache");
 
 var ensure = require("helper/ensure");
 var extend = require("helper/extend");
@@ -48,10 +48,8 @@ module.exports = function (req, res, _next) {
 
     if (callback) callback = callOnce(callback);
 
-    Template.getFullView(
-      blog.id,
-      templateID,
-      name,
+    getCachedFullView(
+      { blog: blog, template: req.template, viewName: name },
       function (err, response) {
         if (err) {
           return next(err);

--- a/app/blog/render/retrieve/popular_tags.js
+++ b/app/blog/render/retrieve/popular_tags.js
@@ -1,10 +1,67 @@
 var Tags = require("models/tags");
+var LRUCache = require("lru-cache").LRUCache;
+
+// Safe cache key includes blog/cache identity and query pagination options.
+var popularTagsCache = new LRUCache({
+  max: 1000,
+});
+
+function cloneDeep(value) {
+  if (Array.isArray(value)) {
+    return value.map(cloneDeep);
+  }
+
+  if (value && typeof value === "object") {
+    var clone = {};
+
+    Object.keys(value).forEach(function (key) {
+      clone[key] = cloneDeep(value[key]);
+    });
+
+    return clone;
+  }
+
+  return value;
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) {
+    return value;
+  }
+
+  Object.keys(value).forEach(function (key) {
+    deepFreeze(value[key]);
+  });
+
+  return Object.freeze(value);
+}
+
+function createCacheKey(blog, options) {
+  var blogID = blog && blog.id;
+  var cacheID = blog && blog.cacheID;
+  var limit = options && options.limit;
+  var offset = options && options.offset;
+
+  return JSON.stringify({
+    blogID: String(blogID),
+    cacheID: String(cacheID),
+    limit: Number(limit),
+    offset: Number(offset),
+  });
+}
 
 module.exports = function (req, res, callback) {
   req.log("Listing popular tags");
 
   // We could make this limit configurable through req.query or config
   var options = { limit: 100, offset: 0 };
+  var key = createCacheKey(req.blog, options);
+
+  if (popularTagsCache.has(key)) {
+    req.log("Retrieved popular tags from cache");
+
+    return callback(null, cloneDeep(popularTagsCache.get(key)));
+  }
 
   Tags.popular(req.blog.id, options, function (err, tags) {
     if (err) {
@@ -21,7 +78,16 @@ module.exports = function (req, res, callback) {
       slug: encodeURIComponent(tag.slug)
     }));
 
+    var immutableCopy = deepFreeze(cloneDeep(tags));
+
+    popularTagsCache.set(key, immutableCopy);
+
     req.log("Listed popular tags");
-    return callback(null, tags);
+    return callback(null, cloneDeep(immutableCopy));
   });
+};
+
+module.exports._createCacheKey = createCacheKey;
+module.exports._clear = function () {
+  popularTagsCache.clear();
 };

--- a/app/blog/render/retrieve/posts.js
+++ b/app/blog/render/retrieve/posts.js
@@ -1,6 +1,76 @@
 const Entry = require("models/entry");
+const EntryInstance = require("models/entry/instance");
 const entriesModel = require("models/entries");
+const LRUCache = require("lru-cache").LRUCache;
 const fetchTaggedEntries = require("./helpers/fetchTaggedEntries");
+
+const postsCache = new LRUCache({
+  max: 1000,
+});
+
+function cloneDeep(value) {
+  if (Array.isArray(value)) {
+    return value.map(cloneDeep);
+  }
+
+  if (value && typeof value === "object") {
+    const clone = value instanceof EntryInstance ? new EntryInstance() : {};
+
+    Object.keys(value).forEach((key) => {
+      clone[key] = cloneDeep(value[key]);
+    });
+
+    return clone;
+  }
+
+  return value;
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) {
+    return value;
+  }
+
+  Object.keys(value).forEach((key) => {
+    deepFreeze(value[key]);
+  });
+
+  return Object.freeze(value);
+}
+
+function normalizeTagKey(tags) {
+  if (Array.isArray(tags)) {
+    return tags.map((tag) => String(tag)).sort();
+  }
+
+  return tags === undefined ? undefined : String(tags);
+}
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = parseInt(value, 10);
+
+  if (!parsed || parsed < 1) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function createCacheKey(req, res, normalizedOptions) {
+  return JSON.stringify({
+    blogID: String(req?.blog?.id),
+    cacheID: String(req?.blog?.cacheID),
+    branch: String(normalizedOptions.branch),
+    tags: normalizeTagKey(normalizedOptions.tags),
+    sortBy: String(normalizedOptions.sortBy),
+    order: String(normalizedOptions.order),
+    pathPrefix: String(normalizedOptions.pathPrefix),
+    pageNumber: Number(normalizedOptions.pageNumber),
+    pageSize: Number(normalizedOptions.pageSize),
+    limit: Number(normalizedOptions.limit),
+    offset: Number(normalizedOptions.offset),
+  });
+}
 
 module.exports = function (req, res, callback) {
   const blogID = req?.blog?.id;
@@ -15,6 +85,31 @@ module.exports = function (req, res, callback) {
   };
 
   const tags = req?.query?.tag || req?.params?.tag || res?.locals?.tag;
+  const normalizedPageNumber = parsePositiveInteger(options.pageNumber, 1);
+  const normalizedPageSize = parsePositiveInteger(options.pageSize, 100);
+  const normalizedLimit = Math.max(1, Math.min(500, normalizedPageSize));
+  const normalizedOffset = (normalizedPageNumber - 1) * normalizedLimit;
+  const normalizedOptions = {
+    branch: tags ? "tagged" : "untagged",
+    tags,
+    sortBy: options.sortBy,
+    order: options.order,
+    pathPrefix: options.pathPrefix,
+    pageNumber: normalizedPageNumber,
+    pageSize: normalizedPageSize,
+    limit: normalizedLimit,
+    offset: normalizedOffset,
+  };
+
+  const key = createCacheKey(req, res, normalizedOptions);
+
+  if (postsCache.has(key)) {
+    const cachedPayload = cloneDeep(postsCache.get(key));
+    log("Retrieved posts from cache");
+    res.locals.pagination = cachedPayload.pagination;
+    return callback(null, cachedPayload.entries);
+  }
+
   if (!tags) {
     log("Loading page of entries");
     return entriesModel.getPage(blogID, options, (err, entries, pagination) => {
@@ -22,8 +117,14 @@ module.exports = function (req, res, callback) {
         return callback(err);
       }
 
-      res.locals.pagination = pagination;
-      callback(null, entries);
+      const payload = { entries, pagination };
+      const immutableCopy = deepFreeze(cloneDeep(payload));
+      postsCache.set(key, immutableCopy);
+      const responsePayload = cloneDeep(immutableCopy);
+
+      res.locals.pagination = responsePayload.pagination;
+
+      callback(null, responsePayload.entries);
     });
   }
 
@@ -48,9 +149,22 @@ module.exports = function (req, res, callback) {
 
       Entry.get(blogID, result.entryIDs || [], (entries) => {
         entries.sort((a, b) => b.dateStamp - a.dateStamp);
-        res.locals.pagination = result.pagination || {};
-        callback(null, entries);
+        const payload = {
+          entries,
+          pagination: result.pagination || {},
+        };
+        const immutableCopy = deepFreeze(cloneDeep(payload));
+        postsCache.set(key, immutableCopy);
+        const responsePayload = cloneDeep(immutableCopy);
+
+        res.locals.pagination = responsePayload.pagination;
+        callback(null, responsePayload.entries);
       });
     }
   );
+};
+
+module.exports._createCacheKey = createCacheKey;
+module.exports._clear = function () {
+  postsCache.clear();
 };

--- a/app/blog/render/retrieve/tests/posts.js
+++ b/app/blog/render/retrieve/tests/posts.js
@@ -141,7 +141,7 @@ describe("posts", function () {
   });
 
 
-  it("keeps tag augmentation isolated between requests", async function () {
+  it("augments tags on posts across cached requests", async function () {
     await this.write({
       path: "/paris.txt",
       content: "Title: Paris\nTags: Paris\n\nBonjour",
@@ -185,5 +185,255 @@ describe("posts", function () {
         expect(res.status).toEqual(400);
       });
     }
+  });
+});
+
+describe("posts cache", function () {
+  const Entry = require("models/entry");
+  const entriesModel = require("models/entries");
+  const helperPath = require.resolve("../helpers/fetchTaggedEntries");
+  const postsPath = require.resolve("../posts");
+
+  function loadPostsWithTaggedStub(taggedStub) {
+    delete require.cache[postsPath];
+    delete require.cache[helperPath];
+    require.cache[helperPath] = {
+      id: helperPath,
+      filename: helperPath,
+      loaded: true,
+      exports: taggedStub,
+    };
+
+    return require("../posts");
+  }
+
+  afterEach(function () {
+    delete require.cache[postsPath];
+    delete require.cache[helperPath];
+  });
+
+  it("reuses cached untagged responses for identical inputs", function (done) {
+    const posts = loadPostsWithTaggedStub(function () {});
+    posts._clear();
+
+    spyOn(entriesModel, "getPage").and.callFake(function (blogID, options, callback) {
+      callback(null, [{ id: "1", title: "A" }], { page: 1, pages: 1 });
+    });
+
+    const req = {
+      blog: { id: "blog-1", cacheID: 100 },
+      query: {},
+      params: {},
+      template: { locals: { page_size: 5 } },
+      log: function () {},
+    };
+
+    posts(req, { locals: {} }, function () {
+      posts(req, { locals: {} }, function () {
+        expect(entriesModel.getPage).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+
+  it("reuses cached tagged responses for identical inputs", function (done) {
+    const taggedSpy = jasmine.createSpy("fetchTaggedEntries").and.callFake(function (
+      blogID,
+      tags,
+      options,
+      callback
+    ) {
+      callback(null, { entryIDs: ["1", "2"], pagination: { page: 1, pages: 1 } });
+    });
+
+    const posts = loadPostsWithTaggedStub(taggedSpy);
+    posts._clear();
+
+    spyOn(Entry, "get").and.callFake(function (blogID, entryIDs, callback) {
+      callback([
+        { id: "1", dateStamp: 1, title: "First" },
+        { id: "2", dateStamp: 2, title: "Second" },
+      ]);
+    });
+
+    const req = {
+      blog: { id: "blog-1", cacheID: 100 },
+      query: { tag: "foo" },
+      params: {},
+      template: { locals: { page_size: 2, path_prefix: "/blog/" } },
+      log: function () {},
+    };
+
+    posts(req, { locals: {} }, function () {
+      posts(req, { locals: {} }, function () {
+        expect(taggedSpy).toHaveBeenCalledTimes(1);
+        expect(Entry.get).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+
+  it("returns isolated copies so caller mutations do not taint cache", function (done) {
+    const posts = loadPostsWithTaggedStub(function () {});
+    posts._clear();
+
+    spyOn(entriesModel, "getPage").and.callFake(function (blogID, options, callback) {
+      callback(null, [{ title: "Original" }], { page: 1, pages: 3, nested: { total: 10 } });
+    });
+
+    const req = {
+      blog: { id: "blog-1", cacheID: 100 },
+      query: {},
+      params: {},
+      template: { locals: {} },
+      log: function () {},
+    };
+
+    const firstRes = { locals: {} };
+
+    posts(req, firstRes, function (err, firstEntries) {
+      expect(err).toBeNull();
+      firstEntries[0].title = "Mutated";
+      firstRes.locals.pagination.nested.total = -1;
+
+      const secondRes = { locals: {} };
+      posts(req, secondRes, function (secondErr, secondEntries) {
+        expect(secondErr).toBeNull();
+        expect(secondEntries[0].title).toBe("Original");
+        expect(secondRes.locals.pagination.nested.total).toBe(10);
+        expect(entriesModel.getPage).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+
+  it("varies cache keys across invalidation and query dimensions", function () {
+    const posts = loadPostsWithTaggedStub(function () {});
+
+    const makeKey = function ({ cacheID, tag, pageNumber, sortBy, order, pathPrefix }) {
+      return posts._createCacheKey(
+        { blog: { id: "blog-1", cacheID }, query: { tag }, params: {}, template: { locals: {} } },
+        { locals: {} },
+        {
+          branch: tag ? "tagged" : "untagged",
+          tags: tag,
+          sortBy,
+          order,
+          pathPrefix,
+          pageNumber,
+          pageSize: 10,
+          limit: 10,
+          offset: (pageNumber - 1) * 10,
+        }
+      );
+    };
+
+    const base = makeKey({
+      cacheID: "v1",
+      tag: "foo",
+      pageNumber: 1,
+      sortBy: "date",
+      order: "desc",
+      pathPrefix: "/blog/",
+    });
+
+    expect(base).not.toBe(
+      makeKey({
+        cacheID: "v2",
+        tag: "foo",
+        pageNumber: 1,
+        sortBy: "date",
+        order: "desc",
+        pathPrefix: "/blog/",
+      })
+    );
+    expect(base).not.toBe(
+      makeKey({
+        cacheID: "v1",
+        tag: "bar",
+        pageNumber: 1,
+        sortBy: "date",
+        order: "desc",
+        pathPrefix: "/blog/",
+      })
+    );
+    expect(base).not.toBe(
+      makeKey({
+        cacheID: "v1",
+        tag: "foo",
+        pageNumber: 2,
+        sortBy: "date",
+        order: "desc",
+        pathPrefix: "/blog/",
+      })
+    );
+    expect(base).not.toBe(
+      makeKey({
+        cacheID: "v1",
+        tag: "foo",
+        pageNumber: 1,
+        sortBy: "slug",
+        order: "desc",
+        pathPrefix: "/blog/",
+      })
+    );
+    expect(base).not.toBe(
+      makeKey({
+        cacheID: "v1",
+        tag: "foo",
+        pageNumber: 1,
+        sortBy: "date",
+        order: "asc",
+        pathPrefix: "/blog/",
+      })
+    );
+    expect(base).not.toBe(
+      makeKey({
+        cacheID: "v1",
+        tag: "foo",
+        pageNumber: 1,
+        sortBy: "date",
+        order: "desc",
+        pathPrefix: "/notes/",
+      })
+    );
+  });
+
+  it("does not collide tagged and untagged key spaces", function () {
+    const posts = loadPostsWithTaggedStub(function () {});
+
+    const tagged = posts._createCacheKey(
+      { blog: { id: "blog-1", cacheID: "v1" }, query: { tag: "foo" }, params: {}, template: { locals: {} } },
+      { locals: {} },
+      {
+        branch: "tagged",
+        tags: "foo",
+        sortBy: "date",
+        order: "desc",
+        pathPrefix: "/blog/",
+        pageNumber: 1,
+        pageSize: 10,
+        limit: 10,
+        offset: 0,
+      }
+    );
+
+    const untagged = posts._createCacheKey(
+      { blog: { id: "blog-1", cacheID: "v1" }, query: {}, params: {}, template: { locals: {} } },
+      { locals: {} },
+      {
+        branch: "untagged",
+        tags: "foo",
+        sortBy: "date",
+        order: "desc",
+        pathPrefix: "/blog/",
+        pageNumber: 1,
+        pageSize: 10,
+        limit: 10,
+        offset: 0,
+      }
+    );
+
+    expect(tagged).not.toBe(untagged);
   });
 });

--- a/app/blog/render/tests/full-view-cache.js
+++ b/app/blog/render/tests/full-view-cache.js
@@ -1,0 +1,183 @@
+var Template = require("models/template");
+var getCachedFullView = require("../full-view-cache");
+
+describe("full view cache", function () {
+  beforeEach(function () {
+    getCachedFullView._clear();
+  });
+
+  it("reuses cached full view responses for identical inputs", function (done) {
+    var response = [{ title: "Hello" }, { head: "" }, [], "text/html", "{{title}}"];
+
+    spyOn(Template, "getFullView").and.callFake(function (
+      blogID,
+      templateID,
+      viewName,
+      callback
+    ) {
+      callback(null, response);
+    });
+
+    var options = {
+      blog: { id: "blog-1", cacheID: 111 },
+      template: { id: "template-1" },
+      viewName: "entry.html",
+    };
+
+    getCachedFullView(options, function (err, firstResult) {
+      expect(err).toBeNull();
+      expect(firstResult).toEqual(response);
+      expect(firstResult).not.toBe(response);
+
+      getCachedFullView(options, function (secondErr, secondResult) {
+        expect(secondErr).toBeNull();
+        expect(secondResult).toEqual(response);
+        expect(secondResult).not.toBe(response);
+        expect(secondResult).not.toBe(firstResult);
+        expect(Template.getFullView).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+
+  it("returns isolated copies so caller mutations do not taint cache", function (done) {
+    spyOn(Template, "getFullView").and.callFake(function (
+      blogID,
+      templateID,
+      viewName,
+      callback
+    ) {
+      callback(null, [
+        { title: "Original" },
+        { head: "" },
+        [{ id: "asset-1" }],
+        "text/html",
+        "{{title}}",
+      ]);
+    });
+
+    var options = {
+      blog: { id: "blog-1", cacheID: 111 },
+      template: { id: "template-1" },
+      viewName: "entry.html",
+    };
+
+    getCachedFullView(options, function (err, firstResult) {
+      expect(err).toBeNull();
+
+      firstResult[0].title = "Mutated";
+      firstResult[2][0].id = "asset-2";
+
+      getCachedFullView(options, function (secondErr, secondResult) {
+        expect(secondErr).toBeNull();
+        expect(secondResult[0].title).toBe("Original");
+        expect(secondResult[2][0].id).toBe("asset-1");
+        expect(Template.getFullView).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+
+  it("misses the cache when blog/template/view inputs differ", function (done) {
+    spyOn(Template, "getFullView").and.callFake(function (
+      blogID,
+      templateID,
+      viewName,
+      callback
+    ) {
+      callback(null, [
+        { blogID: blogID, templateID: templateID, viewName: viewName },
+        {},
+        [],
+        "text/html",
+        "",
+      ]);
+    });
+
+    getCachedFullView(
+      {
+        blog: { id: "blog-1", cacheID: 111 },
+        template: { id: "template-1" },
+        viewName: "entry.html",
+      },
+      function () {
+        getCachedFullView(
+          {
+            blog: { id: "blog-2", cacheID: 111 },
+            template: { id: "template-2" },
+            viewName: "index.html",
+          },
+          function () {
+            expect(Template.getFullView).toHaveBeenCalledTimes(2);
+            done();
+          }
+        );
+      }
+    );
+  });
+
+
+  it("does not collide cache keys when input segments contain colons", function () {
+    var firstKey = getCachedFullView._createCacheKey(
+      { id: "foo:bar", cacheID: "baz" },
+      { id: "qux" },
+      "view"
+    );
+
+    var secondKey = getCachedFullView._createCacheKey(
+      { id: "foo", cacheID: "bar:baz" },
+      { id: "qux" },
+      "view"
+    );
+
+    expect(firstKey).not.toBe(secondKey);
+  });
+
+  it("keeps null and undefined cache key behavior stable", function () {
+    var keyWithNull = getCachedFullView._createCacheKey(
+      { id: null, cacheID: undefined },
+      { id: undefined },
+      null
+    );
+
+    expect(keyWithNull).toBe(
+      JSON.stringify({
+        blogID: "null",
+        cacheID: "undefined",
+        templateID: "undefined",
+        viewName: "null",
+      })
+    );
+  });
+  it("recomputes when blog.cacheID changes", function (done) {
+    spyOn(Template, "getFullView").and.callFake(function (
+      blogID,
+      templateID,
+      viewName,
+      callback
+    ) {
+      callback(null, [{ cacheID: Date.now() }, {}, [], "text/html", ""]);
+    });
+
+    getCachedFullView(
+      {
+        blog: { id: "blog-1", cacheID: 111 },
+        template: { id: "template-1" },
+        viewName: "entry.html",
+      },
+      function () {
+        getCachedFullView(
+          {
+            blog: { id: "blog-1", cacheID: 222 },
+            template: { id: "template-1" },
+            viewName: "entry.html",
+          },
+          function () {
+            expect(Template.getFullView).toHaveBeenCalledTimes(2);
+            done();
+          }
+        );
+      }
+    );
+  });
+});

--- a/app/models/template/tests/updateCdnManifest.js
+++ b/app/models/template/tests/updateCdnManifest.js
@@ -66,7 +66,7 @@ describe("updateCdnManifest", function () {
     expect(renderedOutput).toBe("body{color:red}");
   });
 
-  it("regenerates manifest hashes after cache-busting", async function () {
+  it("regenerates manifest hashes after cache-busting to avoid stale full-view cache", async function () {
     const test = this;
 
     await setViewAsync(test.template.id, {
@@ -82,7 +82,7 @@ describe("updateCdnManifest", function () {
     const metadata1 = await getMetadataAsync(test.template.id);
     const oldHash = metadata1.cdn["style.css"];
 
-    // Render the view before updating its CDN manifest
+    // Prime full-view-cache for the current blog cacheID
     await renderView(test.template.id, "style.css");
 
     // Ensure Date.now() advances so Blog.set writes a new cacheID.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "http-auth": "3.2.3",
     "katex": "0.16.21",
     "lodash": "4.17.21",
+    "lru-cache": "^11.2.6",
     "mailgun.js": "11.0.0",
     "marked": "12.0.1",
     "mime-types": "3.0.1",


### PR DESCRIPTION
## Summary
- Reverts f2710b5119272b74160554b0a3fecc7f3063e56e, re-introducing the in-process LRU caches for full view rendering, popular tags, and posts retrieval
- Restores `app/blog/render/full-view-cache.js` and its tests
- Restores caching logic in `app/blog/render/retrieve/popular_tags.js` and `app/blog/render/retrieve/posts.js` (and their tests)
- Restores the `lru-cache` dependency in `package.json` and the related `README` notes

## Test plan
- [x] Clean `git revert` with no conflicts
- [x] `node --check` on all restored files to confirm they parse
- [ ] CI test suite

---
_Generated by [Claude Code](https://claude.ai/code/session_01SS4aobootii6NQoSnKw1HQ)_