### PR TITLE
Block SSRF via bookmark screenshots and the image downloader

### DIFF
--- a/app/build/plugins/linkScreenshot/index.js
+++ b/app/build/plugins/linkScreenshot/index.js
@@ -1,6 +1,6 @@
-const Url = require("url");
 const { callbackify } = require("util");
 const screenshot = callbackify(require("helper/screenshot"));
+const { assertPublicUrl } = require("helper/publicUrl");
 const { join } = require("path");
 const config = require("config");
 const uuid = require("uuid/v4");
@@ -31,36 +31,43 @@ function render($, callback, { blogID, path }) {
     return callback();
   }
 
-  try {
-    Url.parse(href);
-  } catch (e) {
-    console.log(prefix(), "Invalid HREF");
+  // Reject file://, private/loopback/link-local hosts and the cloud metadata
+  // endpoint before handing the URL to Chrome (SSRF). blockPrivateRequests below
+  // re-checks each request the page makes, including redirects.
+  assertPublicUrl(href).then(runScreenshot, function (e) {
+    console.log(prefix(), "Refusing to screenshot", href, "-", e.message);
     return callback();
-  }
+  });
 
-  screenshot(
-    href,
-    localPathToScreenshot,
-    { width: SCREENSHOT_WIDTH, height: SCREENSHOT_HEIGHT },
-    function (err) {
-      if (err) {
-        console.log(prefix(), "Error fetching screenshot", err);
-        return callback();
-      }
+  function runScreenshot() {
+    screenshot(
+      href,
+      localPathToScreenshot,
+      {
+        width: SCREENSHOT_WIDTH,
+        height: SCREENSHOT_HEIGHT,
+        blockPrivateRequests: true
+      },
+      function (err) {
+        if (err) {
+          console.log(prefix(), "Error fetching screenshot", err);
+          return callback();
+        }
 
-      $.root().html(
-        `<p class="bookmark-container">
+        $.root().html(
+          `<p class="bookmark-container">
         <a class="bookmark-screenshot" href="${href}">
           <img width="${SCREENSHOT_WIDTH}" height="${SCREENSHOT_HEIGHT}" src="${src}" title="Screenshot of ${caption}" />
         </a>
         <a class="bookmark" href="${href}">${caption}</a>
        </p>`
-      );
+        );
 
-      console.log(prefix(), "Valid screenshot", href, src);
-      return callback();
-    }
-  );
+        console.log(prefix(), "Valid screenshot", href, src);
+        return callback();
+      }
+    );
+  }
 }
 
 module.exports = {

--- a/app/helper/publicUrl.js
+++ b/app/helper/publicUrl.js
@@ -1,0 +1,163 @@
+const net = require("net");
+const dns = require("dns");
+const { Agent: HttpAgent } = require("http");
+const { Agent: HttpsAgent } = require("https");
+const config = require("config");
+
+const ALLOWED_PROTOCOLS = ["http:", "https:"];
+
+// Address blocking is enforced in production only. In development the test
+// suite and local tooling legitimately talk to localhost / private services;
+// the exposure the blocking addresses (cloud metadata endpoint, internal
+// services) only exists on the hosted deployment. Overridable for tests.
+let enabled = config.environment === "production";
+const setEnabled = (value) => {
+  enabled = !!value;
+};
+
+// Address ranges that must never be reachable from a server-side fetch:
+// loopback, "this network", RFC1918 private space, CGNAT, link-local (which
+// includes the cloud metadata endpoint 169.254.169.254), benchmarking,
+// multicast, reserved, and their IPv6 equivalents (unspecified, loopback,
+// unique-local, link-local, multicast).
+const blocklist = new net.BlockList();
+
+blocklist.addSubnet("0.0.0.0", 8);
+blocklist.addSubnet("10.0.0.0", 8);
+blocklist.addSubnet("100.64.0.0", 10);
+blocklist.addSubnet("127.0.0.0", 8);
+blocklist.addSubnet("169.254.0.0", 16);
+blocklist.addSubnet("172.16.0.0", 12);
+blocklist.addSubnet("192.0.0.0", 24);
+blocklist.addSubnet("192.168.0.0", 16);
+blocklist.addSubnet("198.18.0.0", 15);
+blocklist.addSubnet("224.0.0.0", 4);
+blocklist.addSubnet("240.0.0.0", 4);
+
+blocklist.addAddress("::", "ipv6");
+blocklist.addAddress("::1", "ipv6");
+blocklist.addSubnet("fc00::", 7, "ipv6");
+blocklist.addSubnet("fe80::", 10, "ipv6");
+blocklist.addSubnet("ff00::", 8, "ipv6");
+
+// Pure classifier, independent of `enabled`. Fails closed: anything that is not
+// a recognisable, routable public IP literal is treated as blocked.
+function isBlockedAddress(address) {
+  let family = net.isIP(address);
+  if (family === 0) return true;
+
+  // Normalise IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) down to plain IPv4 so it
+  // is checked against the IPv4 ranges above.
+  if (
+    family === 6 &&
+    address.toLowerCase().startsWith("::ffff:") &&
+    address.includes(".")
+  ) {
+    address = address.slice(address.lastIndexOf(":") + 1);
+    family = net.isIP(address);
+    if (family === 0) return true;
+  }
+
+  return blocklist.check(address, family === 6 ? "ipv6" : "ipv4");
+}
+
+// For helper/transformer/download/invalid.js: is this host, given as an IP
+// literal, one we must refuse? Hostnames are left to safeLookup below.
+function isBlockedHostLiteral(hostname) {
+  if (!enabled) return false;
+  hostname = (hostname || "").replace(/^\[|\]$/g, "");
+  return net.isIP(hostname) !== 0 && isBlockedAddress(hostname);
+}
+
+// A dns.lookup-compatible function that rejects when the hostname resolves to a
+// blocked address. Passed as the `lookup` option to the fetch agents below so
+// the check runs against the address actually connected to — on the initial
+// request, on every redirect hop, and defeating DNS rebinding.
+function safeLookup(hostname, options, callback) {
+  if (typeof options === "function") {
+    callback = options;
+    options = {};
+  }
+
+  dns.lookup(hostname, { ...options, all: true }, (err, addresses) => {
+    if (err) return callback(err);
+
+    if (enabled) {
+      for (const { address } of addresses) {
+        if (isBlockedAddress(address)) {
+          return callback(
+            new Error(
+              "Refusing to connect to blocked address " +
+                address +
+                " (" +
+                hostname +
+                ")"
+            )
+          );
+        }
+      }
+    }
+
+    if (options.all) return callback(null, addresses);
+    callback(null, addresses[0].address, addresses[0].family);
+  });
+}
+
+const httpAgent = new HttpAgent({ lookup: safeLookup });
+const httpsAgent = new HttpsAgent({ lookup: safeLookup });
+
+// For node-fetch's `agent` option, which is called with the (possibly
+// post-redirect) parsed URL.
+function agent(url) {
+  return url.protocol === "https:" ? httpsAgent : httpAgent;
+}
+
+// Pre-flight guard for a single URL: rejects unless it is an http(s) URL whose
+// host is, or resolves to, a public address. Callers that then perform the
+// request through their own client (e.g. Chrome) should still guard each
+// request, as this check is subject to TOCTOU on its own.
+async function assertPublicUrl(url) {
+  let parsed;
+
+  try {
+    parsed = new URL(url);
+  } catch (e) {
+    throw new Error("Invalid URL " + url);
+  }
+
+  if (!ALLOWED_PROTOCOLS.includes(parsed.protocol))
+    throw new Error("Unsupported protocol " + parsed.protocol + " in " + url);
+
+  if (!enabled) return parsed;
+
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
+
+  if (net.isIP(hostname)) {
+    if (isBlockedAddress(hostname))
+      throw new Error("Blocked address " + hostname + " in " + url);
+    return parsed;
+  }
+
+  const addresses = await dns.promises.lookup(hostname, { all: true });
+
+  if (addresses.length === 0) throw new Error("Could not resolve " + hostname);
+
+  for (const { address } of addresses) {
+    if (isBlockedAddress(address))
+      throw new Error(
+        "Host " + hostname + " resolves to blocked address " + address
+      );
+  }
+
+  return parsed;
+}
+
+module.exports = {
+  assertPublicUrl,
+  isBlockedAddress,
+  isBlockedHostLiteral,
+  safeLookup,
+  agent,
+  blocklist,
+  setEnabled
+};

--- a/app/helper/screenshot/blockPrivateRequests.js
+++ b/app/helper/screenshot/blockPrivateRequests.js
@@ -1,0 +1,23 @@
+const { assertPublicUrl } = require("helper/publicUrl");
+
+// Chrome does its own DNS resolution and redirect following, so a pre-flight
+// check on the target URL alone can be bypassed by a redirect or a subresource
+// request. Intercept every request the page makes and drop anything that isn't
+// an http(s) URL resolving to a public address — this blocks file://, private
+// ranges and the cloud metadata endpoint. data:/blob: carry no network request
+// and are left alone.
+module.exports = async (page) => {
+  await page.setRequestInterception(true);
+
+  page.on("request", (request) => {
+    const url = request.url();
+
+    if (url.startsWith("data:") || url.startsWith("blob:"))
+      return request.continue().catch(() => {});
+
+    assertPublicUrl(url).then(
+      () => request.continue().catch(() => {}),
+      () => request.abort("blockedbyclient").catch(() => {})
+    );
+  });
+};

--- a/app/helper/screenshot/index.js
+++ b/app/helper/screenshot/index.js
@@ -3,6 +3,7 @@ const { dirname } = require("path");
 const fs = require("fs-extra");
 const Bottleneck = require("bottleneck");
 const retry = require("./retry");
+const blockPrivateRequests = require("./blockPrivateRequests");
 const clfdate = require("helper/clfdate");
 
 const prefix = () => `${clfdate()} Screenshot:`;
@@ -168,6 +169,9 @@ async function takeScreenshot(site, path, options = {}) {
 
     page = await browser.newPage();
     await page.setUserAgent(DEFAULT_USER_AGENT);
+
+    // Opt-in SSRF guard for untrusted URLs (e.g. bookmark screenshots).
+    if (options.blockPrivateRequests) await blockPrivateRequests(page);
 
     const viewport = options.mobile ? VIEWPORT.mobile : VIEWPORT.desktop;
     await page.setViewport({

--- a/app/helper/tests/publicUrl.js
+++ b/app/helper/tests/publicUrl.js
@@ -1,0 +1,61 @@
+describe("publicUrl", function () {
+  const publicUrl = require("helper/publicUrl");
+  const { assertPublicUrl, isBlockedAddress } = publicUrl;
+
+  const BLOCKED = [
+    "127.0.0.1",
+    "0.0.0.0",
+    "10.1.2.3",
+    "172.16.5.5",
+    "192.168.1.1",
+    "169.254.169.254", // cloud metadata endpoint
+    "100.64.0.1", // CGNAT
+    "::1",
+    "::ffff:127.0.0.1", // IPv4-mapped loopback
+    "fe80::1", // link-local
+    "fd00::1" // unique-local
+  ];
+
+  const PUBLIC = ["8.8.8.8", "1.1.1.1", "2606:2800:220:1:248:1893:25c8:1946"];
+
+  it("flags private, loopback and link-local addresses", function () {
+    BLOCKED.forEach((ip) => expect(isBlockedAddress(ip)).toBe(true));
+  });
+
+  it("allows routable public addresses", function () {
+    PUBLIC.forEach((ip) => expect(isBlockedAddress(ip)).toBe(false));
+  });
+
+  it("fails closed on anything that is not an IP literal", function () {
+    expect(isBlockedAddress("not-an-ip")).toBe(true);
+    expect(isBlockedAddress("")).toBe(true);
+  });
+
+  it("rejects non-http(s) protocols regardless of environment", async function () {
+    await expectAsync(assertPublicUrl("file:///etc/passwd")).toBeRejected();
+    await expectAsync(assertPublicUrl("ftp://example.com/x")).toBeRejected();
+    await expectAsync(assertPublicUrl("data:text/plain,hi")).toBeRejected();
+  });
+
+  describe("when enforcement is enabled", function () {
+    beforeAll(() => publicUrl.setEnabled(true));
+    afterAll(() => publicUrl.setEnabled(false));
+
+    it("rejects http(s) URLs whose host is a blocked IP literal", async function () {
+      await expectAsync(assertPublicUrl("http://127.0.0.1:6379/")).toBeRejected();
+      await expectAsync(
+        assertPublicUrl("http://169.254.169.254/latest/meta-data/")
+      ).toBeRejected();
+      await expectAsync(assertPublicUrl("http://[::1]/")).toBeRejected();
+    });
+
+    it("rejects hostnames that resolve to a blocked address", async function () {
+      // localhost resolves to 127.0.0.1 / ::1 via the hosts file
+      await expectAsync(assertPublicUrl("http://localhost/")).toBeRejected();
+    });
+
+    it("resolves for an http(s) URL with a public host", async function () {
+      await expectAsync(assertPublicUrl("http://8.8.8.8/")).toBeResolved();
+    });
+  });
+});

--- a/app/helper/transformer/download/index.js
+++ b/app/helper/transformer/download/index.js
@@ -6,6 +6,7 @@ const UID = require("helper/makeUid");
 const callOnce = require("helper/callOnce");
 const tempDir = require("helper/tempDir")();
 const nameFrom = require("helper/nameFrom");
+const { agent } = require("helper/publicUrl");
 const tidy = require("./tidy");
 const invalid = require("./invalid");
 
@@ -47,6 +48,9 @@ module.exports = function (url, headers, callback) {
     },
     redirect: "follow",
     follow: MAX_REDIRECTS,
+    // Blocks the request (and every redirect hop) if the host resolves to a
+    // private, loopback or link-local address. See helper/publicUrl.
+    agent,
     timeout: TIMEOUT
   };
 

--- a/app/helper/transformer/download/invalid.js
+++ b/app/helper/transformer/download/invalid.js
@@ -1,5 +1,6 @@
 var protocols = ["http:", "https:"];
 var Url = require("url");
+var { isBlockedHostLiteral } = require("helper/publicUrl");
 
 function invalid(url) {
   var parsed;
@@ -15,6 +16,12 @@ function invalid(url) {
 
   if (protocols.indexOf(parsed.protocol) === -1)
     return new Error("Has unsupported protocol " + url);
+
+  // Reject hosts given as a private/loopback/link-local IP literal. Hostnames
+  // that resolve to such addresses (incl. via redirect or DNS rebinding) are
+  // caught by the fetch agent in helper/publicUrl.
+  if (isBlockedHostLiteral(parsed.hostname))
+    return new Error("Resolves to a private address " + url);
 
   return false;
 }

--- a/app/helper/transformer/download/tests.js
+++ b/app/helper/transformer/download/tests.js
@@ -1,0 +1,39 @@
+describe("transformer/download invalid()", function () {
+  const publicUrl = require("helper/publicUrl");
+  const invalid = require("./invalid");
+
+  it("rejects non-http(s) URLs", function () {
+    ["file:///etc/passwd", "ftp://example.com/x", "data:text/plain,hi"].forEach(
+      (url) => expect(invalid(url) instanceof Error).toBe(true)
+    );
+  });
+
+  it("allows ordinary http(s) URLs", function () {
+    [
+      "https://example.com/image.png",
+      "https://8.8.8.8/image.png",
+      "http://localhost:8919/foo.html"
+    ].forEach((url) => expect(invalid(url)).toBe(false));
+  });
+
+  describe("with SSRF enforcement enabled", function () {
+    beforeAll(() => publicUrl.setEnabled(true));
+    afterAll(() => publicUrl.setEnabled(false));
+
+    it("rejects private/loopback/link-local IP literals", function () {
+      [
+        "http://169.254.169.254/latest/meta-data/", // cloud metadata endpoint
+        "http://127.0.0.1:6379/", // loopback (e.g. redis)
+        "http://[::1]/",
+        "http://10.0.0.5:8080/x",
+        "http://192.168.1.1/x"
+      ].forEach((url) => expect(invalid(url) instanceof Error).toBe(true));
+    });
+
+    it("still allows public IP literals and hostnames", function () {
+      ["https://8.8.8.8/image.png", "https://example.com/image.png"].forEach(
+        (url) => expect(invalid(url)).toBe(false)
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Two paths dereference a URL taken from user-synced content with no check that the destination is a public address, and no re-check across redirects. Both are HIGH.

**1. `.webloc` screenshot → local file read** — [`app/build/plugins/linkScreenshot/index.js`](https://github.com/davidmerfield/blot/blob/master/app/build/plugins/linkScreenshot/index.js)

The `.webloc` href went straight to puppeteer `page.goto()` behind an inert `Url.parse` guard (legacy `url.parse` throws on almost nothing). Chrome runs `--no-sandbox`. A committed `.webloc` pointing at `file:///etc/passwd`, `file:///var/www/blot/config/index.js`, `http://169.254.169.254/latest/meta-data/…` or `http://127.0.0.1:6379/` was screenshotted and published at a CDN URL on the attacker's own blog — a readable exfiltration channel for local files and internal HTTP responses.

**2. SSRF via the image/thumbnail downloader** — [`app/helper/transformer/download/`](https://github.com/davidmerfield/blot/blob/master/app/helper/transformer/download/index.js)

Any `img src` / `thumbnail:` that parsed as http(s) was fetched with `redirect: "follow", follow: 5`; `invalid.js` only checked protocol + host. `![](http://10.0.0.5:8080/x)` or an attacker host that 302s to `169.254.169.254` became an internal request with a status/timing oracle.

## Fix

New shared helper **`app/helper/publicUrl.js`**:

- `isBlockedAddress(ip)` — fail-closed check against loopback / RFC1918 / CGNAT / link-local (incl. `169.254.169.254`) / benchmarking / multicast / reserved and their IPv6 equivalents, via Node core `net.BlockList`. Normalises IPv4-mapped IPv6.
- `assertPublicUrl(url)` — async pre-flight: scheme allowlist (always) + DNS-resolve-and-range-check (when enforced).
- `agent(url)` — `http(s).Agent` with a custom `lookup` that rejects blocked resolved addresses. As `node-fetch`'s `agent` it re-checks **every redirect hop** and the **actual connected IP**, defeating DNS rebinding.
- `isBlockedHostLiteral(hostname)` — sync, for the bare-IP case (`net.connect` skips `lookup` for IP literals).
- Enforcement is **production-only** (`config.environment === "production"`, `setEnabled()` for tests) so local dev and the test suite keep reaching `localhost`. The exposure (cloud metadata endpoint, internal services) only exists on the hosted deployment.

Wiring:

| File | Change |
|---|---|
| `download/invalid.js` | reject private/loopback IP **literals** |
| `download/index.js` | fetch through the guarded `agent` (covers hostnames, redirects, rebinding) |
| `linkScreenshot/index.js` | replace the inert `Url.parse` guard with an `assertPublicUrl(href)` pre-flight; pass `blockPrivateRequests: true` |
| `screenshot/index.js` + new `screenshot/blockPrivateRequests.js` | opt-in Puppeteer request interception — aborts non-http(s) and private-host requests, covering `file://`, redirects and subresources. Internal template screenshots are unaffected. |

No new dependency: `request-filtering-agent` / `ssrf-req-filter` only cover the Node HTTP-client path, not Puppeteer, and the socket-IP check they provide is a few lines here.

## Tests

- `app/helper/tests/publicUrl.js` — address classification (v4/v6/mapped/garbage), protocol rejection, and address blocking under `setEnabled(true)` including a hostname resolving to loopback.
- `app/helper/transformer/download/tests.js` — `invalid()` stays transparent for ordinary URLs in dev; rejects private IP literals + the metadata endpoint when enforcement is on.

Both new spec files pass under jasmine (11 specs, 0 failures). Existing transformer/screenshot specs are unaffected (verified `invalid()` and the agent stay transparent for `localhost` in dev mode). Full suite needs the Docker+redis harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)