### PR TITLE
Block SSRF in webloc screenshots and image downloads

### DIFF
--- a/app/build/plugins/linkScreenshot/index.js
+++ b/app/build/plugins/linkScreenshot/index.js
@@ -1,4 +1,3 @@
-const Url = require("url");
 const { callbackify } = require("util");
 const screenshot = callbackify(require("helper/screenshot"));
 const { join } = require("path");
@@ -6,6 +5,7 @@ const config = require("config");
 const uuid = require("uuid/v4");
 const { is } = require("build/converters/webloc");
 const clfdate = require("helper/clfdate");
+const { assertPublicHttpUrl } = require("helper/ssrf");
 const SCREENSHOT_DIR = "_bookmark_screenshots";
 const SCREENSHOT_WIDTH = 1200;
 const SCREENSHOT_HEIGHT = 1200;
@@ -31,36 +31,36 @@ function render($, callback, { blogID, path }) {
     return callback();
   }
 
-  try {
-    Url.parse(href);
-  } catch (e) {
-    console.log(prefix(), "Invalid HREF");
-    return callback();
-  }
+  assertPublicHttpUrl(href)
+    .then(function () {
+      screenshot(
+        href,
+        localPathToScreenshot,
+        { width: SCREENSHOT_WIDTH, height: SCREENSHOT_HEIGHT },
+        function (err) {
+          if (err) {
+            console.log(prefix(), "Error fetching screenshot", err);
+            return callback();
+          }
 
-  screenshot(
-    href,
-    localPathToScreenshot,
-    { width: SCREENSHOT_WIDTH, height: SCREENSHOT_HEIGHT },
-    function (err) {
-      if (err) {
-        console.log(prefix(), "Error fetching screenshot", err);
-        return callback();
-      }
-
-      $.root().html(
-        `<p class="bookmark-container">
+          $.root().html(
+            `<p class="bookmark-container">
         <a class="bookmark-screenshot" href="${href}">
           <img width="${SCREENSHOT_WIDTH}" height="${SCREENSHOT_HEIGHT}" src="${src}" title="Screenshot of ${caption}" />
         </a>
         <a class="bookmark" href="${href}">${caption}</a>
        </p>`
-      );
+          );
 
-      console.log(prefix(), "Valid screenshot", href, src);
+          console.log(prefix(), "Valid screenshot", href, src);
+          return callback();
+        }
+      );
+    })
+    .catch(function (e) {
+      console.log(prefix(), "Invalid HREF", href, e && e.message);
       return callback();
-    }
-  );
+    });
 }
 
 module.exports = {

--- a/app/helper/screenshot/index.js
+++ b/app/helper/screenshot/index.js
@@ -4,6 +4,7 @@ const fs = require("fs-extra");
 const Bottleneck = require("bottleneck");
 const retry = require("./retry");
 const clfdate = require("helper/clfdate");
+const { assertPublicHttpUrl } = require("helper/ssrf");
 
 const prefix = () => `${clfdate()} Screenshot:`;
 
@@ -34,6 +35,59 @@ const limiter = new Bottleneck({
   maxConcurrent: CONCURRENT_SCREENSHOTS,
   minTime: MIN_TIME_BETWEEN_OPS,
 });
+
+async function attachRequestFilter(page) {
+  const cache = new Map();
+
+  await page.setRequestInterception(true);
+
+  page.on("request", async (request) => {
+    try {
+      const url = request.url();
+
+      if (url === "about:blank") {
+        await request.continue();
+        return;
+      }
+
+      let parsed;
+      try {
+        parsed = new URL(url);
+      } catch (e) {
+        await request.abort("blockedbyclient");
+        return;
+      }
+
+      if (parsed.protocol === "data:" || parsed.protocol === "blob:") {
+        if (request.isNavigationRequest()) {
+          await request.abort("blockedbyclient");
+        } else {
+          await request.continue();
+        }
+        return;
+      }
+
+      const key = parsed.protocol + "//" + parsed.host;
+      if (!cache.has(key)) {
+        cache.set(key, assertPublicHttpUrl(url));
+      }
+      await cache.get(key);
+      await request.continue();
+    } catch (e) {
+      try {
+        await request.abort("blockedbyclient");
+      } catch (ignored) {}
+    }
+  });
+}
+
+function isBlockedNavigation(error) {
+  const message = (error && error.message) || "";
+  return (
+    (error && error.code === "ERR_SSRF") ||
+    message.includes("ERR_BLOCKED_BY_CLIENT")
+  );
+}
 
 function validateOptions(options) {
   const validatedOptions = { ...options };
@@ -177,6 +231,7 @@ async function takeScreenshot(site, path, options = {}) {
     });
 
     await fs.ensureDir(dirname(path));
+    await attachRequestFilter(page);
 
     console.log(prefix(), "Navigating browser to", site);
     await page.goto(site, {
@@ -189,7 +244,9 @@ async function takeScreenshot(site, path, options = {}) {
 
   } catch (error) {
     console.error(prefix(), "Error during screenshot:", error);
-    await restart();
+    if (!isBlockedNavigation(error)) {
+      await restart();
+    }
     throw error;
   } finally {
     if (page) {
@@ -212,6 +269,8 @@ async function shutdown() {
 
 // Export main function
 const screenshot = async (site, path, options = {}) => {
+  await assertPublicHttpUrl(site);
+
   try {
     return await retry(() =>
       limiter.schedule(() => takeScreenshot(site, path, options))

--- a/app/helper/screenshot/retry.js
+++ b/app/helper/screenshot/retry.js
@@ -1,3 +1,9 @@
+function isFatal(error) {
+  const message = (error && error.message) || "";
+  const code = (error && error.code) || "";
+  return code === "ERR_SSRF" || message.includes("ERR_BLOCKED_BY_CLIENT");
+}
+
 const retry = async (fn, retries = 3, delay = 1000) => {
   let lastError;
 
@@ -8,13 +14,13 @@ const retry = async (fn, retries = 3, delay = 1000) => {
       lastError = error;
       console.log(`Attempt ${attempt} failed:`, error.message);
 
-      if (attempt < retries) {
-        console.log(`Waiting ${delay}ms before retry...`);
-        await new Promise((resolve) => setTimeout(resolve, delay));
-        console.log("Retrying...");
-      } else {
-        console.log("No more retries left.");
+      if (isFatal(error) || attempt >= retries) {
+        break;
       }
+
+      console.log(`Waiting ${delay}ms before retry...`);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      console.log("Retrying...");
     }
   }
 

--- a/app/helper/screenshot/retry.js
+++ b/app/helper/screenshot/retry.js
@@ -14,7 +14,11 @@ const retry = async (fn, retries = 3, delay = 1000) => {
       lastError = error;
       console.log(`Attempt ${attempt} failed:`, error.message);
 
-      if (isFatal(error) || attempt >= retries) {
+      if (isFatal(error)) {
+        throw error;
+      }
+
+      if (attempt >= retries) {
         break;
       }
 

--- a/app/helper/screenshot/tests/index.js
+++ b/app/helper/screenshot/tests/index.js
@@ -29,6 +29,10 @@ describe("screenshot plugin", function () {
       next();
     });
 
+    app.get("/redir-meta", (req, res) => {
+      res.redirect("http://169.254.169.254/latest/meta-data/");
+    });
+
     app.get("/", (req, res) => {
       console.log("sending response");
       res.send(
@@ -65,6 +69,25 @@ describe("screenshot plugin", function () {
     }
 
     fs.unlinkSync(path);
+  });
+
+  it("rejects file URLs", async function () {
+    await expectAsync(screenshot("file:///etc/passwd", path)).toBeRejected();
+    expect(fs.existsSync(path)).toBe(false);
+  });
+
+  it("rejects link-local metadata URLs", async function () {
+    await expectAsync(
+      screenshot("http://169.254.169.254/latest/meta-data/", path)
+    ).toBeRejected();
+    expect(fs.existsSync(path)).toBe(false);
+  });
+
+  it("does not follow a navigation redirect onto a link-local address", async function () {
+    await expectAsync(
+      screenshot(`http://localhost:${port}/redir-meta`, path)
+    ).toBeRejected();
+    expect(fs.existsSync(path)).toBe(false);
   });
 
   it("handles browser restarts smoothly", async function () {

--- a/app/helper/ssrf/index.js
+++ b/app/helper/ssrf/index.js
@@ -1,0 +1,141 @@
+const dns = require("dns");
+const http = require("http");
+const https = require("https");
+const { isIP } = require("net");
+const config = require("config");
+const { isPrivateIP, isLoopback } = require("./isPrivateIP");
+
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+function allowLoopbackDefault() {
+  return config.environment !== "production";
+}
+
+function ssrfError(target, reason) {
+  const err = new Error("Blocked request to " + target + ": " + reason);
+  err.code = "ERR_SSRF";
+  return err;
+}
+
+function parseHttpUrl(input) {
+  if (!input || typeof input !== "string") {
+    throw new Error("URL is required");
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(input);
+  } catch (e) {
+    throw new Error("Could not parse " + input);
+  }
+
+  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+    throw new Error("Has unsupported protocol " + input);
+  }
+
+  if (!parsed.hostname) {
+    throw new Error("Has no host " + input);
+  }
+
+  return parsed;
+}
+
+function addressesAllowed(addresses, allowLoopback) {
+  const ips = addresses
+    .map(function (item) {
+      return typeof item === "string" ? item : item && item.address;
+    })
+    .filter(Boolean);
+
+  if (!ips.length) return false;
+
+  if (!ips.some(isPrivateIP)) return true;
+
+  return !!(allowLoopback && ips.every(isLoopback));
+}
+
+function checkHostnameAddresses(hostname, addresses, allowLoopback) {
+  if (!addresses || !addresses.length || !addressesAllowed(addresses, allowLoopback)) {
+    const ips = (addresses || [])
+      .map(function (item) {
+        return typeof item === "string" ? item : item && item.address;
+      })
+      .filter(Boolean)
+      .join(", ");
+    throw ssrfError(
+      hostname,
+      ips ? "Resolves to private address " + ips : "No usable addresses"
+    );
+  }
+}
+
+async function resolveAddresses(hostname, lookupFn) {
+  if (lookupFn) {
+    const result = await lookupFn(hostname, { all: true });
+    return Array.isArray(result) ? result : [result];
+  }
+
+  return dns.promises.lookup(hostname, { all: true, verbatim: true });
+}
+
+async function assertPublicHttpUrl(input, options) {
+  options = options || {};
+  const parsed = parseHttpUrl(input);
+  const allowLoopback =
+    options.allowLoopback !== undefined
+      ? options.allowLoopback
+      : allowLoopbackDefault();
+  const hostname = parsed.hostname;
+
+  if (isIP(hostname)) {
+    checkHostnameAddresses(hostname, [hostname], allowLoopback);
+    return parsed;
+  }
+
+  const addresses = await resolveAddresses(hostname, options.lookup);
+  checkHostnameAddresses(hostname, addresses, allowLoopback);
+  return parsed;
+}
+
+function safeLookup(hostname, options, callback) {
+  if (typeof options === "function") {
+    callback = options;
+    options = {};
+  }
+
+  const allowLoopback = allowLoopbackDefault();
+
+  dns.lookup(hostname, Object.assign({}, options, { all: true }), function (
+    err,
+    addresses
+  ) {
+    if (err) return callback(err);
+
+    try {
+      checkHostnameAddresses(hostname, addresses, allowLoopback);
+    } catch (e) {
+      return callback(e);
+    }
+
+    if (options && options.all) return callback(null, addresses);
+
+    callback(null, addresses[0].address, addresses[0].family);
+  });
+}
+
+const httpAgent = new http.Agent({ lookup: safeLookup, keepAlive: false });
+const httpsAgent = new https.Agent({ lookup: safeLookup, keepAlive: false });
+
+function requestAgent(parsedURL) {
+  return parsedURL.protocol === "http:" ? httpAgent : httpsAgent;
+}
+
+module.exports = {
+  isPrivateIP,
+  isLoopback,
+  parseHttpUrl,
+  assertPublicHttpUrl,
+  requestAgent,
+  safeLookup,
+  ssrfError,
+};

--- a/app/helper/ssrf/index.js
+++ b/app/helper/ssrf/index.js
@@ -17,6 +17,14 @@ function ssrfError(target, reason) {
   return err;
 }
 
+function hostnameOf(parsed) {
+  let hostname = parsed.hostname || "";
+  if (hostname.charAt(0) === "[" && hostname.charAt(hostname.length - 1) === "]") {
+    hostname = hostname.slice(1, -1);
+  }
+  return hostname;
+}
+
 function parseHttpUrl(input) {
   if (!input || typeof input !== "string") {
     throw new Error("URL is required");
@@ -33,7 +41,7 @@ function parseHttpUrl(input) {
     throw new Error("Has unsupported protocol " + input);
   }
 
-  if (!parsed.hostname) {
+  if (!hostnameOf(parsed)) {
     throw new Error("Has no host " + input);
   }
 
@@ -85,7 +93,7 @@ async function assertPublicHttpUrl(input, options) {
     options.allowLoopback !== undefined
       ? options.allowLoopback
       : allowLoopbackDefault();
-  const hostname = parsed.hostname;
+  const hostname = hostnameOf(parsed);
 
   if (isIP(hostname)) {
     checkHostnameAddresses(hostname, [hostname], allowLoopback);
@@ -104,6 +112,20 @@ function safeLookup(hostname, options, callback) {
   }
 
   const allowLoopback = allowLoopbackDefault();
+  hostname = hostnameOf({ hostname: hostname });
+
+  if (isIP(hostname)) {
+    try {
+      checkHostnameAddresses(hostname, [hostname], allowLoopback);
+    } catch (e) {
+      return callback(e);
+    }
+    const family = isIP(hostname);
+    if (options && options.all) {
+      return callback(null, [{ address: hostname, family: family }]);
+    }
+    return callback(null, hostname, family);
+  }
 
   dns.lookup(hostname, Object.assign({}, options, { all: true }), function (
     err,
@@ -123,8 +145,36 @@ function safeLookup(hostname, options, callback) {
   });
 }
 
-const httpAgent = new http.Agent({ lookup: safeLookup, keepAlive: false });
-const httpsAgent = new https.Agent({ lookup: safeLookup, keepAlive: false });
+function guardConnect(options) {
+  const host = options && (options.host || options.hostname);
+  if (!host) return;
+  const hostname = hostnameOf({ hostname: host });
+  if (!isIP(hostname)) return;
+  checkHostnameAddresses(hostname, [hostname], allowLoopbackDefault());
+}
+
+function createGuardedAgent(Agent) {
+  const agent = new Agent({ lookup: safeLookup, keepAlive: false });
+  const original = agent.createConnection;
+  agent.createConnection = function (options, callback) {
+    try {
+      guardConnect(options);
+    } catch (err) {
+      if (typeof callback === "function") {
+        process.nextTick(function () {
+          callback(err);
+        });
+        return;
+      }
+      throw err;
+    }
+    return original.call(this, options, callback);
+  };
+  return agent;
+}
+
+const httpAgent = createGuardedAgent(http.Agent);
+const httpsAgent = createGuardedAgent(https.Agent);
 
 function requestAgent(parsedURL) {
   return parsedURL.protocol === "http:" ? httpAgent : httpsAgent;

--- a/app/helper/ssrf/isPrivateIP.js
+++ b/app/helper/ssrf/isPrivateIP.js
@@ -38,7 +38,7 @@ function hexPairToIPv4(high, low) {
 function embeddedIPv4(ip) {
   const lower = String(ip).toLowerCase();
 
-  const dotted = lower.match(/^(?::ffff:|64:ff9b::)(\d+\.\d+\.\d+\.\d+)$/);
+  const dotted = lower.match(/^(?:::ffff:|64:ff9b::)(\d+\.\d+\.\d+\.\d+)$/);
   if (dotted && isIP(dotted[1]) === 4) return dotted[1];
 
   const mappedHex = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);

--- a/app/helper/ssrf/isPrivateIP.js
+++ b/app/helper/ssrf/isPrivateIP.js
@@ -1,0 +1,74 @@
+const { BlockList, isIP } = require("net");
+
+const privateV4 = new BlockList();
+privateV4.addSubnet("0.0.0.0", 8, "ipv4");
+privateV4.addSubnet("10.0.0.0", 8, "ipv4");
+privateV4.addSubnet("100.64.0.0", 10, "ipv4");
+privateV4.addSubnet("127.0.0.0", 8, "ipv4");
+privateV4.addSubnet("169.254.0.0", 16, "ipv4");
+privateV4.addSubnet("172.16.0.0", 12, "ipv4");
+privateV4.addSubnet("192.168.0.0", 16, "ipv4");
+
+const privateV6 = new BlockList();
+privateV6.addAddress("::", "ipv6");
+privateV6.addAddress("::1", "ipv6");
+privateV6.addSubnet("fc00::", 7, "ipv6");
+privateV6.addSubnet("fe80::", 10, "ipv6");
+
+const loopbackV4 = new BlockList();
+loopbackV4.addSubnet("127.0.0.0", 8, "ipv4");
+
+const loopbackV6 = new BlockList();
+loopbackV6.addAddress("::1", "ipv6");
+
+function stripZone(ip) {
+  const idx = String(ip).indexOf("%");
+  return idx === -1 ? ip : ip.slice(0, idx);
+}
+
+function hexPairToIPv4(high, low) {
+  const a = parseInt(high, 16);
+  const b = parseInt(low, 16);
+  if (Number.isNaN(a) || Number.isNaN(b)) return null;
+  return [(a >> 8) & 255, a & 255, (b >> 8) & 255, b & 255].join(".");
+}
+
+// Unwrap IPv4-mapped and well-known NAT64 addresses so ::ffff:127.0.0.1
+// is treated the same as 127.0.0.1.
+function embeddedIPv4(ip) {
+  const lower = String(ip).toLowerCase();
+
+  const dotted = lower.match(/^(?::ffff:|64:ff9b::)(\d+\.\d+\.\d+\.\d+)$/);
+  if (dotted && isIP(dotted[1]) === 4) return dotted[1];
+
+  const mappedHex = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (mappedHex) return hexPairToIPv4(mappedHex[1], mappedHex[2]);
+
+  const nat64Hex = lower.match(/^64:ff9b::([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (nat64Hex) return hexPairToIPv4(nat64Hex[1], nat64Hex[2]);
+
+  return null;
+}
+
+function classify(ip, v4List, v6List) {
+  if (!ip) return false;
+  ip = stripZone(ip);
+  const version = isIP(ip);
+  if (version === 4) return v4List.check(ip, "ipv4");
+  if (version === 6) {
+    if (v6List.check(ip, "ipv6")) return true;
+    const v4 = embeddedIPv4(ip);
+    return v4 ? classify(v4, v4List, v6List) : false;
+  }
+  return false;
+}
+
+function isPrivateIP(ip) {
+  return classify(ip, privateV4, privateV6);
+}
+
+function isLoopback(ip) {
+  return classify(ip, loopbackV4, loopbackV6);
+}
+
+module.exports = { isPrivateIP, isLoopback };

--- a/app/helper/ssrf/tests.js
+++ b/app/helper/ssrf/tests.js
@@ -3,7 +3,7 @@ const {
   isLoopback,
   parseHttpUrl,
   assertPublicHttpUrl,
-} = require("../index");
+} = require("helper/ssrf");
 
 function expectRejectedWith(promise, matcher) {
   return promise.then(

--- a/app/helper/ssrf/tests.js
+++ b/app/helper/ssrf/tests.js
@@ -1,0 +1,189 @@
+const {
+  isPrivateIP,
+  isLoopback,
+  parseHttpUrl,
+  assertPublicHttpUrl,
+} = require("../index");
+
+function expectRejectedWith(promise, matcher) {
+  return promise.then(
+    function () {
+      throw new Error("Expected promise to reject");
+    },
+    function (err) {
+      if (typeof matcher === "function") matcher(err);
+      else if (matcher) expect(err.code).toEqual(matcher);
+    }
+  );
+}
+
+describe("ssrf helper", function () {
+  describe("isPrivateIP", function () {
+    it("flags loopback, RFC1918, link-local, and CGNAT IPv4 ranges", function () {
+      [
+        "0.0.0.0",
+        "10.0.0.5",
+        "100.64.0.1",
+        "100.100.100.200",
+        "127.0.0.1",
+        "127.0.0.2",
+        "169.254.169.254",
+        "172.16.0.1",
+        "172.31.255.255",
+        "192.168.1.1",
+      ].forEach(function (ip) {
+        expect(isPrivateIP(ip)).toBe(true);
+      });
+    });
+
+    it("allows public IPv4 addresses", function () {
+      ["1.1.1.1", "8.8.8.8", "93.184.216.34", "172.15.0.1", "172.32.0.1"].forEach(
+        function (ip) {
+          expect(isPrivateIP(ip)).toBe(false);
+        }
+      );
+    });
+
+    it("flags IPv6 loopback, unique-local, and link-local", function () {
+      ["::", "::1", "fc00::1", "fd12:3456:789a::1", "fe80::1"].forEach(function (
+        ip
+      ) {
+        expect(isPrivateIP(ip)).toBe(true);
+      });
+    });
+
+    it("unwraps IPv4-mapped and NAT64 encodings of private addresses", function () {
+      expect(isPrivateIP("::ffff:127.0.0.1")).toBe(true);
+      expect(isPrivateIP("::ffff:169.254.169.254")).toBe(true);
+      expect(isPrivateIP("::ffff:7f00:1")).toBe(true);
+      expect(isPrivateIP("64:ff9b::169.254.169.254")).toBe(true);
+      expect(isPrivateIP("::ffff:8.8.8.8")).toBe(false);
+    });
+  });
+
+  describe("isLoopback", function () {
+    it("matches only loopback addresses", function () {
+      expect(isLoopback("127.0.0.1")).toBe(true);
+      expect(isLoopback("127.255.255.255")).toBe(true);
+      expect(isLoopback("::1")).toBe(true);
+      expect(isLoopback("::ffff:127.0.0.1")).toBe(true);
+      expect(isLoopback("10.0.0.1")).toBe(false);
+      expect(isLoopback("169.254.169.254")).toBe(false);
+      expect(isLoopback("8.8.8.8")).toBe(false);
+    });
+  });
+
+  describe("parseHttpUrl", function () {
+    it("accepts http and https URLs with a host", function () {
+      expect(parseHttpUrl("https://example.com/x").hostname).toEqual("example.com");
+      expect(parseHttpUrl("http://example.com:8080/x").port).toEqual("8080");
+    });
+
+    it("rejects missing hosts and non-http schemes", function () {
+      expect(function () {
+        parseHttpUrl("file:///etc/passwd");
+      }).toThrow();
+      expect(function () {
+        parseHttpUrl("chrome://version");
+      }).toThrow();
+      expect(function () {
+        parseHttpUrl("data:text/html,hello");
+      }).toThrow();
+      expect(function () {
+        parseHttpUrl("javascript:alert(1)");
+      }).toThrow();
+      expect(function () {
+        parseHttpUrl("ftp://example.com/file");
+      }).toThrow();
+      expect(function () {
+        parseHttpUrl("http://");
+      }).toThrow();
+      expect(function () {
+        parseHttpUrl("not a url");
+      }).toThrow();
+    });
+  });
+
+  describe("assertPublicHttpUrl", function () {
+    it("rejects private and link-local IP literals even when loopback is allowed", async function () {
+      await expectRejectedWith(
+        assertPublicHttpUrl("http://169.254.169.254/latest/meta-data/", {
+          allowLoopback: true,
+        }),
+        "ERR_SSRF"
+      );
+      await expectRejectedWith(
+        assertPublicHttpUrl("http://10.0.0.5:8080/x", { allowLoopback: true }),
+        "ERR_SSRF"
+      );
+      await expectRejectedWith(
+        assertPublicHttpUrl("http://192.168.1.1/", { allowLoopback: true }),
+        "ERR_SSRF"
+      );
+    });
+
+    it("rejects loopback IP literals when allowLoopback is false", async function () {
+      await expectRejectedWith(
+        assertPublicHttpUrl("http://127.0.0.1:6379/", { allowLoopback: false }),
+        "ERR_SSRF"
+      );
+      await expectRejectedWith(
+        assertPublicHttpUrl("http://[::1]/", { allowLoopback: false }),
+        "ERR_SSRF"
+      );
+    });
+
+    it("allows loopback IP literals when allowLoopback is true", async function () {
+      await assertPublicHttpUrl("http://127.0.0.1:8919/foo", {
+        allowLoopback: true,
+      });
+      await assertPublicHttpUrl("http://[::1]/", { allowLoopback: true });
+    });
+
+    it("allows public IP literals", async function () {
+      await assertPublicHttpUrl("http://8.8.8.8/", { allowLoopback: false });
+    });
+
+    it("rejects hosts that resolve to a private address", async function () {
+      await expectRejectedWith(
+        assertPublicHttpUrl("http://metadata.internal/", {
+          allowLoopback: false,
+          lookup: async function () {
+            return [{ address: "169.254.169.254", family: 4 }];
+          },
+        }),
+        "ERR_SSRF"
+      );
+    });
+
+    it("rejects dual-homed hosts that include a private address", async function () {
+      await expectRejectedWith(
+        assertPublicHttpUrl("http://mixed.example/", {
+          allowLoopback: false,
+          lookup: async function () {
+            return [
+              { address: "8.8.8.8", family: 4 },
+              { address: "10.0.0.1", family: 4 },
+            ];
+          },
+        }),
+        "ERR_SSRF"
+      );
+    });
+
+    it("allows hosts that resolve only to public addresses", async function () {
+      await assertPublicHttpUrl("http://images.example/photo.jpg", {
+        allowLoopback: false,
+        lookup: async function () {
+          return [{ address: "93.184.216.34", family: 4 }];
+        },
+      });
+    });
+
+    it("allows localhost in development via DNS when loopback is permitted", async function () {
+      await assertPublicHttpUrl("http://localhost:8919/foo.html", {
+        allowLoopback: true,
+      });
+    });
+  });
+});

--- a/app/helper/transformer/download/index.js
+++ b/app/helper/transformer/download/index.js
@@ -17,6 +17,7 @@ const CACHE_CONTROL = "cache-control";
 
 const MAX_REDIRECTS = 5;
 const TIMEOUT = 5000; // 5s
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
 const debug = function () {}; // console.log || noop for debugging
 
@@ -46,8 +47,7 @@ module.exports = function (url, headers, callback) {
       })
     },
     agent: requestAgent,
-    redirect: "follow",
-    follow: MAX_REDIRECTS,
+    redirect: "manual",
     timeout: TIMEOUT
   };
 
@@ -59,7 +59,7 @@ module.exports = function (url, headers, callback) {
   assertPublicHttpUrl(url)
     .then(() => {
       file = createWriteStream(path);
-      return fetch(url, options);
+      return fetchFollowingRedirects(url, options, MAX_REDIRECTS);
     })
     .then(res => {
       debug("Received response:");
@@ -119,6 +119,24 @@ module.exports = function (url, headers, callback) {
       callback(err);
     });
 };
+
+function fetchFollowingRedirects(url, options, hopsLeft) {
+  return fetch(url, options).then(function (res) {
+    if (!REDIRECT_STATUSES.has(res.status)) return res;
+
+    if (hopsLeft <= 0) throw new Error("Too many redirects");
+
+    const location = res.headers.get("location");
+    if (!location) throw new Error("Redirect missing Location");
+
+    if (res.body && typeof res.body.resume === "function") res.body.resume();
+
+    const next = new URL(location, url).toString();
+    return assertPublicHttpUrl(next).then(function () {
+      return fetchFollowingRedirects(next, options, hopsLeft - 1);
+    });
+  });
+}
 
 function isFresh (existing) {
   return (

--- a/app/helper/transformer/download/index.js
+++ b/app/helper/transformer/download/index.js
@@ -8,6 +8,7 @@ const tempDir = require("helper/tempDir")();
 const nameFrom = require("helper/nameFrom");
 const tidy = require("./tidy");
 const invalid = require("./invalid");
+const { assertPublicHttpUrl, requestAgent } = require("helper/ssrf");
 
 const IF_NONE_MATCH = "If-None-Match";
 const IF_MODIFIED_SINCE = "If-Modified-Since";
@@ -35,7 +36,6 @@ module.exports = function (url, headers, callback) {
   callback = callOnce(callback);
 
   const path = tempDir + UID(6) + "-" + nameFrom(url);
-  const file = createWriteStream(path);
 
   const options = {
     headers: {
@@ -45,6 +45,7 @@ module.exports = function (url, headers, callback) {
         [IF_MODIFIED_SINCE]: headers[LAST_MODIFIED]
       })
     },
+    agent: requestAgent,
     redirect: "follow",
     follow: MAX_REDIRECTS,
     timeout: TIMEOUT
@@ -53,7 +54,13 @@ module.exports = function (url, headers, callback) {
   debug("Downloading", url, "to", path, "with fetch headers:");
   debug(print(options.headers));
 
-  fetch(url, options)
+  let file;
+
+  assertPublicHttpUrl(url)
+    .then(() => {
+      file = createWriteStream(path);
+      return fetch(url, options);
+    })
     .then(res => {
       debug("Received response:");
 
@@ -107,7 +114,7 @@ module.exports = function (url, headers, callback) {
     })
     .catch(err => {
       debug("Download error:", err);
-      file.close();
+      if (file) file.close();
       fs.unlink(path).catch(() => {});
       callback(err);
     });

--- a/app/helper/transformer/download/invalid.js
+++ b/app/helper/transformer/download/invalid.js
@@ -1,20 +1,11 @@
-var protocols = ["http:", "https:"];
-var Url = require("url");
+var { parseHttpUrl } = require("helper/ssrf");
 
 function invalid(url) {
-  var parsed;
-
   try {
-    parsed = Url.parse(url);
+    parseHttpUrl(url);
   } catch (e) {
-    return new Error("Could not parse " + url);
+    return e instanceof Error ? e : new Error("Could not parse " + url);
   }
-
-  if (!parsed.host || !parsed.protocol)
-    return new Error("Has no host or protocol " + url);
-
-  if (protocols.indexOf(parsed.protocol) === -1)
-    return new Error("Has unsupported protocol " + url);
 
   return false;
 }

--- a/app/helper/transformer/download/tests.js
+++ b/app/helper/transformer/download/tests.js
@@ -1,0 +1,65 @@
+const http = require("http");
+const fs = require("fs");
+const download = require("./index");
+
+describe("transformer download", function () {
+  it("rejects file URLs before fetching", function (done) {
+    download("file:///etc/passwd", {}, function (err) {
+      expect(err).toBeTruthy();
+      expect(err.message).toMatch(/Invalid URL/);
+      done();
+    });
+  });
+
+  it("rejects link-local IP literals", function (done) {
+    download("http://169.254.169.254/latest/meta-data/", {}, function (err) {
+      expect(err).toBeTruthy();
+      expect(err.code).toEqual("ERR_SSRF");
+      done();
+    });
+  });
+
+  it("does not follow a redirect onto a link-local address", function (done) {
+    const server = http.createServer(function (req, res) {
+      res.statusCode = 302;
+      res.setHeader("Location", "http://169.254.169.254/latest/meta-data/");
+      res.end();
+    });
+
+    server.listen(0, "127.0.0.1", function () {
+      const port = server.address().port;
+      const url = "http://127.0.0.1:" + port + "/redir";
+
+      download(url, {}, function (err, path) {
+        server.close();
+        expect(err).toBeTruthy();
+        expect(err.code).toEqual("ERR_SSRF");
+        expect(path).toBeFalsy();
+        done();
+      });
+    });
+  });
+
+  it("still downloads from a local test origin", function (done) {
+    const body = "hello-ssrf";
+    const server = http.createServer(function (req, res) {
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "text/plain");
+      res.end(body);
+    });
+
+    server.listen(0, "127.0.0.1", function () {
+      const port = server.address().port;
+      const url = "http://127.0.0.1:" + port + "/ok";
+
+      download(url, {}, function (err, path) {
+        server.close();
+        if (err) return done.fail(err);
+        expect(path).toBeTruthy();
+        expect(fs.readFileSync(path, "utf8")).toEqual(body);
+        fs.unlinkSync(path);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Both reports are valid. They are the same class of bug: user-controlled URLs are fetched server-side with only a syntactic `http:`/`https:` check, so `file:`, loopback, RFC1918, and link-local/metadata addresses go through. The screenshot path is the more severe of the two because Chrome will load `file:` and the PNG is written to the blog’s public static dir.

## Are they both valid?

**Yes.**

1. **`.webloc` screenshots (HIGH)** — `Url.parse(href)` in a try/catch rejects almost nothing (`url.parse` does not throw). The href is passed to puppeteer `page.goto` with `--no-sandbox`. A `.webloc` pointing at `file:///etc/passwd`, `http://169.254.169.254/…`, or `http://127.0.0.1:6379/` is screenshotted and published on the attacker’s CDN URL.

2. **Image/thumbnail downloader (HIGH)** — `invalid.js` only checks protocol + host. `node-fetch` follows redirects, so `![](http://10.0.0.5/x)` or an open redirect to the metadata service becomes an internal request. Impact is a status/timing oracle (and a content leak if the response happens to parse as an image).

## Shared helper vs a third-party library

A **shared helper**, not a fetch-specific library. `got-ssrf` / `ssrf-req-filter` only wrap one HTTP client and would not cover puppeteer. `private-ip` is just classification; Node’s `net.BlockList` + `dns.lookup` is enough.

`helper/ssrf`:

- Allowlists `http:` / `https:` (blocks `file:`, `chrome:`, `data:`, `javascript:`, …)
- Resolves the hostname and rejects loopback, RFC1918, link-local (`169.254.0.0/16`), and CGNAT (`100.64.0.0/10`), including IPv4-mapped IPv6 (`::ffff:127.0.0.1`)
- Download path: `redirect: "manual"` so each `Location` is re-checked (Node skips `dns.lookup` for IP literals, so an agent-only hook is not enough); custom agents still pin lookup + `createConnection` to catch DNS rebinding
- Puppeteer: fail-fast `assertPublicHttpUrl` before `goto`, plus a request interceptor so redirects/subresources cannot jump to `file:` or a private host

Loopback (`127.0.0.0/8`, `::1`) is allowed only when `config.environment !== "production"` so existing localhost tests and local screenshotting still work. Production blocks it. Link-local and RFC1918 are blocked in every environment.

## Tests

- `app/helper/ssrf`: 15 specs covering schemes, ranges, mapped IPv6, dual-homed DNS, production vs development loopback
- `app/helper/transformer/download`: file URLs, metadata IPs, 302 → `169.254.169.254`, happy-path local download
- `app/helper/transformer`: existing URL cache/304 tests still pass
- `app/helper/screenshot`: hash still matches with interception; `file:` and metadata URLs rejected; navigation redirect to link-local aborted (`ERR_BLOCKED_BY_CLIENT`)

## Remaining call site

Dashboard import (`app/dashboard/site/import/helper/download_images.js`) fetches user URLs with global `fetch` and has the same gap. Not in these two reports; can reuse `assertPublicHttpUrl` in a follow-up.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a573352-07ca-4818-92f4-b93dc88a2a48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a573352-07ca-4818-92f4-b93dc88a2a48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

