### PR TITLE
Fix reflected XSS on /clients/dropbox/authenticate

### DIFF
--- a/app/clients/dropbox/routes/site.js
+++ b/app/clients/dropbox/routes/site.js
@@ -30,21 +30,16 @@ site.get("/authenticate", cookieParser(), function (req, res, next) {
   }
   let redirect =
     "/sites/" +
-    handle +
+    encodeURIComponent(handle) +
     "/client/dropbox/authenticate?code=" +
-    req.query.code;
+    encodeURIComponent(req.query.code || "");
   if (req.query.full_access) redirect += "&full_access=true";
 
   res.clearCookie("blogToAuthenticate");
-  res.send(`<html>
-<head>
-<meta http-equiv="refresh" content="0;URL='${redirect}'"/>
-<script type="text/javascript">window.location='${redirect}'</script>
-</head>
-<body>
-<noscript><p>Continue to <a href="${redirect}">${redirect}</a>.</p></noscript>
-</body>
-</html>`);
+  // redirect is a same-origin path with all user input percent-encoded, so
+  // no untrusted value is interpolated into HTML or JS. res.redirect emits a
+  // Location header plus a safe default body.
+  res.redirect(redirect);
 });
 
 // We keep a dictionary of synced blogs for testing


### PR DESCRIPTION
## Problem

`app/clients/dropbox/routes/site.js` (the public Dropbox OAuth callback, mounted at `/clients/dropbox/authenticate` on the dashboard vhost `blot.im`) built an HTML response by interpolating `req.query.code` — and the `blogToAuthenticate` cookie value — **unescaped** into three sinks:

- `<meta http-equiv="refresh" content="0;URL='${redirect}'"/>`
- `<script type="text/javascript">window.location='${redirect}'</script>`
- `<a href="${redirect}">${redirect}</a>`

`req.query.code` is fully attacker-controlled. The route is public (only `cookieParser()`), and the only precondition is the `blogToAuthenticate` cookie, which is set for ~15 minutes once a logged-in user starts a Dropbox connect. `sameSite=Lax` does not help — this is a top-level GET navigation.

**Exploit:** a logged-in victim who has just started a Dropbox connect and follows

```
https://blot.im/clients/dropbox/authenticate?code=';alert(document.cookie);'
```

(or `?code=</script><script>…</script>`) runs attacker script on the dashboard origin. There is no `script-src` CSP (`app/server.js` only sets `frame-ancestors`), so inline injected script executes. Impact: authenticated same-origin requests as the victim → account takeover.

## Fix

- Percent-encode `req.query.code` and the `handle` value.
- Replace the hand-rolled HTML/JS page with `res.redirect(redirect)`, which emits a `Location` header and a safe default body. `redirect` stays a same-origin path, so no open-redirect exposure.

Minimal change; no behavioural difference for the normal flow (browser still lands on `/sites/<handle>/client/dropbox/authenticate?code=…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)