### PR TITLE
Pin the are.na image importer to are.na's own image hosts

### DIFF
--- a/app/dashboard/site/import/sources/arena/parse.js
+++ b/app/dashboard/site/import/sources/arena/parse.js
@@ -7,6 +7,40 @@ const async = require("async");
 const helper = require("dashboard/site/import/helper");
 const sanitize = require("./sanitize");
 
+// Every image the are.na API hands back for an Image/Link/Media block lives
+// on are.na's own storage: image.original.url on their CloudFront
+// distribution, the resized variants on images.are.na. Pinning the download
+// to those hosts keeps a hand-crafted channel from pointing this at an
+// internal address, without needing to route it through the airlock -
+// are.na, not the importing user, controls what host this URL resolves to.
+// (The generic imported-HTML image/PDF downloaders in
+// dashboard/site/import/helper still fetch arbitrary URLs - separate issue.)
+const ARENA_IMAGE_HOSTS = new Set(["d2w9rnfcy7mm78.cloudfront.net"]);
+
+function isArenaImageHost(host) {
+  return (
+    ARENA_IMAGE_HOSTS.has(host) || host === "are.na" || host.endsWith(".are.na")
+  );
+}
+
+// Returns a normalized https URL if `raw` points at an are.na image host,
+// otherwise null (credentials, non-https, or any other host are rejected).
+function arenaImageURL(raw) {
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch (e) {
+    return null;
+  }
+  if (parsed.protocol !== "https:" || parsed.username || parsed.password) {
+    return null;
+  }
+  if (!isArenaImageHost(parsed.hostname.toLowerCase())) {
+    return null;
+  }
+  return parsed.toString();
+}
+
 async function parse({ outputDirectory, posts, status }) {
   status = typeof status === "function" ? status : () => {};
   if (posts.length === 0) {
@@ -107,7 +141,17 @@ async function link(item, outputDirectory) {
 }
 
 async function image(item, outputDirectory) {
-  const response = await fetch(item.image.original.url, {
+  const rawURL = item.image && item.image.original && item.image.original.url;
+  const src = arenaImageURL(rawURL);
+
+  if (!src) {
+    throw new Error(`Refusing to download non-are.na image URL: ${rawURL}`);
+  }
+
+  const response = await fetch(src, {
+    // are.na serves these 200 directly; a redirect off an are.na host is
+    // exactly what the allow-list above exists to stop, so don't follow it.
+    redirect: "manual",
     headers: {
       "User-Agent":
         "Mozilla/5.0 (compatible; Blot/1.0; +https://blot.im)",

--- a/app/dashboard/site/import/sources/arena/tests/parse.js
+++ b/app/dashboard/site/import/sources/arena/tests/parse.js
@@ -95,3 +95,98 @@ describe("Are.na text block importer", function () {
     expect(fs.readFileSync(path.join(outputDirectory, "2020", "04-05-Still-imported.txt"), "utf8")).toContain("Success");
   });
 });
+
+describe("Are.na image block importer", function () {
+  const nock = require("nock");
+  let outputDirectory;
+
+  function imageBlock(url, overrides) {
+    return Object.assign(
+      {
+        id: 1,
+        class: "Image",
+        title: "My picture",
+        visibility: "public",
+        created_at: "2020-04-05T06:07:08.000Z",
+        image: { filename: "photo.png", original: { url } },
+      },
+      overrides
+    );
+  }
+
+  beforeEach(function () {
+    outputDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "arena-image-"));
+    nock.disableNetConnect();
+  });
+
+  afterEach(function () {
+    nock.cleanAll();
+    nock.enableNetConnect();
+    fs.removeSync(outputDirectory);
+  });
+
+  it("downloads an image from are.na's CloudFront host", async function () {
+    const scope = nock("https://d2w9rnfcy7mm78.cloudfront.net")
+      .get("/1/original_abc.png")
+      .reply(200, Buffer.from("PNGBYTES"));
+
+    await parse({
+      outputDirectory,
+      status: function () {},
+      posts: [
+        imageBlock(
+          "https://d2w9rnfcy7mm78.cloudfront.net/1/original_abc.png"
+        ),
+      ],
+    });
+
+    expect(scope.isDone()).toBe(true);
+    const written = fs.readdirSync(outputDirectory);
+    expect(written.length).toBe(1);
+    expect(fs.readFileSync(path.join(outputDirectory, written[0]), "utf8")).toBe(
+      "PNGBYTES"
+    );
+  });
+
+  ["http://169.254.169.254/latest/meta-data/", "https://evil.example/x.png", "https://d2w9rnfcy7mm78.cloudfront.net.evil.example/x.png"].forEach(
+    (url) => {
+      it("refuses non-are.na image URL " + url, async function () {
+        const statuses = [];
+        spyOn(console, "error");
+
+        await parse({
+          outputDirectory,
+          status: (message) => statuses.push(message),
+          posts: [imageBlock(url)],
+        });
+
+        expect(
+          statuses.some((m) => m.includes("Refusing to download non-are.na image URL"))
+        ).toBe(true);
+        expect(fs.readdirSync(outputDirectory).length).toBe(0);
+      });
+    }
+  );
+
+  it("does not follow a redirect off the are.na host", async function () {
+    const scope = nock("https://d2w9rnfcy7mm78.cloudfront.net")
+      .get("/1/original_abc.png")
+      .reply(302, "", { Location: "http://169.254.169.254/" });
+    const statuses = [];
+    spyOn(console, "error");
+
+    await parse({
+      outputDirectory,
+      status: (message) => statuses.push(message),
+      posts: [
+        imageBlock(
+          "https://d2w9rnfcy7mm78.cloudfront.net/1/original_abc.png"
+        ),
+      ],
+    });
+
+    expect(scope.isDone()).toBe(true);
+    expect(statuses.some((m) => m.includes("Failed to process"))).toBe(true);
+    expect(fs.readdirSync(outputDirectory).length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Why

`app/dashboard/site/import/sources/arena/parse.js` `image()` downloaded `item.image.original.url` — taken from the are.na API response for a user-supplied channel — with no host check. A hand-crafted channel carrying an internal URL made it an SSRF sink.

Companion PR #1717 originally routed this through the airlock; per feedback it's cleaner to pin it, like the bandcamp embed plugin (#1718). Verified against the live are.na API (`arena-influences`, `design-research`, …): `image.original.url` is **always** on are.na's own CloudFront distribution `d2w9rnfcy7mm78.cloudfront.net`, resized variants on `images.are.na`, across Image/Link/Media block classes. are.na — not the importing user — controls that host.

## What

- Allowlist `d2w9rnfcy7mm78.cloudfront.net` and `*.are.na` (`arenaImageURL()`).
- Reject anything else, non-`https:`, or credentials in the URL — `image()` throws `Refusing to download non-are.na image URL: …` (caught by `parse()`'s per-block handler, so the rest of the import continues).
- `redirect: "manual"` so a redirect off an are.na host can't escape the allowlist; the existing `!response.ok` check turns that into a skip.
- `parse.js` keeps plain `require("node-fetch")` — no airlock dependency.

## Not in this PR

The generic imported-HTML downloaders `app/dashboard/site/import/helper/download_{images,pdfs,audio}.js` fetch arbitrary URLs pulled from imported HTML (are.na Text blocks, WordPress, Ghost, …) using the global `fetch`, with no SSRF protection. That's a larger, cross-importer gap — noted in `config/airlock/README.md`, not addressed here.

## Tests

`app/dashboard/site/import/sources/arena/tests/parse.js` — new "image block importer" describe: downloads from the CloudFront host; refuses `169.254.169.254`, an off-host URL, and a `d2w9….cloudfront.net.evil.example` look-alike; does not follow a `302` off the are.na host. 9 specs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)