### PR TITLE
Warn when a redirect will not run

### DIFF
--- a/app/dashboard/site/index.js
+++ b/app/dashboard/site/index.js
@@ -4,6 +4,7 @@ var load = require("./load");
 var save = require("./save");
 var trace = require("helper/trace");
 var flags = require("./flags");
+var Redirects = require("models/redirects");
 const sse = require("helper/sse")({
   channel: (req) => `sync:status:${req.blog.id}`,
 });
@@ -80,6 +81,19 @@ site.get("/settings/embeds", load.plugins, (req, res) => {
 
 site.get("/settings/services", load.plugins, (req, res) => {
   res.render("dashboard/site/settings/services");
+});
+
+site.get("/settings/redirects/conflict", (req, res, next) => {
+  const from = typeof req.query.from === "string" ? req.query.from : "";
+
+  Redirects.conflicts(req.blog, [{ from }], function (err, redirects) {
+    if (err) return next(err);
+
+    res.set("Cache-Control", "no-store");
+    res.json({
+      conflict: (redirects[0] && redirects[0].conflict) || null,
+    });
+  });
 });
 
 site.get("/settings/redirects", load.redirects, (req, res) => {

--- a/app/dashboard/site/load/redirects.js
+++ b/app/dashboard/site/load/redirects.js
@@ -2,7 +2,13 @@ const Redirects = require("models/redirects");
 
 module.exports = function (req, res, next) {
   Redirects.list(req.blog.id, function (err, redirects) {
-    res.locals.redirects = redirects;
-    next();
+    if (err) return next(err);
+
+    Redirects.conflicts(req.blog, redirects || [], function (conflictErr, annotated) {
+      if (conflictErr) return next(conflictErr);
+
+      res.locals.redirects = annotated;
+      next();
+    });
   });
 };

--- a/app/dashboard/tests/redirects.js
+++ b/app/dashboard/tests/redirects.js
@@ -1,0 +1,52 @@
+describe("dashboard redirects", function () {
+  const { promisify } = require("util");
+  const Redirects = require("models/redirects");
+
+  const setRedirects = promisify(Redirects.set);
+
+  global.test.site({ login: true });
+
+  it("warns when a saved redirect matches a built-in URL", async function () {
+    await setRedirects(this.blog.id, [
+      { from: "/search", to: "/" },
+      { from: "/old-url", to: "/" },
+    ]);
+
+    const $ = await this.parse(
+      `/sites/${this.blog.handle}/settings/redirects`
+    );
+
+    const conflictRow = $("#redirects section.has-conflict");
+    expect(conflictRow.length).toEqual(1);
+    expect(conflictRow.find("input.lab").val()).toEqual("/search");
+    expect(conflictRow.find(".redirect-conflict").attr("hidden")).toBeUndefined();
+    expect(conflictRow.find(".redirect-conflict").attr("data-tooltip")).toMatch(
+      /won't run/i
+    );
+
+    const okRow = $("#redirects section").filter(function () {
+      return $(this).find("input.lab").val() === "/old-url";
+    });
+    expect(okRow.hasClass("has-conflict")).toBe(false);
+    expect(okRow.find(".redirect-conflict").attr("hidden")).toBeDefined();
+  });
+
+  it("returns JSON for a single from path", async function () {
+    const conflictRes = await this.fetch(
+      `/sites/${this.blog.handle}/settings/redirects/conflict?from=/search`
+    );
+    expect(conflictRes.status).toEqual(200);
+
+    const conflict = await conflictRes.json();
+    expect(conflict.conflict.type).toEqual("route");
+    expect(conflict.conflict.message).toMatch(/search/i);
+
+    const freeRes = await this.fetch(
+      `/sites/${this.blog.handle}/settings/redirects/conflict?from=/old-cms-url`
+    );
+    expect(freeRes.status).toEqual(200);
+
+    const free = await freeRes.json();
+    expect(free.conflict).toBe(null);
+  });
+});

--- a/app/dashboard/tests/redirects.js
+++ b/app/dashboard/tests/redirects.js
@@ -20,7 +20,10 @@ describe("dashboard redirects", function () {
     expect(conflictRow.length).toEqual(1);
     expect(conflictRow.find("input.lab").val()).toEqual("/search");
     expect(conflictRow.find(".redirect-conflict").attr("hidden")).toBeUndefined();
-    expect(conflictRow.find(".redirect-conflict").attr("data-tooltip")).toMatch(
+    expect(conflictRow.find(".redirect-conflict").attr("title")).toMatch(
+      /won't run/i
+    );
+    expect(conflictRow.find(".redirect-conflict-tooltip").text()).toMatch(
       /won't run/i
     );
 

--- a/app/models/redirects/README
+++ b/app/models/redirects/README
@@ -4,13 +4,14 @@ Manages per-blog URL redirect rules. Redirect rules are stored in Redis and eval
 
 ## Role in the application
 
-This module sits in the `app/models` layer alongside other Redis-backed data models (entries, tags, 404s, etc.). It is the sole read/write interface for redirect data. The blog request pipeline calls `check` on every unmatched URL; the dashboard calls `set` and `list` to let blog owners manage their redirect rules.
+This module sits in the `app/models` layer alongside other Redis-backed data models (entries, tags, 404s, etc.). It is the sole read/write interface for redirect data. The blog request pipeline calls `check` on every unmatched URL; the dashboard calls `set`, `list`, and `conflicts` to let blog owners manage their redirect rules and see when a rule will not run.
 
 ## File inventory
 
 | File | Responsibility |
 |---|---|
-| `index.js` | Re-exports the public interface: `check`, `drop`, `get`, `key`, `list`, `set`, `util`. |
+| `index.js` | Re-exports the public interface: `check`, `conflicts`, `drop`, `get`, `key`, `list`, `set`, `util`. |
+| `conflicts.js` | Cheap dashboard lookup: for each exact (non-regex) `from` path, reports whether a post, page, template view, built-in route, or folder file would be served instead. |
 | `key.js` | Generates Redis key strings for this model. |
 | `set.js` | Writes a full replacement set of redirect mappings for a blog, atomically. |
 | `get.js` | Looks up the redirect destination for a single `from` path, resolving regex captures if applicable. |
@@ -72,6 +73,23 @@ Resolution order:
 2. If no direct match, scans the sorted set with `zScan`, testing each member that is identified as a regex pattern against `input`.
 3. Returns `undefined` if no rule matches.
 
+### `conflicts(blog, redirects, callback)`
+
+Annotates redirect rules with a `conflict` object when the `from` path would never be evaluated. Used by the dashboard redirects page.
+
+- `blog` — blog object (`id` and `template` are used)
+- `redirects` — array of `{ from, to, ... }` objects (typically from `list`)
+- `callback` — called with `(err, redirects)` where matching items gain a `conflict` of `{ type, message, ... }`
+
+Checks, in request-pipeline order:
+
+1. A published post or page at that URL (`Entry.getByUrl`).
+2. Built-in routes: `/`, `/search`, `/random`, `/robots.txt`, `/page/:n`, `/tagged/...`.
+3. A template view (`getViewByURL`).
+4. A file in the site folder (`fs.stat` of the path and its lowercase variant).
+
+Regex rules are skipped: they still apply to URLs that do not match existing content. Each exact rule is a handful of Redis lookups and at most a couple of `stat` calls.
+
 ### `list(blogID, callback)`
 
 Returns all redirect rules for the blog in insertion order.
@@ -116,7 +134,9 @@ Exported for use by callers that need regex-awareness outside the standard CRUD 
 
 ### Dashboard
 
-`app/dashboard/site/load/redirects.js` calls `Redirects.list` to populate `res.locals.redirects` for the site settings page.
+`app/dashboard/site/load/redirects.js` calls `Redirects.list` then `Redirects.conflicts` to populate `res.locals.redirects` for the site settings page, including per-rule warnings.
+
+`GET /settings/redirects/conflict?from=` returns `{ conflict }` as JSON so the redirects page can re-check a rule as it is typed.
 
 `app/dashboard/site/save/redirects.js` normalizes form input and calls `Redirects.set` to persist the updated rule list. Normalization ensures bare paths without a leading `/` are prefixed before storage.
 

--- a/app/models/redirects/conflicts.js
+++ b/app/models/redirects/conflicts.js
@@ -1,0 +1,223 @@
+var fs = require("fs-extra");
+var ensure = require("helper/ensure");
+var localPath = require("helper/localPath");
+var urlNormalizer = require("helper/urlNormalizer");
+var Entry = require("models/entry");
+var getViewByURL = require("models/template").getViewByURL;
+var isRegex = require("./util").isRegex;
+
+// Redirects are evaluated last, after posts/pages, template views,
+// built-in routes, and files in the site folder. This lookup is used
+// by the dashboard to warn about rules that will never run.
+//
+// Cost is a handful of Redis GETs plus at most a few fs.stat calls
+// per exact (non-regex) redirect — cheap enough for the settings page.
+
+function normalizeFrom(from) {
+  if (!from || typeof from !== "string") return "";
+
+  from = from.trim();
+
+  if (!from) return "";
+
+  try {
+    from = decodeURI(from);
+  } catch (e) {
+    // keep encoded form if malformed
+  }
+
+  // Full URLs are not compared against site paths
+  if (from.indexOf("://") !== -1) return "";
+
+  return urlNormalizer(from);
+}
+
+function messageFor(conflict) {
+  if (!conflict) return "";
+
+  if (conflict.type === "post") {
+    return conflict.title
+      ? 'This redirect won\'t run because the post "' +
+          conflict.title +
+          '" already exists at this URL.'
+      : "This redirect won't run because a post already exists at this URL.";
+  }
+
+  if (conflict.type === "page") {
+    return conflict.title
+      ? 'This redirect won\'t run because the page "' +
+          conflict.title +
+          '" already exists at this URL.'
+      : "This redirect won't run because a page already exists at this URL.";
+  }
+
+  if (conflict.type === "template") {
+    return conflict.view
+      ? "This redirect won't run because it matches a page in your template (" +
+          conflict.view +
+          ")."
+      : "This redirect won't run because it matches a page in your template.";
+  }
+
+  if (conflict.type === "file") {
+    return "This redirect won't run because a file in your folder exists at this URL.";
+  }
+
+  if (conflict.type === "route") {
+    return conflict.label
+      ? "This redirect won't run because this URL is used by " +
+          conflict.label +
+          "."
+      : "This redirect won't run because this URL is already used by your site.";
+  }
+
+  return "This redirect won't run because it matches an existing post, page, or template URL.";
+}
+
+function withMessage(conflict) {
+  if (!conflict) return null;
+  conflict.message = messageFor(conflict);
+  return conflict;
+}
+
+function getEntry(blogID, url) {
+  return new Promise(function (resolve) {
+    Entry.getByUrl(blogID, url, function (entry) {
+      resolve(entry || null);
+    });
+  });
+}
+
+function getViewName(templateID, url) {
+  return new Promise(function (resolve) {
+    if (!templateID) return resolve(null);
+
+    getViewByURL(templateID, url, function (err, viewName) {
+      if (err || !viewName) return resolve(null);
+      resolve(viewName);
+    });
+  });
+}
+
+function matchBuiltIn(url) {
+  if (url === "/") {
+    return { type: "route", label: "your homepage" };
+  }
+
+  if (url === "/search") {
+    return { type: "route", label: "search" };
+  }
+
+  if (url === "/random" || url.indexOf("/random/") === 0) {
+    return { type: "route", label: "random posts" };
+  }
+
+  if (url === "/robots.txt") {
+    return { type: "route", label: "robots.txt" };
+  }
+
+  if (/^\/page\/\d+$/.test(url)) {
+    return { type: "route", label: "paginated posts" };
+  }
+
+  if (/^\/tagged\//.test(url)) {
+    return { type: "route", label: "tagged posts" };
+  }
+
+  return null;
+}
+
+async function existingFile(blogID, url) {
+  if (!url || url === "/") return null;
+
+  var candidates = [url];
+  var lower = url.toLowerCase();
+
+  if (lower !== url) candidates.push(lower);
+
+  for (var i = 0; i < candidates.length; i++) {
+    var path = localPath(blogID, candidates[i]);
+
+    try {
+      var stat = await fs.stat(path);
+      if (stat.isFile()) return candidates[i];
+    } catch (e) {
+      // missing path
+    }
+  }
+
+  return null;
+}
+
+async function checkOne(blog, from, viewCache) {
+  var url = normalizeFrom(from);
+
+  if (!url || isRegex(from)) return null;
+
+  var entry = await getEntry(blog.id, url);
+
+  if (entry && !entry.deleted && !entry.draft && !entry.scheduled) {
+    return withMessage({
+      type: entry.page ? "page" : "post",
+      title: entry.title || "",
+      url: entry.url,
+    });
+  }
+
+  var builtIn = matchBuiltIn(url);
+
+  if (builtIn) return withMessage(builtIn);
+
+  var viewName;
+
+  if (viewCache && viewCache.has(url)) {
+    viewName = await viewCache.get(url);
+  } else {
+    var pending = getViewName(blog.template, url);
+    if (viewCache) viewCache.set(url, pending);
+    viewName = await pending;
+  }
+
+  if (viewName) {
+    return withMessage({
+      type: "template",
+      view: viewName,
+    });
+  }
+
+  var file = await existingFile(blog.id, url);
+
+  if (file) {
+    return withMessage({
+      type: "file",
+      path: file,
+    });
+  }
+
+  return null;
+}
+
+module.exports = function (blog, redirects, callback) {
+  ensure(blog, "object").and(redirects, "array").and(callback, "function");
+
+  var viewCache = new Map();
+
+  Promise.all(
+    redirects.map(function (redirect) {
+      var from = redirect && redirect.from;
+      return checkOne(blog, from, viewCache).then(function (conflict) {
+        if (!redirect || typeof redirect !== "object") return redirect;
+        if (conflict) {
+          redirect.conflict = conflict;
+        } else {
+          delete redirect.conflict;
+        }
+        return redirect;
+      });
+    })
+  )
+    .then(function (annotated) {
+      callback(null, annotated);
+    })
+    .catch(callback);
+};

--- a/app/models/redirects/index.js
+++ b/app/models/redirects/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   check: require("./check"),
+  conflicts: require("./conflicts"),
   drop: require("./drop"),
   get: require("./get"),
   key: require("./key"),

--- a/app/models/redirects/tests/conflicts.js
+++ b/app/models/redirects/tests/conflicts.js
@@ -1,0 +1,152 @@
+describe("redirect conflicts", function () {
+  const { promisify } = require("util");
+  const Redirects = require("models/redirects");
+  const Template = require("models/template");
+  const Blog = require("models/blog");
+
+  const conflicts = promisify(Redirects.conflicts);
+  const createTemplate = promisify(Template.create);
+  const setView = promisify(Template.setView);
+  const setBlog = promisify(Blog.set);
+
+  global.test.blog();
+
+  it("does not warn for a path that nothing else uses", async function () {
+    const annotated = await conflicts(this.blog, [
+      { from: "/old-cms-url", to: "/" },
+    ]);
+
+    expect(annotated[0].conflict).toBeUndefined();
+  });
+
+  it("skips regex redirects", async function () {
+    const annotated = await conflicts(this.blog, [
+      { from: "/posts/(.*)", to: "/blog/$1" },
+    ]);
+
+    expect(annotated[0].conflict).toBeUndefined();
+  });
+
+  it("warns when a from path matches a post", async function () {
+    await this.blog.write({
+      path: "/Hello.txt",
+      content: "Link: /hello\n\nHello world",
+    });
+    await this.blog.rebuild();
+
+    const annotated = await conflicts(this.blog, [
+      { from: "/hello", to: "/elsewhere" },
+      { from: "/free", to: "/" },
+    ]);
+
+    expect(annotated[0].conflict.type).toEqual("post");
+    expect(annotated[0].conflict.message).toMatch(/won't run/i);
+    expect(annotated[0].conflict.message).toMatch(/post/i);
+    expect(annotated[1].conflict).toBeUndefined();
+  });
+
+  it("warns when a from path matches a page", async function () {
+    await this.blog.write({
+      path: "/About.txt",
+      content: "Page: yes\nLink: /about\n\nAbout this site",
+    });
+    await this.blog.rebuild();
+
+    const annotated = await conflicts(this.blog, [
+      { from: "/about", to: "/" },
+    ]);
+
+    expect(annotated[0].conflict.type).toEqual("page");
+    expect(annotated[0].conflict.message).toMatch(/page/i);
+  });
+
+  it("does not warn for a draft at the same URL", async function () {
+    await this.blog.write({
+      path: "/Secret.txt",
+      content: "Draft: yes\nLink: /secret\n\nSecret",
+    });
+    await this.blog.rebuild();
+
+    const annotated = await conflicts(this.blog, [
+      { from: "/secret", to: "/" },
+    ]);
+
+    expect(annotated[0].conflict).toBeUndefined();
+  });
+
+  it("warns for built-in routes", async function () {
+    const annotated = await conflicts(this.blog, [
+      { from: "/", to: "/elsewhere" },
+      { from: "/search", to: "/" },
+      { from: "/page/2", to: "/" },
+      { from: "/tagged/foo", to: "/" },
+    ]);
+
+    expect(annotated[0].conflict.type).toEqual("route");
+    expect(annotated[0].conflict.message).toMatch(/homepage/i);
+    expect(annotated[1].conflict.type).toEqual("route");
+    expect(annotated[1].conflict.message).toMatch(/search/i);
+    expect(annotated[2].conflict.type).toEqual("route");
+    expect(annotated[3].conflict.type).toEqual("route");
+  });
+
+  it("warns when a from path matches a template view", async function () {
+    const template = await createTemplate(this.blog.id, "conflict-theme", {});
+
+    await setView(template.id, {
+      name: "archives.html",
+      content: "archives",
+      url: "/archives",
+    });
+
+    await setBlog(this.blog.id, { template: template.id });
+    this.blog.template = template.id;
+
+    const annotated = await conflicts(this.blog, [
+      { from: "/archives", to: "/" },
+    ]);
+
+    expect(annotated[0].conflict.type).toEqual("template");
+    expect(annotated[0].conflict.view).toEqual("archives.html");
+    expect(annotated[0].conflict.message).toMatch(/template/i);
+  });
+
+  it("warns when a from path matches a file in the folder", async function () {
+    await this.blog.write({
+      path: "/notes.pdf",
+      content: "not-an-entry",
+    });
+
+    const annotated = await conflicts(this.blog, [
+      { from: "/notes.pdf", to: "/" },
+    ]);
+
+    expect(annotated[0].conflict.type).toEqual("file");
+    expect(annotated[0].conflict.message).toMatch(/file/i);
+  });
+
+  it("prefers a post over a template view at the same URL", async function () {
+    const template = await createTemplate(this.blog.id, "prefer-post", {});
+
+    await setView(template.id, {
+      name: "about.html",
+      content: "about view",
+      url: "/about",
+    });
+
+    await setBlog(this.blog.id, { template: template.id });
+    this.blog.template = template.id;
+
+    await this.blog.write({
+      path: "/About.txt",
+      content: "Link: /about\n\nAbout the author",
+    });
+    await this.blog.rebuild();
+
+    const annotated = await conflicts(this.blog, [
+      { from: "/about", to: "/" },
+    ]);
+
+    expect(annotated[0].conflict.type).toEqual("post");
+  });
+});

--- a/app/views/dashboard/dashboard.css
+++ b/app/views/dashboard/dashboard.css
@@ -338,9 +338,13 @@ span.file {
   display: none;
 }
 
-#redirects .redirect-conflict:hover::after,
-#redirects .redirect-conflict:focus::after {
-  content: attr(data-tooltip);
+#redirects .redirect-conflict:hover .redirect-conflict-tooltip,
+#redirects .redirect-conflict:focus .redirect-conflict-tooltip {
+  display: block;
+}
+
+#redirects .redirect-conflict-tooltip {
+  display: none;
   position: absolute;
   right: 0;
   bottom: calc(100% + 6px);

--- a/app/views/dashboard/dashboard.css
+++ b/app/views/dashboard/dashboard.css
@@ -319,6 +319,41 @@ span.file {
   border-right: 1px solid #eeeeec;
 }
 
+#redirects section.has-conflict {
+  border-color: var(--warning-text-color);
+}
+
+#redirects .redirect-conflict {
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 6px 10px;
+  color: var(--warning-text-color);
+  cursor: help;
+  border-left: 1px solid #eeeeec;
+  flex-shrink: 0;
+}
+
+#redirects .redirect-conflict[hidden] {
+  display: none;
+}
+
+#redirects .redirect-conflict:hover::after,
+#redirects .redirect-conflict:focus::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 6px);
+  width: 220px;
+  padding: 8px 10px;
+  background: #111;
+  color: #fff;
+  font-size: 13px;
+  line-height: 1.35;
+  border-radius: var(--border-radius);
+  z-index: 5;
+  pointer-events: none;
+}
 
 .pageLink {
 line-height: 48px;

--- a/app/views/dashboard/site/settings/redirects/conflict-warning.html
+++ b/app/views/dashboard/site/settings/redirects/conflict-warning.html
@@ -1,9 +1,9 @@
 <span
   class="redirect-conflict"
   {{^conflict}}hidden{{/conflict}}
-  {{#conflict}}data-tooltip="{{message}}" title="{{message}}"{{/conflict}}
+  {{#conflict}}title="{{message}}"{{/conflict}}
   tabindex="0"
   role="img"
   aria-label="{{#conflict}}{{message}}{{/conflict}}{{^conflict}}This redirect may not run{{/conflict}}"
   ><span class="icon-small-alert"></span
-></span>
+  ><span class="redirect-conflict-tooltip">{{#conflict}}{{message}}{{/conflict}}</span></span>

--- a/app/views/dashboard/site/settings/redirects/conflict-warning.html
+++ b/app/views/dashboard/site/settings/redirects/conflict-warning.html
@@ -1,0 +1,9 @@
+<span
+  class="redirect-conflict"
+  {{^conflict}}hidden{{/conflict}}
+  {{#conflict}}data-tooltip="{{message}}" title="{{message}}"{{/conflict}}
+  tabindex="0"
+  role="img"
+  aria-label="{{#conflict}}{{message}}{{/conflict}}{{^conflict}}This redirect may not run{{/conflict}}"
+  ><span class="icon-small-alert"></span
+></span>

--- a/app/views/dashboard/site/settings/redirects/index.html
+++ b/app/views/dashboard/site/settings/redirects/index.html
@@ -43,7 +43,7 @@
 
 <section id="stage">
   
-  <section id="redirects" class="fullRow sortable" style="max-width: 100%">
+  <section id="redirects" class="fullRow sortable" style="max-width: 100%" data-conflict-check="{{{base}}}/settings/redirects/conflict">
 
     <span id="emptyRedirects" style="display: none;{{^redirects.length}}display: block;{{/redirects.length}}border:1px solid #eeeeec;text-align: center;border-radius: 4px;padding:48px 24px;font-size: var(--small-font-size);color:var(--light-text-color)"
       >
@@ -52,7 +52,7 @@
 
 
     {{#redirects}}
-    <section>
+    <section class="{{#conflict}}has-conflict{{/conflict}}">
       <span class="handle"><svg xmlns="http://www.w3.org/2000/svg" width="8" height="16" fill="none" viewBox="0 0 8 16"><circle cx="6.5" cy="3" r="1.4" fill="currentColor" transform="rotate(90 6.5 3)"></circle><circle cx="1.5" cy="3" r="1.4" fill="currentColor" transform="rotate(90 1.5 3)"></circle><circle cx="6.5" cy="8" r="1.4" fill="currentColor" transform="rotate(90 6.5 8)"></circle><circle cx="1.5" cy="8" r="1.4" fill="currentColor" transform="rotate(90 1.5 8)"></circle><circle cx="6.5" cy="13" r="1.4" fill="currentColor" transform="rotate(90 6.5 13)"></circle><circle cx="1.5" cy="13" r="1.4" fill="currentColor" transform="rotate(90 1.5 13)"></circle></svg></span>
           <input
         class="lab"
@@ -66,6 +66,7 @@
         type="text"
         name="redirects.{{ index }}.to"
         value="{{ to }}" />
+      {{> conflict-warning}}
       <a href="#!" class="removeLink">
         <svg style="fill: currentColor;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path d="M11 1.75V3h2.25a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1 0-1.5H5V1.75C5 .784 5.784 0 6.75 0h2.5C10.216 0 11 .784 11 1.75ZM4.496 6.675l.66 6.6a.25.25 0 0 0 .249.225h5.19a.25.25 0 0 0 .249-.225l.66-6.6a.75.75 0 0 1 1.492.149l-.66 6.6A1.748 1.748 0 0 1 10.595 15h-5.19a1.75 1.75 0 0 1-1.741-1.575l-.66-6.6a.75.75 0 1 1 1.492-.15ZM6.5 1.75V3h3V1.75a.25.25 0 0 0-.25-.25h-2.5a.25.25 0 0 0-.25.25Z"></path></svg>
         Delete
@@ -92,6 +93,7 @@
     type="text"
     name="redirects.{index}.to"
     value="" />
+  {{> conflict-warning}}
   <a href="#!" class="removeLink">
     <svg style="fill:currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path d="M11 1.75V3h2.25a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1 0-1.5H5V1.75C5 .784 5.784 0 6.75 0h2.5C10.216 0 11 .784 11 1.75ZM4.496 6.675l.66 6.6a.25.25 0 0 0 .249.225h5.19a.25.25 0 0 0 .249-.225l.66-6.6a.75.75 0 0 1 1.492.149l-.66 6.6A1.748 1.748 0 0 1 10.595 15h-5.19a1.75 1.75 0 0 1-1.741-1.575l-.66-6.6a.75.75 0 1 1 1.492-.15ZM6.5 1.75V3h3V1.75a.25.25 0 0 0-.25-.25h-2.5a.25.25 0 0 0-.25.25Z"></path></svg>
     Delete</a>

--- a/app/views/how/configure/redirects.html
+++ b/app/views/how/configure/redirects.html
@@ -64,5 +64,7 @@
 <h2>Why isn't my redirect working?</h2>
 <p>
   Redirects are evaluated last. This means that a redirect will not resolve if
-  it matches an existing post’s URL, or the path to a file in your folder.
+  it matches an existing post’s URL, or the path to a file in your folder. The
+  <a href="/sites/default/settings/redirects">Redirects</a> page warns you when
+  a rule matches a post, page, or template URL.
 </p>

--- a/app/views/js/redirects.js
+++ b/app/views/js/redirects.js
@@ -4,6 +4,71 @@ const redirectsContainer = document.getElementById("redirects");
 
 if (redirectsContainer) {
 
+const conflictCheckURL = redirectsContainer.getAttribute("data-conflict-check");
+
+function setConflict(section, conflict) {
+  const warning = section.querySelector(".redirect-conflict");
+  if (!warning) return;
+
+  if (conflict && conflict.message) {
+    warning.hidden = false;
+    warning.setAttribute("data-tooltip", conflict.message);
+    warning.setAttribute("title", conflict.message);
+    warning.setAttribute("aria-label", conflict.message);
+    section.classList.add("has-conflict");
+  } else {
+    warning.hidden = true;
+    warning.removeAttribute("data-tooltip");
+    warning.removeAttribute("title");
+    warning.setAttribute("aria-label", "This redirect may not run");
+    section.classList.remove("has-conflict");
+  }
+}
+
+async function checkFrom(section) {
+  const fromInput = section.querySelector('input[name*=".from"]');
+  if (!fromInput || !conflictCheckURL) return;
+
+  const from = fromInput.value.trim();
+  if (!from) {
+    setConflict(section, null);
+    return;
+  }
+
+  try {
+    const url = new URL(conflictCheckURL, window.location.origin);
+    url.searchParams.set("from", from);
+    const res = await fetch(url.toString(), {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return;
+    const data = await res.json();
+    setConflict(section, data.conflict);
+  } catch (err) {
+    // leave the existing warning in place if the check fails
+  }
+}
+
+function bindConflictCheck(section) {
+  const fromInput = section.querySelector('input[name*=".from"]');
+  if (!fromInput || fromInput.dataset.conflictBound) return;
+  fromInput.dataset.conflictBound = "true";
+
+  let timer;
+  fromInput.addEventListener("input", function () {
+    clearTimeout(timer);
+    timer = setTimeout(function () {
+      checkFrom(section);
+    }, 300);
+  });
+  fromInput.addEventListener("blur", function () {
+    clearTimeout(timer);
+    checkFrom(section);
+  });
+}
+
+redirectsContainer.querySelectorAll("section").forEach(bindConflictCheck);
+
 const sortable = new Sortable(sortEl, {
     handle: ".handle",
     ghostClass: "sortable-ghost",
@@ -68,6 +133,8 @@ const sortable = new Sortable(sortEl, {
     });
 
     redirectsContainer.appendChild(newlink);
+    bindConflictCheck(newlink);
+    if (from) checkFrom(newlink);
 
     if (from) {
       newlink.querySelector('input[name*="to"]').focus();
@@ -75,7 +142,6 @@ const sortable = new Sortable(sortEl, {
       newlink.querySelector('input[name*="from"]').focus();
     }
 
-    e.preventDefault();
     return false;
   }
 

--- a/app/views/js/redirects.js
+++ b/app/views/js/redirects.js
@@ -10,17 +10,19 @@ function setConflict(section, conflict) {
   const warning = section.querySelector(".redirect-conflict");
   if (!warning) return;
 
+  const tooltip = warning.querySelector(".redirect-conflict-tooltip");
+
   if (conflict && conflict.message) {
     warning.hidden = false;
-    warning.setAttribute("data-tooltip", conflict.message);
     warning.setAttribute("title", conflict.message);
     warning.setAttribute("aria-label", conflict.message);
+    if (tooltip) tooltip.textContent = conflict.message;
     section.classList.add("has-conflict");
   } else {
     warning.hidden = true;
-    warning.removeAttribute("data-tooltip");
     warning.removeAttribute("title");
     warning.setAttribute("aria-label", "This redirect may not run");
+    if (tooltip) tooltip.textContent = "";
     section.classList.remove("has-conflict");
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Redirects are evaluated last, after posts, pages, template views, built-in routes, and files in the site folder. People often set up a redirect that matches an existing URL and then cannot tell why it never fires.

This adds a cheap check on the dashboard Redirects page:

- For each exact (non-regex) `from` path, look up whether a published post or page, a built-in route (`/`, `/search`, `/tagged/…`, `/page/:n`, etc.), a template view, or a file in the folder would be served instead.
- Show a warning icon with a tooltip explaining why that rule will not run.
- Re-check as the `from` field is edited, using `GET /settings/redirects/conflict`.

Regex rules are left alone: they still apply to URLs that do not match existing content. Each exact rule is a handful of Redis lookups and at most a couple of `stat` calls, so the settings page stays inexpensive.

[Redirects page with conflict warnings and tooltip](https://cursor.com/agents/bc-6506ce46-071f-4e8e-91e2-9730ba602cb2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fredirects_conflict_tooltip_page.png)

[Close-up of the redirect conflict tooltip](https://cursor.com/agents/bc-6506ce46-071f-4e8e-91e2-9730ba602cb2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fredirects_conflict_tooltip_closeup.png)

**Testing**
- Unit coverage in `app/models/redirects/tests/conflicts.js` (9 specs) for posts, pages, drafts, built-in routes, template views, and files.
- Dashboard coverage in `app/dashboard/tests/redirects.js` (2 specs) for the warning UI and JSON endpoint.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6506ce46-071f-4e8e-91e2-9730ba602cb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6506ce46-071f-4e8e-91e2-9730ba602cb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

