### PR TITLE
Keep the profile h-card URL when no avatar is set

### DIFF
--- a/app/templates/source/profile/entries.html
+++ b/app/templates/source/profile/entries.html
@@ -31,9 +31,11 @@
 <div class="profile">
 <section id="wrapper">
 <header class="h-card">
+{{#avatar}}
 <a class="u-url" href="/">
 <img id="avatar" src="{{{avatar}}}">
 </a>
+{{/avatar}}
 <h1 class="p-name" rel="me">{{title}}</h1>
 <h4 class="p-role">{{description}}</h4>
 </header>

--- a/app/templates/source/profile/entries.html
+++ b/app/templates/source/profile/entries.html
@@ -32,11 +32,11 @@
 <section id="wrapper">
 <header class="h-card">
 {{#avatar}}
-<a class="u-url" href="/">
-<img id="avatar" src="{{{avatar}}}">
+<a href="/">
+<img id="avatar" class="u-photo" src="{{{avatar}}}" alt="">
 </a>
 {{/avatar}}
-<h1 class="p-name" rel="me">{{title}}</h1>
+<h1 class="p-name"><a class="u-url" href="/" rel="me">{{title}}</a></h1>
 <h4 class="p-role">{{description}}</h4>
 </header>
 </section>

--- a/app/templates/tests/profile-hcard.js
+++ b/app/templates/tests/profile-hcard.js
@@ -1,0 +1,60 @@
+const fs = require("fs");
+const path = require("path");
+const mustache = require("mustache");
+
+describe("profile homepage h-card", function () {
+  const template = fs.readFileSync(
+    path.join(__dirname, "../source/profile/entries.html"),
+    "utf8"
+  );
+
+  const partials = {
+    title: "{{title}}",
+    navigation: "",
+    footer: "",
+    "post-list": "",
+  };
+
+  function render(view) {
+    return mustache.render(template, view, partials);
+  }
+
+  function hcard(html) {
+    const match = html.match(/<header class="h-card">([\s\S]*?)<\/header>/);
+    expect(match).not.toBeNull();
+    return match[1];
+  }
+
+  it("omits the avatar image when avatar is missing", function () {
+    const html = hcard(render({ title: "David", description: "Writer" }));
+    expect(html).not.toMatch(/<img\b/);
+    expect(html).not.toMatch(/src=""/);
+  });
+
+  it("omits the avatar image when avatar is empty", function () {
+    const html = hcard(
+      render({ title: "David", description: "Writer", avatar: "" })
+    );
+    expect(html).not.toMatch(/<img\b/);
+    expect(html).not.toMatch(/src=""/);
+  });
+
+  it("keeps an h-card u-url when avatar is missing", function () {
+    const html = hcard(render({ title: "David", description: "Writer" }));
+    expect(html).toMatch(/<a class="u-url" href="\/" rel="me">David<\/a>/);
+  });
+
+  it("renders the avatar and u-url when avatar is present", function () {
+    const html = hcard(
+      render({
+        title: "David",
+        description: "Writer",
+        avatar: "/avatar.jpg",
+      })
+    );
+    expect(html).toMatch(/id="avatar"/);
+    expect(html).toMatch(/class="u-photo"/);
+    expect(html).toMatch(/src="\/avatar.jpg"/);
+    expect(html).toMatch(/<a class="u-url" href="\/" rel="me">David<\/a>/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses the Codex review on #1681: hiding the homepage avatar also removed the only `u-url` in the profile `h-card`, so microformats consumers could no longer associate the card with the site when no avatar is set.

## Change
- Keep the photo (and its wrapping link) behind `{{#avatar}}`, so a missing/empty avatar still emits no `<img>`
- Move `u-url` onto the `p-name` link so the h-card always has a homepage URL
- Mark the photo as `u-photo`, matching the profile entry h-card
- Move `rel="me"` onto the name link (it was on the `<h1>`)

This branch also includes the original #1681 change that gates the broken avatar image.

## Testing
- Jasmine mustache renders of `entries.html` for missing, empty, and present `avatar`
- Empty/missing cases emit no `<img>` and still include `<a class="u-url">`
- A present avatar still renders the circle plus `u-url` on the name

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4373aa81-b8aa-4593-b9a6-039bfff31b3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4373aa81-b8aa-4593-b9a6-039bfff31b3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

