### PR TITLE
Update 2026 summer newsletter with this week's changes

### DIFF
--- a/app/helper/email/newsletters/2026-2-summer.txt
+++ b/app/helper/email/newsletters/2026-2-summer.txt
@@ -10,6 +10,10 @@ Summer newsletter
 - Obsidian callout support: /how/files/markdown#callouts
 
 **Changes**
+- Improved many of the built-in templates and fixed a batch of mobile layout bugs across the template collection
+- The web template editor has clearer controls for the Links, Documentation, Magazine and Fieldnotes templates
+- The [redirects settings page](https://blot.im/sites/default/settings/redirects) now warns you when two redirects conflict
+- iCloud folder setup no longer times out during the initial connection and reports progress on the sync status line
 - Relative links in your posts are now resolved based on the location of the source file, not the post's URL (previously relative links, unlike images, were resolved against the post's URL, which often broke them)
 - Google Docs now support superscript, subscript, strike, underline
 - Support Wikilink lookup by title for pages as well as posts
@@ -33,6 +37,9 @@ Summer newsletter
 - Fixed a bug that allowed unauthorized access to another site’s files by submitting a crafted site ID
 - Fixed an authorization bug that let you install and view another site’s private template
 - Fixed the HTML produced for blockquotes in [Google Docs](https://blot.im/how/files/google-docs), which could make quoted text wider than the rest of your writing
+- Fixed a reflected cross-site scripting flaw on the Dropbox authentication page
+- Hardened the dashboard against cross-site request forgery
+- Closed a way to bypass the login rate limiter with a forged X-Forwarded-For header
 
 **Questions**
 


### PR DESCRIPTION
## What

Adds lines to the 2026 summer newsletter draft (`app/helper/email/newsletters/2026-2-summer.txt`) for user-facing changes merged since the start of the week.

**Changes**
- Built-in template improvements + a batch of mobile layout fixes (Zine, Documentation, Event, Profile, Keynote, Organization, Hypertext, Journal; Blog sidenotes, Links header, Portfolio, Album index, Fieldnotes)
- Clearer web template-editor controls for the Links, Documentation, Magazine and Fieldnotes templates
- Redirect conflict warnings on the redirects settings page
- More reliable iCloud folder setup (no first-connect timeout, progress on the sync status line)

**Bug fixes (security)**
- Reflected XSS on `/clients/dropbox/authenticate`
- Dashboard CSRF cookie hardened with the `__Host-` prefix
- Login rate-limiter `X-Forwarded-For` bypass closed

## Why

Keeps the seasonal newsletter draft current with the past week's merged work.

## Notes for reviewers

- Internal-only work (CI/test fixes, dev-env scripts, doc tweaks, `re2` swap, cancelled-account admin email) was intentionally excluded.
- The empty **Questions / Mistakes / Plans for the autumn** sections were left untouched — not derivable from commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)