### PR TITLE
Route importer image downloads through helper/transformer

### DIFF
--- a/app/dashboard/site/import/helper/download_images.js
+++ b/app/dashboard/site/import/helper/download_images.js
@@ -8,46 +8,32 @@ var fs = require("fs-extra");
 var sharp = require("sharp");
 var mime = require("mime-types");
 var assetDirectory = require("./asset_directory");
-var Transformer = require("helper/transformer");
-var hash = require("helper/hash");
-var tempDir = require("helper/tempDir")();
+var download = require("helper/transformer/download");
 
 // Consider using this algorithm to determine best part of alt tag or caption to use
 // as the file's name:
 // http://www.bearcave.com/misl/misl_tech/wavelets/compression/shannon.html
 
-// Remote assets are fetched through helper/transformer rather than a bare
-// fetch() here. That buys us three things the old hand-rolled download lacked:
+// Remote assets are fetched through helper/transformer's download module
+// rather than a bare fetch(). That module routes every request - and every
+// redirect - through the airlock forward proxy (see config/airlock), whose
+// nftables egress filter blocks a URL that resolves to a private range, a
+// cloud metadata endpoint or a DNS-rebinding target. An import pulls
+// arbitrary URLs out of a user-supplied WordPress / Blogger / Are.na export,
+// so this matters.
 //
-//   1. SSRF protection - transformer/download routes every request through the
-//      airlock forward proxy (see config/airlock), which filters egress to
-//      private ranges, cloud metadata endpoints and DNS-rebinding targets. An
-//      import pulls arbitrary URLs out of a user-supplied WordPress/Blogger/
-//      Are.na export, so this matters.
-//   2. Deduplication - the same image URL referenced by many posts (or by a
-//      re-run of a failed import) is downloaded and inspected once, then served
-//      from cache keyed by the file's content hash.
-//   3. Conditional requests - stored ETag/Last-Modified mean an unchanged
-//      remote asset is not re-downloaded on a later import.
-//
-// The store is namespaced "import" rather than per-blog: an import stages files
-// into a temp directory before the blog folder exists, and identical asset URLs
-// should dedupe across every blog's imports. flush() is never called here.
-var cache = new Transformer("import", "images");
+// It deliberately does NOT use the full Transformer (the Redis-backed,
+// content-hash-keyed result cache): that cache is process-global, and
+// Transformer.fromURL serves the last good result when a later download
+// fails - so an expired signed URL that now 403s for a different account
+// would hand back the first account's bytes. Every import re-downloads, the
+// same as before this change.
 
-// transformer deletes the downloaded temp file as soon as the transform
-// callback returns, and a cache hit hands back only the stored JSON (no bytes),
-// so the transform copies each asset into this stable, content-addressed
-// directory. download_images() then materialises the per-post asset file from
-// here on both a miss and a hit.
-var IMAGE_CACHE_DIR = join(tempDir, "import-image-cache");
-fs.ensureDirSync(IMAGE_CACHE_DIR);
-
-// Resolve a remote src to a cached asset: { name, cachePath, format }. Calls
-// back with no result (rather than an error) for anything we should skip -
-// data: URIs, unparseable hosts, download failures - matching the old
-// behaviour of leaving the original src untouched.
-function localize(src, callback) {
+// Fetch a remote src to a temp file: { tempPath, name }. Calls back with no
+// result (rather than an error) for anything we should skip - data: URIs,
+// unparseable hosts, download failures, an access-denied response - matching
+// the old behaviour of leaving the original src untouched.
+function fetchAsset(src, callback) {
   if (!src || src.indexOf("data:") === 0) return callback();
 
   try {
@@ -56,61 +42,50 @@ function localize(src, callback) {
     return callback();
   }
 
-  cache.lookup(src, persist(src), function (err, result) {
-    if (err) {
-      console.log("Failed to localize image", src, err.message);
+  // Empty headers: no If-None-Match / If-Modified-Since, so no 304 - the
+  // download always produces a temp file on success.
+  download(src, {}, function (err, tempPath) {
+    if (err || !tempPath) {
+      if (err) console.log("Failed to download image", src, err.message);
       return callback();
     }
 
-    if (!result || !result.name || !result.cachePath) return callback();
-
-    callback(result);
+    sharp(tempPath).metadata(function (err, metadata) {
+      // Response headers are not surfaced here, so the filename is derived
+      // from the URL plus sharp's detected format only (a host that serves
+      // opaque image URLs, e.g. Blogger, therefore loses its
+      // Content-Disposition filename - an accepted, cosmetic trade).
+      var format = metadata && metadata.format ? metadata.format : undefined;
+      callback(null, { tempPath: tempPath, name: nameFrom(src, null, format) });
+    });
   });
 }
 
-// The transform. Only runs on a cache miss; receives the path of the freshly
-// downloaded temp file. transformer has already applied the airlock proxy,
-// redirect cap and timeout.
-function persist(src) {
-  return function (path, done) {
-    sharp(path).metadata(function (err, metadata) {
-      // Response headers are not available to a transform, so the filename is
-      // derived from the URL plus sharp's detected format only (a Blogger
-      // opaque URL therefore loses its Content-Disposition filename - an
-      // accepted, cosmetic trade for the airlock/dedup wins above).
-      var format = metadata && metadata.format ? metadata.format : undefined;
-      var name = nameFrom(src, null, format);
-      var cachePath = join(IMAGE_CACHE_DIR, hash(src) + extname(name));
-
-      fs.copy(path, cachePath, { overwrite: true }, function (err) {
-        if (err) return done(err);
-        done(null, { name: name, cachePath: cachePath, format: format || null });
-      });
-    });
-  };
-}
-
-// Copy a localized asset into the entry's staging directory and rewrite the
-// element. A missing cachePath (temp dir pruned between imports) surfaces here
-// as a copy error and is skipped, same as any other download failure.
-function place(post, el, $, src, result, next) {
+// Move a fetched asset into the entry's staging directory and rewrite the
+// element. The temp file is always consumed - moved on success, removed on
+// any bail.
+function place(post, el, $, src, asset, next) {
   assetDirectory(post, function (err, directory) {
-    if (err) return next(false);
+    if (err) {
+      fs.remove(asset.tempPath);
+      return next(false);
+    }
 
-    fs.copy(
-      result.cachePath,
-      join(directory, result.name),
+    fs.move(
+      asset.tempPath,
+      join(directory, asset.name),
       { overwrite: true },
       function (err) {
         if (err) {
-          console.log("Failed to copy cached image", src, err.message);
+          console.log("Failed to store image", src, err.message);
+          fs.remove(asset.tempPath);
           return next(false);
         }
 
         if (el) {
-          $(el).attr("src", result.name);
+          $(el).attr("src", asset.name);
           if ($(el).parent().attr("href") === src)
-            $(el).parent().attr("href", result.name);
+            $(el).parent().attr("href", asset.name);
         }
 
         next(true);
@@ -126,11 +101,11 @@ function download_thumbnail(post, callback) {
 
   if (!thumbnail) return callback();
 
-  localize(thumbnail, function (result) {
-    if (!result) return callback();
+  fetchAsset(thumbnail, function (err, asset) {
+    if (!asset) return callback();
 
-    place(post, null, null, thumbnail, result, function (ok) {
-      callback(null, ok ? result.name : undefined);
+    place(post, null, null, thumbnail, asset, function (ok) {
+      callback(null, ok ? asset.name : undefined);
     });
   });
 }
@@ -156,10 +131,10 @@ module.exports = function download_images(post, callback) {
 
         if (!src) return next();
 
-        localize(src, function (result) {
-          if (!result) return next();
+        fetchAsset(src, function (err, asset) {
+          if (!asset) return next();
 
-          place(post, el, $, src, result, function (ok) {
+          place(post, el, $, src, asset, function (ok) {
             if (ok) changes = true;
             next();
           });

--- a/app/dashboard/site/import/helper/download_images.js
+++ b/app/dashboard/site/import/helper/download_images.js
@@ -1,73 +1,122 @@
 var cheerio = require("cheerio");
 var basename = require("path").basename;
 var extname = require("path").extname;
+var join = require("path").join;
 var parse = require("url").parse;
 var each_el = require("./each_el");
 var fs = require("fs-extra");
 var sharp = require("sharp");
 var mime = require("mime-types");
-var callOnce = require("helper/callOnce");
 var assetDirectory = require("./asset_directory");
+var Transformer = require("helper/transformer");
+var hash = require("helper/hash");
+var tempDir = require("helper/tempDir")();
 
 // Consider using this algorithm to determine best part of alt tag or caption to use
 // as the file's name:
 // http://www.bearcave.com/misl/misl_tech/wavelets/compression/shannon.html
-var TIMEOUT = 5 * 1000; // 10s
 
-function download(url, _callback) {
-  console.log("Attempting to download", url);
+// Remote assets are fetched through helper/transformer rather than a bare
+// fetch() here. That buys us three things the old hand-rolled download lacked:
+//
+//   1. SSRF protection - transformer/download routes every request through the
+//      airlock forward proxy (see config/airlock), which filters egress to
+//      private ranges, cloud metadata endpoints and DNS-rebinding targets. An
+//      import pulls arbitrary URLs out of a user-supplied WordPress/Blogger/
+//      Are.na export, so this matters.
+//   2. Deduplication - the same image URL referenced by many posts (or by a
+//      re-run of a failed import) is downloaded and inspected once, then served
+//      from cache keyed by the file's content hash.
+//   3. Conditional requests - stored ETag/Last-Modified mean an unchanged
+//      remote asset is not re-downloaded on a later import.
+//
+// The store is namespaced "import" rather than per-blog: an import stages files
+// into a temp directory before the blog folder exists, and identical asset URLs
+// should dedupe across every blog's imports. flush() is never called here.
+var cache = new Transformer("import", "images");
 
-  var time;
+// transformer deletes the downloaded temp file as soon as the transform
+// callback returns, and a cache hit hands back only the stored JSON (no bytes),
+// so the transform copies each asset into this stable, content-addressed
+// directory. download_images() then materialises the per-post asset file from
+// here on both a miss and a hit.
+var IMAGE_CACHE_DIR = join(tempDir, "import-image-cache");
+fs.ensureDirSync(IMAGE_CACHE_DIR);
 
-  var callback = callOnce(function (err, data, format, headers) {
-    console.log("Finishing attempt to download", url);
-    clearTimeout(time);
-    _callback(err, data, format, headers);
+// Resolve a remote src to a cached asset: { name, cachePath, format }. Calls
+// back with no result (rather than an error) for anything we should skip -
+// data: URIs, unparseable hosts, download failures - matching the old
+// behaviour of leaving the original src untouched.
+function localize(src, callback) {
+  if (!src || src.indexOf("data:") === 0) return callback();
+
+  try {
+    if (!parse(src).hostname) return callback();
+  } catch (e) {
+    return callback();
+  }
+
+  cache.lookup(src, persist(src), function (err, result) {
+    if (err) {
+      console.log("Failed to localize image", src, err.message);
+      return callback();
+    }
+
+    if (!result || !result.name || !result.cachePath) return callback();
+
+    callback(result);
   });
+}
 
-  if (!require("url").parse(url).hostname)
-    return callback(new Error("Failed to parse hostname: " + url));
+// The transform. Only runs on a cache miss; receives the path of the freshly
+// downloaded temp file. transformer has already applied the airlock proxy,
+// redirect cap and timeout.
+function persist(src) {
+  return function (path, done) {
+    sharp(path).metadata(function (err, metadata) {
+      // Response headers are not available to a transform, so the filename is
+      // derived from the URL plus sharp's detected format only (a Blogger
+      // opaque URL therefore loses its Content-Disposition filename - an
+      // accepted, cosmetic trade for the airlock/dedup wins above).
+      var format = metadata && metadata.format ? metadata.format : undefined;
+      var name = nameFrom(src, null, format);
+      var cachePath = join(IMAGE_CACHE_DIR, hash(src) + extname(name));
 
-  if (!url || url.indexOf("data:") === 0)
-    return callback(new Error("Invalid URL: " + url));
-
-  time = setTimeout(function () {
-    console.log("Timing out downloading", url);
-    callback(new Error("Timeout: >10s downloading " + url));
-  }, TIMEOUT);
-
-  fetch(url)
-    .then(function (res) {
-      if (!res.ok) {
-        throw new Error("Bad status code: " + res.status);
-      }
-
-      console.log("Successfully downloaded", url);
-
-      var headers = {
-        contentType: res.headers.get("content-type"),
-        contentDisposition: res.headers.get("content-disposition"),
-      };
-
-      return res.arrayBuffer().then(function (arrayBuffer) {
-        return { arrayBuffer: arrayBuffer, headers: headers };
+      fs.copy(path, cachePath, { overwrite: true }, function (err) {
+        if (err) return done(err);
+        done(null, { name: name, cachePath: cachePath, format: format || null });
       });
-    })
-    .then(function (result) {
-      const buffer = Buffer.from(result.arrayBuffer);
-      sharp(buffer).metadata(function (err, metadata) {
-        var format;
-        if (metadata && metadata.format) {
-          format = metadata.format;
+    });
+  };
+}
+
+// Copy a localized asset into the entry's staging directory and rewrite the
+// element. A missing cachePath (temp dir pruned between imports) surfaces here
+// as a copy error and is skipped, same as any other download failure.
+function place(post, el, $, src, result, next) {
+  assetDirectory(post, function (err, directory) {
+    if (err) return next(false);
+
+    fs.copy(
+      result.cachePath,
+      join(directory, result.name),
+      { overwrite: true },
+      function (err) {
+        if (err) {
+          console.log("Failed to copy cached image", src, err.message);
+          return next(false);
         }
 
-        callback(null, buffer, format, result.headers);
-      });
-    })
-    .catch(function (err) {
-      console.log("Failed to download", url, err);
-      callback(err);
-    });
+        if (el) {
+          $(el).attr("src", result.name);
+          if ($(el).parent().attr("href") === src)
+            $(el).parent().attr("href", result.name);
+        }
+
+        next(true);
+      }
+    );
+  });
 }
 
 function download_thumbnail(post, callback) {
@@ -77,18 +126,11 @@ function download_thumbnail(post, callback) {
 
   if (!thumbnail) return callback();
 
-  download(thumbnail, function (err, data, format, headers) {
-    if (err || !data) return callback();
+  localize(thumbnail, function (result) {
+    if (!result) return callback();
 
-    var name = nameFrom(thumbnail, headers, format);
-
-    assetDirectory(post, function (err, directory) {
-      if (err) return callback(err);
-
-      fs.outputFile(directory + "/" + name, data, function (err) {
-        if (err) return callback(err);
-        callback(null, name);
-      });
+    place(post, null, null, thumbnail, result, function (ok) {
+      callback(null, ok ? result.name : undefined);
     });
   });
 }
@@ -114,27 +156,12 @@ module.exports = function download_images(post, callback) {
 
         if (!src) return next();
 
-        download(src, function (err, data, format, headers) {
-          if (err || !data) {
-            return next();
-          }
+        localize(src, function (result) {
+          if (!result) return next();
 
-          var name = nameFrom(src, headers, format);
-
-          assetDirectory(post, function (err, directory) {
-            if (err) return next();
-
-            fs.outputFile(directory + "/" + name, data, function (err) {
-              if (err) return next();
-              changes = true;
-
-              $(el).attr("src", name);
-
-              if ($(el).parent().attr("href") === src)
-                $(el).parent().attr("href", name);
-
-              next();
-            });
+          place(post, el, $, src, result, function (ok) {
+            if (ok) changes = true;
+            next();
           });
         });
       },

--- a/app/dashboard/site/import/helper/download_images.js
+++ b/app/dashboard/site/import/helper/download_images.js
@@ -8,32 +8,49 @@ var fs = require("fs-extra");
 var sharp = require("sharp");
 var mime = require("mime-types");
 var assetDirectory = require("./asset_directory");
-var download = require("helper/transformer/download");
+var Transformer = require("helper/transformer");
+var hashFile = require("helper/transformer/hash");
+var tempDir = require("helper/tempDir")();
 
 // Consider using this algorithm to determine best part of alt tag or caption to use
 // as the file's name:
 // http://www.bearcave.com/misl/misl_tech/wavelets/compression/shannon.html
 
-// Remote assets are fetched through helper/transformer's download module
-// rather than a bare fetch(). That module routes every request - and every
-// redirect - through the airlock forward proxy (see config/airlock), whose
-// nftables egress filter blocks a URL that resolves to a private range, a
-// cloud metadata endpoint or a DNS-rebinding target. An import pulls
-// arbitrary URLs out of a user-supplied WordPress / Blogger / Are.na export,
-// so this matters.
+// Remote assets go through helper/transformer, the same module the image
+// plugin, thumbnail builder and gdoc / img converters use. The wins for an
+// importer, which pulls arbitrary URLs out of a user-supplied WordPress /
+// Blogger / Are.na export:
 //
-// It deliberately does NOT use the full Transformer (the Redis-backed,
-// content-hash-keyed result cache): that cache is process-global, and
-// Transformer.fromURL serves the last good result when a later download
-// fails - so an expired signed URL that now 403s for a different account
-// would hand back the first account's bytes. Every import re-downloads, the
-// same as before this change.
+//   1. SSRF - transformer/download routes every request and redirect through
+//      the airlock forward proxy (config/airlock), which filters egress to
+//      private ranges, cloud metadata and DNS-rebinding targets.
+//   2. Dedup - the same asset is downloaded and inspected once, keyed by its
+//      content hash, then reused across posts and across re-runs.
+//   3. Conditional requests on later imports.
+//
+// The store is namespaced "import" rather than per-blog: an import stages
+// files before the blog folder exists, and identical asset URLs should dedupe
+// across every blog's imports. One accepted, low-severity consequence:
+// Transformer.fromURL serves the last good result when a later download of
+// the same URL fails, so an expiring signed URL re-imported by a second
+// account after it 403s could receive the first account's cached bytes.
+// flush() is never called here.
+var cache = new Transformer("import", "images");
 
-// Fetch a remote src to a temp file: { tempPath, name }. Calls back with no
-// result (rather than an error) for anything we should skip - data: URIs,
-// unparseable hosts, download failures, an access-denied response - matching
-// the old behaviour of leaving the original src untouched.
-function fetchAsset(src, callback) {
+// transformer deletes the downloaded temp file once the transform returns and
+// hands back only stored JSON on a cache hit, so the transform copies each
+// asset into this directory, keyed by CONTENT hash. That keeps the backing
+// file immutable: transformer already dedupes results by the same content
+// hash, so a hit that reuses a result always finds the right bytes even if
+// the source URL later serves something different.
+var IMAGE_CACHE_DIR = join(tempDir, "import-image-cache");
+fs.ensureDirSync(IMAGE_CACHE_DIR);
+
+// Resolve a remote src to a cached asset: { name, cachePath }. Calls back with
+// no result (rather than an error) for anything we should skip - data: URIs,
+// unparseable hosts, download failures - matching the old behaviour of
+// leaving the original src untouched.
+function localize(src, callback) {
   if (!src || src.indexOf("data:") === 0) return callback();
 
   try {
@@ -42,50 +59,66 @@ function fetchAsset(src, callback) {
     return callback();
   }
 
-  // Empty headers: no If-None-Match / If-Modified-Since, so no 304 - the
-  // download always produces a temp file on success.
-  download(src, {}, function (err, tempPath) {
-    if (err || !tempPath) {
-      if (err) console.log("Failed to download image", src, err.message);
+  cache.lookup(src, persist(src), function (err, result) {
+    if (err) {
+      console.log("Failed to localize image", src, err.message);
       return callback();
     }
 
-    sharp(tempPath).metadata(function (err, metadata) {
-      // Response headers are not surfaced here, so the filename is derived
-      // from the URL plus sharp's detected format only (a host that serves
-      // opaque image URLs, e.g. Blogger, therefore loses its
-      // Content-Disposition filename - an accepted, cosmetic trade).
-      var format = metadata && metadata.format ? metadata.format : undefined;
-      callback(null, { tempPath: tempPath, name: nameFrom(src, null, format) });
-    });
+    if (!result || !result.name || !result.cachePath) return callback();
+
+    callback(result);
   });
 }
 
-// Move a fetched asset into the entry's staging directory and rewrite the
-// element. The temp file is always consumed - moved on success, removed on
-// any bail.
-function place(post, el, $, src, asset, next) {
-  assetDirectory(post, function (err, directory) {
-    if (err) {
-      fs.remove(asset.tempPath);
-      return next(false);
-    }
+// The transform. Runs only on a cache miss; receives the path of the freshly
+// downloaded temp file (transformer has already applied the airlock proxy,
+// redirect cap and timeout).
+function persist(src) {
+  return function (path, done) {
+    hashFile(path, function (err, contentHash) {
+      if (err) return done(err);
 
-    fs.move(
-      asset.tempPath,
-      join(directory, asset.name),
+      sharp(path).metadata(function (err, metadata) {
+        // Response headers are not available to a transform, so the filename
+        // is derived from the URL plus sharp's detected format only (a host
+        // that serves opaque image URLs, e.g. Blogger, therefore loses its
+        // Content-Disposition filename - an accepted, cosmetic trade).
+        var format = metadata && metadata.format ? metadata.format : undefined;
+        var name = nameFrom(src, null, format);
+        var cachePath = join(IMAGE_CACHE_DIR, contentHash + extname(name));
+
+        fs.copy(path, cachePath, { overwrite: true }, function (err) {
+          if (err) return done(err);
+          done(null, { name: name, cachePath: cachePath });
+        });
+      });
+    });
+  };
+}
+
+// Copy a localized asset into the entry's staging directory and rewrite the
+// element. A missing cachePath (the temp dir was pruned between imports, and
+// the transformer result outlived its backing file) surfaces here as a copy
+// error and is skipped, same as any other download failure.
+function place(post, el, $, src, result, next) {
+  assetDirectory(post, function (err, directory) {
+    if (err) return next(false);
+
+    fs.copy(
+      result.cachePath,
+      join(directory, result.name),
       { overwrite: true },
       function (err) {
         if (err) {
-          console.log("Failed to store image", src, err.message);
-          fs.remove(asset.tempPath);
+          console.log("Failed to copy cached image", src, err.message);
           return next(false);
         }
 
         if (el) {
-          $(el).attr("src", asset.name);
+          $(el).attr("src", result.name);
           if ($(el).parent().attr("href") === src)
-            $(el).parent().attr("href", asset.name);
+            $(el).parent().attr("href", result.name);
         }
 
         next(true);
@@ -101,11 +134,11 @@ function download_thumbnail(post, callback) {
 
   if (!thumbnail) return callback();
 
-  fetchAsset(thumbnail, function (err, asset) {
-    if (!asset) return callback();
+  localize(thumbnail, function (result) {
+    if (!result) return callback();
 
-    place(post, null, null, thumbnail, asset, function (ok) {
-      callback(null, ok ? asset.name : undefined);
+    place(post, null, null, thumbnail, result, function (ok) {
+      callback(null, ok ? result.name : undefined);
     });
   });
 }
@@ -131,10 +164,10 @@ module.exports = function download_images(post, callback) {
 
         if (!src) return next();
 
-        fetchAsset(src, function (err, asset) {
-          if (!asset) return next();
+        localize(src, function (result) {
+          if (!result) return next();
 
-          place(post, el, $, src, asset, function (ok) {
+          place(post, el, $, src, result, function (ok) {
             if (ok) changes = true;
             next();
           });

--- a/app/dashboard/site/import/sources/blogger/tests/index.js
+++ b/app/dashboard/site/import/sources/blogger/tests/index.js
@@ -1,6 +1,7 @@
 const fs = require("fs-extra");
 const os = require("os");
 const path = require("path");
+const nock = require("nock");
 const blogger = require("../index");
 
 describe("Blogger importer", function () {
@@ -8,12 +9,13 @@ describe("Blogger importer", function () {
   const atomFixture = path.join(__dirname, "fixtures", "export.atom");
 
   // The full import pipeline runs helper.download_images / download_pdfs, which
-  // fetch() the external asset URLs embedded in export.xml (e.g.
+  // fetch the external asset URLs embedded in export.xml (e.g.
   // https://blogger.googleusercontent.com/...). Those real network calls make
-  // the pipeline specs depend on CI egress and time out intermittently
-  // (helper/download_images.js has its own 5s timeout that collides with
-  // Jasmine's). Stub fetch so downloads fail fast and offline; none of these
-  // specs assert on downloaded asset content.
+  // the pipeline specs depend on CI egress and time out intermittently. None of
+  // these specs assert on downloaded asset content, so keep them offline:
+  //   - download_pdfs still uses the global fetch, so stub that.
+  //   - download_images now goes through helper/transformer, which uses
+  //     node-fetch; nock.disableNetConnect() makes those calls fail fast.
   let realFetch;
 
   beforeAll(function () {
@@ -28,10 +30,14 @@ describe("Blogger importer", function () {
         json: () => Promise.resolve({}),
       });
     };
+    nock.disableNetConnect();
+    nock.enableNetConnect("127.0.0.1");
   });
 
   afterAll(function () {
     global.fetch = realFetch;
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 
   it("selects published posts and pages and maps Atom fields", async function () {


### PR DESCRIPTION
## What

The importer's [`download_images`](app/dashboard/site/import/helper/download_images.js) helper (run for every WordPress, Blogger and Are.na import) fetched each remote `<img>` `src` and each post thumbnail with a bare `fetch()`. It now goes through [`helper/transformer`](app/helper/transformer/index.js) — the same module the image plugin, thumbnail builder and gdoc / img converters use.

## Why

An import pulls arbitrary URLs out of a user-supplied export file. The bare `fetch()` ran straight from the app process with no egress filtering. Through the transformer we get:

1. **SSRF protection** — `transformer/download` routes every request and redirect through the airlock forward proxy (`config/airlock`), which filters egress to private ranges, cloud-metadata endpoints and DNS-rebinding targets. Plus a redirect cap and timeout.
2. **Dedup** — an asset is downloaded and inspected once, keyed by content hash, then reused across posts and across re-runs.
3. **Conditional requests** on later imports.

## How it fits the transformer

The transformer deletes the downloaded temp file once the transform returns, and hands back only stored JSON on a cache hit. So the transform copies each asset into a small backing directory under `tmp_directory`, **keyed by content hash** (`helper/transformer/hash`, the same hash the transformer keys its own results by). `download_images` then materialises the per-post file from there.

Store namespace is `"import"`, not per-blog — an import stages files before the blog folder exists, and identical URLs should dedupe across every blog's imports.

## Review follow-up (thanks @chatgpt-codex-connector)

- **Backing file keyed by URL vs content** — fixed. Keyed by content hash now, so it's immutable: a hit that reuses a result always resolves to matching bytes, and a URL that later serves different content writes a new backing file rather than repointing an existing one.
- **Cross-account reuse of a cached result after an expiring signed URL 403s** — accepted as low-frequency / low-severity (needs the same URL string, two accounts, a second import after expiry; the payload is an image already published at a URL the second account also holds).
- **Backing file pruned while the transformer result survives** — accepted. Nothing in Blot prunes `tmp_directory`, it lives under the data directory, and the failure mode is a skipped image (falls back to the original remote `src`), not wrong content.

## Behaviour notes

- Skip semantics unchanged: `data:` URIs, unparseable hosts and download failures leave the original `src` untouched.
- Filenames no longer use `Content-Disposition` (a transform can't see response headers); they fall back to the URL basename plus the format `sharp` detects. Cosmetic, only visible for hosts serving opaque image URLs (e.g. Blogger). `nameFrom` / `filenameFromContentDisposition` are unchanged and still exported for tests.

## Tests

- `helper/tests/download_images.js` — unchanged; the naming functions are untouched pure functions.
- `sources/blogger/tests/index.js` — the pipeline specs stubbed `global.fetch` to stay offline. Image downloads now go through `node-fetch` (in `transformer/download`), so this adds `nock.disableNetConnect()`. `download_pdfs` still uses the global fetch, so that stub stays.
- Full suite runs in the Docker harness (`npm test`), which needs Docker + Redis; not run in this environment. Syntax-checked with `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)