### PR TITLE
Fix flaky sync.update test timeout

### DIFF
--- a/app/sync/tests/update.js
+++ b/app/sync/tests/update.js
@@ -2,6 +2,14 @@ describe("update", function () {
   var sync = require("../index");
   var fs = require("fs-extra");
 
+  // The "rebuilds an entry if the source file changes" spec below writes
+  // the source file every 10ms for ~3 seconds while sync.update recurses
+  // to catch up (see app/sync/update/index.js), so it can legitimately take
+  // longer than Jasmine's 5 second default under load, causing an
+  // intermittent timeout (and a stray late failure attributed to whichever
+  // spec runs next).
+  global.test.timeout(15 * 1000);
+
   // Set up a test blog before each test
   global.test.blog();
 


### PR DESCRIPTION
## Summary

Root-caused the flaky failures in [this run](https://github.com/davidmerfield/blot/actions/runs/33967211600/job/101309524081?pr=1709):

- `update rebuilds an entry if the source file changes` timed out after 5000ms (Jasmine's default per-spec timeout).
- `build uses link metadata` failed with `No entry exists with path: /connect/.../connect.txt` — but that path doesn't belong to the "uses link metadata" spec at all (it uses `/hey.txt`). It's the faker-generated path from the *other* failing spec above.

**Why:** `app/sync/tests/update.js`'s "rebuilds an entry if the source file changes" spec writes its source file every 10ms for ~3 seconds (300 iterations) while `sync.update` (`app/sync/update/index.js`) recomputes the file's hash before/after each pass and recursively re-syncs whenever the hash changed mid-sync — by design, so it converges on the final content. That convergence loop's legitimate runtime (3s of writes, plus DB/redis overhead per recursive pass) sits right at the edge of Jasmine's 5000ms default timeout — the run's own "Slowest specs" list shows it taking 5198ms. Under normal CI load it tips over.

When it times out, Jasmine moves on to the next spec, but the still-pending async work (the recursive `update()` calls, the eventual `checkEntry` callback) keeps running in the background. When it finally settles, its stray `testDone.fail(err)` call fires with Jasmine already on a different spec, so the failure gets misattributed to whatever spec happens to be running then — in this run, `build uses link metadata`.

## Fix

Add `global.test.timeout(15 * 1000)` to the `update` describe block, matching the existing convention used by other slow suites (e.g. `app/blog/tests/wikilinks.js`, `app/site/tests/config.js`) — this gives the spec's legitimate ~3s+ of work comfortable headroom instead of racing the default timeout.

## Test plan

- [ ] CI run passes for `app/sync` without the timeout/misattributed failure recurring.