### PR TITLE
Fieldnotes: expose Isola colors, type, uploads, and layout as dashboard controls

### DIFF
--- a/app/templates/source/fieldnotes/archives.html
+++ b/app/templates/source/fieldnotes/archives.html
@@ -16,7 +16,7 @@
               <h2>{{year}}</h2>
               {{#months}}
               {{#entries}}
-            <a href="{{{url}}}">{{title}}</a>&nbsp;&nbsp;<span style="color:#777">{{date}}</span>
+            <a href="{{{url}}}">{{title}}</a>{{#date}}&nbsp;&nbsp;<span class="archive-date">{{date}}</span>{{/date}}
               <br>
                 {{/entries}}
                 {{/months}}

--- a/app/templates/source/fieldnotes/article.html
+++ b/app/templates/source/fieldnotes/article.html
@@ -26,12 +26,13 @@
 
 	<footer class="entry-footer">
 		<div class="entry-meta">
+			{{#date}}
 			<span class="posted-on"
 				><a href="{{{url}}}" rel="bookmark"
 					><time
 						class="entry-date published"
 						datetime="{{#formatDate}}YYYY-MM-DD[T]HH:mm:ssZ{{/formatDate}}"
-						>{{#date}}{{date}}{{/date}}</time
+						>{{date}}</time
 					><time
 						class="updated"
 						datetime="{{#formatUpdated}}YYYY-MM-DD[T]HH:mm:ssZ{{/formatUpdated}}"
@@ -39,6 +40,14 @@
 					></a
 				></span
 			>
+			{{/date}}
+			{{#author}}
+			<span class="byline">
+				<span class="author vcard">
+					<a class="url fn n" href="{{{siteURL}}}">{{author}}</a>
+				</span>
+			</span>
+			{{/author}}
 		</div>
 		{{#tags.length}}
 		<span class="tags-links">

--- a/app/templates/source/fieldnotes/entries.html
+++ b/app/templates/source/fieldnotes/entries.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{lang}}">
 {{> head}}
-<body class="home blog">
+<body class="home blog{{#infinite_scroll}} infinite-scroll neverending{{/infinite_scroll}}">
 <div id="page" class="hfeed site">
 	{{> header}}
 	<div id="content" class="site-content">
@@ -10,6 +10,7 @@
 				{{#posts}}
 				{{> article}}
 				{{/posts}}
+				{{^infinite_scroll}}
 				<nav class="navigation paging-navigation" role="navigation">
 					<h1 class="screen-reader-text">Posts navigation</h1>
 					<div class="nav-links">
@@ -27,11 +28,11 @@
 						{{/pagination}}
 					</div><!-- .nav-links -->
 				</nav><!-- .navigation -->
+				{{/infinite_scroll}}
 			</main><!-- #main -->
+			{{#infinite_scroll}}
 			<script type="text/javascript">
 				var init = {{pagination.next}};
-
-				jQuery('main nav').remove();
 
 jQuery(window).on("scroll", function() {
 	var scrollHeight = jQuery(document).height();
@@ -48,6 +49,7 @@ jQuery(window).on("scroll", function() {
 					});
 				}
 </script>
+			{{/infinite_scroll}}
 		</div><!-- #primary -->
 	</div><!-- #content -->
 	{{> footer}}

--- a/app/templates/source/fieldnotes/entries.html
+++ b/app/templates/source/fieldnotes/entries.html
@@ -31,6 +31,7 @@
 				{{/infinite_scroll}}
 			</main><!-- #main -->
 			{{#infinite_scroll}}
+			{{#pagination.next}}
 			<script type="text/javascript">
 				var init = {{pagination.next}};
 
@@ -49,6 +50,7 @@ jQuery(window).on("scroll", function() {
 					});
 				}
 </script>
+			{{/pagination.next}}
 			{{/infinite_scroll}}
 		</div><!-- #primary -->
 	</div><!-- #content -->

--- a/app/templates/source/fieldnotes/entry.html
+++ b/app/templates/source/fieldnotes/entry.html
@@ -34,7 +34,7 @@
 								<div
 									id="jp-relatedposts"
 									class="jp-relatedposts"
-									style="display: block;"
+									{{#show_related_posts}}style="display: block;"{{/show_related_posts}}
 								>
 									<h3 class="jp-relatedposts-headline"><em>Related</em></h3>
 									<div
@@ -44,6 +44,7 @@
 										{{#recent_entries}} {{> related}} {{/recent_entries}}
 									{{#entry}}
 									</div>
+									{{#show_related_posts}}
 									<script type="text/javascript">
 										var related = document.querySelector(
 											".jp-relatedposts-items"
@@ -58,18 +59,20 @@
 											related.removeChild(related.lastChild);
 										}
 									</script>
+									{{/show_related_posts}}
 								</div>
 							</div>
 							<!-- .entry-content -->
 
 							<footer class="entry-footer">
 								<div class="entry-meta">
+									{{#date}}
 									<span class="posted-on"
 										><a href="{{{url}}}" rel="bookmark"
 											><time
 												class="entry-date published"
 												datetime="{{#formatDate}}YYYY-MM-DD[T]HH:mm:ssZ{{/formatDate}}"
-												>{{#date}}{{date}}{{/date}}</time
+												>{{date}}</time
 											><time
 												class="updated"
 												datetime="{{#formatUpdated}}YYYY-MM-DD[T]HH:mm:ssZ{{/formatUpdated}}"
@@ -77,6 +80,14 @@
 											></a
 										></span
 									>
+									{{/date}}
+									{{#author}}
+									<span class="byline">
+										<span class="author vcard">
+											<a class="url fn n" href="{{{siteURL}}}">{{author}}</a>
+										</span>
+									</span>
+									{{/author}}
 								</div>
 								{{#tags.length}}
 								<span class="tags-links">

--- a/app/templates/source/fieldnotes/head.html
+++ b/app/templates/source/fieldnotes/head.html
@@ -12,18 +12,11 @@
 	{{^entry}}<meta name="description" content="{{> description}}">{{/entry}}
 
 	<link rel="profile" href="http://gmpg.org/xfn/11" />
-	<link rel="dns-prefetch" href="//fonts.googleapis.com" />
 	<link rel="alternate" type="application/rss+xml" title="RSS Feed for {{title}}" href="{{{siteURL}}}{{{feedURL}}}">
-	{{#avatar}}<link rel="icon" href="{{{avatar}}}" type="image/x-icon">{{/avatar}}
+	{{#favicon_url}}<link rel="icon" href="{{{favicon_url}}}" type="image/x-icon">{{/favicon_url}}
+	{{^favicon_url}}{{#avatar}}<link rel="icon" href="{{{avatar}}}" type="image/x-icon">{{/avatar}}{{/favicon_url}}
 	<link rel="preconnect" href="{{{cdn}}}" />
 	<link rel="stylesheet" href="{{#cdn}}/style.css{{/cdn}}" type="text/css" media="all" />
-	<link
-		rel="stylesheet"
-		id="isola-source-sans-pro-css"
-		href="https://fonts.googleapis.com/css?family=Source+Sans+Pro%3A400%2C600%2C700%2C300italic%2C400italic%2C600italic%2C700italic&#038;subset=latin%2Clatin-ext&#038;ver=5.3.2"
-		type="text/css"
-		media="all"
-	/>
 
 	{{#entry}}
 	{{#absoluteURL}}

--- a/app/templates/source/fieldnotes/header.html
+++ b/app/templates/source/fieldnotes/header.html
@@ -83,6 +83,11 @@
 		<!-- #site-navigation -->
 	</div>
 	<!-- .site-header-inner -->
+	{{#header_image_url}}
+	<div class="site-header-image">
+		<div></div>
+	</div>
+	{{/header_image_url}}
 </header>
 <!-- #masthead -->
 <div id="toggle-sidebar">

--- a/app/templates/source/fieldnotes/package.json
+++ b/app/templates/source/fieldnotes/package.json
@@ -19,7 +19,6 @@
     },
     "favicon_url": "",
     "header_image_url": "",
-    "sticky_navigation": false,
     "infinite_scroll": true,
     "show_related_posts": true,
     "syntax_highlighter": {

--- a/app/templates/source/fieldnotes/package.json
+++ b/app/templates/source/fieldnotes/package.json
@@ -7,7 +7,28 @@
     "hide_dates": false,
     "date_display": "MMMM D, Y",
     "author": "",
-    "subtitle": ""
+    "subtitle": "",
+    "background_color": "#ffffff",
+    "text_color": "#333333",
+    "link_color": "#44c2b2",
+    "header_background_color": "#efefef",
+    "body_font": {
+      "id": "source-sans",
+      "font_size": 16,
+      "line_height": 1.625
+    },
+    "favicon_url": "",
+    "header_image_url": "",
+    "sticky_navigation": false,
+    "infinite_scroll": true,
+    "show_related_posts": true,
+    "syntax_highlighter": {
+      "id": "stackoverflow-light"
+    },
+    "syntax_highlighter_font": {
+      "id": "courier-new",
+      "font_size": 13
+    }
   },
   "views": {
     "archives.html": {

--- a/app/templates/source/fieldnotes/related.html
+++ b/app/templates/source/fieldnotes/related.html
@@ -30,7 +30,9 @@
 	<p class="jp-relatedposts-post-excerpt">
 		{{summary}}
 	</p>
+	{{#date}}
 	<p class="jp-relatedposts-post-date" style="display: block;">
 		{{date}}
 	</p>
+	{{/date}}
 </div>

--- a/app/templates/source/fieldnotes/style.css
+++ b/app/templates/source/fieldnotes/style.css
@@ -1,5 +1,21 @@
 {{{app_css}}}
 
+{{{body_font.styles}}}
+{{{syntax_highlighter_font.styles}}}
+
+:root {
+	--background-color: {{background_color}};
+	--text-color: {{text_color}};
+	--link-color: {{link_color}};
+	--header-background-color: {{header_background_color}};
+	--muted-color: rgba({{#rgb}}{{text_color}}{{/rgb}}, 0.55);
+	{{#body_font}}
+	--body-font-family: {{{stack}}};
+	--body-font-size: {{{font_size}}}px;
+	--body-line-height: {{{line_height}}};
+	{{/body_font}}
+}
+
 /* START wp emoji */
 
 img.wp-smiley,
@@ -2990,3 +3006,163 @@ div#respond,
 }
 
 /* END relatedposts */
+
+{{{syntax_highlighter.styles}}}
+
+/* Dashboard-controlled Isola theme tokens. Later rules override the
+   hardcoded WordPress/Isola colors and type above. */
+body {
+	background: var(--background-color);
+	color: var(--text-color);
+	font-family: var(--body-font-family);
+	font-size: var(--body-font-size);
+	line-height: var(--body-line-height);
+}
+
+button,
+input,
+select,
+textarea {
+	background: var(--background-color);
+	font-family: var(--body-font-family);
+}
+
+button,
+input[type="button"],
+input[type="reset"],
+input[type="submit"],
+#infinite-handle span {
+	background-color: var(--muted-color);
+	color: var(--background-color);
+}
+
+a,
+a:visited {
+	color: var(--link-color);
+}
+
+a:hover,
+a:focus,
+a:active {
+	color: color-mix(in srgb, var(--link-color) 75%, white);
+}
+
+.site-header {
+	background: var(--header-background-color);
+	{{#sticky_navigation}}
+	position: sticky;
+	top: 0;
+	{{/sticky_navigation}}
+}
+
+{{#header_image_url}}
+.site-header-image div {
+	background-image: url("{{{header_image_url}}}");
+}
+{{/header_image_url}}
+
+.site-title a,
+.site-footer,
+.site-footer a,
+.main-navigation a,
+.page-title,
+.entry-footer,
+.entry-footer a,
+.widget-title,
+.widget-title a,
+#menu-close,
+#infinite-footer .container,
+#infinite-footer .container a {
+	color: var(--muted-color);
+}
+
+.main-navigation a:hover,
+.main-navigation .current_page_item > a,
+.main-navigation .current-menu-item > a {
+	color: rgba({{#rgb}}{{text_color}}{{/rgb}}, 0.35);
+}
+
+.entry-title a {
+	color: var(--text-color);
+}
+
+.toggle .menu-toggle-image,
+.header-search .search-icon .icon {
+	fill: var(--muted-color);
+}
+
+.toggle:hover .menu-toggle-image,
+.toggle:focus .menu-toggle-image,
+.toggle:active .menu-toggle-image {
+	fill: var(--text-color);
+}
+
+#toggle-sidebar {
+	background-color: var(--header-background-color);
+}
+
+hr {
+	background-color: var(--header-background-color);
+}
+
+.page-header,
+.main-navigation a {
+	border-color: var(--header-background-color);
+}
+
+.byline a,
+.edit-link a,
+.tags-links a,
+.posted-on a,
+.reply a,
+.comments-link a {
+	background: var(--header-background-color);
+	border-color: var(--header-background-color);
+}
+
+.archive-date {
+	color: var(--muted-color);
+}
+
+{{#author}}
+.byline {
+	display: inline-block;
+}
+{{/author}}
+
+#infinite-footer .container {
+	background: var(--background-color);
+}
+
+@media screen and (min-width: 60em) {
+	.site-content,
+	.site-footer {
+		border-color: var(--header-background-color);
+	}
+
+	.site-footer {
+		border-top-color: var(--header-background-color);
+	}
+}
+
+pre {
+	{{#syntax_highlighter_font}}
+	font-family: {{{stack}}};
+	font-size: {{{font_size}}}px;
+	{{/syntax_highlighter_font}}
+}
+
+code,
+kbd,
+tt,
+var {
+	{{#syntax_highlighter_font}}
+	font-family: {{{stack}}};
+	{{/syntax_highlighter_font}}
+}
+
+pre code.hljs {
+	display: block;
+	overflow-x: auto;
+	padding: 26px;
+}

--- a/app/templates/source/fieldnotes/style.css
+++ b/app/templates/source/fieldnotes/style.css
@@ -9,6 +9,7 @@
 	--link-color: {{link_color}};
 	--header-background-color: {{header_background_color}};
 	--muted-color: rgba({{#rgb}}{{text_color}}{{/rgb}}, 0.55);
+	--divider-color: rgba({{#rgb}}{{text_color}}{{/rgb}}, 0.1);
 	{{#body_font}}
 	--body-font-family: {{{stack}}};
 	--body-font-size: {{{font_size}}}px;
@@ -3098,12 +3099,12 @@ a:active {
 }
 
 hr {
-	background-color: var(--header-background-color);
+	background-color: var(--divider-color);
 }
 
 .page-header,
 .main-navigation a {
-	border-color: var(--header-background-color);
+	border-color: var(--divider-color);
 }
 
 .byline a,
@@ -3112,8 +3113,8 @@ hr {
 .posted-on a,
 .reply a,
 .comments-link a {
-	background: var(--header-background-color);
-	border-color: var(--header-background-color);
+	background: var(--divider-color);
+	border-color: var(--divider-color);
 }
 
 .archive-date {
@@ -3133,11 +3134,11 @@ hr {
 @media screen and (min-width: 60em) {
 	.site-content,
 	.site-footer {
-		border-color: var(--header-background-color);
+		border-color: var(--divider-color);
 	}
 
 	.site-footer {
-		border-top-color: var(--header-background-color);
+		border-top-color: var(--divider-color);
 	}
 }
 

--- a/app/templates/source/fieldnotes/style.css
+++ b/app/templates/source/fieldnotes/style.css
@@ -3049,10 +3049,6 @@ a:active {
 
 .site-header {
 	background: var(--header-background-color);
-	{{#sticky_navigation}}
-	position: sticky;
-	top: 0;
-	{{/sticky_navigation}}
 }
 
 {{#header_image_url}}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Audit of the Fieldnotes template so site owners can configure Isola chrome from the dashboard instead of hardcoded CSS.

## Existing controls
`page_size`, `date_display`, `hide_dates`, `lang`, `subtitle`. `author` existed but was unused.

## Changes
Only `app/templates/source/fieldnotes/`:
- Color pickers: `background_color`, `text_color`, `link_color`, `header_background_color`
- Font picker: `body_font` (replaces Google Fonts Source Sans Pro)
- Uploads: `favicon_url`, `header_image_url`
- Toggles: `infinite_scroll`, `show_related_posts`
- Syntax highlighting: `syntax_highlighter` + `syntax_highlighter_font`
- `author` now renders as a byline when set
- Hidden dates no longer leave empty date chips
- Infinite-scroll script is only emitted when there is a next page (previously rendered `var init = ;` on the last page)

Vendor Gutenberg/mediaelement CSS is unchanged.

A `sticky_navigation` toggle was prototyped but dropped: Isola's header is already `position: fixed` on desktop, and on mobile the slide-down menu panel and banner image sit outside the header bar, so a sticky header can't be done without a larger rework.

## Testing
- `package.json` is valid JSON
- All locals are referenced
- Mustache render checks for banner, favicon, infinite scroll (with and without a next page), related posts, dates, and author
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba7c3fff-e28f-4368-8e49-2ceeb446e075?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba7c3fff-e28f-4368-8e49-2ceeb446e075&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
