### PR TITLE
Decouple iCloud folder setup from the dashboard request

### DIFF
--- a/app/clients/icloud/macserver/routes/setup.js
+++ b/app/clients/icloud/macserver/routes/setup.js
@@ -98,7 +98,7 @@ try
     end tell
 
     -- Wait for the iCloud sharing system dialog to appear
-    set timeoutSeconds to 5 -- Set the timeout (in seconds)
+    set timeoutSeconds to 10 -- Set the timeout (in seconds)
     set startTime to (current date) -- Track the start time
 
     tell application "System Events"
@@ -137,8 +137,8 @@ try
         end tell
     end tell
 
-    -- wait 1 second for the Finder to process the new folder if it was created
-    delay 1
+    -- wait 2 seconds for the Finder to process the new folder if it was created
+    delay 2
     
     -- Close all Finder windows after interacting with the sharing dialog
     tell application "Finder"
@@ -157,7 +157,7 @@ async function acceptSharingLink(sharingLink) {
     ({ stdout, stderr } = await exec(
       "osascript",
       ["-e", appleScript(escapedSharingLink)],
-      { timeout: 15000 }
+      { timeout: 25000 }
     ));
   } catch (error) {
     console.error(
@@ -199,18 +199,39 @@ export default async (req, res) => {
     return res.status(400).send("Missing sharingLink header");
   }
 
-  console.log(clfdate(), 
+  console.log(clfdate(),
     `Received setup request for blogID: ${blogID}, sharingLink: ${sharingLink}`
   );
 
-  try {
-    await setupBlog(blogID, sharingLink);
-    console.log(clfdate(), `Setup complete for blogID: ${blogID}`);
-    await status(blogID, { acceptedSharingLink: true, error: null });
-    return res.sendStatus(200);
-  } catch (error) {
-    console.error(clfdate(), `Setup failed for blogID (${blogID}):`, error);
-    await status(blogID, { acceptedSharingLink: false, error: error.message });
-    return res.status(500).json({ error: error.message });
-  }
+  // Setting up a folder involves driving the Finder UI via AppleScript and then
+  // waiting for iCloud to materialise the shared folder, which can take tens of
+  // seconds. Rather than holding the HTTP connection open for the whole
+  // operation, acknowledge the request immediately and report the outcome
+  // asynchronously via the status client (POST /status on the remote server).
+  const reportStatus = async (payload) => {
+    try {
+      await status(blogID, payload);
+    } catch (error) {
+      console.error(
+        clfdate(),
+        `Failed to report setup status for blogID (${blogID}):`,
+        error
+      );
+    }
+  };
+
+  setupBlog(blogID, sharingLink)
+    .then(() => {
+      console.log(clfdate(), `Setup complete for blogID: ${blogID}`);
+      return reportStatus({ acceptedSharingLink: true, error: null });
+    })
+    .catch((error) => {
+      console.error(clfdate(), `Setup failed for blogID (${blogID}):`, error);
+      return reportStatus({
+        acceptedSharingLink: false,
+        error: error.message,
+      });
+    });
+
+  return res.status(202).json({ accepted: true });
 };

--- a/app/clients/icloud/routes/dashboard.js
+++ b/app/clients/icloud/routes/dashboard.js
@@ -100,20 +100,53 @@ dashboard
           return next(new Error("Invalid sharing link format"));
         }
 
-        await database.store(blogID, { sharingLink, blotiCloudAccount });
+        // If a setup for this exact link is already under way, don't start a
+        // second Macserver run – it would race the first and can clobber its
+        // result. The window lets a genuinely stuck setup be retried.
+        const existing = await database.get(blogID);
+        if (
+          existing &&
+          existing.sharingLink === sharingLink &&
+          !existing.error &&
+          !existing.setupComplete &&
+          existing.setupStartedAt &&
+          Date.now() - existing.setupStartedAt < 1000 * 90
+        ) {
+          console.log(
+            `Setup already in progress for blogID: ${blogID}, ignoring duplicate request`
+          );
+          return res.redirect(req.baseUrl);
+        }
+
+        await database.store(blogID, {
+          sharingLink,
+          blotiCloudAccount,
+          error: null,
+          setupComplete: false,
+          setupStartedAt: Date.now(),
+        });
       } else {
         return next(new Error("Paste the sharing link into the box"));
       }
 
+      // Seed the dashboard status line. The Macserver creates the folder
+      // asynchronously and reports progress back via POST /status, which the
+      // sync status line (SSE) surfaces to the user – see routes/site/status.js
+      // and clients/icloud/sync/initialTransfer.js.
       const { folder, done } = await establishSyncLock(blogID);
-      folder.status("Waiting for folder setup to complete...");
+      folder.status("Setting up your iCloud folder");
       await done();
 
-      // Make the request to the Macserver /setup endpoint
+      // Ask the Macserver to begin setup. This returns as soon as the request
+      // has been accepted (202) – it does NOT wait for the folder to be
+      // created, so the timeout here only needs to cover the acknowledgement.
+      // The outcome arrives later via POST /status.
       console.log(`Sending setup request to Macserver for blogID: ${blogID}`);
       try {
         await fetch(`${MACSERVER_URL}/setup`, {
           method: "POST",
+          timeout: 1000 * 15, // 15 seconds to acknowledge the request
+          retries: 1, // don't retry: /setup is not idempotent
           headers: {
             "Content-Type": "application/json",
             Authorization: MACSERVER_AUTH, // Use the Macserver Authorization header
@@ -126,24 +159,25 @@ dashboard
           `Macserver /setup request failed for blogID: ${blogID}`,
           error
         );
-        // Clean up the database entry if setup failed
+        // Surface the failure on the dashboard so the user can retry.
+        const message =
+          "Couldn't reach the setup server, please try again in a moment";
         try {
-          await database.delete(blogID);
-        } catch (dbError) {
+          await database.store(blogID, { error: message });
+          const { folder, done } = await establishSyncLock(blogID);
+          folder.status("Error: " + message);
+          await done();
+        } catch (statusError) {
           console.error(
-            `Error cleaning up database after setup failure: ${dbError.message}`
+            `Error recording setup failure for blogID ${blogID}: ${statusError.message}`
           );
         }
-        return next(
-          new Error(
-            `Failed to set up folder: ${error.message || "Unknown error"}`
-          )
-        );
+        return next(new Error(message));
       }
 
-      console.log(`Macserver /setup request succeeded for blogID: ${blogID}`);
+      console.log(`Macserver accepted setup request for blogID: ${blogID}`);
 
-      // Redirect back to the dashboard
+      // Redirect back to the dashboard – the status line takes it from here.
       res.redirect(req.baseUrl);
     } catch (error) {
       if (

--- a/app/clients/icloud/routes/site/status.js
+++ b/app/clients/icloud/routes/site/status.js
@@ -119,7 +119,38 @@ module.exports = async function (req, res) {
       await initialTransfer(blogID);
     } catch (err) {
       return handle("Error in initialTransfer", err);
-    } 
+    }
+  } else if (status.error) {
+    // The macserver reported a setup failure (e.g. an invalid sharing link, or
+    // the shared folder never appeared). The error is already persisted by the
+    // database.store() call above, which drives the dashboard error UI; here we
+    // also push it onto the live status line. Reply before taking the sync lock
+    // so we never hold the macserver's status request open while it waits on us.
+    try {
+      res.send("ok");
+
+      const { done, folder } = await establishSyncLock(blogID);
+
+      try {
+        folder.status("Error: " + status.error);
+        console.log("Setup failed", { blogID, error: status.error });
+      } finally {
+        await done();
+      }
+    } catch (err) {
+      if (
+        handleSyncLockError({
+          err,
+          res,
+          blogID,
+          action: "status setup error",
+        })
+      ) {
+        return;
+      }
+
+      return handle("Error handling setup failure status", err);
+    }
   } else {
     try {
       const { done, folder } = await establishSyncLock(blogID);

--- a/app/clients/icloud/views/index.html
+++ b/app/clients/icloud/views/index.html
@@ -9,13 +9,13 @@
       <input type="hidden" name="_csrf" value="{{csrftoken}}">
       {{error}}
       <div class="buttons">
-          <button type="submit">Re-connect to iCloud</button> 
-          <button type="submit" name="cancel" value="true">Cancel</button> 
-      </div>  
+          <a href="{{{base}}}/setup">Try setup again</a>
+          <button type="submit" name="cancel" value="true">Cancel</button>
+      </div>
   </form>
-  
-  
-  
+
+
+
   {{/error}}
   
 


### PR DESCRIPTION
## Problem

`POST /set-up-folder` blocked on the Macserver `/setup` response, which is only sent **after** the entire folder-creation flow completes: AppleScript Finder automation + polling for iCloud to materialise the shared folder — up to ~40s worst case.

- The client per-attempt timeout (15s, previously 10s) was well below that worst case.
- `rateLimitedFetchWithRetriesAndTimeout` defaults to **3 retries**, and `/setup` is not idempotent — a slow-but-successful setup could re-fire the Finder automation and a later attempt would report `"Invalid sharing link"`, **overwriting the success status**.
- Raising the client timeout to cover the worst case just means holding a browser POST open for 30–40s on GUI automation, and re-breaks every time a Macserver-side timeout is bumped.

## Approach

Setup completion is **already** reported asynchronously — the Macserver calls `POST /status`, whose `acceptedSharingLink` branch kicks off `initialTransfer`, which narrates progress through `folder.status()` onto the SSE sync status line. The dashboard doesn't need to block on any of it; it only needs to know the request was accepted. This is the pattern the Dropbox client already uses (fire-and-forget `setup()` + `folder.status()` progress + `/status` SSE).

## Changes

| File | Change |
|---|---|
| `macserver/routes/setup.js` | `/setup` starts `setupBlog()` in the background and returns **202** immediately; success/failure reported via the status client exactly as before. Also raises the `osascript` timeout 15s → 25s to keep margin over the longer AppleScript dialog wait (5s → 10s) and Finder delay (1s → 2s). |
| `routes/dashboard.js` | `/set-up-folder` seeds the status line (`"Setting up your iCloud folder"`), sends the request with `retries: 1`, and only waits for the 202 ack before redirecting. On failure it records the error (shown on the status line + dashboard) instead of deleting the account row. Adds a 90s in-flight guard so a double-submit doesn't start a second Macserver run for the same link. |
| `routes/site/status.js` | Handles the Macserver's `error` payloads (setup failure, `"Blog directory deleted"`) explicitly — surfaces them on the status line — instead of falling through to the normal "sync update" branch. Replies before taking the sync lock so the Macserver's status request never waits on a lock the dashboard might hold. |
| `views/index.html` | The error block now links to `/setup` (the paste-the-link page) instead of re-posting to `/set-up-folder` with no link (which would just error). |

## Status line the user sees

`Setting up your iCloud folder` → *(Macserver, ~10–40s)* → `Setting up iCloud sync` → `Resolving case conflicts` → `Transferring files to iCloud` → `Verifying transfer` → `Syncing from iCloud` → `Transfer complete` → `Setup complete`. On failure: `Error: <message>` and the dashboard error block.

## Deploy note

`macserver/routes/setup.js` ships to the Mac mini separately from the Blot web app. The Blot side treats 200 and 202 identically, so ordering isn't fragile, but the UX is only fully decoupled once both are deployed.

## Testing

Not covered by automated tests (per repo convention for this client). Manual verification: happy path, invalid link, Macserver down, Macserver slow, double-submit, and confirming no `Failed to acquire folder lock` from `initialTransfer` racing the dashboard's brief status lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)