### PR TITLE
Improve template Keynote

### DIFF
--- a/app/templates/source/keynote/style.css
+++ b/app/templates/source/keynote/style.css
@@ -96,7 +96,7 @@ hr {width: 100%;border: none;border-bottom: 1px solid rgba(0,0,0,0.15)}
     padding: 0.4em 0.5em;
   }
 
-  #title {
+  #header #title {
     float: none;
     position: static;
     top: auto;

--- a/app/templates/source/keynote/style.css
+++ b/app/templates/source/keynote/style.css
@@ -79,3 +79,41 @@ hr {width: 100%;border: none;border-bottom: 1px solid rgba(0,0,0,0.15)}
 .margin a {font-weight: normal;}
 
 .videoContainer {margin: 1em 0}
+
+@media screen and (max-width: 800px) {
+  #header {
+    padding: 1.25em 1.25em 1em;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    row-gap: 0.4em;
+    position: relative;
+    z-index: 1;
+  }
+
+  #header a {
+    margin: 0 0.35em 0 0;
+    padding: 0.4em 0.5em;
+  }
+
+  #title {
+    float: none;
+    position: static;
+    top: auto;
+    flex: 0 0 100%;
+    order: -1;
+    margin: 0;
+    padding: 0.15em 0;
+    font-size: 26px;
+    overflow-wrap: anywhere;
+  }
+
+  .gallery {
+    top: 10em;
+    padding: 0 1.25em;
+  }
+
+  .contents {
+    margin: 0 1.25em 2em;
+  }
+}

--- a/app/templates/source/keynote/style.css
+++ b/app/templates/source/keynote/style.css
@@ -87,8 +87,7 @@ hr {width: 100%;border: none;border-bottom: 1px solid rgba(0,0,0,0.15)}
     flex-wrap: wrap;
     align-items: center;
     row-gap: 0.4em;
-    position: relative;
-    z-index: 1;
+    flex: 0 0 auto;
   }
 
   #header a {
@@ -108,8 +107,20 @@ hr {width: 100%;border: none;border-bottom: 1px solid rgba(0,0,0,0.15)}
     overflow-wrap: anywhere;
   }
 
+  body:has(.gallery) {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+  }
+
   .gallery {
-    top: 10em;
+    position: relative;
+    top: auto;
+    bottom: auto;
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
     padding: 0 1.25em;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stop the Keynote header from overlapping on mobile.

`#header` used 4em padding and `#title` was `float: right` with no breakpoint, so at 400px Search sat on top of the site title. Below 800px the title now stacks on its own row above the nav.

The homepage gallery was still absolutely positioned from a fixed `10em` offset. A wrapping title or extra nav rows made the flex header taller than that, and the header covered the first filmstrip cards. On small screens the gallery now sits in normal column layout under the real header height and fills the remaining viewport. The horizontal `.gallery` filmstrip (320px cards, overflow-x scroll) is unchanged. Desktop header is unchanged.

## Testing
- Puppeteer layout fixture at 400×650: Search overlapped David before; zero overlaps after
- Long 70-character wrapping title and extra wrapping nav items: gallery starts below the header (no overlap)
- Desktop 1060×780: title still right, nav still left
- Gallery still 320px inline-block with overflow-x: scroll
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79792642-e2ab-4582-b05f-16dde4e2170e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79792642-e2ab-4582-b05f-16dde4e2170e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

