### PR TITLE
Improve template Organization

### DIFF
--- a/app/templates/source/organization/entries.html
+++ b/app/templates/source/organization/entries.html
@@ -31,6 +31,7 @@
                 <a class="excerpt" href="{{{url}}}">{{summary}}</a>
               </p>
               <div>
+                {{#tags.length}}
                 <small class="d-block text-muted">
             In <span class="catlist">
 
@@ -40,6 +41,7 @@
 
                 </span>
         </small>
+                {{/tags.length}}
                 <small class="text-muted">
             {{#date}}{{date}}{{/date}}
         </small>
@@ -67,6 +69,7 @@
               <h2 class="mb-2 h6 font-weight-bold">
                     <a class="text-dark" href="{{{url}}}">{{title}}</a>
                     </h2>
+              {{#tags.length}}
               <small class="d-block text-muted">
                         In <span class="catlist">
 
@@ -77,6 +80,7 @@
 
                         </span>
                     </small>
+              {{/tags.length}}
               <small class="text-muted">
             {{#date}}{{date}}{{/date}}
                     </small>
@@ -127,6 +131,7 @@
               <p class="excerpt">
                 {{summary}}
               </p>
+              {{#tags.length}}
               <small class="d-block text-muted">
     In <span class="catlist">
 
@@ -135,6 +140,7 @@
       {{/tags}}
     </span>
   </small>
+              {{/tags.length}}
               <small class="text-muted">
             {{#date}}{{date}}{{/date}}
   </small>
@@ -188,6 +194,7 @@
                 <h6 class="font-weight-bold">
                     <a href="{{{url}}}" class="text-dark">{{title}}</a>
                 </h6>
+                {{#tags.length}}
                 <span class="d-block text-muted">
                     In <span class="catlist">
 
@@ -196,6 +203,7 @@
                 {{/tags}}
                 </span>
                 </span>
+                {{/tags.length}}
                 </span>
               </li>
               {{/tagged.featured}}

--- a/app/templates/source/organization/entries.html
+++ b/app/templates/source/organization/entries.html
@@ -57,15 +57,17 @@
 
           {{#posts}}
           {{^first}}
-          <div class="mb-3 d-flex align-items-center">
+          <div class="mb-3 d-md-flex align-items-center entry-list-item">
 
-            <div class="col-md-4">
+            {{#thumbnail.large.url}}
+            <div class="col-md-4 entry-list-thumb">
               <a href="{{{url}}}" class="w-100">
     <div style="background-image: url( {{{thumbnail.large.url}}}); height: 80px;    background-size: cover;    background-repeat: no-repeat;"></div>
     </a>
             </div>
+            {{/thumbnail.large.url}}
 
-            <div>
+            <div class="entry-list-copy">
               <h2 class="mb-2 h6 font-weight-bold">
                     <a class="text-dark" href="{{{url}}}">{{title}}</a>
                     </h2>
@@ -123,8 +125,8 @@
           <h4 class="font-weight-bold spanborder"><span>All Stories</span></h4>
 
           {{#posts}}
-          <div class="mb-5 d-flex justify-content-between main-loop-card">
-            <div class="pr-3">
+          <div class="mb-5 d-md-flex justify-content-between main-loop-card">
+            <div class="pr-3 entry-list-copy">
               <h2 class="mb-1 h4 font-weight-bold">
   <a class="text-dark" href="{{{url}}}">{{title}}</a>
   </h2>
@@ -145,11 +147,13 @@
             {{#date}}{{date}}{{/date}}
   </small>
             </div>
-            <div class="col-md-3 pr-0 text-right">
+            {{#thumbnail.large.url}}
+            <div class="col-md-3 pr-0 text-right entry-list-thumb">
               <a href="{{{url}}}">
-  <img class="w-100" src="{{{thumbnail.large.url}}}" alt="Red Riding Hood">
+  <img class="w-100" src="{{{thumbnail.large.url}}}" alt="{{title}}">
   </a>
             </div>
+            {{/thumbnail.large.url}}
           </div>
           {{/posts}}
 

--- a/app/templates/source/organization/header.html
+++ b/app/templates/source/organization/header.html
@@ -9,7 +9,7 @@
         <ul class="navbar-nav mr-auto d-flex align-items-center">
           <!--  Replace menu links here -->
           {{#menu}}
-          <li class="nav-item" data-label="{{label}}">
+          <li class="nav-item" data-url="{{{url}}}" data-label="{{label}}">
             <a class="nav-link" href="{{{url}}}">{{label}}</a>
           </li>
           {{/menu}}
@@ -20,16 +20,6 @@
           <form class="bd-search hidden-sm-down w-100" action="/search">
             <input type="text" class="form-control text-small" id="lunrsearch" name="q" value="{{query}}" placeholder="Search">
           </form>
-          <style>
-            #MagicMenu .navbar-nav.mr-auto .nav-item[data-label="Search"],
-            #MagicMenu .navbar-nav.mr-auto .nav-item[data-label="search"],
-            #MagicMenu .navbar-nav.mr-auto a[href="/search"],
-            #MagicMenu .navbar-nav.mr-auto a[href="/search/"],
-            #MagicMenu .navbar-nav.mr-auto .nav-item:has(> a[href="/search"]),
-            #MagicMenu .navbar-nav.mr-auto .nav-item:has(> a[href="/search/"]) {
-              display: none;
-            }
-          </style>
         </ul>
       </div>
     </div>

--- a/app/templates/source/organization/header.html
+++ b/app/templates/source/organization/header.html
@@ -9,7 +9,7 @@
         <ul class="navbar-nav mr-auto d-flex align-items-center">
           <!--  Replace menu links here -->
           {{#menu}}
-          <li class="nav-item">
+          <li class="nav-item" data-label="{{label}}">
             <a class="nav-link" href="{{{url}}}">{{label}}</a>
           </li>
           {{/menu}}
@@ -20,6 +20,16 @@
           <form class="bd-search hidden-sm-down w-100" action="/search">
             <input type="text" class="form-control text-small" id="lunrsearch" name="q" value="{{query}}" placeholder="Search">
           </form>
+          <style>
+            #MagicMenu .navbar-nav.mr-auto .nav-item[data-label="Search"],
+            #MagicMenu .navbar-nav.mr-auto .nav-item[data-label="search"],
+            #MagicMenu .navbar-nav.mr-auto a[href="/search"],
+            #MagicMenu .navbar-nav.mr-auto a[href="/search/"],
+            #MagicMenu .navbar-nav.mr-auto .nav-item:has(> a[href="/search"]),
+            #MagicMenu .navbar-nav.mr-auto .nav-item:has(> a[href="/search/"]) {
+              display: none;
+            }
+          </style>
         </ul>
       </div>
     </div>

--- a/app/templates/source/organization/style.css
+++ b/app/templates/source/organization/style.css
@@ -14063,3 +14063,10 @@ div.a2a_full_footer {
 .show-5> :nth-child(5) {
   display: block !important;
 }
+
+/* Hide the Search menu item when the header already has a search form */
+#MagicMenu .navbar-nav.mr-auto .nav-item[data-url="/search" i],
+#MagicMenu .navbar-nav.mr-auto .nav-item[data-url="/search/" i],
+#MagicMenu .navbar-nav.mr-auto .nav-item[data-label="Search" i] {
+  display: none;
+}

--- a/app/templates/source/organization/style.css
+++ b/app/templates/source/organization/style.css
@@ -14070,3 +14070,33 @@ div.a2a_full_footer {
 #MagicMenu .navbar-nav.mr-auto .nav-item[data-label="Search" i] {
   display: none;
 }
+
+/* List rows mixed d-flex (nowrap) with col-md-* thumbs. Below md, those
+   columns are width:100%, so empty thumb boxes shoved copy into a sliver.
+   Flex only from md up; omit empty thumbs in markup; copy fills leftover space. */
+.entry-list-copy {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+@media (max-width: 767.98px) {
+  .entry-list-item .entry-list-thumb,
+  .main-loop-card .entry-list-thumb {
+    width: 100%;
+    max-width: 100%;
+    flex-basis: 100%;
+    padding-left: 0;
+    margin-bottom: 0.75rem;
+  }
+
+  .main-loop-card .entry-list-copy {
+    padding-right: 0;
+  }
+}
+
+@media (min-width: 768px) {
+  .entry-list-item .entry-list-thumb,
+  .main-loop-card .entry-list-thumb {
+    flex-shrink: 0;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Organization homepage printed a literal `In` before `{{#tags}}`, so posts without tags (Scripts, Mathematics, Leaves) showed a dangling "In". Each of those category lines is now wrapped in `{{#tags.length}}` so the prefix only appears when tags exist.

The header also listed a Search menu item next to a dedicated search form. Menu items whose URL is `/search` or whose label is Search are hidden in CSS (same pattern as Documentation, Album, Text, and Links), while Home, Archives, Feed, and the search box stay visible.

List rows mixed `d-flex` (nowrap) with `col-md-*` thumbnail columns. Below the md breakpoint those columns are `width: 100%`, so empty thumb boxes shoved titles and dates into a narrow right-hand sliver. Rows now flex only from md up, thumbnail markup is omitted when there is no image URL, and copy uses the remaining width. Desktop two-column layout is unchanged.

## Testing
- Mustache renders: tagged posts still print `In …`; untagged posts do not
- Home/Archives/Feed remain; Search is hidden
- Mobile ~400px: list entries use the full content width; empty thumbs do not reserve a column; dates/titles no longer wrap in a sliver
- Desktop 800px: homepage still two-column; entries with thumbs keep a side-by-side thumb + copy row
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79792642-e2ab-4582-b05f-16dde4e2170e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79792642-e2ab-4582-b05f-16dde4e2170e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

