### PR TITLE
Align local development docs with local.blot

### DIFF
--- a/README
+++ b/README
@@ -12,36 +12,11 @@ The internet <> Reverse proxy (Openresty) <> Blot (express.js node application) 
 
 Self-hosting Blot is currently unsupported. Please don’t file issues or contact support about it. I hope to support this properly someday, but not yet.
 
-That said, to get Blot running locally, you will need Docker, mkcert and dnsmasq. 
-
-Once you have Docker installed and running, clone the repository:
+To run Blot locally, you will need Docker, mkcert and dnsmasq. Then:
 
 git clone https://github.com/davidmerfield/blot --depth 1
-
-Blot requires a huge number of subdomains to work e.g.
-
-https://local.blot
-https://cdn.local.blot
-https://site.local.blot
-https://preview-of-blog-on-site.local.blot
-https://preview-of-hypertext-on-site.local.blot
-
-etc...
-
-We use dnsmasq to point all requests to the fake TLD '.blot' to the loopback:
-
-brew install dnsmasq
-mkdir -pv $(brew --prefix)/etc/
-echo 'address=/.blot/127.0.0.1' >> $(brew --prefix)/etc/dnsmasq.conf
-echo 'port=53' >> $(brew --prefix)/etc/dnsmasq.conf
-sudo brew services start dnsmasq
-sudo mkdir -v /etc/resolver
-sudo bash -c 'echo "nameserver 127.0.0.1" > /etc/resolver/blot'
-
-To create the SSL certificate required for this to work locally, we use:
-
-brew install mkcert nss
-
-Then start the server:
-
 npm start
+
+The dashboard is https://local.blot and the example site is https://example.local.blot. For the full setup, see:
+
+https://blot.im/developers/guides/run-blot-locally

--- a/app/views/developers/guides/run-blot-locally.html
+++ b/app/views/developers/guides/run-blot-locally.html
@@ -5,27 +5,38 @@
 <h2>1. Install Docker</h2>
 <p>You will need <a href="https://www.docker.com/" target="_blank">Docker</a>. Ensure that Docker is installed and running on your machine before proceeding.</p>
 
-<h2>2. Clone the repository</h2>
-<p>Use <a href="https://git-scm.com/" target="_blank">Git</a> to clone Blot’s source code:</p>
-<pre class="bash"><code>git clone https://github.com/davidmerfield/blot</code></pre>
+<h2>2. Install dnsmasq and mkcert</h2>
+<p>Blot requires a huge number of subdomains to work, for example:</p>
+<pre><code>https://local.blot
+https://cdn.local.blot
+https://site.local.blot
+https://preview-of-blog-on-site.local.blot
+https://preview-of-hypertext-on-site.local.blot
+</code></pre>
+<p>We use dnsmasq to point all requests for the fake TLD <code>.blot</code> to the loopback address:</p>
+<pre class="bash"><code>brew install dnsmasq
+mkdir -pv $(brew --prefix)/etc/
+echo 'address=/.blot/127.0.0.1' >> $(brew --prefix)/etc/dnsmasq.conf
+echo 'port=53' >> $(brew --prefix)/etc/dnsmasq.conf
+sudo brew services start dnsmasq
+sudo mkdir -v /etc/resolver
+sudo bash -c 'echo "nameserver 127.0.0.1" > /etc/resolver/blot'</code></pre>
+<p>We use mkcert to create a locally-trusted SSL certificate. Install it, then <code>npm start</code> will generate and trust the certificate:</p>
+<pre class="bash"><code>brew install mkcert nss</code></pre>
 
-<h2>3. Start the server</h2>
+<h2>3. Clone the repository</h2>
+<p>Use <a href="https://git-scm.com/" target="_blank">Git</a> to clone Blot’s source code:</p>
+<pre class="bash"><code>git clone https://github.com/davidmerfield/blot --depth 1</code></pre>
+
+<h2>4. Start the server</h2>
 <p>In the cloned repository, start the server:</p>
 <pre class="bash"><code>npm start</code></pre>
 
-<h2>4. Trust local SSL certificates</h2>
-<p>Before you start editing code, open these URLs and trust the self-signed certificates:</p>
-<ul>
-    <li><a href="https://localhost" target="_blank">https://localhost/</a></li>
-    <li><a href="https://cdn.localhost" target="_blank">https://cdn.localhost/</a></li>
-    <li><a href="https://example.localhost" target="_blank">https://example.localhost/</a></li>
-</ul>
-
 <h2>5. Open the dashboard and example site</h2>
-<p>After trusting the certificates, open:</p>
+<p>When the server starts it prints a dashboard login URL. You can also open:</p>
 <ul>
-    <li>The dashboard: <a href="https://localhost" target="_blank">https://localhost</a></li>
-    <li>The example site: <a href="https://example.localhost" target="_blank">https://example.localhost</a></li>
+    <li>The dashboard: <a href="https://local.blot" target="_blank">https://local.blot</a></li>
+    <li>The example site: <a href="https://example.local.blot" target="_blank">https://example.local.blot</a></li>
 </ul>
 
 <h2>6. Edit the example blog</h2>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The README and `/developers/guides/run-blot-locally` described two different local setups.

The development stack is the source of truth: `npm start` defaults `BLOT_HOST` to `local.blot`, generates a mkcert wildcard, and expects `*.blot` to resolve to loopback. Against the running local stack:

- `https://localhost/` → 404
- `https://local.blot/` → 200
- `https://example.local.blot/` → 200

The README already had the newer hostnames and tools, but it also duplicated the long dnsmasq/mkcert brew steps. The guide still told people to trust self-signed certs on `localhost`.

This change:
- Keeps `./README` short (clone, `npm start`, the two URLs, a link to the guide)
- Moves the matching setup into the guide (Docker, dnsmasq, mkcert, clone, `npm start`, dashboard, example site, blog folder)
- Drops the outdated “add a browser exception for self-signed localhost certs” step, since `npm start` runs `mkcert -install`

[Updated Run Blot locally guide](https://cursor.com/agents/bc-b278863c-31a4-49ae-aa58-2bb69076ab0c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frun_blot_locally_guide.png)
[https://local.blot homepage](https://cursor.com/agents/bc-b278863c-31a4-49ae-aa58-2bb69076ab0c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_local_blot.png)
[https://example.local.blot example site](https://cursor.com/agents/bc-b278863c-31a4-49ae-aa58-2bb69076ab0c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexample_local_blot.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b278863c-31a4-49ae-aa58-2bb69076ab0c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b278863c-31a4-49ae-aa58-2bb69076ab0c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

