### PR TITLE
Improve template Blog

### DIFF
--- a/app/templates/source/blog/plugin.css
+++ b/app/templates/source/blog/plugin.css
@@ -195,3 +195,29 @@ p, div, section {position: relative;overflow: visible;}
 
   .wide, .wide.left, .wide.right {width: 100%;margin: 0}
 }
+
+/* Phone: unfloat Tufte sidenotes and stack multi-column figures.
+   The 933px query above keeps a 30% float for tablets; at ~400px
+   that becomes a 3–5 word column with body text wrapping around it. */
+@media screen and (max-width: 600px) {
+
+  .margin,
+  .margin.right,
+  .margin.left {
+    width: 100%;
+    float: none;
+    padding-left: 0;
+    padding-right: 0;
+    text-align: left;
+  }
+
+  .column,
+  .column.two,
+  .column.three,
+  .column.four,
+  .column.two + .column.two {
+    width: 100%;
+    float: none;
+    padding: 0;
+  }
+}

--- a/app/templates/source/blog/style.css
+++ b/app/templates/source/blog/style.css
@@ -188,7 +188,7 @@ blockquote {
 }
 
 .entry a {
-  text-decoration: underlink;
+  text-decoration: underline;
   color: {{links_color}};
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Unfloat Tufte sidenotes and stack multi-column figures on small screens in the Blog template.

At max-width 933px, `.margin` stayed a 30% right float and `.column.two` stayed 50%, so a 400px viewport wrapped sidenote text word-by-word and kept two images side-by-side. A 600px query now makes `.margin` full width and stacks `.column` figures. Desktop Tufte layout is unchanged. Also fixes `text-decoration: underlink` → `underline`.

## Testing
- Puppeteer applied the blog CSS to the Typography layout at 400 / 800 / 1200
- 400px: sidenote full width, figures stacked
- 800px: tablet 30% float and side-by-side columns
- 1200px: Tufte absolute sidenotes unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79792642-e2ab-4582-b05f-16dde4e2170e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79792642-e2ab-4582-b05f-16dde4e2170e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

