### PR TITLE
Let the airlock resolve DNS when the upstream resolver is in a blocked range

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,29 @@ jobs:
           echo "Sanity check: an unfiltered sibling container CAN reach the target..."
           docker exec airlock_test_control sh -c "nc -z -w3 $target_ip 80"
 
-          airlock_id=$(docker run -d --network airlock_test_network --cap-add=NET_ADMIN "$IMAGE")
+          # Docker's embedded resolver (127.0.0.11) only proxies DNS - it
+          # forwards cache misses to the host's upstream nameservers. On the
+          # production cloud host that upstream is the VPC resolver, itself
+          # at a private address egress.nft rejects, so a bare "127.0.0.11
+          # accept" still leaves every lookup returning SERVFAIL (this is a
+          # real incident the probe caught). A GitHub runner's upstream
+          # happens to be reachable, so to actually exercise that path here
+          # we stand up our own resolver on a sibling container - its IP is
+          # from Docker's default pool, entirely inside the 172.16.0.0/12
+          # range egress.nft blocks - and point the airlock at it. The
+          # forward can only succeed via the `meta skuid 0 udp/tcp dport 53`
+          # rules in egress.nft; drop those and this step goes red.
+          docker run -d --name airlock_test_dns --network airlock_test_network \
+            alpine:3.20 sh -c 'apk add --no-cache dnsmasq >/dev/null && exec dnsmasq -k --no-resolv --server=1.1.1.1 --server=8.8.8.8'
+          dns_ip=$(docker inspect --format='{{(index .NetworkSettings.Networks "airlock_test_network").IPAddress}}' airlock_test_dns)
+          echo "Sibling resolver (in the blocked range) is at $dns_ip"
+          for i in $(seq 1 20); do
+            if docker exec airlock_test_control sh -c "nslookup example.com $dns_ip >/dev/null 2>&1"; then break; fi
+            [ "$i" = 20 ] && { echo "sibling resolver never came up"; docker logs airlock_test_dns || true; exit 1; }
+            sleep 1
+          done
+
+          airlock_id=$(docker run -d --network airlock_test_network --cap-add=NET_ADMIN --dns "$dns_ip" "$IMAGE")
 
           timeout=30; interval=2; elapsed=0
           until [ "$(docker inspect --format='{{json .State.Health.Status}}' "$airlock_id")" = '"healthy"' ]; do
@@ -250,11 +272,14 @@ jobs:
             exit 1
           fi
 
+          # These also confirm DNS works: the airlock's only resolver is the
+          # sibling at $dns_ip, in a range egress.nft blocks, so a resolved
+          # name proves the uid-0 :53 forward rules are in place.
           echo "Checking the public internet is reachable, direct and via the proxy..."
           docker exec "$airlock_id" sh -c 'curl -m8 -sSf -o /dev/null https://example.com'
           docker exec "$airlock_id" sh -c 'curl -m8 -sSf -x http://127.0.0.1:8888 -o /dev/null https://example.com'
 
-          docker rm -f "$airlock_id" airlock_test_target airlock_test_control
+          docker rm -f "$airlock_id" airlock_test_target airlock_test_control airlock_test_dns
           docker network rm airlock_test_network
 
   manifest-airlock:

--- a/config/airlock/README.md
+++ b/config/airlock/README.md
@@ -312,6 +312,14 @@ didn't take - check the `Connecting … to blotnet` line in the deploy log).
   default bridge `/etc/resolv.conf` points at a private address that the
   filter drops, so name resolution fails. Dev compose and the production
   steps above both use a named network.
+  * `127.0.0.11` only proxies DNS - it forwards cache misses to the host's
+    upstream nameservers, which on a cloud host are themselves at a private
+    or link-local address the filter would otherwise reject (on the prod
+    EC2 host it's the VPC resolver at `172.30.0.2`). `egress.nft` allows
+    **uid 0** (the dockerd-owned forwarding socket) to reach port 53
+    anywhere so that forward can complete; untrusted uid 1001 code still
+    can't, and still resolves only via `127.0.0.11`. Without that rule
+    every lookup inside the container returns `SERVFAIL`.
 * `airlock` becomes a build-pipeline dependency: if it's down, bookmark
   screenshots and remote-image transforms fail (they already degrade
   gracefully — the post builds without the image). Give it a restart policy

--- a/config/airlock/egress.nft
+++ b/config/airlock/egress.nft
@@ -48,6 +48,21 @@ table inet airlock {
         # waiting for a connection nothing will ever answer.
         oif "lo" reject
 
+        # Docker's embedded resolver at 127.0.0.11 (allowed above) does not
+        # answer from cache alone - it forwards cache misses to the host's
+        # upstream nameservers, and on a cloud host those are themselves at a
+        # private / link-local address (the VPC resolver, e.g. 172.30.0.2 on
+        # this EC2 host, or 169.254.169.253) that the rules below reject. So
+        # a bare 127.0.0.11 accept still leaves every name lookup returning
+        # SERVFAIL. That forwarding socket is opened by dockerd itself, as
+        # root (uid 0), so let uid 0 reach port 53 on any address. Untrusted
+        # code (Chromium, tinyproxy) runs as uid 1001, cannot match this, and
+        # must still resolve via 127.0.0.11 - and any name it does resolve is
+        # re-checked by real destination IP at connect() time below, so this
+        # does not widen what it can actually reach.
+        meta skuid 0 udp dport 53 accept
+        meta skuid 0 tcp dport 53 accept
+
         # --- IPv4: drop every non-public destination ---
         ip daddr {
             0.0.0.0/8,


### PR DESCRIPTION
## The bug

The post-boot airlock probe added in #1676 has been failing in production:

```
[green] Airlock probe: browser check FAILED at step "navigate-or-screenshot"
Error: net::ERR_NAME_NOT_RESOLVED at https://example.com/
```

`egress.nft` allows uid 1001 code (Chromium, tinyproxy) to reach Docker's
embedded resolver at `127.0.0.11`, but `127.0.0.11` only *proxies* DNS - it
forwards cache misses to the host's upstream nameservers. On the prod EC2
host that upstream is the VPC resolver at `172.30.0.2`, itself inside the
`172.16.0.0/12` range `egress.nft` rejects. So the forward is dropped and
every lookup inside the container returns `SERVFAIL`.

Confirmed on the box:

```
$ cat /etc/resolv.conf
nameserver 172.30.0.2
$ docker exec blot-airlock nslookup example.com
** server can't find example.com: SERVFAIL
$ docker exec blot-airlock nft flush chain inet airlock output \
    && docker exec blot-airlock nslookup example.com
Non-authoritative answer:
Name:  example.com
Address: 104.20.23.154
```

This is exactly what the staged rollout was for - real traffic still takes
the direct path (`BLOT_AIRLOCK_BROWSER_URL` is unset until the cutover PR
#1696), so nothing is degraded; the probe caught it first. CI stayed green
because a GitHub runner's upstream resolver isn't in a blocked range.

## The fix

The forwarding socket is opened by dockerd itself, as **root (uid 0)**. Two
rules in `egress.nft`:

```
meta skuid 0 udp dport 53 accept
meta skuid 0 tcp dport 53 accept
```

Untrusted uid 1001 code can't match these - it still resolves only via
`127.0.0.11` - and any name it does resolve is still re-checked by real
destination IP at `connect()` time by the reject blocks below, so a name
resolving to `10.0.0.5` still can't be connected to. The metadata address
(`169.254.169.254:80`, uid 1001) is untouched.

## CI regression test

The "Verify egress filter" step now stands up its own `dnsmasq` resolver on
a sibling container - its IP is from Docker's default pool, entirely inside
the blocked `172.16.0.0/12` - and points the airlock at it with `--dns`.
The existing `curl https://example.com` checks (direct + via proxy) then
only pass if the uid-0 `:53` forward rules are present.

## Verification

Built the image and reproduced the prod topology locally (resolver at
`172.19.0.2`, a blocked address, as the airlock's only upstream):

- with the rules: `nslookup` + `curl` (direct and proxy) succeed
- delete just those two rules: `SERVFAIL` / "Could not resolve host" - the
  prod symptom exactly

Once this deploys and the probe logs green, #1696 (the cutover) is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)