### PR TITLE
Fix screenshots workflow: bump Node so re2 can install

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -30,11 +30,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [21.7.3]
-        # Matches the version installed in the Dockerfile. The macOS build must
-        # be arm64: the runners are Apple silicon and an x86_64 pandoc would be
-        # translated by Rosetta on every conversion, which the folder build does
-        # thousands of.
+        # Matches the Node 22 major used in the Dockerfile (node:22-alpine) and
+        # production (BLOT_NODE_VERSION=22.14.0). Native addons such as re2 ship
+        # prebuilds per Node ABI; Node 21 (ABI 120) has none for current re2, so
+        # npm install would compile from source and fail on these runners.
+        node-version: [22.14.0]
+        # The macOS build must be arm64: the runners are Apple silicon and an
+        # x86_64 pandoc would be translated by Rosetta on every conversion,
+        # which the folder build does thousands of.
         pandoc-version: [3.6.1]
 
     env:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The screenshots action failed on `npm install` after `re2@1.26.1` was added. Purging the cache and re-running is **not** enough.

## Why it failed

The job still ran Node **21.7.3** (ABI 120). `re2` is a native addon and 1.26.1 only publishes prebuilds for Node 22/24/26 (ABI 127/137/147). There is no `darwin-arm64-120` binary, so install fell back to compiling with `node-gyp` 13, which itself requires Node 22.22.2+ and crashed:

```
Trying https://github.com/uhop/node-re2/releases/download/1.26.1/darwin-arm64-120.br ...
Building locally ...
gyp ERR! stack TypeError: webidl.util.markAsUncloneable is not a function
```

The node_modules cache key already includes `hashFiles('package.json')`, so adding `re2` produced a cache miss and a fresh (failing) install. Deleting the cache would do the same thing again on Node 21.

This was a latent mismatch: production and the Dockerfile moved to Node 22, but screenshots stayed on 21. Native addons made that mismatch fatal.

## Fix

Bump the screenshots runner to **22.14.0**, matching `BLOT_NODE_VERSION` and the Dockerfile's Node 22 major. The cache key also includes `matrix.node-version`, so the next run will install against Node 22 and pick up the `darwin-arm64-127` prebuild.

Failed job: https://github.com/davidmerfield/blot/actions/runs/33962067351/job/101296788073
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3dcee710-4767-4639-9fbe-f037b6732914?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dcee710-4767-4639-9fbe-f037b6732914&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

