### PR TITLE
Improve template Links

### DIFF
--- a/app/templates/source/links/_header.html
+++ b/app/templates/source/links/_header.html
@@ -17,4 +17,3 @@
       </a>{{/menu}}
     </div>
   </div>
-  <div style="flex-grow:1;display:flex;flex-direction:column"></div>

--- a/app/templates/source/links/style.css
+++ b/app/templates/source/links/style.css
@@ -975,6 +975,8 @@ input#toggle {
     align-items: normal;
   }
 
+  /* flex-basis: 100% belongs on header children (full-width menu rows),
+     not .header — body is a column flex, so that would fill the viewport. */
   .header>*,
   .header {
     z-index: 1;
@@ -982,6 +984,9 @@ input#toggle {
     max-width: none !important;
     width: 100% !important;
     min-height: 3.4em;
+  }
+
+  .header>* {
     flex-basis: 100% !important;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Keep the links homepage header at content height on mobile so posts are visible.

Mobile CSS applied `flex-basis: 100%` to `.header` as well as its children. Body is a column flex container, so that made the header fill the viewport and vertically center the title, pushing thumbnails below the fold. An empty `flex-grow` spacer between header and posts is removed. Desktop header/search/nav layout is unchanged.

## Testing
- Puppeteer 400×650 with html/body height 100%: before header 651px, titleTop 305, first post below the fold; after header 55px, first post at 97px in view
- Desktop 1260×778: header 55px, three-column grid visible
- Mobile menu still expands
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79792642-e2ab-4582-b05f-16dde4e2170e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79792642-e2ab-4582-b05f-16dde4e2170e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

