### PR TITLE
Drop Chromium from the production app image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,17 +13,16 @@ ENV NODE_PATH=/usr/src/app/app
 # Set the working directory in the Docker container
 WORKDIR /usr/src/app
 
-# Install necessary packages for Puppeteer, the git client, and HEIF-enabled libvips
+# Install the git client and a few runtime basics. Chromium is NOT installed
+# here: production takes screenshots by connecting to the shared "airlock"
+# container's headless Chromium over the Docker network (see
+# app/helper/screenshot and config/airlock), so the prod image ships no
+# browser. The dev stage below adds Chromium back for the test suite.
 RUN apk add --no-cache --update \
     git \
     tini \
     curl \
-    chromium \
-    nss \
-    freetype \
-    harfbuzz \
-    ca-certificates \
-    ttf-freefont
+    ca-certificates
 
 # Configure git to handle lots of large binary files in memory-constrained environments.
 RUN git config --system pack.threads 1 \
@@ -34,8 +33,11 @@ RUN git config --system pack.threads 1 \
 # Use tini as the init process so simple-git child processes are reaped instead of becoming zombies.
 ENTRYPOINT ["/sbin/tini", "--"]
 
-# Set the Puppeteer executable path
-ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+# Puppeteer is used only as a CDP client (it connect()s to the airlock's
+# Chromium), so don't let `npm install` download its ~130MB bundled browser.
+# The dev stage, which does launch() a local Chromium for tests, installs the
+# system package and points Puppeteer at it instead.
+ENV PUPPETEER_SKIP_DOWNLOAD=true
 
 # Install Pandoc
 RUN ARCH=$(echo ${TARGETPLATFORM} | sed -nE 's/^linux\/(amd64|arm64)$/\1/p') \
@@ -86,6 +88,12 @@ FROM base AS dev
 
 ENV NODE_ENV=development
 ENV PATH=/usr/src/app/node_modules/.bin:$PATH
+
+# The test suite (app/site/tests) and scripts/development/translate launch a
+# local headless Chromium via Puppeteer. Production does not - it connects to
+# the airlock - so the browser and its font/nss deps live in this stage only.
+RUN apk add --no-cache chromium nss freetype harfbuzz ca-certificates ttf-freefont
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 RUN npm install --no-package-lock && npm cache clean --force
     

--- a/config/index.js
+++ b/config/index.js
@@ -24,19 +24,24 @@ const reverse_proxies = process.env.BLOT_REVERSE_PROXY_URLS
 
 // See the "airlock" config block below. A warning, not a thrown error that
 // would crash every container on boot over a single misconfigured/down
-// dependency - but it means bookmark screenshots and remote-image downloads
-// are fetching user-controlled URLs directly, with no SSRF protection. Once
-// the airlock deploy has been stable for a while, consider tightening this
-// to fail closed (but only after confirming the airlock, not blindly).
+// dependency - but the consequences differ by variable:
+//   - BLOT_AIRLOCK_BROWSER_URL unset: the production image ships no Chromium
+//     of its own (see the Dockerfile), so bookmark-link screenshots do not
+//     just lose SSRF protection - they cannot run at all.
+//   - BLOT_AIRLOCK_PROXY_URL unset: remote-image downloads fetch
+//     user-controlled URLs directly, with no SSRF protection.
+// Once the airlock deploy has been stable for a while, consider tightening
+// this to fail closed (but only after confirming the airlock, not blindly).
 if (
   environment === "production" &&
   !(process.env.BLOT_AIRLOCK_BROWSER_URL && process.env.BLOT_AIRLOCK_PROXY_URL)
 ) {
   console.warn(
     "WARNING: BLOT_AIRLOCK_BROWSER_URL / BLOT_AIRLOCK_PROXY_URL are not both " +
-      "set in production. Bookmark-link screenshots and remote-image " +
-      "downloads are fetching user-controlled URLs directly, with no SSRF " +
-      "protection. See config/airlock/README.md."
+      "set in production. Without BLOT_AIRLOCK_BROWSER_URL, bookmark-link " +
+      "screenshots will fail (the prod image has no local Chromium). Without " +
+      "BLOT_AIRLOCK_PROXY_URL, remote-image downloads fetch user-controlled " +
+      "URLs directly, with no SSRF protection. See config/airlock/README.md."
   );
 }
 


### PR DESCRIPTION
## Summary

Since screenshots were cut over to the airlock container (`0f5ea20f6`), the main app image no longer launches its own Chromium at runtime — [app/helper/screenshot](app/helper/screenshot/index.js) `connect()`s to the airlock's headless browser over the Docker network. But the Alpine `chromium` package (plus `nss`/font deps) **and** Puppeteer's ~130 MB bundled Chrome download were still baked into every image through the shared `base` stage, costing the prod image roughly **450–550 MB** it never uses.

## Changes

- **`base` stage**: remove `chromium`, `nss`, `freetype`, `harfbuzz`, `ttf-freefont` (keep `ca-certificates`); set `PUPPETEER_SKIP_DOWNLOAD=true` so `npm install` doesn't fetch the bundled browser.
- **`dev` stage**: install the system Chromium here instead and point `PUPPETEER_EXECUTABLE_PATH` at it. `app/site/tests/util/setup.js` and `scripts/development/translate/screenshot.js` call `puppeteer.launch()`; CI builds those with `--target dev` ([node.yml](.github/workflows/node.yml)), so they're unaffected.
- **`prod` stage**: inherits from `base` → ships no browser.
- **`config/index.js`**: sharpen the production warning — an unset `BLOT_AIRLOCK_BROWSER_URL` now means bookmark screenshots cannot run at all, not merely that they run without SSRF protection.

## Not affected

- The template-gallery screenshot workflow ([screenshots.yml](.github/workflows/screenshots.yml)) runs on a macOS runner with its own Puppeteer Chrome.
- [linkScreenshot](app/build/plugins/linkScreenshot/index.js) already renders the plain link when a screenshot fails, so an unreachable airlock degrades gracefully rather than breaking builds.

## Notes / risk

- Production now has **no local browser fallback** — screenshots depend entirely on the airlock being reachable. This matches the intent of the airlock cut-over.
- `puppeteer` (not `puppeteer-core`) stays in `package.json`; with the download skipped it behaves as a CDP client. Switching to `puppeteer-core` is a reasonable follow-up but not required for the size win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)