### PR TITLE
Clear Event template headings under wrapped mobile nav

### DIFF
--- a/app/templates/source/event/entries.html
+++ b/app/templates/source/event/entries.html
@@ -1,5 +1,5 @@
 {{> head}}
-<div style="display: flex;">
+<div class="site-header">
 
     <div style="width:50%;" class="main">
         <a href="/" style="text-decoration: none;padding: 1em 0;font-size: 0.9em;display: block;">{{title}}</a>

--- a/app/templates/source/event/entry.html
+++ b/app/templates/source/event/entry.html
@@ -40,7 +40,7 @@
 {{/entry.metadata.slides.length}}
 
 {{^entry.metadata.slides.length}}
-<div style="display: flex;">
+<div class="site-header">
 
 <div style="width:50%;" class="main">
     <a href="/" style="text-decoration: none;padding: 1em 0;font-size: 0.9em;display: block;">{{title}}</a>

--- a/app/templates/source/event/entry.html
+++ b/app/templates/source/event/entry.html
@@ -17,7 +17,10 @@
                 </video>
                 {{/Video}}
                 {{#Caption}}
-                <span class="slide-caption">{{Caption}} <a href="{{Link}}">{{Credit}}</a></span>
+                <span class="slide-caption">
+                    <span class="slide-caption-text">{{Caption}}</span>
+                    {{#Credit}}<a class="slide-caption-credit" href="{{Link}}">{{Credit}}</a>{{/Credit}}
+                </span>
                 {{/Caption}}
             </div>
             {{/entry.metadata.slides}}

--- a/app/templates/source/event/style.css
+++ b/app/templates/source/event/style.css
@@ -90,6 +90,8 @@ hr { border: none; border-bottom: 1px solid var(--border-color); clear: both; }
 
 .collapse-on-mobile { display: flex; flex-direction: row; }
 
+.site-header { display: flex; }
+
 
 /* NAVIGATION */
 .navigation {
@@ -372,7 +374,9 @@ kbd {
 }
 
 @media screen and (max-width: 640px) {
-  .slides {
+  /* Wrapped nav is two rows; keep slide-less pages (Speakers, FAQs) clear too. */
+  .slides,
+  .site-header {
     margin-top: 5.75em;
   }
 }

--- a/app/templates/source/event/style.css
+++ b/app/templates/source/event/style.css
@@ -21,7 +21,7 @@
   --border-color: rgba({{#rgb}}{{text_color}}{{/rgb}}, 0.06);
   --link-color: {{link_color}};
   --dots-height: 2.8rem;
-  --caption-height: 1.4rem;
+  --caption-height: 2.6rem;
   --slides-width: 50vw;
   --slides-height: 100vh;
   --padding: 1.4rem;
@@ -93,14 +93,16 @@ hr { border: none; border-bottom: 1px solid var(--border-color); clear: both; }
 
 /* NAVIGATION */
 .navigation {
-  display: flex; justify-content: flex-start; gap: 0.5em;
-  align-items: baseline; position: sticky; background: var(--background-color);
+  display: flex; flex-wrap: wrap; justify-content: flex-start; gap: 0.5em;
+  align-items: center; position: sticky; background: var(--background-color);
   padding: 0.75em 0; top: 0; z-index: 1000;
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
 }
 .navigation a {
   text-decoration: none; font-size: 0.9em; margin-bottom: -1px;
   color: var(--light-text-color); background: var(--off-background-color);
-  border-radius: 2em; display: inline-block; padding: 0.25em 0.75em; text-wrap: nowrap;
+  border-radius: 2em; display: inline-block; padding: 0.25em 0.75em;
+  flex: 0 0 auto; white-space: nowrap; text-wrap: nowrap;
 }
 .navigation a.active {
   color: var(--text-color); background-color: var(--border-color);
@@ -275,10 +277,16 @@ kbd {
 .slide-caption {
   color: var(--text-color); position: absolute; height: var(--caption-height);
   bottom: 0; left: 0; font-size: 0.85em; right: 0; text-align: center; cursor: auto;
-  margin: 0 2rem;
+  margin: 0 2rem; display: flex; flex-direction: column; align-items: center;
+  justify-content: center; gap: 0.15em; line-height: 1.25; box-sizing: border-box;
 }
-.slide-caption a {
-  color: var(--text-color); font-size: 0.75em; text-transform: uppercase; opacity: 0.5;
+.slide-caption-text {
+  display: block; max-width: 100%;
+}
+.slide-caption a,
+.slide-caption-credit {
+  display: block; color: var(--text-color); font-size: 0.75em;
+  text-transform: uppercase; letter-spacing: 0.04em; opacity: 0.5;
 }
 
 .flickity-page-dots {
@@ -361,4 +369,10 @@ kbd {
   }
   
   .main { width: 100%; }
+}
+
+@media screen and (max-width: 640px) {
+  .slides {
+    margin-top: 5.75em;
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses the Codex review on #1689: wrapped mobile nav overlapped headings on slide-less Event pages.

#1689 made `.navigation` wrap at 400px and only increased `.slides` top margin. Speakers, FAQs, Announcements, and other slide-less pages use a title + nav header instead of `.slides`, so the two-row fixed nav covered that header and sat on the `h1`. Those pages now share a `.site-header` with the same 5.75em offset.

This branch includes the Event template work from #1689 plus that spacing fix.

## Changes
- Add `.site-header` around the title + nav row on slide-less Event pages
- At `max-width: 640px`, apply the wrapped-nav top margin to both `.slides` and `.site-header`

## Testing
Preview of Event on the lecture demo at 400×650 (headless Chrome).

- Before: Speakers/FAQs `h1` started 6px below the 85px two-row nav; site title was hidden under the pills
- After: `.site-header` starts at 86px; Speakers/FAQs `h1` at 177px (93px gap); no overlap
- Information (slides) and Tickets keep the existing slide offset; caption and credit stay on separate lines
- All five nav pills on-screen; none clipped

[Speakers at 400px before the heading offset](https://cursor.com/agents/bc-6e465096-3aa0-4fd4-a218-b53514e12350/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_speakers_400x650_before.png)
[Speakers at 400px after the heading offset](https://cursor.com/agents/bc-6e465096-3aa0-4fd4-a218-b53514e12350/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_speakers_400x650.png)
[FAQs at 400px with heading below wrapped nav](https://cursor.com/agents/bc-6e465096-3aa0-4fd4-a218-b53514e12350/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_faqs_400x650.png)
[Information page at 400px with slides still offset](https://cursor.com/agents/bc-6e465096-3aa0-4fd4-a218-b53514e12350/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevent_information_400x650.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e465096-3aa0-4fd4-a218-b53514e12350?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e465096-3aa0-4fd4-a218-b53514e12350&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

