### PR TITLE
Fix four flaky CI specs

### DIFF
--- a/app/blog/tests/scheduled.js
+++ b/app/blog/tests/scheduled.js
@@ -1,6 +1,8 @@
 describe("scheduled entries", function () {
   require("./util/setup")();
 
+  global.test.timeout(20 * 1000);
+
   let now;
 
   beforeEach(function () {
@@ -18,21 +20,34 @@ describe("scheduled entries", function () {
     const buffer = 1000; // 1 second
     const futureDate = new Date(now.getTime() + publishDelay).toISOString();
 
-    console.log("Writing scheduled.txt with date", futureDate);
-
     await this.write({
       path: "/scheduled.txt",
       content: "Link: a\nDate: " + futureDate + "\n\nHello, future!",
     });
 
-    console.log("Advancing clock by", publishDelay + buffer, "ms");
+    // Advancing the mocked clock fires the publication job synchronously, but
+    // the work it kicks off (app/models/entry/_addToSchedule.js: Entry.set
+    // re-save -> entry rebuild -> Blog.set cacheID) is a multi-step chain of
+    // real Redis/filesystem I/O that the mocked clock does not drive. A single
+    // setImmediate is not enough turns for it to finish under CI load, so poll
+    // the live endpoint until the entry is served instead.
     jasmine.clock().tick(publishDelay + buffer);
 
-    // Force queued microtasks to run
-    await new Promise((resolve) => setImmediate(resolve));
+    // process.hrtime stays real while Jasmine's clock (setTimeout + Date) is
+    // mocked, so use it to bound the wait.
+    const start = process.hrtime.bigint();
+    const timeoutMs = 10 * 1000;
 
-    console.log("Immediate resolved, checking /a again");
-    const postPublishRes = await this.get("/a");
+    let postPublishRes = await this.get("/a");
+
+    while (
+      postPublishRes.status !== 200 &&
+      Number(process.hrtime.bigint() - start) / 1e6 < timeoutMs
+    ) {
+      await new Promise((resolve) => setImmediate(resolve));
+      postPublishRes = await this.get("/a");
+    }
+
     const body = await postPublishRes.text();
 
     expect(postPublishRes.status).toEqual(200);

--- a/app/dashboard/site/import/sources/blogger/tests/index.js
+++ b/app/dashboard/site/import/sources/blogger/tests/index.js
@@ -7,6 +7,33 @@ describe("Blogger importer", function () {
   const legacyFixture = path.join(__dirname, "fixtures", "export.xml");
   const atomFixture = path.join(__dirname, "fixtures", "export.atom");
 
+  // The full import pipeline runs helper.download_images / download_pdfs, which
+  // fetch() the external asset URLs embedded in export.xml (e.g.
+  // https://blogger.googleusercontent.com/...). Those real network calls make
+  // the pipeline specs depend on CI egress and time out intermittently
+  // (helper/download_images.js has its own 5s timeout that collides with
+  // Jasmine's). Stub fetch so downloads fail fast and offline; none of these
+  // specs assert on downloaded asset content.
+  let realFetch;
+
+  beforeAll(function () {
+    realFetch = global.fetch;
+    global.fetch = function () {
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        headers: { get: () => null },
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+        text: () => Promise.resolve(""),
+        json: () => Promise.resolve({}),
+      });
+    };
+  });
+
+  afterAll(function () {
+    global.fetch = realFetch;
+  });
+
   it("selects published posts and pages and maps Atom fields", async function () {
     const entries = await blogger.parse(await fs.readFile(legacyFixture, "utf8"));
     expect(entries.length).toBe(5);

--- a/app/models/template/tests/updateCdnManifest.js
+++ b/app/models/template/tests/updateCdnManifest.js
@@ -134,8 +134,16 @@ describe("updateCdnManifest", function () {
 
     expect(newHash).not.toBe(oldHash);
 
-    // Verify old rendered output is removed
-    const oldOutputAfter = await getAsync(oldRenderedKey);
+    // updateCdnManifest deletes the previous hash's rendered output in the
+    // background without awaiting it (util/updateCdnManifest.js: "Run cleanup
+    // in background - don't await"), so the delete can land just after
+    // getMetadata resolves. Poll rather than assume it completed synchronously.
+    let oldOutputAfter = await getAsync(oldRenderedKey);
+    const deadline = Date.now() + 5000;
+    while (oldOutputAfter !== null && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      oldOutputAfter = await getAsync(oldRenderedKey);
+    }
     expect(oldOutputAfter).toBeNull();
 
     // Verify new rendered output exists

--- a/app/sync/tests/update.js
+++ b/app/sync/tests/update.js
@@ -43,6 +43,14 @@ describe("update", function () {
       }, 10);
 
       folder.update(path, function (err) {
+        // Stop the background writes as soon as update() has read the file.
+        // Left running, this interval can keep writing into the blog's
+        // folder well past this test's own completion (or a slow-CI
+        // Jasmine timeout), racing a later test's teardown and causing an
+        // ENOTEMPTY when it tries to remove a directory this interval is
+        // still writing into.
+        clearInterval(poll);
+
         if (err) testDone.fail(err);
 
         checkEntry(


### PR DESCRIPTION
Fixes four specs that fail intermittently on `master` CI. Each asserts on the
result of asynchronous work that completes on its own schedule rather than the
test's, so all four fixes are **test-only** — no production code changes.

Investigation notes (historical failing runs, root causes) live in the session
report; summary per spec below.

## 1. `scheduled entries > promotes a scheduled entry once its publication time arrives`
`app/blog/tests/scheduled.js` — `Expected 404 to equal 200`

After `jasmine.clock().tick()` fires the publication job, the entry rebuild it
triggers (`app/models/entry/_addToSchedule.js`: `Entry.set` re-save → rebuild →
`Blog.set` cacheID) is a multi-step chain of real Redis/filesystem I/O that the
mocked clock does not drive. The single `setImmediate` wait was not enough
event-loop turns under CI load, so the entry was still flagged `scheduled` when
`GET /a` ran. Now polls the live endpoint until it is served, bounded by
`process.hrtime` (which stays real while `setTimeout`/`Date` are mocked), and
raises the block timeout to 20s.

Failing runs: 33963974884, 33745255941, 31474121489, 30940877949, 28125000406, 27674563638.

## 2. `updateCdnManifest > removes old rendered output from Redis when hash changes`
`app/models/template/tests/updateCdnManifest.js` — `Expected 'body{color:pink}' to be null`

Production deletes the previous hash's Redis entry in the background without
awaiting it (`util/updateCdnManifest.js`: *"Run cleanup in background - don't
await"*), so the delete can land just after `getMetadata` resolves. Now polls
the key until it clears.

Failing run: 33620949883.

## 3. `Blogger importer > writes Markdown, metadata, pages, and collision-safe paths`
`app/dashboard/site/import/sources/blogger/tests/index.js` — `Timeout - Async callback was not invoked within 5000ms`

The import pipeline `fetch()`es the external asset URLs embedded in
`fixtures/export.xml` (`blogger.googleusercontent.com/...`), so the spec
depended on CI egress and hit Jasmine's 5s timeout when the request was slow
(`helper/download_images.js` has its own colliding 5s timeout). Now stubs
`global.fetch` for the suite (restored in `afterAll`) so downloads fail fast and
offline; no spec in the file asserts on downloaded asset content.

Failing run: 31467123717.

## 4. `sync > update > rebuilds an entry if the source file changes`
`app/sync/tests/update.js`

The spec starts a `setInterval` writing to the source file every 10ms, cleared
only once content passes ~300 (~3s), never on `folder.update()`'s own callback.
On slow CI it can hit Jasmine's timeout first, leaving the interval writing into
the blog folder during a later test's teardown → intermittent `ENOTEMPTY`. Now
clears the interval as soon as `update()`'s callback fires.

This commit (`Fix flaky app/sync test: clear the polling interval on update()
callback`) was previously carried on the airlock PR branch
(`claude/ip-block-enforcement-library-85ed72`); moved here so all flaky-spec
fixes land together.

## Verification
Each affected spec file run in the Docker test harness: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)