### PR TITLE
Document that the transformer does not de-dupe concurrent lookups

### DIFF
--- a/app/build/plugins/image/index.js
+++ b/app/build/plugins/image/index.js
@@ -8,7 +8,11 @@ function render($, callback, options) {
   var blogID = options.blogID;
   var cache = new Transformer(blogID, "image-cache");
 
-  // Process 5 images concurrently
+  // Process 5 images concurrently. If a post references the same image more
+  // than once, those lookups can race and each run the transform once before
+  // either result is cached. That duplicated one-off work is an accepted
+  // trade-off - the transformer deliberately does not de-duplicate in-flight
+  // lookups (see helper/transformer/readme.txt).
   eachEl(
     $,
     "img",

--- a/app/helper/transformer/index.js
+++ b/app/helper/transformer/index.js
@@ -40,6 +40,11 @@ function Transformer(blogID, name) {
 
   var keys = Keys(blogID, name);
 
+  // Note: lookup does NOT de-duplicate concurrent calls for the same source.
+  // The "transform once" guarantee covers repeat lookups once a result is
+  // cached, not lookups that are in flight simultaneously - those may each
+  // run the transform and each write the (idempotent, hash-keyed) result.
+  // This is an accepted trade-off, not a bug; see readme.txt.
   function lookup(src, transform, callback) {
     if (type(src) !== "string") {
       return callback(new Error("Transformer: src is not a string"));

--- a/app/helper/transformer/readme.txt
+++ b/app/helper/transformer/readme.txt
@@ -12,3 +12,29 @@ url and dimensions from the database.
 As you can imagine, this massively speeds up
 saving existing entries, since images don't need
 to be reuploaded each time!
+
+
+Non-goal: concurrent lookup de-duplication
+------------------------------------------
+
+The "only applies the transformation function to the same file once"
+guarantee is about *repeat* lookups over time: once a result is cached
+against the file's content hash, later lookups reuse it and never run the
+transform again.
+
+It is NOT a guarantee about lookups that are in flight at the same moment.
+If two lookups for the same source race each other before either has
+written its result to the cache (for example the image plugin processing a
+post that references the same image twice, with several images transformed
+concurrently), both will run the transform and both will write the cache.
+The writes are idempotent - they key on the same content hash and store an
+equivalent result - so the only cost is the duplicated transform work for
+that one build.
+
+This is a deliberate, accepted trade-off. We are not going to add an
+in-flight promise/lock map to collapse concurrent lookups: it adds shared
+mutable state and failure-handling complexity (rejections, eviction, keys
+that differ only by path vs. URL vs. case) to a hot path, in exchange for
+saving a small amount of one-off work on the rare duplicate. Please do not
+re-report this as a bug - if it is costing something real, revisit it here
+with numbers first.


### PR DESCRIPTION
## What

Documents a deliberate non-goal of `helper/transformer`: it does **not**
de-duplicate lookups that are in flight at the same time.

The module's "only applies the transformation function to the same file
once" guarantee is about *repeat* lookups — once a result is cached against
the file's content hash, later lookups reuse it. It is not a guarantee
about concurrent lookups: if two lookups for the same source race before
either has written its result (e.g. the image plugin processing a post that
references the same image twice, with several images transformed
concurrently), both run the transform and both write the cache. Those
writes are idempotent (same content hash, equivalent result), so the only
cost is duplicated transform work for that one build.

## Why

This keeps getting surfaced as a bug in reviews. Adding an in-flight
promise/lock map trades real complexity (shared mutable state, rejection
and eviction handling, keys that differ by path vs URL vs case) on a hot
path for saving a small amount of one-off work in a rare case. Recording
the decision where the code lives stops the churn.

## Changes

- `app/helper/transformer/readme.txt` — new "Non-goal: concurrent lookup
  de-duplication" section.
- `app/helper/transformer/index.js` — comment at `lookup()`.
- `app/build/plugins/image/index.js` — comment at the concurrent `eachEl`
  loop, pointing back to the readme.

No behaviour change. Bug fixes from the transformer analysis will follow in
separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)