### PR TITLE
Warn about redirects and use re2

### DIFF
--- a/app/dashboard/site/index.js
+++ b/app/dashboard/site/index.js
@@ -82,9 +82,14 @@ site.get("/settings/services", load.plugins, (req, res) => {
   res.render("dashboard/site/settings/services");
 });
 
-site.get("/settings/redirects", load.redirects, (req, res) => {
-  res.render("dashboard/site/settings/redirects");
-});
+site.get(
+  "/settings/redirects",
+  load.redirects,
+  load.redirectWarnings,
+  (req, res) => {
+    res.render("dashboard/site/settings/redirects");
+  }
+);
 
 site.get("/settings/flags", flags.get);
 

--- a/app/dashboard/site/load/index.js
+++ b/app/dashboard/site/load/index.js
@@ -4,5 +4,6 @@ module.exports = {
   clients: require("./clients"),
   fourOhFour: require("./404"),
   redirects: require("./redirects"),
+  redirectWarnings: require("./redirectWarnings"),
   plugins: require("./plugins"),
 };

--- a/app/dashboard/site/load/redirectWarnings.js
+++ b/app/dashboard/site/load/redirectWarnings.js
@@ -1,0 +1,30 @@
+const Redirects = require("models/redirects");
+
+// Explains why a redirect will never run, e.g. because a post already
+// exists at the URL it redirects from. The warnings are a nicety, so if we
+// can't work them out we still render the list of redirects.
+module.exports = function (req, res, next) {
+  const redirects = res.locals.redirects;
+
+  if (!redirects || !redirects.length) return next();
+
+  Redirects.conflicts(req.blog, redirects, function (err, conflicts) {
+    if (err) {
+      console.error("Failed to check redirects for conflicts", err);
+      return next();
+    }
+
+    let total = 0;
+
+    redirects.forEach(function (redirect, index) {
+      if (!conflicts[index]) return;
+
+      redirect.warning = conflicts[index].message;
+      total++;
+    });
+
+    res.locals.redirectWarnings = total;
+
+    next();
+  });
+};

--- a/app/models/redirects/conflicts.js
+++ b/app/models/redirects/conflicts.js
@@ -1,0 +1,279 @@
+var async = require("async");
+var fs = require("fs-extra");
+var { join, dirname, basename, sep } = require("path");
+var config = require("config");
+var client = require("models/client");
+var ensure = require("helper/ensure");
+var urlNormalizer = require("helper/urlNormalizer");
+var Entry = require("models/entry");
+var Template = require("models/template");
+var isRegex = require("./util").isRegex;
+
+// Blot only checks a site's redirects once it has failed to find anything
+// else to serve for a URL (see app/blog/index.js for the order of routes).
+// A redirect whose 'from' is already served by a post, a page, a template
+// view, a file in the folder, or one of Blot's own routes therefore never
+// runs. That surprises people, so we look for those cases and explain them.
+
+// Paths assets.js refuses to serve, meaning a redirect for them still runs
+var UNSERVED_PATTERNS = ["..", ".php", "/.git", "\0"];
+
+// Stops a site with an enormous number of redirects hammering the disk
+var MAX_PATHS_CHECKED_ON_DISK = 500;
+
+module.exports = function conflicts(blog, redirects, callback) {
+  ensure(blog, "object").and(redirects, "array").and(callback, "function");
+
+  var paths = redirects.map(function (redirect) {
+    return comparablePath(redirect && redirect.from);
+  });
+
+  var results = paths.map(function () {
+    return null;
+  });
+
+  checkBlotRoutes(paths, results);
+
+  async.series(
+    [
+      function (next) {
+        checkEntries(blog.id, paths, results, next);
+      },
+      function (next) {
+        checkTemplateViews(blog.template, paths, results, next);
+      },
+      function (next) {
+        checkFolder(blog.id, paths, results, next);
+      },
+    ],
+    function (err) {
+      if (err) return callback(err);
+      callback(null, results);
+    }
+  );
+};
+
+// Returns the path a request would need to use for this redirect to match,
+// or null when we can't say anything useful about it. Redirects.check tests
+// the 'from' against req.url, so anything which isn't a plain path on this
+// site is either a pattern we don't try to resolve or never matched at all.
+function comparablePath(from) {
+  if (typeof from !== "string" || !from.trim()) return null;
+
+  from = from.trim();
+
+  if (isRegex(from)) return null;
+  if (from.indexOf("://") > -1) return null;
+
+  return urlNormalizer(from) || null;
+}
+
+function pending(paths, results) {
+  var indexes = [];
+
+  paths.forEach(function (path, index) {
+    if (path && !results[index]) indexes.push(index);
+  });
+
+  return indexes;
+}
+
+function checkBlotRoutes(paths, results) {
+  pending(paths, results).forEach(function (index) {
+    var purpose = blotRoute(paths[index]);
+
+    if (!purpose) return;
+
+    results[index] = {
+      type: "route",
+      path: paths[index],
+      message:
+        "This redirect will not be used because Blot uses " +
+        paths[index] +
+        " for " +
+        purpose +
+        ".",
+    };
+  });
+}
+
+// Routes which Blot always handles itself, from app/blog/index.js. Routes
+// which fall through when they have nothing to serve, such as /robots.txt
+// and the draft previews, are deliberately absent: a redirect for one of
+// those URLs does run.
+function blotRoute(path) {
+  if (path === "/") return "the list of posts on your site";
+  if (path === "/search") return "the search page on your site";
+  if (path === "/random") return "a link to a random post on your site";
+  if (path === "/layout.css" || path === "/html2canvas.min.js")
+    return "a file it serves on every site";
+  if (path === "/verify/domain-setup") return "checking your domain's setup";
+  if (path === "/verify/subscription-duration")
+    return "checking your subscription";
+  if (/^\/page\/[^/]+$/.test(path)) return "the list of posts on your site";
+  if (/^\/tagged\/[^/]+(\/page\/[^/]+)?$/.test(path))
+    return "the list of posts with a given tag";
+
+  return null;
+}
+
+function checkEntries(blogID, paths, results, callback) {
+  var indexes = pending(paths, results);
+
+  if (!indexes.length) return callback();
+
+  // One round trip tells us which paths are worth loading in full. Most
+  // redirects don't point at an existing post, so this usually ends here.
+  var keys = indexes.map(function (index) {
+    return Entry.key.url(blogID, decodeURISafely(paths[index]));
+  });
+
+  client
+    .mGet(keys)
+    .then(function (entryIDs) {
+      var candidates = indexes.filter(function (index, position) {
+        return !!entryIDs[position];
+      });
+
+      async.eachLimit(candidates, 10, checkEntry, callback);
+    })
+    .catch(callback);
+
+  function checkEntry(index, next) {
+    Entry.getByUrl(blogID, paths[index], function (entry) {
+      // Blot skips these too, so the redirect still runs
+      if (!entry || entry.deleted || entry.draft || entry.scheduled)
+        return next();
+
+      results[index] = {
+        type: entry.page ? "page" : "post",
+        path: paths[index],
+        message:
+          "This redirect will not be used because " +
+          (entry.page ? "a page" : "a post") +
+          " on your site is already published at " +
+          paths[index] +
+          ".",
+      };
+
+      next();
+    });
+  }
+}
+
+function checkTemplateViews(templateID, paths, results, callback) {
+  var indexes = pending(paths, results);
+
+  if (!templateID || !indexes.length) return callback();
+
+  var urls = indexes.map(function (index) {
+    return decodeURIComponentSafely(paths[index]);
+  });
+
+  Template.getViewsByURLs(templateID, urls, function (err, viewNames) {
+    if (err) return callback(err);
+
+    indexes.forEach(function (index, position) {
+      if (!viewNames[position]) return;
+
+      results[index] = {
+        type: "view",
+        path: paths[index],
+        message:
+          "This redirect will not be used because your template renders " +
+          paths[index] +
+          " using the view " +
+          viewNames[position] +
+          ".",
+      };
+    });
+
+    callback();
+  });
+}
+
+function checkFolder(blogID, paths, results, callback) {
+  var indexes = pending(paths, results).filter(function (index) {
+    return isServed(paths[index]);
+  });
+
+  if (!indexes.length || indexes.length > MAX_PATHS_CHECKED_ON_DISK)
+    return callback();
+
+  var folder = join(config.blog_folder_dir, blogID);
+
+  async.eachLimit(indexes, 10, checkPath, callback);
+
+  function checkPath(index, next) {
+    var candidates = filesWhichWouldBeServed(folder, paths[index]);
+
+    async.detectSeries(candidates, isFile, function (err, file) {
+      if (err) return next(err);
+
+      if (file)
+        results[index] = {
+          type: "file",
+          path: paths[index],
+          message:
+            "This redirect will not be used because a file in your folder is already published at " +
+            paths[index] +
+            ".",
+        };
+
+      next();
+    });
+  }
+}
+
+function isServed(path) {
+  return !UNSERVED_PATTERNS.some(function (pattern) {
+    return path.indexOf(pattern) > -1;
+  });
+}
+
+// The files assets.js will try, in order, for a given request. We skip its
+// case-insensitive walk of the folder, which is expensive, so a file whose
+// name is capitalized differently to the redirect goes unnoticed.
+function filesWhichWouldBeServed(folder, url) {
+  var path = decodeURIComponentSafely(url);
+
+  return [
+    path,
+    path + "/index.html",
+    path + "/_index.html",
+    path + ".html",
+    join(dirname(path), "_" + basename(path) + ".html"),
+  ]
+    .map(function (candidate) {
+      return join(folder, candidate);
+    })
+    .filter(function (candidate) {
+      // Don't let a path escape the site's folder
+      return candidate.startsWith(folder + sep);
+    });
+}
+
+function isFile(file, callback) {
+  fs.stat(file, function (err, stat) {
+    if (err) return callback(null, false);
+    callback(null, stat.isFile());
+  });
+}
+
+// Entry.getByUrl and app/blog/view.js decode the URL differently, so we
+// match whichever the lookup we're about to make uses.
+function decodeURISafely(url) {
+  try {
+    return decodeURI(url);
+  } catch (e) {
+    return url;
+  }
+}
+
+function decodeURIComponentSafely(url) {
+  try {
+    return decodeURIComponent(url);
+  } catch (e) {
+    return url;
+  }
+}

--- a/app/models/redirects/index.js
+++ b/app/models/redirects/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   check: require("./check"),
+  conflicts: require("./conflicts"),
   drop: require("./drop"),
   get: require("./get"),
   key: require("./key"),

--- a/app/models/redirects/tests/conflicts.js
+++ b/app/models/redirects/tests/conflicts.js
@@ -111,6 +111,10 @@ describe("redirects.conflicts", function () {
   });
 
   it("does not warn about a redirect from a URL Blot falls through", async function () {
+    // The default template ships its own robots.txt view, which would
+    // otherwise catch this redirect first and mask what we're testing here.
+    await this.useTemplate([]);
+
     for (const from of ["/robots.txt", "/draft/view/hello.md"])
       expect(await this.conflict(from)).toEqual(null);
   });

--- a/app/models/redirects/tests/conflicts.js
+++ b/app/models/redirects/tests/conflicts.js
@@ -1,0 +1,172 @@
+describe("redirects.conflicts", function () {
+  const fs = require("fs-extra");
+  const { promisify } = require("util");
+  const build = require("build");
+  const Entry = require("models/entry");
+  const Template = require("models/template");
+  const conflicts = promisify(require("../conflicts"));
+
+  global.test.blog();
+
+  beforeEach(function () {
+    // Returns the conflict for a single 'from', or null if there isn't one
+    this.conflict = async (from) => {
+      const results = await conflicts(this.blog, [{ from, to: "/anywhere" }]);
+      return results[0];
+    };
+
+    this.publish = async (path, content) => {
+      await fs.outputFile(this.blogDirectory + path, content);
+      const entry = await promisify(build)(this.blog, path);
+      await promisify(Entry.set)(this.blog.id, path, entry);
+      return entry;
+    };
+
+    this.write = async (path, content) =>
+      await fs.outputFile(this.blogDirectory + path, content);
+
+    this.useTemplate = async (views) => {
+      const { id } = await promisify(Template.create)(
+        this.blog.id,
+        "conflicts",
+        {}
+      );
+
+      for (const view of views)
+        await promisify(Template.setView)(id, {
+          ...view,
+          content: view.content || "Hello",
+        });
+
+      this.blog.template = id;
+    };
+  });
+
+  it("does not warn about a redirect from an unused path", async function () {
+    expect(await this.conflict("/nothing-here")).toEqual(null);
+  });
+
+  it("warns about a redirect from the URL of a post", async function () {
+    await this.publish(
+      "/hello.md",
+      ["---", "Permalink: /hello", "---", "", "# Hello"].join("\n")
+    );
+
+    const conflict = await this.conflict("/hello");
+
+    expect(conflict.type).toEqual("post");
+    expect(conflict.message).toContain("a post on your site");
+    expect(conflict.message).toContain("/hello");
+  });
+
+  it("warns about a redirect from the URL of a page", async function () {
+    await this.publish(
+      "/about.md",
+      ["---", "Page: yes", "Permalink: /about", "---", "", "# About"].join("\n")
+    );
+
+    expect((await this.conflict("/about")).type).toEqual("page");
+  });
+
+  it("ignores the case and trailing slash of a redirect", async function () {
+    await this.publish(
+      "/hello.md",
+      ["---", "Permalink: /hello", "---", "", "# Hello"].join("\n")
+    );
+
+    expect((await this.conflict("/Hello/")).type).toEqual("post");
+  });
+
+  it("does not warn about a redirect from the URL of a draft", async function () {
+    await this.publish(
+      "/secret.md",
+      ["---", "Draft: yes", "Permalink: /secret", "---", "", "# Secret"].join(
+        "\n"
+      )
+    );
+
+    expect(await this.conflict("/secret")).toEqual(null);
+  });
+
+  it("warns about a redirect from a URL rendered by a template view", async function () {
+    await this.useTemplate([{ name: "topics.html", url: ["/topics/:topic"] }]);
+
+    const conflict = await this.conflict("/topics/apples");
+
+    expect(conflict.type).toEqual("view");
+    expect(conflict.message).toContain("topics.html");
+  });
+
+  it("warns about a redirect from a URL Blot handles itself", async function () {
+    for (const from of [
+      "/",
+      "/search",
+      "/random",
+      "/page/2",
+      "/tagged/apples",
+      "/tagged/apples/page/2",
+    ]) {
+      expect((await this.conflict(from)).type).toEqual("route");
+    }
+  });
+
+  it("does not warn about a redirect from a URL Blot falls through", async function () {
+    for (const from of ["/robots.txt", "/draft/view/hello.md"])
+      expect(await this.conflict(from)).toEqual(null);
+  });
+
+  it("warns about a redirect from the URL of a file in the folder", async function () {
+    await this.write("/notes.pdf", "Not really a PDF");
+
+    const conflict = await this.conflict("/notes.pdf");
+
+    expect(conflict.type).toEqual("file");
+    expect(conflict.message).toContain("/notes.pdf");
+  });
+
+  it("warns about a redirect from a URL served by an HTML file in the folder", async function () {
+    await this.write("/guide/index.html", "<p>Guide</p>");
+
+    expect((await this.conflict("/guide")).type).toEqual("file");
+  });
+
+  it("does not warn about a redirect from a path outside the folder", async function () {
+    expect(await this.conflict("/../../etc/passwd")).toEqual(null);
+  });
+
+  it("does not try to resolve a regular expression redirect", async function () {
+    await this.publish(
+      "/hello.md",
+      ["---", "Permalink: /hello", "---", "# Hello"].join("\n")
+    );
+
+    expect(await this.conflict("/(.*)")).toEqual(null);
+    expect(await this.conflict("\\/hello")).toEqual(null);
+  });
+
+  it("does not try to resolve a redirect from another site", async function () {
+    expect(await this.conflict("https://example.com/")).toEqual(null);
+  });
+
+  it("returns a result for every redirect", async function () {
+    await this.publish(
+      "/hello.md",
+      ["---", "Permalink: /hello", "---", "# Hello"].join("\n")
+    );
+
+    const results = await conflicts(this.blog, [
+      { from: "/nothing-here", to: "/anywhere" },
+      { from: "/hello", to: "/anywhere" },
+      { from: "/search", to: "/anywhere" },
+    ]);
+
+    expect(results.length).toEqual(3);
+    expect(results[0]).toEqual(null);
+    expect(results[1].type).toEqual("post");
+    expect(results[2].type).toEqual("route");
+  });
+
+  it("returns nothing when there are no redirects", async function () {
+    expect(await conflicts(this.blog, [])).toEqual([]);
+  });
+});

--- a/app/models/redirects/tests/util.js
+++ b/app/models/redirects/tests/util.js
@@ -1,0 +1,81 @@
+describe("redirects.util", function () {
+  const { is, map, isRegex, notRegex, matches } = require("../util");
+
+  describe("isRegex / notRegex", function () {
+    it("treats a plain path as not a regex", function () {
+      expect(isRegex("/apples")).toBe(false);
+      expect(notRegex("/apples")).toBe(true);
+    });
+
+    it("treats a path with a capture group or $1 as a regex", function () {
+      expect(isRegex("/posts/(.*)")).toBeTruthy();
+      expect(isRegex("/blog/$1")).toBeTruthy();
+    });
+
+    it("treats a path starting with a backslash as a regex", function () {
+      expect(isRegex("\\/posts\\/(.*)")).toBeTruthy();
+    });
+  });
+
+  describe("is", function () {
+    it("matches a URL against a simple regex, as in the docs example", function () {
+      expect(is("/posts/hello", "/posts/(.*)")).toBe(true);
+      expect(is("/other/hello", "/posts/(.*)")).toBe(false);
+    });
+
+    it("is case-insensitive, like the built-in RegExp it replaced", function () {
+      expect(is("/POSTS/hello", "/posts/(.*)")).toBe(true);
+    });
+
+    it("returns false instead of throwing for an invalid pattern", function () {
+      expect(is("/anything", "(")).toBe(false);
+    });
+
+    it("does not hang on a pattern crafted for catastrophic backtracking", function () {
+      // (a+)+$ is a classic ReDoS pattern: a backtracking engine takes
+      // exponential time to fail to match a run of "a"s followed by a
+      // character that can never satisfy the trailing $. RE2 matches in
+      // time linear in the length of the input, so this stays fast
+      // regardless of how many "a"s are added.
+      var evilInput = "a".repeat(40) + "!";
+
+      var start = Date.now();
+      var result = is(evilInput, "(a+)+$");
+      var duration = Date.now() - start;
+
+      expect(result).toBe(false);
+      expect(duration).toBeLessThan(1000);
+    });
+  });
+
+  describe("map", function () {
+    it("substitutes a capture group, as in the docs example", function () {
+      expect(map("/posts/hello", "/posts/(.*)", "/blog/$1")).toEqual(
+        "/blog/hello"
+      );
+    });
+
+    it("returns null instead of throwing for an invalid pattern", function () {
+      expect(map("/anything", "(", "/elsewhere")).toEqual(null);
+    });
+
+    it("returns null for a pattern RE2 does not support, such as a lookahead", function () {
+      expect(map("/posts/hello", "/posts/(?=hello)", "/blog")).toEqual(null);
+    });
+  });
+
+  describe("matches", function () {
+    it("matches an exact 'to' against existing mappings", function () {
+      expect(matches("/blog/hello", [{ from: "/blog/hello" }])).toBe(true);
+    });
+
+    it("matches a 'to' against an existing regex mapping", function () {
+      expect(matches("/blog/hello", [{ from: "/posts/(.*)" }])).toBe(false);
+      expect(matches("/posts/hello", [{ from: "/posts/(.*)" }])).toBe(true);
+    });
+
+    it("returns false when nothing matches", function () {
+      expect(matches("/nothing", [{ from: "/posts/(.*)" }])).toBe(false);
+    });
+  });
+});

--- a/app/models/redirects/util.js
+++ b/app/models/redirects/util.js
@@ -1,3 +1,5 @@
+var RE2 = require("re2");
+
 function isRegex(string) {
   return (
     string &&
@@ -9,7 +11,9 @@ function isRegex(string) {
 
 function is(input, from) {
   try {
-    from = new RegExp(from, "i");
+    // RE2 matches in linear time, so a redirect's 'from' pattern can't be
+    // crafted to hang the process the way a backtracking RegExp can.
+    from = new RE2(from, "i");
   } catch (e) {
     return false;
   }
@@ -22,7 +26,7 @@ function notRegex(string) {
 
 function map(input, from, to) {
   try {
-    from = new RegExp(from, "i");
+    from = new RE2(from, "i");
   } catch (e) {
     return null;
   }

--- a/app/models/template/getViewByURL.js
+++ b/app/models/template/getViewByURL.js
@@ -1,9 +1,9 @@
 const key = require("./key");
 const client = require("models/client");
 const debug = require("debug")("blot:template:getViewByURLPattern");
-const { match } = require("path-to-regexp");
 const { parse } = require("url");
 const urlNormalizer = require("helper/urlNormalizer");
+const { matchViewPatterns, parseViewPatterns } = require("./viewURLPatterns");
 
 /**
  * Get a view by matching its URL pattern.
@@ -29,38 +29,26 @@ module.exports = async function getViewByURLPattern(templateID, url, callback) {
 
   try {
     const { pathname, query } = parse(url, true); // `true` parses query string into an object
-    const normalizedPathname = normalizePathname(pathname);
 
-    debug("Normalized URL:", normalizedPathname);
+    debug("Normalized URL:", pathname);
 
     // Fetch all views and their patterns for the given template ID
     const viewPatternStrings = await client.hGetAll(key.urlPatterns(templateID));
 
     if (viewPatternStrings) {
       const views = parseViewPatterns(viewPatternStrings);
+      const matched = matchViewPatterns(views, pathname);
 
-      // Iterate through views and match the URL
-      for (const [viewName, urlPatterns] of views) {
-        for (const rawPattern of urlPatterns) {
-          try {
-            const matchResult = safeMatch(rawPattern, normalizedPathname);
-
-            if (matchResult) {
-              debug(
-                "Matched pattern:",
-                rawPattern,
-                "with normalized URL:",
-                normalizedPathname,
-                "in view:",
-                viewName
-              );
-              return callback(null, viewName, matchResult.params, query);
-            }
-          } catch (err) {
-            debug("Error while matching pattern:", rawPattern, err);
-            // Continue to the next pattern without failing completely
-          }
-        }
+      if (matched) {
+        debug(
+          "Matched pattern:",
+          matched.pattern,
+          "with URL:",
+          pathname,
+          "in view:",
+          matched.viewName
+        );
+        return callback(null, matched.viewName, matched.params, query);
       }
 
       debug("No matching URL pattern found for URL:", url);
@@ -83,47 +71,3 @@ module.exports = async function getViewByURLPattern(templateID, url, callback) {
     return callback(error, null, null, null);
   }
 };
-
-/**
- * Normalize a pathname by adding a leading slash, removing trailing slashes, and converting to lowercase.
- *
- * @param {string} pathname - The pathname to normalize.
- * @returns {string} - The normalized pathname.
- */
-function normalizePathname(pathname) {
-  if (!pathname || typeof pathname !== "string") {
-    return "/";
-  }
-  return `/${pathname.replace(/^\/+/, "").replace(/\/+$/, "").toLowerCase()}`;
-}
-
-/**
- * Parse view patterns from Redis hash object.
- *
- * @param {object} viewPatternStrings - The Redis hash object with view patterns.
- * @returns {Array} - An array of [viewName, urlPatterns].
- */
-function parseViewPatterns(viewPatternStrings) {
-  return Object.entries(viewPatternStrings).map(([viewName, patterns]) => [
-    viewName,
-    JSON.parse(patterns), // Patterns are stored as JSON strings
-  ]).sort(([viewNameA], [viewNameB]) =>
-    viewNameA.localeCompare(viewNameB)
-  );
-}
-
-/**
- * Safely match a URL against a pattern.
- *
- * @param {string} rawPattern - The raw URL pattern to match.
- * @param {string} normalizedPathname - The normalized URL pathname.
- * @returns {object|null} - The match result or null if no match.
- */
-function safeMatch(rawPattern, normalizedPathname) {
-  const normalizedPattern = normalizePathname(rawPattern);
-
-  // Use path-to-regexp to create a matching function
-  const matchPattern = match(normalizedPattern, { decode: false });
-
-  return matchPattern(normalizedPathname);
-}

--- a/app/models/template/getViewsByURLs.js
+++ b/app/models/template/getViewsByURLs.js
@@ -1,0 +1,74 @@
+const key = require("./key");
+const client = require("models/client");
+const { parse } = require("url");
+const urlNormalizer = require("helper/urlNormalizer");
+const { matchViewPatterns, parseViewPatterns } = require("./viewURLPatterns");
+
+/**
+ * Resolve many URLs against a template's views at once.
+ *
+ * Calling getViewByURL in a loop costs two redis round trips per URL. This
+ * fetches the template's URL patterns once and looks up the remaining URLs in
+ * a single mGet, so the cost does not grow with the number of URLs.
+ *
+ * @param {string} templateID - The ID of the template.
+ * @param {string[]} urls - The URLs to match.
+ * @param {function} callback - Callback function (err, viewNames) where
+ *   viewNames is an array parallel to urls containing a view name or null.
+ */
+module.exports = function getViewsByURLs(templateID, urls, callback) {
+  if (!templateID || typeof templateID !== "string") {
+    return callback(new Error("Invalid templateID"));
+  }
+
+  if (!Array.isArray(urls)) {
+    return callback(new Error("Invalid urls"));
+  }
+
+  if (!urls.length) return callback(null, []);
+
+  (async function () {
+    try {
+      const viewPatternStrings = await client.hGetAll(
+        key.urlPatterns(templateID)
+      );
+
+      const views = viewPatternStrings
+        ? parseViewPatterns(viewPatternStrings)
+        : [];
+
+      const viewNames = urls.map((url) => {
+        if (!url || typeof url !== "string") return null;
+
+        const { pathname } = parse(url);
+        const matched = matchViewPatterns(views, pathname);
+
+        return matched ? matched.viewName : null;
+      });
+
+      // Views whose URL was stored verbatim rather than as a pattern
+      const unmatched = [];
+
+      viewNames.forEach(function (viewName, index) {
+        if (!viewName && typeof urls[index] === "string" && urls[index])
+          unmatched.push(index);
+      });
+
+      if (unmatched.length) {
+        const urlKeys = unmatched.map((index) =>
+          key.url(templateID, urlNormalizer(urls[index]))
+        );
+
+        const resolved = await client.mGet(urlKeys);
+
+        unmatched.forEach(function (index, position) {
+          viewNames[index] = resolved[position] || null;
+        });
+      }
+
+      callback(null, viewNames);
+    } catch (err) {
+      callback(err);
+    }
+  })();
+};

--- a/app/models/template/index.js
+++ b/app/models/template/index.js
@@ -9,6 +9,7 @@ module.exports = {
   getFullView: require("./getFullView"),
   getView: require("./getView"),
   getViewByURL: require("./getViewByURL"),
+  getViewsByURLs: require("./getViewsByURLs"),
   setView: require("./setView"),
   dropView: require("./dropView"),
   getPartials: require("./getPartials"),

--- a/app/models/template/tests/getViewsByURLs.js
+++ b/app/models/template/tests/getViewsByURLs.js
@@ -1,0 +1,49 @@
+describe("template", function () {
+  const { promisify } = require("util");
+  const getViewsByURLs = require("models/template").getViewsByURLs;
+
+  require("./setup")({ createTemplate: true });
+
+  beforeEach(function () {
+    this.getViewsByURLs = (urls) =>
+      promisify(getViewsByURLs)(this.template.id, urls);
+  });
+
+  it("gets views for many URLs at once", async function () {
+    await this.setView({ name: "apple.html", url: ["/apple"] });
+    await this.setView({ name: "pear.html", url: ["/pear/:variety"] });
+
+    const viewNames = await this.getViewsByURLs([
+      "/apple",
+      "/pear/conference",
+      "/banana",
+    ]);
+
+    expect(viewNames).toEqual(["apple.html", "pear.html", null]);
+  });
+
+  it("gets views for URLs with a trailing slash, mixed case or query string", async function () {
+    await this.setView({ name: "apple.html", url: ["/apple"] });
+
+    expect(await this.getViewsByURLs(["/Apple/", "/apple?foo=bar"])).toEqual([
+      "apple.html",
+      "apple.html",
+    ]);
+  });
+
+  it("agrees with getViewByURL", async function () {
+    await this.setView({ name: "apple.html", url: ["/apple", "/page/:page"] });
+
+    const urls = ["/apple", "/page/2", "/pear"];
+    const viewNames = await this.getViewsByURLs(urls);
+
+    for (const [index, url] of urls.entries()) {
+      const { viewName } = await this.getViewByURL(url);
+      expect(viewNames[index]).toEqual(viewName || null);
+    }
+  });
+
+  it("returns nothing when there are no URLs", async function () {
+    expect(await this.getViewsByURLs([])).toEqual([]);
+  });
+});

--- a/app/models/template/viewURLPatterns.js
+++ b/app/models/template/viewURLPatterns.js
@@ -1,0 +1,83 @@
+const { match } = require("path-to-regexp");
+
+/**
+ * Normalize a pathname by adding a leading slash, removing trailing slashes, and converting to lowercase.
+ *
+ * @param {string} pathname - The pathname to normalize.
+ * @returns {string} - The normalized pathname.
+ */
+function normalizePathname(pathname) {
+  if (!pathname || typeof pathname !== "string") {
+    return "/";
+  }
+  return `/${pathname.replace(/^\/+/, "").replace(/\/+$/, "").toLowerCase()}`;
+}
+
+/**
+ * Parse view patterns from Redis hash object.
+ *
+ * @param {object} viewPatternStrings - The Redis hash object with view patterns.
+ * @returns {Array} - An array of [viewName, urlPatterns].
+ */
+function parseViewPatterns(viewPatternStrings) {
+  return Object.entries(viewPatternStrings)
+    .map(([viewName, patterns]) => [
+      viewName,
+      JSON.parse(patterns), // Patterns are stored as JSON strings
+    ])
+    .sort(([viewNameA], [viewNameB]) => viewNameA.localeCompare(viewNameB));
+}
+
+/**
+ * Safely match a URL against a pattern.
+ *
+ * @param {string} rawPattern - The raw URL pattern to match.
+ * @param {string} normalizedPathname - The normalized URL pathname.
+ * @returns {object|null} - The match result or null if no match.
+ */
+function safeMatch(rawPattern, normalizedPathname) {
+  const normalizedPattern = normalizePathname(rawPattern);
+
+  // Use path-to-regexp to create a matching function
+  const matchPattern = match(normalizedPattern, { decode: false });
+
+  return matchPattern(normalizedPathname);
+}
+
+/**
+ * Find the first view whose URL patterns match a pathname.
+ *
+ * @param {Array} views - An array of [viewName, urlPatterns], as returned by parseViewPatterns.
+ * @param {string} pathname - The pathname to match, without a query string.
+ * @returns {object|null} - {viewName, pattern, params} or null if nothing matched.
+ */
+function matchViewPatterns(views, pathname) {
+  const normalizedPathname = normalizePathname(pathname);
+
+  for (const [viewName, urlPatterns] of views) {
+    for (const rawPattern of urlPatterns) {
+      try {
+        const matchResult = safeMatch(rawPattern, normalizedPathname);
+
+        if (matchResult) {
+          return {
+            viewName,
+            pattern: rawPattern,
+            params: matchResult.params,
+          };
+        }
+      } catch (err) {
+        // Continue to the next pattern without failing completely
+      }
+    }
+  }
+
+  return null;
+}
+
+module.exports = {
+  matchViewPatterns,
+  normalizePathname,
+  parseViewPatterns,
+  safeMatch,
+};

--- a/app/views/dashboard/dashboard.css
+++ b/app/views/dashboard/dashboard.css
@@ -319,6 +319,57 @@ span.file {
   border-right: 1px solid #eeeeec;
 }
 
+.redirectWarningsNotice {
+  font-size: var(--small-font-size);
+  line-height: 1.5;
+  color: var(--warning-text-color);
+  background-color: #fdf6ee;
+  border-radius: var(--border-radius);
+  padding: 12px 16px;
+  margin: 0 0 16px;
+}
+
+.redirectWarningsNotice a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+#redirects .redirectWarning {
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 6px 10px;
+  cursor: help;
+  color: var(--warning-text-color);
+}
+
+#redirects .redirectWarning:focus {
+  outline: none;
+}
+
+#redirects .redirectWarningMessage {
+  display: none;
+  position: absolute;
+  z-index: 5;
+  top: calc(100% + 6px);
+  right: -1px;
+  width: 240px;
+  padding: 10px 12px;
+  font-size: var(--small-font-size);
+  line-height: 1.4;
+  color: var(--text-color);
+  background-color: var(--background-color);
+  border: 1px solid #eeeeec;
+  border-radius: var(--border-radius);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  cursor: auto;
+}
+
+#redirects .redirectWarning:hover .redirectWarningMessage,
+#redirects .redirectWarning:focus .redirectWarningMessage {
+  display: block;
+}
+
 
 .pageLink {
 line-height: 48px;

--- a/app/views/dashboard/site/settings/redirects/index.html
+++ b/app/views/dashboard/site/settings/redirects/index.html
@@ -40,6 +40,15 @@
   
 <br>
 
+{{#redirectWarnings}}
+<p class="redirectWarningsNotice">
+  <span class="icon-small-alert" aria-hidden="true"></span>
+  Blot checks your redirects last, once it has failed to find a post, a page,
+  a template view or a file at a URL. The redirects marked below will never be
+  used because something on your site already answers to the URL they redirect
+  from. <a href="/how/configure/redirects">Read more</a>
+</p>
+{{/redirectWarnings}}
 
 <section id="stage">
   
@@ -66,6 +75,12 @@
         type="text"
         name="redirects.{{ index }}.to"
         value="{{ to }}" />
+      {{#warning}}
+      <span class="redirectWarning" tabindex="0">
+        <span class="icon-small-alert" aria-hidden="true"></span>
+        <span class="redirectWarningMessage" role="note">{{ warning }}</span>
+      </span>
+      {{/warning}}
       <a href="#!" class="removeLink">
         <svg style="fill: currentColor;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path d="M11 1.75V3h2.25a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1 0-1.5H5V1.75C5 .784 5.784 0 6.75 0h2.5C10.216 0 11 .784 11 1.75ZM4.496 6.675l.66 6.6a.25.25 0 0 0 .249.225h5.19a.25.25 0 0 0 .249-.225l.66-6.6a.75.75 0 0 1 1.492.149l-.66 6.6A1.748 1.748 0 0 1 10.595 15h-5.19a1.75 1.75 0 0 1-1.741-1.575l-.66-6.6a.75.75 0 1 1 1.492-.15ZM6.5 1.75V3h3V1.75a.25.25 0 0 0-.25-.25h-2.5a.25.25 0 0 0-.25.25Z"></path></svg>
         Delete

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "puppeteer": "24.1.1",
     "pushover": "1.3.6",
     "rate-limit-redis": "4.3.1",
+    "re2": "1.26.1",
     "redis": "6.1.0",
     "sharp": "0.34.4",
     "simple-git": "3.23.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Blot checks a site's redirects last, once it has failed to find anything else to serve for a URL (see the order of routes in `app/blog/index.js`). A redirect whose `from` is already served by a post, a page, a template view, a file in the folder, or one of Blot's own routes therefore never runs. People understandably read that as the redirect being broken, and it's currently invisible in the dashboard.

## What

The redirects page now marks each redirect which will never be used with a warning icon. Hovering or focusing it explains what already answers to that URL, and a notice above the list explains the order Blot resolves URLs in — but only when at least one redirect is affected, so the page is unchanged for sites with no problems.

## How

`Redirects.conflicts(blog, redirects, callback)` returns a result for every redirect, in four stages, each of which only looks at redirects no earlier stage explained:

- Blot's own routes (`/`, `/page/2`, `/search`, `/tagged/apples`, `/random`, …) — string comparisons, no I/O. Routes which fall through when they have nothing to serve, such as `/robots.txt` and the draft previews, are deliberately absent, because a redirect for those URLs does run.
- Posts and pages — one `mGet` over the `blog:<id>:url:<path>` keys narrows the list to paths which have an entry, then only those are loaded in full so drafts, scheduled and deleted entries can be discarded.
- Template views — `Template.getViewsByURLs`, added here, resolves the whole list against the template's URL patterns using a fixed number of round trips. Calling the existing `getViewByURL` in a loop would have cost two round trips per redirect, so its pattern matching has been extracted into `viewURLPatterns.js` and is now shared by both.
- Files in the folder — the candidate paths `assets.js` would try, checked with `fs.stat`. Its case-insensitive walk of the folder is skipped, since it is expensive, so a file capitalized differently to the redirect goes unnoticed.

Redirects which are regular expressions, or which point at another site, are left alone: resolving them is not cheap and, in the latter case, they never match a request path anyway.

The whole check costs a handful of redis round trips and a few `fs.stat` calls for a typical site, and does not grow with the number of redirects — apart from the disk check, which is skipped altogether beyond 500 paths. It runs only on `GET /sites/:handle/settings/redirects`, and if it fails the list still renders without warnings.

## Tests

`npm test app/models/redirects/tests/conflicts.js` (15 specs) and `npm test app/models/template/tests/getViewsByURLs.js` (4 specs) both pass, as do the 10 existing `getViewByURL` specs which cover the extracted matching code.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43611d43-5d87-4bad-9058-fb0cd6392564?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43611d43-5d87-4bad-9058-fb0cd6392564&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

