### PR TITLE
Allow wrapping before zine index dates

### DIFF
--- a/app/templates/source/zine/entries.html
+++ b/app/templates/source/zine/entries.html
@@ -8,8 +8,8 @@
       {{#posts}}
       <span class="entry"
         ><a href="{{{url}}}"><span>{{title}}</span></a
-        ><span class="entry-date"
-          >&nbsp;<span class="light">{{date}}{{^last}} //{{/last}}</span></span
+        > <span class="entry-date"
+          ><span class="light">{{date}}{{^last}} //{{/last}}</span></span
         ></span
       >
       {{/posts}}

--- a/app/templates/source/zine/entries.html
+++ b/app/templates/source/zine/entries.html
@@ -6,10 +6,12 @@
 
     <p class="entries">
       {{#posts}}
-      <a href="{{{url}}}"
-        ><span>{{title}}</span>
-      </a>
-      <span class="light">{{date}} {{^last}}//{{/last}}</span>
+      <span class="entry"
+        ><a href="{{{url}}}"><span>{{title}}</span></a
+        ><span class="entry-date"
+          >&nbsp;<span class="light">{{date}}{{^last}} //{{/last}}</span></span
+        ></span
+      >
       {{/posts}}
     </p>
 

--- a/app/templates/source/zine/style.css
+++ b/app/templates/source/zine/style.css
@@ -30,6 +30,16 @@ body {
   font-size: calc({{{body_font.font_size}}}px * 1.25);
 }
 
+.entries .entry {
+  display: inline-block;
+  max-width: 100%;
+  vertical-align: baseline;
+}
+
+.entries .entry-date {
+  white-space: nowrap;
+}
+
 .entries a + span {opacity:0.75}
 
 .light {

--- a/app/templates/tests/zine-entries-wrapping.js
+++ b/app/templates/tests/zine-entries-wrapping.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("zine entries index wrapping", function () {
+  const html = fs.readFileSync(
+    path.join(__dirname, "../source/zine/entries.html"),
+    "utf8"
+  );
+  const css = fs.readFileSync(
+    path.join(__dirname, "../source/zine/style.css"),
+    "utf8"
+  );
+
+  const entryMarkup = html.match(/\{\{#posts\}\}([\s\S]*?)\{\{\/posts\}\}/)[1];
+
+  it("keeps each date on one line", function () {
+    expect(css).toMatch(
+      /\.entries \.entry-date\s*\{[^}]*white-space:\s*nowrap/
+    );
+  });
+
+  it("allows wrapping between the title and the date", function () {
+    expect(entryMarkup).toMatch(/<\/a\s*> <span class="entry-date"/);
+    expect(entryMarkup).not.toMatch(/&nbsp;/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the Codex review on #1688: keep each zine index date on one line, but allow a break *before* the date so the title’s last word is not glued to it.

The same commit is also on #1688 (`cursor/improve-zine-template-170e`).

## Why
#1688 wrapped each post and set `white-space: nowrap` on the date so phrases like `September 5, 2026 //` stay intact. The separator before that date was a non-breaking space *inside* the nowrap span, so the title’s last word and the whole date became one unbreakable run. On a ~400px viewport that glued the last title word to the date (`A` / `Visit September 5, 2026 //`) instead of moving the intact date to the next line.

## Change
- Use a normal (breakable) space between the title and `.entry-date`
- Leave `white-space: nowrap` on the date itself
- Add a small template test so the break stays outside the nowrap span

## Testing
- Jasmine: `app/templates/tests/zine-entries-wrapping.js` — 2 specs, 0 failures (also green in CI `test (app/templates)`)
- Headless Chrome layout check at 400×650 and 1060×780: dates stay a single client rect; long dates wrap as a unit after the title; short entries still sit side by side on desktop

[Zine index wrap before and after at 400px, plus desktop side-by-side entries](https://cursor.com/agents/bc-e89b3269-5ee1-43f0-b75a-ae022e141f62/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fzine_wrap_compare.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e89b3269-5ee1-43f0-b75a-ae022e141f62?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e89b3269-5ee1-43f0-b75a-ae022e141f62&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

