### PR TITLE
Improve template Profile

### DIFF
--- a/app/templates/source/profile/entries.html
+++ b/app/templates/source/profile/entries.html
@@ -31,9 +31,11 @@
 <div class="profile">
 <section id="wrapper">
 <header class="h-card">
+{{#avatar}}
 <a class="u-url" href="/">
 <img id="avatar" src="{{{avatar}}}">
 </a>
+{{/avatar}}
 <h1 class="p-name" rel="me">{{title}}</h1>
 <h4 class="p-role">{{description}}</h4>
 </header>

--- a/app/templates/source/profile/entries.html
+++ b/app/templates/source/profile/entries.html
@@ -32,11 +32,11 @@
 <section id="wrapper">
 <header class="h-card">
 {{#avatar}}
-<a class="u-url" href="/">
-<img id="avatar" src="{{{avatar}}}">
+<a href="/">
+<img id="avatar" class="u-photo" src="{{{avatar}}}" alt="">
 </a>
 {{/avatar}}
-<h1 class="p-name" rel="me">{{title}}</h1>
+<h1 class="p-name"><a class="u-url" href="/" rel="me">{{title}}</a></h1>
 <h4 class="p-role">{{description}}</h4>
 </header>
 </section>

--- a/app/templates/tests/profile-hcard.js
+++ b/app/templates/tests/profile-hcard.js
@@ -1,0 +1,60 @@
+const fs = require("fs");
+const path = require("path");
+const mustache = require("mustache");
+
+describe("profile homepage h-card", function () {
+  const template = fs.readFileSync(
+    path.join(__dirname, "../source/profile/entries.html"),
+    "utf8"
+  );
+
+  const partials = {
+    title: "{{title}}",
+    navigation: "",
+    footer: "",
+    "post-list": "",
+  };
+
+  function render(view) {
+    return mustache.render(template, view, partials);
+  }
+
+  function hcard(html) {
+    const match = html.match(/<header class="h-card">([\s\S]*?)<\/header>/);
+    expect(match).not.toBeNull();
+    return match[1];
+  }
+
+  it("omits the avatar image when avatar is missing", function () {
+    const html = hcard(render({ title: "David", description: "Writer" }));
+    expect(html).not.toMatch(/<img\b/);
+    expect(html).not.toMatch(/src=""/);
+  });
+
+  it("omits the avatar image when avatar is empty", function () {
+    const html = hcard(
+      render({ title: "David", description: "Writer", avatar: "" })
+    );
+    expect(html).not.toMatch(/<img\b/);
+    expect(html).not.toMatch(/src=""/);
+  });
+
+  it("keeps an h-card u-url when avatar is missing", function () {
+    const html = hcard(render({ title: "David", description: "Writer" }));
+    expect(html).toMatch(/<a class="u-url" href="\/" rel="me">David<\/a>/);
+  });
+
+  it("renders the avatar and u-url when avatar is present", function () {
+    const html = hcard(
+      render({
+        title: "David",
+        description: "Writer",
+        avatar: "/avatar.jpg",
+      })
+    );
+    expect(html).toMatch(/id="avatar"/);
+    expect(html).toMatch(/class="u-photo"/);
+    expect(html).toMatch(/src="\/avatar.jpg"/);
+    expect(html).toMatch(/<a class="u-url" href="\/" rel="me">David<\/a>/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The profile homepage always rendered an avatar `<img>` even when the site had no avatar. On the david demo that produced a broken-image icon in the circular frame.

The desktop screenshot showed this on the homepage. The mobile screenshot `app/views/images/examples/profile/0.mobile.png` shows the same broken avatar in a circle. There is no separate mobile markup: homepage desktop and mobile both render `entries.html`, so the same `{{#avatar}}` guard omits the image (and its circular broken-image icon) at every viewport.

The photo and its wrapping link are now inside `{{#avatar}}`, matching favicon and Open Graph handling. If no avatar is set, the image is omitted. Other profile views (`entry.html` post-meta and h-card photo) were already guarded. No extra CSS was needed: `.profile #avatar` styles the `<img>` itself, and the mobile media query only adjusts header padding.

A follow-up commit keeps the h-card homepage URL when no avatar is set. The first change also removed the only `u-url` in the homepage `h-card`. That property now lives on the `p-name` link, and the photo is marked `u-photo`.

## Testing
- Mustache renders of `entries.html` for empty, missing, and present `avatar`
- Empty/missing cases emit no `<img>` and no empty `src`, and still include `<a class="u-url">`
- A present avatar still renders the circle plus `u-url` on the name
- Confirmed a single homepage template (no mobile-only avatar HTML); mobile `@media (max-width: 540px)` does not create a leftover empty circle

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79792642-e2ab-4582-b05f-16dde4e2170e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79792642-e2ab-4582-b05f-16dde4e2170e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

