### PR TITLE
Install Biome without a biome.json

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -147,7 +147,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Find unused dependencies
         # node-addon-api,node-gyp are required to build sharp
-        run: npx depcheck --ignores=node-addon-api,node-gyp,depcheck,nyc,nodemon,blessed-contrib,fontkit,text-to-svg --skip-missing
+        run: npx depcheck --ignores=node-addon-api,node-gyp,depcheck,nyc,nodemon,blessed-contrib,fontkit,text-to-svg,@biomejs/biome --skip-missing
 
   detect-unused-files:
     needs: setup-tests

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "featured": "docker exec blot-node-app-1 node app/documentation/featured/build",
     "folder": "./scripts/development/folder.sh",
     "translate": "./scripts/development/translate/translate.sh",
-    "preview-newsletter": "./scripts/development/preview-newsletter.sh"
+    "preview-newsletter": "./scripts/development/preview-newsletter.sh",
+    "biome": "biome check .",
+    "biome:format": "biome format .",
+    "biome:lint": "biome lint ."
   },
   "version": "0.0.0",
   "dependencies": {
@@ -82,11 +85,12 @@
     "typeset": "0.2.9",
     "uuid": "3.2.1",
     "vhost": "3.0.2",
-    "yaml": "2.7.0",
     "xml2js": "0.5.0",
+    "yaml": "2.7.0",
     "yauzl": "^3.2.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.5.12",
     "blessed": "0.1.81",
     "depcheck": "1.4.7",
     "dir-compare": "4.0.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Zero-config Biome on this repo, measured against Biome 2.5.12 with no `biome.json`.

This is an alternative to #1158, which added a config file (`indentStyle: space`, `recommended: false`, and path excludes). The goal here is to avoid that file.

## What this PR changes

- Adds `@biomejs/biome` `2.5.12` as a pinned devDependency
- Adds opt-in scripts: `npm run biome`, `npm run biome:format`, `npm run biome:lint`
- Ignores the CLI package in the depcheck job
- Does **not** add `biome.json`
- Does **not** reformat the tree
- Does **not** fail CI on `biome check` (it cannot pass on current defaults)

## What defaults would do

`biome rage` reports `Status: Not set`. Built-in defaults that fight this tree:

| Default | This repo |
| --- | --- |
| `formatter.indentStyle: tab` | ~1223 JS files are 2-space; ~10 are tabs |
| `lineWidth: 80`, `trailingCommas: all` | Many long lines; trailing commas are inconsistent |
| `quoteStyle: double` | Mostly matches (~1180 double vs ~85 single) |
| `linter.rules.recommended: true` | Thousands of hits on existing CJS |
| `html.formatter: false`, `html.linter: true` | 639 Mustache HTML files still get linted |
| `css.linter: true` | Template + dashboard CSS included |
| `vcs.enabled: false` | `.gitignore` is ignored (`app/views-built`, `data/`) |

### Formatter

Ran `biome format .` with true defaults:

- **2062** files checked, **2050** would change (1449 JS, 487 CSS, 114 JSON)
- **66** parse errors (formatter aborts those files)
- Walks gitignored output: **224** files under `app/views-built`, **114** under `data/`
- Would rewrite minified vendor (`html2canvas.min.js`, `pickr/es5.min.js`, `*.min.js`)

With gitignore enabled via CLI only (`--vcs-enabled=true --vcs-client-kind=git --vcs-use-ignore-file=true`):

- **1836** files checked, **1824** still need formatting
- **54** parse errors remain

Adding `--indent-style=space` (still no config file) only drops that to **1329** files. Remaining churn is trailing commas, 80-col wraps, mixed quotes, CSS 4-space → 2-space, lowercase hex, `rgba()` spacing.

Typical JS diff under defaults is spaces → tabs, for example `app/index.js`.

### Parse errors (54 gitignore-aware files)

- **33** Mustache in `app/templates/source` `.js`/`.css` (`{{{`, `{{#…}}`)
- **9** top-level `return` (legal Node CJS; Biome treats it as illegal)
- **5** `package` used as an identifier (reserved in strict mode)
- **4** other JS (`static` identifier, `0`-prefixed octal, private-name parse, extra `}` in CSS)
- **3** other template CSS (IE `*zoom`, etc.)

### Linter (recommended rules)

Linted `app/*`, `scripts`, and `config`, skipping `app/templates/source` (that tree stalled ~4 minutes on large Mustache CSS and produced no report).

| | |
| --- | --- |
| Files | ~2293 |
| Errors | 7499 |
| Warnings | 11518 |
| Infos | 2890 |
| Distinct rules | 78 |

Hottest rules:

- `complexity/useArrowFunction` 6107 (warn)
- `suspicious/noAssignInExpressions` 2700 (error)
- `style/useTemplate` 2128 (info)
- `complexity/noCommaOperator` 1964 (warn)
- `suspicious/noDoubleEquals` 1794 (error)
- `correctness/noInnerDeclarations` 1632 (error)
- plus CSS `noDescendingSpecificity` and HTML a11y (`noSvgWithoutTitle`, `useAltText`, `useHtmlLang`)

`app/views` alone is 410 files / 3947 errors: Mustache HTML (linter on) plus vendored dashboard JS (CodeMirror, Pickr, …).

`app/models` (typical app CJS) is 206 files / 141 errors / 1037 warnings, of which 850 are `useArrowFunction`.

## Why there is still no `biome.json`

CLI flags on npm scripts can paper over some of this (`--indent-style=space`, gitignore, disable HTML/CSS lint). The editor LSP does **not** read those flags. Without a config file, Biome format-on-save in VS Code/Cursor applies **tabs**. That is why #1158 added `biome.json`.

Zero-config `biome check` cannot be a CI gate until one of these is true:

1. Accept tabs + recommended lint + rewrite/exclude Mustache and vendor files, or
2. Add a small `biome.json` (or `.editorconfig` + `useEditorconfig`) so CLI and editor agree

This PR only installs the tool so those options can be tried with `npx biome`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d3ab9ce-1bfd-4abf-b91f-f9106e58ae75?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d3ab9ce-1bfd-4abf-b91f-f9106e58ae75&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

