### PR TITLE
Fix Organization template homepage and preview folder

### DIFF
--- a/app/templates/source/organization/archives.html
+++ b/app/templates/source/organization/archives.html
@@ -3,7 +3,7 @@
 
 {{> head}}
 
-<body class=" {{^pagination.previous}}homefirstpage{{/pagination.previous}}">
+<body>
 
   {{> header}}
 
@@ -23,15 +23,8 @@
           {{#entries}}
           <div class="mb-2 d-flex justify-content-between main-loop-card">
             <div class="pr-3">
-  <a class="text-dark" href="{{{url}}}">{{title}} <small class="text-muted">
-            {{#date}}{{date}}{{/date}}
-  </small></a>
-             
-              
-  </small>
-              
+              <a class="text-dark" href="{{{url}}}">{{title}} <small class="text-muted">{{#date}}{{date}}{{/date}}</small></a>
             </div>
-            
           </div>
           {{/entries}}
           {{/months}}

--- a/app/templates/source/organization/entries.html
+++ b/app/templates/source/organization/entries.html
@@ -20,31 +20,33 @@
         {{#first}}
         <div class="col-md-6">
           <div class="card border-0 mb-4 box-shadow">
+            {{#thumbnail.large.url}}
             <a href="{{{url}}}">
-    <div style="background-image: url( {{{thumbnail.large.url}}}); height: 200px;    background-size: cover;    background-repeat: no-repeat;"></div>
-    </a>
+              <div class="entry-hero-thumb" style="background-image: url({{{thumbnail.large.url}}});"></div>
+            </a>
+            {{/thumbnail.large.url}}
             <div class="card-body px-0 pb-0 d-flex flex-column align-items-start">
               <h2 class="h4 font-weight-bold">
-    <a class="text-dark" href="{{{url}}}">{{title}}</a>
-    </h2>
+                <a class="text-dark" href="{{{url}}}">{{title}}</a>
+              </h2>
+              {{#summary}}
               <p class="card-text">
                 <a class="excerpt" href="{{{url}}}">{{summary}}</a>
               </p>
+              {{/summary}}
               <div>
                 {{#tags.length}}
                 <small class="d-block text-muted">
-            In <span class="catlist">
-
-                  {{#tags}}
-                <a class="text-capitalize text-muted smoothscroll" href="/tagged/{{slug}}">{{tag}}</a><span class="sep">, </span>
-                  {{/tags}}
-
-                </span>
-        </small>
+                  In <span class="catlist">
+                    {{#tags}}
+                    <a class="text-capitalize text-muted smoothscroll" href="/tagged/{{slug}}">{{tag}}</a><span class="sep">, </span>
+                    {{/tags}}
+                  </span>
+                </small>
                 {{/tags.length}}
                 <small class="text-muted">
-            {{#date}}{{date}}{{/date}}
-        </small>
+                  {{#date}}{{date}}{{/date}}
+                </small>
               </div>
             </div>
           </div>
@@ -62,30 +64,27 @@
             {{#thumbnail.large.url}}
             <div class="col-md-4 entry-list-thumb">
               <a href="{{{url}}}" class="w-100">
-    <div style="background-image: url( {{{thumbnail.large.url}}}); height: 80px;    background-size: cover;    background-repeat: no-repeat;"></div>
-    </a>
+                <div class="entry-list-thumb-image" style="background-image: url({{{thumbnail.large.url}}});"></div>
+              </a>
             </div>
             {{/thumbnail.large.url}}
 
             <div class="entry-list-copy">
               <h2 class="mb-2 h6 font-weight-bold">
-                    <a class="text-dark" href="{{{url}}}">{{title}}</a>
-                    </h2>
+                <a class="text-dark" href="{{{url}}}">{{title}}</a>
+              </h2>
               {{#tags.length}}
               <small class="d-block text-muted">
-                        In <span class="catlist">
-
-                        {{#tags}}
-                        <a class="text-capitalize text-muted smoothscroll" href="/tagged/{{slug}}">{{tag}}</a>{{^last}}, {{/last}}
-                        {{/tags}}
-
-
-                        </span>
-                    </small>
+                In <span class="catlist">
+                  {{#tags}}
+                  <a class="text-capitalize text-muted smoothscroll" href="/tagged/{{slug}}">{{tag}}</a>{{^last}}, {{/last}}
+                  {{/tags}}
+                </span>
+              </small>
               {{/tags.length}}
               <small class="text-muted">
-            {{#date}}{{date}}{{/date}}
-                    </small>
+                {{#date}}{{date}}{{/date}}
+              </small>
             </div>
           </div>
           {{/first}}
@@ -95,19 +94,23 @@
 
       </div>
 
-      <!-- Highlight (your own choice of highlighting a link, no post here) -->
+      <!-- Fifth post as a banner; hidden when the page has fewer than five posts -->
       <div class="jumbotron jumbotron-fluid jumbotron-home pt-0 pb-0 mb-2rem bg-lightblue position-relative show-5">
         {{#posts}}
-        <div class="pl-4 pr-0 h-100 tofront ">
-          <div class="row justify-content-between ">
-            <div class="col-md-6 pt-6 pb-6 align-self-center">
+        <div class="pl-4 pr-0 h-100 tofront">
+          <div class="row justify-content-between">
+            <div class="{{#thumbnail.large.url}}col-md-6{{/thumbnail.large.url}}{{^thumbnail.large.url}}col-12{{/thumbnail.large.url}} pt-6 pb-6 align-self-center">
               <h1 class="mb-3">{{title}}</h1>
+              {{#summary}}
               <p class="mb-3 lead">
                 {{summary}}
               </p>
+              {{/summary}}
               <a href="{{{url}}}" class="btn btn-dark">Read More</a>
             </div>
-            <div class="col-md-6 d-none d-md-block pr-0" style="background-size:cover;background-image:url({{{thumbnail.large.url}}});"> </div>
+            {{#thumbnail.large.url}}
+            <div class="col-md-6 d-none d-md-block pr-0 jumbotron-home-image" style="background-size:cover;background-image:url({{{thumbnail.large.url}}});"></div>
+            {{/thumbnail.large.url}}
           </div>
         </div>
         {{/posts}}
@@ -116,7 +119,7 @@
 
       <!--endif page url is / -->
 
-      <!-- Now the rest of the posts with the usual loop but with an offset:4 on the first page so we can skeep the first 4 posts displayed above -->
+      <!-- Remaining posts: the first page already showed 1 + 3 + the banner -->
 
       <div class="row mt-3">
 
@@ -128,30 +131,31 @@
           <div class="mb-5 d-md-flex justify-content-between main-loop-card">
             <div class="pr-3 entry-list-copy">
               <h2 class="mb-1 h4 font-weight-bold">
-  <a class="text-dark" href="{{{url}}}">{{title}}</a>
-  </h2>
+                <a class="text-dark" href="{{{url}}}">{{title}}</a>
+              </h2>
+              {{#summary}}
               <p class="excerpt">
                 {{summary}}
               </p>
+              {{/summary}}
               {{#tags.length}}
               <small class="d-block text-muted">
-    In <span class="catlist">
-
-      {{#tags}}
-    <a class="text-capitalize text-muted smoothscroll" href="/tagged/{{summary}}">{{tag}}</a><span class="sep">, </span>
-      {{/tags}}
-    </span>
-  </small>
+                In <span class="catlist">
+                  {{#tags}}
+                  <a class="text-capitalize text-muted smoothscroll" href="/tagged/{{slug}}">{{tag}}</a><span class="sep">, </span>
+                  {{/tags}}
+                </span>
+              </small>
               {{/tags.length}}
               <small class="text-muted">
-            {{#date}}{{date}}{{/date}}
-  </small>
+                {{#date}}{{date}}{{/date}}
+              </small>
             </div>
             {{#thumbnail.large.url}}
             <div class="col-md-3 pr-0 text-right entry-list-thumb">
               <a href="{{{url}}}">
-  <img class="w-100" src="{{{thumbnail.large.url}}}" alt="{{title}}">
-  </a>
+                <img class="w-100" src="{{{thumbnail.large.url}}}" alt="{{title}}">
+              </a>
             </div>
             {{/thumbnail.large.url}}
           </div>
@@ -188,30 +192,27 @@
 
         <div class="col-md-4">
           <div class="sticky-top sticky-top-offset">
-            <h4 class="font-weight-bold spanborder"><span>Featured</span></h4>
+            <h4 class="font-weight-bold spanborder"><span>Latest</span></h4>
             <ol class="list-featured clip-5">
 
-              {{#all_entries}}
-              {{#tagged.featured}}
+              {{#recent_entries}}
               <li class="mb-4">
                 <span>
-                <h6 class="font-weight-bold">
+                  <h6 class="font-weight-bold">
                     <a href="{{{url}}}" class="text-dark">{{title}}</a>
-                </h6>
-                {{#tags.length}}
-                <span class="d-block text-muted">
+                  </h6>
+                  {{#tags.length}}
+                  <span class="d-block text-muted">
                     In <span class="catlist">
-
-                    {{#tags}}
-                    <a class="text-capitalize text-muted smoothscroll" href="{{{url}}}">{{tag}}</a><span class="sep">, </span>
-                {{/tags}}
-                </span>
-                </span>
-                {{/tags.length}}
+                      {{#tags}}
+                      <a class="text-capitalize text-muted smoothscroll" href="/tagged/{{slug}}">{{tag}}</a><span class="sep">, </span>
+                      {{/tags}}
+                    </span>
+                  </span>
+                  {{/tags.length}}
                 </span>
               </li>
-              {{/tagged.featured}}
-              {{/all_entries}}
+              {{/recent_entries}}
 
             </ol>
           </div>

--- a/app/templates/source/organization/entry.html
+++ b/app/templates/source/organization/entry.html
@@ -26,12 +26,7 @@
               </p>
               <h1 class="display-4 mb-4 article-headline">{{title}}</h1>
               <div class="d-flex align-items-center">
-
-                <span  style="display:block" class="w-100 text-muted d-block mt-1">{{#date}}{{date}}{{/date}} 
-  
-</span>
-                </span>
-                </small>
+                <span class="w-100 text-muted d-block mt-1">{{#date}}{{date}}{{/date}}</span>
               </div>
             </div>
 

--- a/app/templates/source/organization/header.html
+++ b/app/templates/source/organization/header.html
@@ -15,9 +15,9 @@
           {{/menu}}
 
         </ul>
-        <ul class="navbar-nav ml-auto d-flex align-items-center" style="flex-grow:1;padding-left:3em">
+        <ul class="navbar-nav ml-auto d-flex align-items-center site-search">
 
-          <form class="bd-search hidden-sm-down w-100" action="/search">
+          <form class="bd-search d-none d-md-block w-100" action="/search">
             <input type="text" class="form-control text-small" id="lunrsearch" name="q" value="{{query}}" placeholder="Search">
           </form>
         </ul>

--- a/app/templates/source/organization/package.json
+++ b/app/templates/source/organization/package.json
@@ -3,7 +3,8 @@
   "locals": {
     "page_size": 12,
     "hide_dates": false,
-    "date_display": "MMMM D, Y"
+    "date_display": "MMMM D, Y",
+    "demo_folder": "lecture"
   },
   "isPublic": false,
   "views": {

--- a/app/templates/source/organization/search.html
+++ b/app/templates/source/organization/search.html
@@ -3,7 +3,7 @@
 
 {{> head}}
 
-<body class=" {{^pagination.previous}}homefirstpage{{/pagination.previous}}">
+<body>
 
   {{> header}}
 
@@ -23,15 +23,8 @@
           {{#entries}}
           <div class="mb-2 d-flex justify-content-between main-loop-card">
             <div class="pr-3">
-  <a class="text-dark" href="{{{url}}}">{{title}} <small class="text-muted">
-            {{#date}}{{date}}{{/date}}
-  </small></a>
-             
-              
-  </small>
-              
+              <a class="text-dark" href="{{{url}}}">{{title}} <small class="text-muted">{{#date}}{{date}}{{/date}}</small></a>
             </div>
-            
           </div>
           {{/entries}}
 

--- a/app/templates/source/organization/style.css
+++ b/app/templates/source/organization/style.css
@@ -14064,6 +14064,47 @@ div.a2a_full_footer {
   display: block !important;
 }
 
+.jumbotron-home.show-5:not(:has(> :nth-child(5))) {
+  display: none;
+}
+
+.entry-hero-thumb {
+  height: 200px;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.entry-list-thumb-image {
+  height: 80px;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.jumbotron-home .lead {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.site-search {
+  padding-left: 1.5rem;
+  max-width: 16rem;
+  flex-grow: 0;
+}
+
+@media (min-width: 768px) {
+  .jumbotron-home .row {
+    min-height: 280px;
+  }
+
+  .jumbotron-home-image {
+    min-height: 280px;
+  }
+}
+
 /* Hide the Search menu item when the header already has a search form */
 #MagicMenu .navbar-nav.mr-auto .nav-item[data-url="/search" i],
 #MagicMenu .navbar-nav.mr-auto .nav-item[data-url="/search/" i],

--- a/app/templates/source/organization/tagged.html
+++ b/app/templates/source/organization/tagged.html
@@ -3,7 +3,7 @@
 
 {{> head}}
 
-<body class=" {{^pagination.previous}}homefirstpage{{/pagination.previous}}">
+<body>
 
   {{> header}}
 
@@ -22,15 +22,8 @@
           {{#entries}}
           <div class="mb-2 d-flex justify-content-between main-loop-card">
             <div class="pr-3">
-  <a class="text-dark" href="{{{url}}}">{{title}} <small class="text-muted">
-            {{#date}}{{date}}{{/date}}
-  </small></a>
-
-
-  </small>
-
+              <a class="text-dark" href="{{{url}}}">{{title}} <small class="text-muted">{{#date}}{{date}}{{/date}}</small></a>
             </div>
-
           </div>
           {{/entries}}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Organization gallery screenshot was a personal-blog homepage because the template used the default `david` folder. The lead card also reserved a blank 200px thumbnail, the mint banner picked a poor 5th post, Featured was empty without a `featured` tag, tag links used `/tagged/{{summary}}`, and the header search crowded the nav.

## Changes
- Set `demo_folder` to `lecture` (announcements, speakers, tickets)
- Render thumbnails only when `thumbnail.large.url` exists
- Hide the banner when there is no 5th post; clamp excerpts
- Sidebar lists `recent_entries`
- Constrain the header search; fix tag hrefs and broken archives/search/tagged markup

Regenerate previews with:

```
gh workflow run screenshots.yml --ref cursor/fix-organization-template-a99f -f templates=organization
```

Review the updated images under `app/views/images/examples/organization/` once that run commits. Workflow dispatch from this agent is blocked (`403 Resource not accessible by integration`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1eaa2018-abd9-43ce-bed5-b99f1d07a99f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1eaa2018-abd9-43ce-bed5-b99f1d07a99f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

