### PR TITLE
Harden the bandcamp embed plugin against SSRF

### DIFF
--- a/app/build/plugins/videoEmbeds/bandcamp.js
+++ b/app/build/plugins/videoEmbeds/bandcamp.js
@@ -1,15 +1,32 @@
 const fetch = require("node-fetch");
 const cheerio = require("cheerio");
-const { parse } = require("url");
 
 const ERROR_MESSAGE = "Could not retrieve song properties";
 
+// bandcamp.com or <artist>.bandcamp.com, nothing else.
+const BANDCAMP_HOST = /^([a-z0-9-]+\.)*bandcamp\.com$/i;
+
+// Bandcamp is not an oEmbed provider, so unlike the other video embeds this
+// one scrapes the target page itself. To keep that from being an SSRF sink
+// (it is not routed through the airlock - see config/airlock/README.md) it
+// never fetches the raw user href: the host is pinned to bandcamp.com, the
+// URL is rebuilt from just the validated host + path (no scheme downgrade,
+// no credentials, no port, no query), and redirects are not followed - a
+// 3xx (or anything non-2xx) is treated as "not a bandcamp track".
 module.exports = async function (href, callback) {
   try {
-    const { hostname, pathname } = parse(href);
-    const path = pathname.toLowerCase();
+    let parsed;
 
-    if (!hostname.endsWith("bandcamp.com")) {
+    try {
+      parsed = new URL(href);
+    } catch (e) {
+      return callback(new Error(ERROR_MESSAGE));
+    }
+
+    const host = parsed.hostname.toLowerCase();
+    const path = parsed.pathname.toLowerCase();
+
+    if (!BANDCAMP_HOST.test(host)) {
       return callback(new Error(ERROR_MESSAGE));
     }
 
@@ -17,7 +34,15 @@ module.exports = async function (href, callback) {
       return callback(new Error(ERROR_MESSAGE));
     }
 
-    const res = await fetch(href);
+    // Rebuild from validated parts - never fetch `href` directly.
+    const safeUrl = "https://" + host + parsed.pathname;
+
+    const res = await fetch(safeUrl, { redirect: "manual" });
+
+    if (!res.ok) {
+      return callback(new Error(ERROR_MESSAGE));
+    }
+
     const body = await res.text();
     const $ = cheerio.load(body, null, false);
 

--- a/app/build/plugins/videoEmbeds/index.js
+++ b/app/build/plugins/videoEmbeds/index.js
@@ -4,7 +4,10 @@ var eachEl = require("build/plugins/eachEl");
 var Players = {
   bandcamp: {
     module: require("./bandcamp"),
-    regex: /.bandcamp.com$/m,
+    // bandcamp.com or an <artist>.bandcamp.com subdomain only - the old
+    // /.bandcamp.com$/ also matched notbandcamp.com / evil-bandcamp.com.
+    // bandcamp.js re-checks this before it fetches anything.
+    regex: /^([a-z0-9-]+\.)*bandcamp\.com$/i,
   },
   youtube: {
     module: require("./youtube"),

--- a/app/build/plugins/videoEmbeds/tests/bandcamp.js
+++ b/app/build/plugins/videoEmbeds/tests/bandcamp.js
@@ -68,6 +68,58 @@ describe("bandcamp embeds", function () {
     });
   });
 
+  ["https://notbandcamp.com/album/x", "https://evil-bandcamp.com/track/y"].forEach(
+    (href) => {
+      it("refuses look-alike host " + href, function (done) {
+        // No nock set up: if the plugin tried to fetch this it would throw
+        // on the disabled net connection, not return ERROR_MESSAGE.
+        bandcamp(href, (err, template) => {
+          expect(err.message).toEqual("Could not retrieve song properties");
+          expect(template).toEqual(undefined);
+          done();
+        });
+      });
+    }
+  );
+
+  it("does not follow a redirect off bandcamp", function (done) {
+    nock("https://oliviachaney.bandcamp.com")
+      .get("/album/circus-of-desire")
+      .reply(302, "", { Location: "http://169.254.169.254/latest/meta-data/" });
+    // nock.disableNetConnect() means a request to the Location would throw.
+    bandcamp(
+      "https://oliviachaney.bandcamp.com/album/circus-of-desire",
+      (err, template) => {
+        expect(err.message).toEqual("Could not retrieve song properties");
+        expect(template).toEqual(undefined);
+        done();
+      }
+    );
+  });
+
+  it("fetches the rebuilt https URL, not the raw href", function (done) {
+    // Credentials + explicit port + query string in the href must not reach
+    // the network - only https://<host>/<path> is fetched.
+    nock("https://oliviachaney.bandcamp.com")
+      .get("/album/circus-of-desire")
+      .reply(
+        200,
+        bandcampOgHtml({
+          src: "https://bandcamp.com/EmbeddedPlayer/v=2/album=1/size=large/",
+          width: 400,
+          height: 120,
+        })
+      );
+    bandcamp(
+      "https://user:pw@oliviachaney.bandcamp.com:8443/album/circus-of-desire?foo=bar",
+      (err, template) => {
+        expect(err).toEqual(null);
+        expect(template).toContain("bandcamp.com/EmbeddedPlayer");
+        done();
+      }
+    );
+  });
+
   it("handles a valid link to a track on a bandcamp subdomain", function (done) {
     const href = "https://cloquet.bandcamp.com/track/new-drugs";
     nock("https://cloquet.bandcamp.com")


### PR DESCRIPTION
## Why

`app/build/plugins/videoEmbeds/bandcamp.js` is the one video-embed player that scrapes the target page itself (Bandcamp is not an oEmbed provider). It was doing `fetch(href)` on the raw user-supplied post link and following redirects — an SSRF sink: scheme downgrade (`file:`, `http://169.254…`), credentials in the URL, or a `302` to an internal address.

It only ever legitimately talks to `bandcamp.com` / `<artist>.bandcamp.com`, so this pins it there rather than routing it through the airlock (companion PR #1717 handles the genuinely-arbitrary sinks).

## What

- **Tighten the host check.** The dispatch regex `/.bandcamp.com$/` (unescaped `.`, unanchored) and `hostname.endsWith("bandcamp.com")` both matched `notbandcamp.com` / `evil-bandcamp.com`. Both now require `bandcamp.com` or a real `*.bandcamp.com` subdomain (`/^([a-z0-9-]+\.)*bandcamp\.com$/i`).
- **Never fetch `href` directly.** Rebuild the URL from the validated host + path only — forces `https:`, drops credentials, port, query and fragment.
- **`redirect: "manual"`.** A `3xx` (or any non-2xx) is treated as "not a bandcamp track" instead of being followed.

Residual risk is only a genuine `*.bandcamp.com` DNS record resolving to a private IP, which needs a Bandcamp-side compromise — the same posture as the `vimeo`/`youtube`/`bluesky`/`flickr` embed plugins.

## Tests

`app/build/plugins/videoEmbeds/tests/bandcamp.js` — existing subdomain cases still pass; added:
- look-alike hosts (`notbandcamp.com`, `evil-bandcamp.com`) are rejected;
- a `302 → http://169.254.169.254/` reply yields the generic error and no second request;
- credentials + explicit port + query string in the `href` are dropped (only `https://<host>/<path>` is fetched).

9 specs, 0 failures locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)