### PR TITLE
Cache deployment workflow dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,8 +108,20 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: "npm"
+          cache-dependency-path: ./package.json
+
+      - name: Cache Node modules and the Puppeteer browser
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            ~/.cache/puppeteer
+          key: node-modules-${{ runner.os }}-${{ runner.arch }}-22-${{ hashFiles('package.json') }}
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Deploy via npm script
@@ -127,4 +139,3 @@ jobs:
           echo "=========================================="
           echo "Commit SHA: ${{ github.sha }}"
           echo "Deployment completed successfully! 🚀"
-


### PR DESCRIPTION
### Motivation

- Reduce deployment run time by reusing previously installed Node dependencies and the Puppeteer browser download instead of reinstalling them on every deploy. 
- Make the cache invalidation deterministic by tying it to `package.json` so dependency changes force a rebuild. 

### Description

- Enable the built-in npm cache in the existing `actions/setup-node@v4` step by adding `cache: "npm"` and `cache-dependency-path: ./package.json`. 
- Add an `actions/cache@v4` step (`id: cache-node-modules`) to cache `node_modules` and `~/.cache/puppeteer` with a key built from `runner.os`, `runner.arch`, Node.js version `22`, and `hashFiles('package.json')`. 
- Run `npm install` only when the cache misses by adding `if: steps.cache-node-modules.outputs.cache-hit != 'true'` to the existing install step. 
- Preserve the existing SSH setup, deploy command, environment configuration, and overall workflow ordering. 

### Testing

- Validated the edited workflow is legal YAML with `ruby -e "require 'yaml'; YAML.parse_file('.github/workflows/deploy.yml')"`, which succeeded. 
- Ran `git diff --check` to ensure no whitespace or patch errors, which succeeded. 
- Inspected the diff and repository status with `git status --short` and `git log -1 --oneline` to confirm the intended changes were staged and recorded. 
- Prepared a pull request title and body describing the deployment-time improvement and the `package.json`-based invalidation strategy; opening the PR via the GitHub CLI was not performed because the environment was not authenticated with GitHub.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9d17c1b9b483298995f713d24f8f96)