### PR TITLE
Fix hang/crash, max-age caching, and path traversal in the transformer

### DIFF
--- a/app/build/plugins/image/index.js
+++ b/app/build/plugins/image/index.js
@@ -8,7 +8,11 @@ function render($, callback, options) {
   var blogID = options.blogID;
   var cache = new Transformer(blogID, "image-cache");
 
-  // Process 5 images concurrently
+  // Process 5 images concurrently. If a post references the same image more
+  // than once, those lookups can race and each run the transform once before
+  // either result is cached. That duplicated one-off work is an accepted
+  // trade-off - the transformer deliberately does not de-duplicate in-flight
+  // lookups (see helper/transformer/readme.txt).
   eachEl(
     $,
     "img",

--- a/app/build/plugins/image/index.js
+++ b/app/build/plugins/image/index.js
@@ -8,11 +8,12 @@ function render($, callback, options) {
   var blogID = options.blogID;
   var cache = new Transformer(blogID, "image-cache");
 
-  // Process 5 images concurrently. If a post references the same image more
-  // than once, those lookups can race and each run the transform once before
-  // either result is cached. That duplicated one-off work is an accepted
-  // trade-off - the transformer deliberately does not de-duplicate in-flight
-  // lookups (see helper/transformer/readme.txt).
+  // eachEl walks the <img> tags with async.eachOfSeries, so images in one
+  // entry are transformed one at a time - the same image referenced twice
+  // in a post does not race here. Concurrent transforms of one source can
+  // still happen across independent builds (e.g. parallel entry rebuilds);
+  // the transformer does not de-duplicate in-flight lookups by design (see
+  // helper/transformer/readme.txt).
   eachEl(
     $,
     "img",

--- a/app/helper/transformer/download/index.js
+++ b/app/helper/transformer/download/index.js
@@ -83,12 +83,13 @@ module.exports = function (url, headers, callback) {
       const lastModified = res.headers.get(LAST_MODIFIED);
       const expires = res.headers.get("expires");
       const etag = res.headers.get("etag");
+      const age = res.headers.get("age");
 
       headers[LAST_MODIFIED] = lastModified || headers[LAST_MODIFIED] || "";
       headers.etag = etag || headers.etag || "";
       headers.expires =
         tidy.date(expires) ||
-        tidy.expire(cacheControl) ||
+        tidy.expire(cacheControl, age) ||
         headers.expires ||
         "";
       headers.url = headers.url || url;
@@ -106,21 +107,46 @@ module.exports = function (url, headers, callback) {
 
       debug("  updated latest response headers for status", res.status);
 
+      var expectedLength = Number(res.headers.get("content-length"));
+      if (!Number.isFinite(expectedLength) || expectedLength < 0)
+        expectedLength = null;
+
       return new Promise((resolve, reject) => {
         var settled = false;
+        var received = 0;
+        var idleTimer = null;
+
+        function clearIdle() {
+          if (idleTimer) {
+            clearTimeout(idleTimer);
+            idleTimer = null;
+          }
+        }
+
+        // Independent streaming watchdog. We do not rely solely on
+        // res.body emitting 'error': node-fetch's `timeout` option does
+        // not arm a body timer when the stream is consumed via pipe(), and
+        // some truncated-body cases (socket destroyed after a partial
+        // chunk) can leave the PassThrough open without 'error'/'end'/
+        // 'close'. Without this, the promise never settles and the build
+        // hangs. This is the ESOCKETIMEDOUT case the old TODO referred to.
+        function armIdle() {
+          clearIdle();
+          idleTimer = setTimeout(function () {
+            onError(
+              new Error("Download stalled: no data for " + TIMEOUT + "ms")
+            );
+          }, TIMEOUT);
+        }
 
         function cleanup() {
+          clearIdle();
           res.body.removeListener("error", onError);
+          res.body.removeListener("data", onData);
           file.removeListener("error", onError);
           file.removeListener("finish", onFinish);
         }
 
-        // The response body is a stream too: a socket reset, premature
-        // close, or the fetch timeout firing mid-download emits 'error'
-        // on res.body, NOT on the file. pipe() does not forward that, so
-        // without this listener the promise never settles (build hangs)
-        // and an unhandled stream 'error' can crash the process. This is
-        // the ESOCKETIMEDOUT case the old TODO referred to.
         function onError(err) {
           if (settled) return;
           settled = true;
@@ -130,17 +156,38 @@ module.exports = function (url, headers, callback) {
           reject(err);
         }
 
+        function onData(chunk) {
+          received += chunk.length;
+          armIdle();
+        }
+
         function onFinish() {
           if (settled) return;
+          // A body that ends short of its advertised Content-Length is a
+          // truncated download, not a success - node-fetch does not always
+          // surface this as an 'error'.
+          if (expectedLength !== null && received < expectedLength) {
+            return onError(
+              new Error(
+                "Download truncated: received " +
+                  received +
+                  " of " +
+                  expectedLength +
+                  " bytes"
+              )
+            );
+          }
           settled = true;
           cleanup();
           resolve({ status: res.status, path, headers });
         }
 
         res.body.on("error", onError);
+        res.body.on("data", onData);
         file.on("error", onError);
         file.on("finish", onFinish);
 
+        armIdle();
         res.body.pipe(file); // start piping the response body to the file
       });
     })

--- a/app/helper/transformer/download/index.js
+++ b/app/helper/transformer/download/index.js
@@ -102,13 +102,28 @@ module.exports = function (url, headers, callback) {
 
       if (!res.ok) {
         debug("  it has a bad status code:", res.status);
+        // Nobody consumes the body on this path; drop it so the socket
+        // isn't held open.
+        res.body.destroy();
         throw new Error(res.status);
       }
 
       debug("  updated latest response headers for status", res.status);
 
+      // node-fetch transparently decompresses gzip/deflate/br bodies but
+      // leaves Content-Length describing the *encoded* payload, so a
+      // decoded byte count can legitimately differ from it. Only use the
+      // header for the truncation check when the body is served identity.
+      var contentEncoding = res.headers.get("content-encoding");
+      var canCompareLength =
+        !contentEncoding || /^identity$/i.test(contentEncoding.trim());
+
       var expectedLength = Number(res.headers.get("content-length"));
-      if (!Number.isFinite(expectedLength) || expectedLength < 0)
+      if (
+        !canCompareLength ||
+        !Number.isFinite(expectedLength) ||
+        expectedLength < 0
+      )
         expectedLength = null;
 
       return new Promise((resolve, reject) => {
@@ -141,10 +156,13 @@ module.exports = function (url, headers, callback) {
 
         function cleanup() {
           clearIdle();
-          res.body.removeListener("error", onError);
           res.body.removeListener("data", onData);
           file.removeListener("error", onError);
           file.removeListener("finish", onFinish);
+          // Deliberately keep the res.body 'error' listener: destroy() and
+          // late premature-close errors can still fire after we've settled,
+          // and an unhandled 'error' on the stream would crash the process.
+          // onError's `settled` guard makes the extra call a no-op.
         }
 
         function onError(err) {
@@ -152,6 +170,11 @@ module.exports = function (url, headers, callback) {
           settled = true;
           cleanup();
           res.body.unpipe(file);
+          // Destroy the response stream, not just unpipe it: an unpiped,
+          // unconsumed PassThrough stays paused and backpressures - and so
+          // holds open - the underlying HTTP socket, and node-fetch has
+          // already cleared its request timeout once headers arrived.
+          res.body.destroy();
           file.destroy();
           reject(err);
         }

--- a/app/helper/transformer/download/index.js
+++ b/app/helper/transformer/download/index.js
@@ -105,11 +105,43 @@ module.exports = function (url, headers, callback) {
       }
 
       debug("  updated latest response headers for status", res.status);
-      res.body.pipe(file); // start piping the response body to the file
 
       return new Promise((resolve, reject) => {
-        file.on("finish", () => resolve({ status: res.status, path, headers }));
-        file.on("error", reject);
+        var settled = false;
+
+        function cleanup() {
+          res.body.removeListener("error", onError);
+          file.removeListener("error", onError);
+          file.removeListener("finish", onFinish);
+        }
+
+        // The response body is a stream too: a socket reset, premature
+        // close, or the fetch timeout firing mid-download emits 'error'
+        // on res.body, NOT on the file. pipe() does not forward that, so
+        // without this listener the promise never settles (build hangs)
+        // and an unhandled stream 'error' can crash the process. This is
+        // the ESOCKETIMEDOUT case the old TODO referred to.
+        function onError(err) {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          res.body.unpipe(file);
+          file.destroy();
+          reject(err);
+        }
+
+        function onFinish() {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          resolve({ status: res.status, path, headers });
+        }
+
+        res.body.on("error", onError);
+        file.on("error", onError);
+        file.on("finish", onFinish);
+
+        res.body.pipe(file); // start piping the response body to the file
       });
     })
     .then(result => {
@@ -129,7 +161,7 @@ module.exports = function (url, headers, callback) {
     })
     .catch(err => {
       debug("Download error:", err);
-      file.close();
+      if (!file.destroyed) file.destroy();
       fs.unlink(path).catch(() => {});
       callback(err);
     });

--- a/app/helper/transformer/download/tidy.js
+++ b/app/helper/transformer/download/tidy.js
@@ -1,9 +1,18 @@
-function expire(str) {
+// Given a Cache-Control header value (and optionally the response's Age
+// header), return an absolute expiry timestamp in ms, or null if the
+// response cannot be reused without revalidation.
+function expire(str, ageSeconds) {
   var now = Date.now();
 
   if (!str) return null;
 
-  // Pull the delta-seconds out of a Cache-Control header, e.g.
+  // no-cache / no-store require revalidation before every reuse, so a
+  // co-present max-age must NOT be turned into a future expiry that lets
+  // isFresh() skip the request. (must-revalidate is different - it only
+  // applies once the entry is already stale - so it is not matched here.)
+  if (/(?:^|[,\s])no-(?:cache|store)(?:[,\s]|$)/i.test(str)) return null;
+
+  // Pull the delta-seconds out of the header, e.g.
   // "public, max-age=600, immutable" -> 600. The previous implementation
   // sliced to the start of "max-age=" but never past it, so parseInt
   // always saw "max-age=..." and returned NaN - meaning max-age was
@@ -16,7 +25,18 @@ function expire(str) {
 
   if (isNaN(seconds)) return null;
 
-  return now + seconds * 1000;
+  // A response relayed by a CDN/proxy may already be part-way through its
+  // life; Age tells us how far. Charge that against max-age so we don't
+  // restart the freshness lifetime on every hop.
+  var age = parseInt(ageSeconds, 10);
+
+  if (isNaN(age) || age < 0) age = 0;
+
+  var remaining = seconds - age;
+
+  if (remaining <= 0) return null;
+
+  return now + remaining * 1000;
 }
 
 function date(str) {

--- a/app/helper/transformer/download/tidy.js
+++ b/app/helper/transformer/download/tidy.js
@@ -1,20 +1,22 @@
 function expire(str) {
-  var expires = null;
   var now = Date.now();
 
-  if (!str) return expires;
+  if (!str) return null;
 
-  if (str.indexOf("max-age=") === -1) return expires;
+  // Pull the delta-seconds out of a Cache-Control header, e.g.
+  // "public, max-age=600, immutable" -> 600. The previous implementation
+  // sliced to the start of "max-age=" but never past it, so parseInt
+  // always saw "max-age=..." and returned NaN - meaning max-age was
+  // silently ignored and such responses were re-downloaded every build.
+  var match = /(?:^|[,\s])max-age\s*=\s*"?(\d+)"?/i.exec(str);
 
-  try {
-    str = str.slice(str.indexOf("max-age="));
-    str = parseInt(str) * 1000;
-    expires = now + str;
-  } catch (e) {
-    expires = null;
-  }
+  if (!match) return null;
 
-  return expires;
+  var seconds = parseInt(match[1], 10);
+
+  if (isNaN(seconds)) return null;
+
+  return now + seconds * 1000;
 }
 
 function date(str) {

--- a/app/helper/transformer/index.js
+++ b/app/helper/transformer/index.js
@@ -38,11 +38,13 @@ function Transformer(blogID, name) {
 
   var keys = Keys(blogID, name);
 
-  // Note: lookup does NOT de-duplicate concurrent calls for the same source.
-  // The "transform once" guarantee covers repeat lookups once a result is
-  // cached, not lookups that are in flight simultaneously - those may each
-  // run the transform and each write the (idempotent, hash-keyed) result.
-  // This is an accepted trade-off, not a bug; see readme.txt.
+  // Note: lookup does NOT de-duplicate concurrent calls for the same source
+  // (only repeat calls once a result is cached). Simultaneous callers each
+  // run the transform. They write the same content-hash key so the last
+  // write wins; a non-deterministic or file-writing transform - e.g. the
+  // image cache's optimize(), which mints a uuid per call - can therefore
+  // leave an orphaned artifact. Accepted trade-off, not a bug; see
+  // readme.txt.
   function lookup(src, transform, callback) {
     if (type(src) !== "string") {
       return callback(new Error("Transformer: src is not a string"));

--- a/app/helper/transformer/index.js
+++ b/app/helper/transformer/index.js
@@ -40,6 +40,11 @@ function Transformer(blogID, name) {
 
   var keys = Keys(blogID, name);
 
+  // Note: lookup does NOT de-duplicate concurrent calls for the same source.
+  // The "transform once" guarantee covers repeat lookups once a result is
+  // cached, not lookups that are in flight simultaneously - those may each
+  // run the transform and each write the (idempotent, hash-keyed) result.
+  // This is an accepted trade-off, not a bug; see readme.txt.
   function lookup(src, transform, callback) {
     if (type(src) !== "string") {
       return callback(new Error("Transformer: src is not a string"));

--- a/app/helper/transformer/index.js
+++ b/app/helper/transformer/index.js
@@ -10,12 +10,10 @@ var fs = require("fs-extra");
 var localPath = require("../localPath");
 var config = require("config");
 var join = require("path").join;
+var resolve = require("path").resolve;
 var async = require("async");
 var caseSensitivePath = require("../caseSensitivePath");
 var he = require("he");
-
-// TODO:
-// Fix bug with transformer to handle ESOCKETIMEDOUT error...
 
 // Maps https://cdn.blot.im/blog_xyz/_image_cache/abc.jpg to
 // /_image_cache/abc.jpg to enable us to look up the file quickly
@@ -88,9 +86,15 @@ function Transformer(blogID, name) {
       decodedURI = null;
     }
 
-    // Images pulled from Word Documents are stored in the static folder
+    // Images pulled from Word Documents are stored in the static folder.
+    // `src` comes from an <img src> in the rendered entry, so a value like
+    // "../../<other blog id>/secret.jpg" must not be able to climb out of
+    // this blog's own static directory. resolve("/", src) strips any "../"
+    // and yields an absolute path, which join() then re-roots under the
+    // blog's folder - the same containment trick helper/localPath uses.
     tasks.push(function (next) {
-      fullLocalPath = join(config.blog_static_files_dir, blogID, src);
+      var staticRoot = join(config.blog_static_files_dir, blogID);
+      fullLocalPath = join(staticRoot, resolve("/", src));
       fromPath(fullLocalPath, transform, next);
     });
 
@@ -244,10 +248,12 @@ function Transformer(blogID, name) {
 
           if (err) return callback(err);
 
-          setURL(url, headers, hash, result, function (err) {
-            if (err) throw err;
-
-            callback(err, result);
+          setURL(url, headers, hash, result, function (setErr) {
+            // The transform already succeeded. A failed cache write must
+            // not throw from this async callback (crash / hung build) or
+            // discard the result - worst case we transform again next time.
+            if (setErr) debug("failed to cache result for url", url, setErr);
+            callback(null, result);
           });
         });
       });
@@ -275,10 +281,12 @@ function Transformer(blogID, name) {
           // Pass hash so that
           // from URL doesn't have to compute it again
           debug(path, "saving result of new transform");
-          set(hash, result, function (err) {
-            if (err) throw err;
-
-            callback(err, result, hash);
+          set(hash, result, function (setErr) {
+            // Never throw from this async callback. If the cache write
+            // fails, still return the freshly computed result rather than
+            // hanging the build or crashing the process.
+            if (setErr) debug("failed to cache result for hash", hash, setErr);
+            callback(null, result, hash);
           });
         });
       });
@@ -404,7 +412,10 @@ function Transformer(blogID, name) {
 }
 
 function nothing(err) {
-  if (err) throw err;
+  // Default callback for fire-and-forget cache writes. Swallow the error
+  // (log under debug) - throwing here would surface as an unhandled
+  // rejection from the async write and take down the process.
+  if (err) debug("transformer: ignored cache write error", err);
 }
 
 function missing(src) {

--- a/app/helper/transformer/readme.txt
+++ b/app/helper/transformer/readme.txt
@@ -12,3 +12,29 @@ url and dimensions from the database.
 As you can imagine, this massively speeds up
 saving existing entries, since images don't need
 to be reuploaded each time!
+
+
+Non-goal: concurrent lookup de-duplication
+------------------------------------------
+
+The "only applies the transformation function to the same file once"
+guarantee is about *repeat* lookups over time: once a result is cached
+against the file's content hash, later lookups reuse it and never run the
+transform again.
+
+It is NOT a guarantee about lookups that are in flight at the same moment.
+If two lookups for the same source race each other before either has
+written its result to the cache (for example the image plugin processing a
+post that references the same image twice, with several images transformed
+concurrently), both will run the transform and both will write the cache.
+The writes are idempotent - they key on the same content hash and store an
+equivalent result - so the only cost is the duplicated transform work for
+that one build.
+
+This is a deliberate, accepted trade-off. We are not going to add an
+in-flight promise/lock map to collapse concurrent lookups: it adds shared
+mutable state and failure-handling complexity (rejections, eviction, keys
+that differ only by path vs. URL vs. case) to a hot path, in exchange for
+saving a small amount of one-off work on the rare duplicate. Please do not
+re-report this as a bug - if it is costing something real, revisit it here
+with numbers first.

--- a/app/helper/transformer/readme.txt
+++ b/app/helper/transformer/readme.txt
@@ -23,18 +23,33 @@ against the file's content hash, later lookups reuse it and never run the
 transform again.
 
 It is NOT a guarantee about lookups that are in flight at the same moment.
-If two lookups for the same source race each other before either has
-written its result to the cache (for example the image plugin processing a
-post that references the same image twice, with several images transformed
-concurrently), both will run the transform and both will write the cache.
-The writes are idempotent - they key on the same content hash and store an
-equivalent result - so the only cost is the duplicated transform work for
-that one build.
+Note this does not happen within a single entry render: the image plugin
+walks <img> tags with async.eachOfSeries (see build/plugins/eachEl.js), so
+the same image referenced twice in one post is looked up one call after
+the other, not concurrently. The race is between *independent* callers of
+the same (blogID, name) store - e.g. two entries rebuilt in parallel that
+reference the same URL. When that happens both lookups run the transform.
+
+What the duplication costs depends on the transform:
+
+  - A deterministic, side-effect-free transform (hash a file, read image
+    dimensions): both runs produce an equal result, they write the same
+    content-hash key, last write wins, and the only cost is the wasted
+    second run.
+
+  - A transform that writes files or is non-deterministic: it can leave
+    debris. build/plugins/image/optimize.js mints a fresh uuid per call
+    and uses it in BOTH the file it writes under _image_cache/ AND the src
+    it returns. Two concurrent runs therefore persist two copies on disk
+    and hand their two callers different URLs; only one result wins the
+    Redis key, so the other file is orphaned (still referenced by the
+    entry that made it, but unknown to flush()).
 
 This is a deliberate, accepted trade-off. We are not going to add an
 in-flight promise/lock map to collapse concurrent lookups: it adds shared
 mutable state and failure-handling complexity (rejections, eviction, keys
 that differ only by path vs. URL vs. case) to a hot path, in exchange for
-saving a small amount of one-off work on the rare duplicate. Please do not
-re-report this as a bug - if it is costing something real, revisit it here
-with numbers first.
+saving a rare duplicate transform. Please do not re-report the missing
+de-duplication itself as a bug - if it is costing something real (disk
+filling with orphaned _image_cache copies, say), revisit it here with
+numbers first.

--- a/app/helper/transformer/tests/lookup.js
+++ b/app/helper/transformer/tests/lookup.js
@@ -318,6 +318,29 @@ describe("transformer", function () {
     });
   });
 
+  it("accepts a gzip-encoded response whose Content-Length is the encoded size", function (done) {
+    var test = this;
+    var transform = jasmine.createSpy().and.callFake(test.transform);
+
+    // A compressible body: the gzip Content-Length is far smaller than the
+    // bytes node-fetch yields after decoding, which must not read as a
+    // truncated download.
+    test.queueRemoteResponse({
+      gzip: true,
+      body: "gzipped body ".repeat(64) + Date.now(),
+      etag: null,
+      lastModified: null,
+    });
+
+    test.transformer.lookup(test.sequenceUrl, transform, function (err, result) {
+      if (err) return done.fail(err);
+
+      expect(transform).toHaveBeenCalled();
+      expect(result.size).toEqual(jasmine.any(Number));
+      done();
+    });
+  });
+
   describe("url download caching", function () {
     it("stores the transformed result after a successful download", function (done) {
       var test = this;

--- a/app/helper/transformer/tests/lookup.js
+++ b/app/helper/transformer/tests/lookup.js
@@ -282,6 +282,42 @@ describe("transformer", function () {
     });
   });
 
+  it("revalidates a no-cache response even when it carries a max-age", function (done) {
+    var test = this;
+    var firstTransform = jasmine.createSpy().and.callFake(test.transform);
+    var secondTransform = jasmine.createSpy().and.callFake(test.transform);
+
+    // no-cache means "revalidate before reuse", so the second lookup must
+    // still hit the network despite the hour-long max-age. With no ETag /
+    // Last-Modified the revalidation is a plain 200 with a new body, so the
+    // transform runs again.
+    test.queueRemoteResponse({
+      body: "short " + Date.now(),
+      etag: null,
+      lastModified: null,
+      headers: { "Cache-Control": "no-cache, max-age=3600" },
+    });
+    test.queueRemoteResponse({
+      body: "a considerably longer second body " + Date.now(),
+      etag: null,
+      lastModified: null,
+      headers: { "Cache-Control": "no-cache, max-age=3600" },
+    });
+
+    test.transformer.lookup(test.sequenceUrl, firstTransform, function (err, firstResult) {
+      if (err) return done.fail(err);
+
+      test.transformer.lookup(test.sequenceUrl, secondTransform, function (err, secondResult) {
+        if (err) return done.fail(err);
+
+        expect(firstTransform).toHaveBeenCalled();
+        expect(secondTransform).toHaveBeenCalled();
+        expect(secondResult.size).not.toEqual(firstResult.size);
+        done();
+      });
+    });
+  });
+
   describe("url download caching", function () {
     it("stores the transformed result after a successful download", function (done) {
       var test = this;
@@ -417,7 +453,7 @@ describe("transformer", function () {
         expect(spy).not.toHaveBeenCalled();
         done();
       });
-    });
+    }, 20000);
 
     it("falls back to the cached result when a later download drops mid-body", function (done) {
       var test = this;
@@ -440,6 +476,6 @@ describe("transformer", function () {
           done();
         });
       });
-    });
+    }, 20000);
   });
 });

--- a/app/helper/transformer/tests/lookup.js
+++ b/app/helper/transformer/tests/lookup.js
@@ -86,6 +86,25 @@ describe("transformer", function () {
       done();
     });
   });
+  it("will not resolve a source that climbs out of the blog's static folder", function (done) {
+    var spy = jasmine.createSpy().and.callFake(this.transform);
+
+    // A file that exists in the static root but NOT in this blog's subtree.
+    var secretName = "secret-" + Date.now() + ".txt";
+    var secretPath = STATIC_DIRECTORY + "/" + secretName;
+    fs.outputFileSync(secretPath, "top secret");
+
+    this.transformer.lookup("../" + secretName, spy, function (err, result) {
+      fs.removeSync(secretPath);
+
+      expect(err instanceof Error).toBe(true);
+      expect(err.code).toEqual("ENOENT");
+      expect(spy).not.toHaveBeenCalled();
+      expect(result).not.toBeTruthy();
+      done();
+    });
+  });
+
   it("transforms a file in the blog's static directory", function (done) {
     var fullPath = this.blogDirectory + "/" + this.path;
     var path = "/" + Date.now() + "-" + this.path;
@@ -228,6 +247,41 @@ describe("transformer", function () {
     });
   });
 
+  it("treats a response with only Cache-Control: max-age as fresh", function (done) {
+    var test = this;
+    var firstTransform = jasmine.createSpy().and.callFake(test.transform);
+    var secondTransform = jasmine.createSpy().and.callFake(test.transform);
+
+    // First response is cacheable for an hour via max-age alone (no Expires,
+    // no ETag / Last-Modified). The second queued response has a different
+    // body - if the transformer re-requests it, sizes will differ.
+    test.queueRemoteResponse({
+      body: "fresh body " + Date.now(),
+      etag: null,
+      lastModified: null,
+      headers: { "Cache-Control": "max-age=3600" },
+    });
+    test.queueRemoteResponse({
+      body: "this body should never be fetched " + Date.now(),
+      etag: null,
+      lastModified: null,
+      headers: { "Cache-Control": "max-age=3600" },
+    });
+
+    test.transformer.lookup(test.sequenceUrl, firstTransform, function (err, firstResult) {
+      if (err) return done.fail(err);
+
+      test.transformer.lookup(test.sequenceUrl, secondTransform, function (err, secondResult) {
+        if (err) return done.fail(err);
+
+        expect(firstTransform).toHaveBeenCalled();
+        expect(secondTransform).not.toHaveBeenCalled();
+        expect(secondResult).toEqual(firstResult);
+        done();
+      });
+    });
+  });
+
   describe("url download caching", function () {
     it("stores the transformed result after a successful download", function (done) {
       var test = this;
@@ -347,6 +401,43 @@ describe("transformer", function () {
 
             done();
           });
+        });
+      });
+    });
+
+    it("errors instead of hanging when the connection drops mid-download", function (done) {
+      var test = this;
+      var spy = jasmine.createSpy().and.callFake(test.transform);
+
+      test.queueRemoteResponse({ destroy: true });
+
+      test.transformer.lookup(test.sequenceUrl, spy, function (err, result) {
+        expect(err instanceof Error).toBe(true);
+        expect(result).not.toBeTruthy();
+        expect(spy).not.toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it("falls back to the cached result when a later download drops mid-body", function (done) {
+      var test = this;
+      var body = "Good body " + Date.now();
+      var firstTransform = jasmine.createSpy().and.callFake(test.transform);
+      var secondTransform = jasmine.createSpy().and.callFake(test.transform);
+
+      test.queueRemoteResponse({ body: body, etag: null, lastModified: null });
+      test.queueRemoteResponse({ destroy: true });
+
+      test.transformer.lookup(test.sequenceUrl, firstTransform, function (err, firstResult) {
+        if (err) return done.fail(err);
+
+        test.transformer.lookup(test.sequenceUrl, secondTransform, function (err, secondResult) {
+          if (err) return done.fail(err);
+
+          expect(firstTransform).toHaveBeenCalled();
+          expect(secondTransform).not.toHaveBeenCalled();
+          expect(secondResult).toEqual(firstResult);
+          done();
         });
       });
     });

--- a/app/helper/transformer/tests/setup.js
+++ b/app/helper/transformer/tests/setup.js
@@ -64,6 +64,19 @@ module.exports = function setup(options) {
 
     if (status >= 400) return res.send(config.body || "");
 
+    // Serve the body gzip-encoded: Content-Length then describes the
+    // compressed size, which is smaller than the bytes node-fetch hands
+    // back after decoding.
+    if (config.gzip) {
+      var zlib = require("zlib");
+      var gz = zlib.gzipSync(Buffer.from(body));
+      res.set({
+        "Content-Encoding": "gzip",
+        "Content-Length": String(gz.length),
+      });
+      return res.end(gz);
+    }
+
     res.send(body);
   });
 

--- a/app/helper/transformer/tests/setup.js
+++ b/app/helper/transformer/tests/setup.js
@@ -33,6 +33,15 @@ module.exports = function setup(options) {
     }
 
     var config = sequenceQueue.shift() || {};
+
+    // Simulate the connection dropping part-way through the body: promise
+    // the client 1000 bytes, send a handful, then kill the socket.
+    if (config.destroy) {
+      res.set({ "Content-Length": "1000" });
+      res.write("partial");
+      return res.socket.destroy();
+    }
+
     var status = config.status === undefined ? 200 : config.status;
     var body = config.body === undefined ? responseBody : config.body;
     var etagValue =

--- a/app/helper/transformer/tests/tidy.js
+++ b/app/helper/transformer/tests/tidy.js
@@ -1,0 +1,52 @@
+describe("transformer/download/tidy", function () {
+  var tidy = require("../download/tidy");
+
+  describe("expire", function () {
+    it("turns max-age into an absolute expiry", function () {
+      var before = Date.now();
+      var got = tidy.expire("public, max-age=3600, immutable");
+
+      expect(got).toEqual(jasmine.any(Number));
+      expect(got).toBeGreaterThan(before + 3599 * 1000);
+      expect(got).toBeLessThanOrEqual(Date.now() + 3600 * 1000);
+    });
+
+    it("returns null when there is no max-age", function () {
+      expect(tidy.expire("public")).toBe(null);
+      expect(tidy.expire("")).toBe(null);
+      expect(tidy.expire(null)).toBe(null);
+    });
+
+    it("ignores max-age when no-cache or no-store is present", function () {
+      expect(tidy.expire("no-cache, max-age=3600")).toBe(null);
+      expect(tidy.expire("max-age=3600, no-store")).toBe(null);
+    });
+
+    it("does not treat must-revalidate as no-cache", function () {
+      expect(tidy.expire("max-age=3600, must-revalidate")).toEqual(
+        jasmine.any(Number)
+      );
+    });
+
+    it("charges the response Age against max-age", function () {
+      var now = Date.now();
+      var got = tidy.expire("max-age=3600", "3500");
+
+      // ~100s of life left, not a fresh hour
+      expect(got).toBeGreaterThan(now);
+      expect(got).toBeLessThan(now + 200 * 1000);
+    });
+
+    it("returns null once Age has consumed max-age", function () {
+      expect(tidy.expire("max-age=100", "500")).toBe(null);
+      expect(tidy.expire("max-age=0")).toBe(null);
+    });
+
+    it("tolerates a missing or junk Age", function () {
+      expect(tidy.expire("max-age=3600", undefined)).toEqual(jasmine.any(Number));
+      expect(tidy.expire("max-age=3600", "not-a-number")).toEqual(
+        jasmine.any(Number)
+      );
+    });
+  });
+});


### PR DESCRIPTION
Transformer analysis follow-up: the four high/medium-severity fixes, plus
the "concurrent lookups are not de-duplicated" documentation (originally
opened as #1719, which was closed — that commit now rides along here).

### 1. Download body-stream errors were unhandled — hang / crash (HIGH)
`download/index.js` only listened for `error` on the **file** stream, never
on `res.body`. A socket reset / premature close / fetch-timeout mid-download
emits `error` on `res.body`, and `pipe()` does not forward it — so the
promise never settled (the entry build hung) and the unhandled stream error
could take down the worker. Both streams are now watched; on failure the
partial temp file is destroyed and unlinked and the download rejects
cleanly so `fromURL` can fall back to a cached result. Also adds an
independent inactivity watchdog and a `Content-Length` truncation check so
the promise still settles when node-fetch emits neither `error`, `end`, nor
`close` (per Codex review). Stale `ESOCKETIMEDOUT` TODO removed.

### 2. `throw` inside async DB-write callbacks — hang / crash (HIGH)
`fromPath`, `fromURL`, and the default `nothing` callback did
`if (err) throw err` from inside an async cache write. A transient Redis
failure became an unhandled rejection **and** the real callback was never
called, hanging the build and discarding the just-computed transform.
Cache writes are now best-effort: log under `debug`, return the result.

### 3. `Cache-Control: max-age` never parsed (MEDIUM)
`tidy.expire()` sliced to the start of `"max-age="` but not past it, so
`parseInt("max-age=600")` was always `NaN` and `max-age`-only responses
were re-downloaded on **every build**. Now parsed with a regex, `NaN`-
guarded. Per Codex review it also (a) returns null when Cache-Control has
`no-cache`/`no-store` so a co-present `max-age` can't skip revalidation,
and (b) charges the response `Age` against `max-age`.

### 4. Path traversal in the static-folder lookup (MEDIUM)
The first lookup task did `join(blog_static_files_dir, blogID, src)` with
`src` straight from an `<img src>`, so `../../<other-blog>/x.jpg` escaped
the blog's static directory. Now re-rooted with
`join(staticRoot, resolve("/", src))` — the containment trick
`helper/localPath` already uses for the other tasks.

### Docs: concurrent lookup de-duplication is a non-goal
`readme.txt` + code comments record that the transformer does not collapse
in-flight lookups for the same source. Revised per Codex's review of
#1719: the race is between *independent* callers (parallel rebuilds), not
within one entry's serial `eachOfSeries` image loop, and concurrent image
transforms are **not** idempotent — `optimize.js` mints a uuid per call, so
a race can orphan a duplicate `_image_cache` file.

### Tests
`app/helper/transformer` 28/28. New `tests/tidy.js` (max-age, `no-cache`/
`no-store`, `must-revalidate`, `Age`); `no-cache` revalidation integration
test; static-folder traversal guard; mid-download socket-drop (errors
instead of hanging; falls back to cache when one exists). `build/converters/img`
18/18 and `build/plugins/image` 7/7 unaffected.

Lower-severity items from the analysis are deliberately left for a
follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)