### PR TITLE
Magazine: add heading/code fonts and layout toggles to dashboard controls

### DIFF
--- a/app/templates/source/magazine/_featured.html
+++ b/app/templates/source/magazine/_featured.html
@@ -4,14 +4,14 @@
        <span class="db fr w-two-thirds">
         <span class="db" style="max-height:23.4375rem;overflow:hidden">
         {{#thumbnail.medium}}
-       <img style="width:100%;outline: 1px solid rgba(0,0,0,.12); outline-offset: -1px;vertical-align:bottom" src="{{{url}}}">
+       <img class="thumbnail-frame" style="width:100%;vertical-align:bottom" src="{{{url}}}">
         {{/thumbnail.medium}}
         </span>
 
       </span>
       
       <span class="db fl w-third" style="">
-      <span class="mr4 fw9 black-80 db lh-title f3 mb3 tracked-tight" style="line-height:1.1675">{{title}}</span>
+      <span class="mr4 fw9 black-80 db lh-title f3 mb3 tracked-tight">{{title}}</span>
       <span class="mr4 black-50 mr3 f6 lh-copy db" style="text-overflow:ellipsis;max-height:9.1875rem;overflow:hidden">{{summary}}</span>      
      <span class=" db f6 mt4 " style="height:1.5em;overflow:hidden">
         {{#date}}<span date-from-now="{{dateStamp}}" class="dib black-50 mr2">{{date}}</span>{{/date}}
@@ -22,7 +22,7 @@
 
       {{^summary}}
       <span class="w-100" style="">
-        <span class=" fw9 black-80 db lh-title f3 tracked-tight" style="line-height:1.1675">{{title}}</span>
+        <span class=" fw9 black-80 db lh-title f3 tracked-tight">{{title}}</span>
 
        <span class=" db f6 mt1 mb3" style="height:1.5em;overflow:hidden">
           {{#date}}<span date-from-now="{{dateStamp}}" class="dib black-50 mr2">{{date}}</span>{{/date}}
@@ -32,7 +32,7 @@
 
         <span class="db">
         {{#thumbnail.large}}
-       <img style="width:100%;outline: 1px solid rgba(0,0,0,.12); outline-offset: -1px;vertical-align:bottom" src="{{{url}}}">
+       <img class="thumbnail-frame" style="width:100%;vertical-align:bottom" src="{{{url}}}">
         {{/thumbnail.large}}
         </span>
       </span>

--- a/app/templates/source/magazine/css-theme.css
+++ b/app/templates/source/magazine/css-theme.css
@@ -200,6 +200,7 @@ pre, code {
   {{#syntax_highlighter_font}}
   font-family: {{{stack}}};
   font-size: {{font_size}}px;
+  line-height: {{line_height}};
   {{/syntax_highlighter_font}}
 }
 
@@ -328,6 +329,7 @@ h4, h5, h6, p, blockquote, ul, ol, table {margin:2rem 0}
 h1, h2, h3, h4, h5, h6, .fw9 {
   {{#heading_font}}
   font-family: {{{stack}}};
+  line-height: {{line_height}};
   {{/heading_font}}
 }
 
@@ -337,7 +339,6 @@ h1 {
   padding:0;
   {{#heading_font}}
   font-size: {{font_size}}px;
-  line-height: {{line_height}};
   {{/heading_font}}
 }
 
@@ -383,6 +384,14 @@ figure cite, figure cite a {font-size:0.8rem;color:rgba({{#rgb}}{{text_color}}{{
   {{#heading_font}}
   line-height: {{line_height}};
   {{/heading_font}}
+}
+
+/* Let the configured body line height reach the article body, which
+   Tachyons' .lh-copy would otherwise pin to 1.5 */
+.entry .lh-copy {
+  {{#body_font}}
+  line-height: {{line_height}};
+  {{/body_font}}
 }
 
 .pv2-5 {padding-top:0.75rem;padding-bottom:0.75rem}

--- a/app/templates/source/magazine/css-theme.css
+++ b/app/templates/source/magazine/css-theme.css
@@ -1,5 +1,6 @@
-{{{coding_font.styles}}}
+{{{syntax_highlighter_font.styles}}}
 {{{body_font.styles}}}
+{{{heading_font.styles}}}
 {{{syntax_highlighter.styles}}}
 
 /* This template tag is replaced by CSS when this file is rendered */
@@ -19,7 +20,11 @@
 html {
   margin: 0;
   padding: 0;
-  font-size: {{body_font.font_size}}px;
+  {{#body_font}}
+  font-size: {{font_size}}px;
+  line-height: {{line_height}};
+  font-family: {{{stack}}};
+  {{/body_font}}
   width: 100%;
   height: 100%;
 }
@@ -28,7 +33,9 @@ html {
 .bg-sidebar {background:{{background_color}}}
 
 html,body {
-  font-family: {{{body_font.stack}}}
+  {{#body_font}}
+  font-family: {{{stack}}};
+  {{/body_font}}
 }
 
 body {
@@ -57,12 +64,24 @@ body {
     color: rgba({{#rgb}}{{text_color}}{{/rgb}},.8);
 }
 
+.black-60 {
+    color: rgba({{#rgb}}{{text_color}}{{/rgb}},.6);
+}
+
 .black-50 {
     color: rgba({{#rgb}}{{text_color}}{{/rgb}},.5);
 }
 
 .black-30 {
     color: rgba({{#rgb}}{{text_color}}{{/rgb}},.3);
+}
+
+.white {
+    color: {{background_color}};
+}
+
+.bg-black-20 {
+    background-color: rgba({{#rgb}}{{text_color}}{{/rgb}},.2);
 }
 
 .b--black-10 {border-color:rgba({{#rgb}}{{text_color}}{{/rgb}},.10);}
@@ -77,15 +96,15 @@ body {
   }
 
 .bigfoot-footnote.is-scrollable .bigfoot-footnote__wrapper:before {
-    background-image: -webkit-gradient(linear, left top, left bottom, from({{background_color}}), to(rgba(250, 250, 250, 0)));
-    background-image: -webkit-linear-gradient(top, {{background_color}} 50%, rgba(250, 250, 250, 0) 100%);
-    background-image: linear-gradient(to bottom, {{background_color}} 50%, rgba(250, 250, 250, 0) 100%);
+    background-image: -webkit-gradient(linear, left top, left bottom, from({{background_color}}), to(rgba({{#rgb}}{{background_color}}{{/rgb}}, 0)));
+    background-image: -webkit-linear-gradient(top, {{background_color}} 50%, rgba({{#rgb}}{{background_color}}{{/rgb}}, 0) 100%);
+    background-image: linear-gradient(to bottom, {{background_color}} 50%, rgba({{#rgb}}{{background_color}}{{/rgb}}, 0) 100%);
 }
 
 .bigfoot-footnote.is-scrollable .bigfoot-footnote__wrapper:after {
-    background-image: -webkit-gradient(linear, left bottom, left top, from({{background_color}}), to(rgba(250, 250, 250, 0)));
-    background-image: -webkit-linear-gradient(bottom, {{background_color}}  50%, rgba(250, 250, 250, 0) 100%);
-    background-image: linear-gradient(to top, {{background_color}}  50%, rgba(250, 250, 250, 0) 100%);
+    background-image: -webkit-gradient(linear, left bottom, left top, from({{background_color}}), to(rgba({{#rgb}}{{background_color}}{{/rgb}}, 0)));
+    background-image: -webkit-linear-gradient(bottom, {{background_color}}  50%, rgba({{#rgb}}{{background_color}}{{/rgb}}, 0) 100%);
+    background-image: linear-gradient(to top, {{background_color}}  50%, rgba({{#rgb}}{{background_color}}{{/rgb}}, 0) 100%);
 }
 
 .bigfoot-footnote { 
@@ -167,8 +186,8 @@ table {
   line-height:1.5;
 }
 th {text-align:left}
-tr {border-bottom: 1px solid #eee}
-thead tr {border-color: #444}
+tr {border-bottom: 1px solid rgba({{#rgb}}{{text_color}}{{/rgb}},.08)}
+thead tr {border-color: rgba({{#rgb}}{{text_color}}{{/rgb}},.73)}
 td, th {padding-right: 2rem;padding-left:2rem} 
 td:first-child, th:first-child  {padding-left:0}
 td:last-child, th:last-child {padding-right:0}  
@@ -177,17 +196,20 @@ b, strong, h1, h2, h3, h4, h5, h6, th {font-weight:500}
   
 .entry b, .entry strong {font-weight: 600}
   
+pre, code {
+  {{#syntax_highlighter_font}}
+  font-family: {{{stack}}};
+  font-size: {{font_size}}px;
+  {{/syntax_highlighter_font}}
+}
+
 code {
-  font-family: {{{coding_font.stack}}};
   padding: .2rem .4rem;
   margin: 0;
-  font-size: 85%;
-  background-color: rgba(0,0,0,.04);
+  background-color: rgba({{#rgb}}{{text_color}}{{/rgb}},.04);
   border-radius: 3px;
   font-weight: 400;
 }
-  
-pre, code {font-size:.92rem}
   
 pre {margin:2rem 0}
   
@@ -201,7 +223,7 @@ a {
 
 a:not(.no-underline) {color:{{accent_color}};border-bottom:1px solid rgba({{#rgb}}{{accent_color}}{{/rgb}},0.25)}
 a:not(.no-underline):hover {border-color: rgba({{#rgb}}{{accent_color}}{{/rgb}},1)}
-a:hover {color:rgba({{accent_color}}, 1)}
+a:hover {color:{{accent_color}}}
 
 a.dim {transition: opacity .2s linear;opacity:1}
 a.dim:hover {opacity:0.8}
@@ -211,7 +233,7 @@ a.dim:visited {opacity:0.3}
 hr {
   margin: 3em auto;
   height: 2px;
-  background-color: #e7e7e5;
+  background-color: rgba({{#rgb}}{{text_color}}{{/rgb}},.1);
   border: none;
 }
   
@@ -219,6 +241,10 @@ hr {
 
 .nav {overflow:hidden;}
 .nav a.no-wrap {width:1000%;text-decoration:none;}
+.thumbnail-frame {
+  outline: 1px solid rgba({{#rgb}}{{text_color}}{{/rgb}},.12);
+  outline-offset: -1px;
+}
 
 /* 
 
@@ -278,7 +304,7 @@ blockquote, ol, ul {
   padding-left:4rem;
 }
 blockquote {
-  color:#676767;
+  color: rgba({{#rgb}}{{text_color}}{{/rgb}},.4);
 }
   
 .tracked-tight {letter-spacing:-0.01em}
@@ -299,7 +325,21 @@ h1, h2, h3 {margin: 3rem 0 2rem}
 
 h4, h5, h6, p, blockquote, ul, ol, table {margin:2rem 0}
   
-h1 {font-weight:900;margin:0;padding:0;font-size:2.25rem;}
+h1, h2, h3, h4, h5, h6, .fw9 {
+  {{#heading_font}}
+  font-family: {{{stack}}};
+  {{/heading_font}}
+}
+
+h1 {
+  font-weight:900;
+  margin:0;
+  padding:0;
+  {{#heading_font}}
+  font-size: {{font_size}}px;
+  line-height: {{line_height}};
+  {{/heading_font}}
+}
 
 /* Italic style sucks in font-weight: 900 */ 
 h1 em {font-style:normal}
@@ -332,20 +372,32 @@ h1 em {font-style:normal}
 .lh-title.f2, .lh-title.f1 {line-height:1}
 
 figure {margin:3rem 0;}
-figcaption, .caption {font-size:0.9rem;color:#666;margin:0rem 0 0;}
-figure cite, figure cite a {font-size:0.8rem;color:#999;font-style:normal;border:none!important;}
+figcaption, .caption {font-size:0.9rem;color:rgba({{#rgb}}{{text_color}}{{/rgb}},.4);margin:0rem 0 0;}
+figure cite, figure cite a {font-size:0.8rem;color:rgba({{#rgb}}{{text_color}}{{/rgb}},.4);font-style:normal;border:none!important;}
 
 .caption {display: block;margin-bottom: 3rem}
   
 
 /* Tachyons customizations */
-.lh-title.tracked-tight {line-height:1.15}
+.lh-title.tracked-tight {
+  {{#heading_font}}
+  line-height: {{line_height}};
+  {{/heading_font}}
+}
 
 .pv2-5 {padding-top:0.75rem;padding-bottom:0.75rem}
 .w-15 {width:15%}
 .w-85 {width:85%}
 
-.nav {width:12rem}
+.nav {
+  width:12rem;
+  {{#sticky_navigation}}
+  position: fixed;
+  {{/sticky_navigation}}
+  {{^sticky_navigation}}
+  position: absolute;
+  {{/sticky_navigation}}
+}
 
 /* Month baseline fix on Archives page */
 h3.f6 {line-height:1.25;}
@@ -373,8 +425,8 @@ h3.f6 {line-height:1.25;}
   .nav {width:100%;padding-left:4rem}
   #open-nav, #open-nav-container {display:block}
   .nav {display:none} 
-  .nav-is-open #close-nav {display:block;right:1rem}
-  .nav-is-open .nav {display:block;z-index:668;left:0}
+  .nav-is-open #close-nav {display:block;right:1rem;position:fixed}
+  .nav-is-open .nav {display:block;z-index:668;left:0;position:fixed}
 }
 
 @media (max-width:500px) {

--- a/app/templates/source/magazine/css-theme.css
+++ b/app/templates/source/magazine/css-theme.css
@@ -304,7 +304,7 @@ blockquote, ol, ul {
   padding-left:4rem;
 }
 blockquote {
-  color: rgba({{#rgb}}{{text_color}}{{/rgb}},.4);
+  color: rgba({{#rgb}}{{text_color}}{{/rgb}},.6);
 }
   
 .tracked-tight {letter-spacing:-0.01em}
@@ -372,7 +372,7 @@ h1 em {font-style:normal}
 .lh-title.f2, .lh-title.f1 {line-height:1}
 
 figure {margin:3rem 0;}
-figcaption, .caption {font-size:0.9rem;color:rgba({{#rgb}}{{text_color}}{{/rgb}},.4);margin:0rem 0 0;}
+figcaption, .caption {font-size:0.9rem;color:rgba({{#rgb}}{{text_color}}{{/rgb}},.6);margin:0rem 0 0;}
 figure cite, figure cite a {font-size:0.8rem;color:rgba({{#rgb}}{{text_color}}{{/rgb}},.4);font-style:normal;border:none!important;}
 
 .caption {display: block;margin-bottom: 3rem}

--- a/app/templates/source/magazine/entries.html
+++ b/app/templates/source/magazine/entries.html
@@ -24,6 +24,7 @@
 {{! First page}}
 {{^pagination.previous}}
 
+{{#show_featured_entry}}
 <div class="clip-1 mt3 featured-entry" style="display:flex;flex-direction:row;flex-wrap:  wrap">
   {{#posts}}
   {{#first}}
@@ -33,8 +34,9 @@
   {{/first}}
   {{/posts}}
 </div>
+{{/show_featured_entry}}
 
-<div style="display:flex;flex-direction:row;flex-wrap:wrap"   {{#posts}} {{#first}} {{#thumbnail.large}} class="skip-1" {{/thumbnail.large}} {{/first}} {{/posts}}>
+<div style="display:flex;flex-direction:row;flex-wrap:wrap"   {{#show_featured_entry}}{{#posts}} {{#first}} {{#thumbnail.large}} class="skip-1" {{/thumbnail.large}} {{/first}} {{/posts}}{{/show_featured_entry}}>
 
   {{#posts}}
   {{> entry_line}}

--- a/app/templates/source/magazine/entry.html
+++ b/app/templates/source/magazine/entry.html
@@ -54,8 +54,7 @@
 <a href="{{{url}}}" class="db pb3 lh-title  dim no-underline">
 <span class="db">
   {{#previous.thumbnail.medium}}
-  <span class="db" style="outline: 1px solid rgba(0,0,0,.12);
-    outline-offset: -1px;max-height:14rem;overflow:hidden">
+  <span class="db thumbnail-frame" style="max-height:14rem;overflow:hidden">
     <img style="width:100%" src="{{{url}}}">
    </span>
   </span>
@@ -74,8 +73,7 @@
 <a href="{{{url}}}" class="db pb3 lh-title  dim no-underline">
 <span class="db">
   {{#next.thumbnail.medium}}
-  <span class="db" style="outline: 1px solid rgba(0,0,0,.12);
-    outline-offset: -1px;max-height:14rem;overflow:hidden">
+  <span class="db thumbnail-frame" style="max-height:14rem;overflow:hidden">
     <img style="width:100%" src="{{{url}}}">
    </span>
   </span>

--- a/app/templates/source/magazine/entry_line.html
+++ b/app/templates/source/magazine/entry_line.html
@@ -16,7 +16,7 @@
   {{#summary}}
 
   <span class="w-third db fr">
-    <span class="ml3 db" style="max-height:10rem;overflow:hidden;outline: 1px solid rgba(0,0,0,.12); outline-offset: -1px;">
+    <span class="ml3 db thumbnail-frame" style="max-height:10rem;overflow:hidden;">
     {{#thumbnail.medium}}
     <img style="width:100%;vertical-align:bottom" src="{{{url}}}">
     {{/thumbnail.medium}}
@@ -33,7 +33,7 @@
   {{^summary}}
 
   <span class="w-two-thirds db fr">
-    <span class="db" style="overflow:hidden;outline: 1px solid rgba(0,0,0,.12); outline-offset: -1px;">
+    <span class="db thumbnail-frame" style="overflow:hidden;">
     {{#thumbnail.large}}
     <img style="width:100%;vertical-align:bottom" src="{{{url}}}">
     {{/thumbnail.large}}

--- a/app/templates/source/magazine/header.html
+++ b/app/templates/source/magazine/header.html
@@ -20,17 +20,19 @@
           <a href="/"  id="open-nav" class="dib no-underline pa3 fr" style="transform:rotate(90deg);"><span class="bg-background black-50  w2 h2 lh2 tc black relative db fr f2 fw2" style="box-sizing:border-box"><span class="tc" style="">|||</span></span></a>
       </div>
       
-		<div class="nav fixed bg-sidebar br b--black-10 lh-copy pr5 " style="top:-10rem;bottom:-10rem;padding-top:10rem;padding-bottom:10rem;">
-			<a href="/" id="close-nav" style="z-index:2" class="relative no-underline fixed black-50 mt3  w2 h2 tc black db fl f2 fw1">✕</a>
+		<div class="nav bg-sidebar br b--black-10 lh-copy pr5 " style="top:-10rem;bottom:-10rem;padding-top:10rem;padding-bottom:10rem;">
+			<a href="/" id="close-nav" style="z-index:2" class="relative no-underline {{#sticky_navigation}}fixed{{/sticky_navigation}} black-50 mt3  w2 h2 tc black db fl f2 fw1">✕</a>
 			<a href="/" class="no-underline dim mv4 db f3 fw3 black-80" title="The homepage of {{title}}">
 				{{#avatar}}<img class="avatar v-btm" src="{{{avatar}}}">{{/avatar}}
 				{{^avatar}}{{title}}{{/avatar}}
 			</a>
+			{{#show_tags_in_navigation}}
 			<div class="clip-tags mt5 mb5">
 			{{#popular_tags}}
 				<a href="/tagged/{{slug}}"  class="no-underline no-wrap db f3 fw3 black-50"  title="{{slug}}">{{name}}</a>
 			{{/popular_tags}}
 			</div>
+			{{/show_tags_in_navigation}}
 			{{#menu}}
 			<a href="{{{url}}}"  class="no-underline no-wrap db black-80 f6 fw6 "  title="{{label}}">{{label}}</a>
 			{{/menu}}

--- a/app/templates/source/magazine/package.json
+++ b/app/templates/source/magazine/package.json
@@ -8,10 +8,25 @@
     "hide_dates": false,
     "date_display": "MMMM D, Y",
     "relative_dates": false,
+    "sticky_navigation": true,
+    "show_tags_in_navigation": true,
+    "show_featured_entry": true,
     "syntax_highlighter": {
       "id": "stackoverflow-light"
     },
-    "body_font": {},
+    "syntax_highlighter_font": {
+      "id": "system-mono",
+      "font_size": 15
+    },
+    "body_font": {
+      "font_size": 16,
+      "line_height": 1.5
+    },
+    "heading_font": {
+      "id": "system-sans",
+      "font_size": 36,
+      "line_height": 1.15
+    },
     "demo_folder": "bjorn",
     "template_categories": [
       "writing"

--- a/app/templates/source/magazine/tagged.html
+++ b/app/templates/source/magazine/tagged.html
@@ -1,7 +1,7 @@
 {{> header}}
 
 <div class="flex pt4 mt2 pb2" style="align-items:baseline;flex-direction:row">
-  <h1 style="border-color:#f1f1f1;flex-grow:1" class="fw9 measure-wide black db mv2 pt0 pb3 lh-title f1 ">{{tag}}</h1>
+  <h1 style="border-color:rgba({{#rgb}}{{text_color}}{{/rgb}},.06);flex-grow:1" class="fw9 measure-wide black db mv2 pt0 pb3 lh-title f1 ">{{tag}}</h1>
   <a class="fr pt4 black-50 no-underline mb4" href="/tags">All sections →</a>
 </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Audit of the Magazine template so previously hardcoded type and layout settings are dashboard-configurable.

## Existing controls
`accent_color`, `background_color`, `text_color`, `date_display`, `hide_dates`, `relative_dates`, `page_size`, `syntax_highlighter`, and a partial `body_font`.

## Changes
Only `app/templates/source/magazine/`:
- `syntax_highlighter_font` for `pre, code` (replaces undeclared `coding_font`)
- `heading_font` for headings and `.fw9` titles
- `body_font.font_size` / `line_height` on `html`/`body`
- Toggles: `sticky_navigation`, `show_tags_in_navigation`, `show_featured_entry`
- Decorative greys now follow `text_color` / `background_color`

No dark-mode colors, extra pagination controls, or logo upload (site Photo/`{{avatar}}` already covers the sidebar mark).

## Testing
- `package.json` is valid JSON
- Interpolatable locals are referenced
- Mustache interpolation checked for palette, heading size, and unsticky nav
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba7c3fff-e28f-4368-8e49-2ceeb446e075?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba7c3fff-e28f-4368-8e49-2ceeb446e075&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

