### PR TITLE
Deploy: accept optional branch + commit hash inputs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,12 +3,8 @@ name: Deploy to EC2
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: "Branch to deploy from"
-        required: false
-        default: "master"
       commit:
-        description: "Optional commit hash or short code on that branch (defaults to the tip of the branch)"
+        description: "Optional commit hash or short code on master (defaults to the dispatched commit)"
         required: false
         default: ""
 
@@ -26,40 +22,54 @@ jobs:
     timeout-minutes: 30
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
-      ref: ${{ steps.resolve.outputs.ref }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Need full history so an arbitrary/older commit or short code can be
-          # resolved and verified against the target branch.
+          # Need full history so an older commit or short code can be
+          # resolved and verified against master.
           fetch-depth: 0
+
+      - name: Check branch
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/master" ]; then
+            echo "❌ Error: This workflow can only be run on the master branch."
+            echo "Current branch: ${{ github.ref }}"
+            exit 1
+          fi
+          echo "✅ Branch check passed: running on master branch"
 
       - name: Resolve target commit
         id: resolve
+        env:
+          # Bind inputs to the environment so a dispatcher cannot inject
+          # shell syntax into the script below.
+          COMMIT_INPUT: ${{ github.event.inputs.commit }}
+          DISPATCH_SHA: ${{ github.sha }}
         run: |
-          REF="${{ github.event.inputs.ref }}"
-          REF="${REF:-master}"
-          COMMIT="${{ github.event.inputs.commit }}"
+          git fetch --quiet origin master
 
-          git fetch --quiet origin "$REF"
-
-          if [ -n "$COMMIT" ]; then
-            SHA=$(git rev-parse --verify --quiet "${COMMIT}^{commit}") || {
-              echo "❌ Error: could not resolve commit '$COMMIT'"
+          if [ -z "$COMMIT_INPUT" ]; then
+            # Default: the immutable commit the run was dispatched against.
+            SHA="$DISPATCH_SHA"
+          else
+            SHA=$(git rev-parse --verify --quiet "${COMMIT_INPUT}^{commit}") || {
+              echo "❌ Error: could not resolve commit '$COMMIT_INPUT'"
               exit 1
             }
-            if ! git merge-base --is-ancestor "$SHA" "origin/$REF"; then
-              echo "❌ Error: commit $SHA is not on branch '$REF'"
-              exit 1
-            fi
-          else
-            SHA=$(git rev-parse --verify "origin/$REF^{commit}")
+          fi
+
+          # The deploy environment's branch policy is evaluated against the
+          # run ref (master), so the target must live on master too - both to
+          # honour that policy and because build.yml only publishes images
+          # for master commits.
+          if ! git merge-base --is-ancestor "$SHA" origin/master; then
+            echo "❌ Error: commit $SHA is not on master"
+            exit 1
           fi
 
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "ref=$REF" >> "$GITHUB_OUTPUT"
-          echo "✅ Target commit: $SHA (branch $REF)"
+          echo "✅ Target commit: $SHA"
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -69,9 +79,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for build images to be available
+        env:
+          TARGET_SHA: ${{ steps.resolve.outputs.sha }}
         run: |
-          IMAGE="${{ env.REGISTRY_URL }}:${{ steps.resolve.outputs.sha }}"
-          AIRLOCK_IMAGE="${{ env.AIRLOCK_REGISTRY_URL }}:${{ steps.resolve.outputs.sha }}"
+          IMAGE="${{ env.REGISTRY_URL }}:${TARGET_SHA}"
+          AIRLOCK_IMAGE="${{ env.AIRLOCK_REGISTRY_URL }}:${TARGET_SHA}"
           WAIT_INTERVAL=10
 
           # The app image is required.
@@ -161,18 +173,20 @@ jobs:
         run: npm install
 
       - name: Deploy via npm script
-        run: npm run deploy-node -- ${{ needs.wait-for-build.outputs.sha }}
         env:
+          TARGET_SHA: ${{ needs.wait-for-build.outputs.sha }}
           # Skip branch check since we're in CI and may be checking out a specific commit
           SKIP_BRANCH_CHECK: true
+        run: npm run deploy-node -- "$TARGET_SHA"
 
       - name: Deployment summary
         if: success()
+        env:
+          TARGET_SHA: ${{ needs.wait-for-build.outputs.sha }}
         run: |
           echo ""
           echo "=========================================="
           echo "Deployment Summary"
           echo "=========================================="
-          echo "Branch:     ${{ needs.wait-for-build.outputs.ref }}"
-          echo "Commit SHA: ${{ needs.wait-for-build.outputs.sha }}"
+          echo "Commit SHA: ${TARGET_SHA}"
           echo "Deployment completed successfully! 🚀"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
     timeout-minutes: 30
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
+      custom: ${{ steps.resolve.outputs.custom }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,11 +53,13 @@ jobs:
           if [ -z "$COMMIT_INPUT" ]; then
             # Default: the immutable commit the run was dispatched against.
             SHA="$DISPATCH_SHA"
+            CUSTOM=false
           else
             SHA=$(git rev-parse --verify --quiet "${COMMIT_INPUT}^{commit}") || {
               echo "❌ Error: could not resolve commit '$COMMIT_INPUT'"
               exit 1
             }
+            CUSTOM=true
           fi
 
           # The deploy environment's branch policy is evaluated against the
@@ -69,7 +72,8 @@ jobs:
           fi
 
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "✅ Target commit: $SHA"
+          echo "custom=$CUSTOM" >> "$GITHUB_OUTPUT"
+          echo "✅ Target commit: $SHA (custom=$CUSTOM)"
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -81,23 +85,40 @@ jobs:
       - name: Wait for build images to be available
         env:
           TARGET_SHA: ${{ steps.resolve.outputs.sha }}
+          CUSTOM: ${{ steps.resolve.outputs.custom }}
         run: |
           IMAGE="${{ env.REGISTRY_URL }}:${TARGET_SHA}"
           AIRLOCK_IMAGE="${{ env.AIRLOCK_REGISTRY_URL }}:${TARGET_SHA}"
           WAIT_INTERVAL=10
 
+          # For the default (dispatched) commit the build workflow may still
+          # be running, so wait up to 25 min. For an explicitly chosen commit
+          # the image should already exist - build.yml tags only the push-tip
+          # github.sha of each master push, so an intermediate or merged-in
+          # commit never gets one. Fail fast with a clear reason instead of
+          # polling 25 min for a tag that will never appear.
+          if [ "$CUSTOM" = "true" ]; then
+            MAX_APP_TRIES=12   # ~2 min grace
+          else
+            MAX_APP_TRIES=150  # ~25 min
+          fi
+
           # The app image is required.
-          echo "Waiting for app image: $IMAGE"
-          for i in $(seq 1 150); do   # up to 25 min
+          echo "Waiting for app image: $IMAGE (up to $((MAX_APP_TRIES * WAIT_INTERVAL / 60)) min)"
+          for i in $(seq 1 "$MAX_APP_TRIES"); do
             if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
               echo "✅ App image found: $IMAGE"
               break
             fi
-            if [ "$i" -eq 150 ]; then
-              echo "❌ Timeout: app image not found after 25 minutes: $IMAGE"
+            if [ "$i" -eq "$MAX_APP_TRIES" ]; then
+              echo "❌ App image not found: $IMAGE"
+              if [ "$CUSTOM" = "true" ]; then
+                echo "   build.yml only publishes an image for the tip commit of each master push."
+                echo "   Pick a commit that was a push tip on master (not an intermediate or merge parent)."
+              fi
               exit 1
             fi
-            echo "  not ready yet ($i/150)..."; sleep $WAIT_INTERVAL
+            echo "  not ready yet ($i/$MAX_APP_TRIES)..."; sleep $WAIT_INTERVAL
           done
 
           # The airlock image is best-effort. build-airlock runs in parallel

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,15 @@ name: Deploy to EC2
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch to deploy from"
+        required: false
+        default: "master"
+      commit:
+        description: "Optional commit hash or short code on that branch (defaults to the tip of the branch)"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -15,18 +24,42 @@ jobs:
   wait-for-build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+      ref: ${{ steps.resolve.outputs.ref }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Need full history so an arbitrary/older commit or short code can be
+          # resolved and verified against the target branch.
+          fetch-depth: 0
 
-      - name: Check branch
+      - name: Resolve target commit
+        id: resolve
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/master" ]; then
-            echo "❌ Error: This workflow can only be run on the master branch."
-            echo "Current branch: ${{ github.ref }}"
-            exit 1
+          REF="${{ github.event.inputs.ref }}"
+          REF="${REF:-master}"
+          COMMIT="${{ github.event.inputs.commit }}"
+
+          git fetch --quiet origin "$REF"
+
+          if [ -n "$COMMIT" ]; then
+            SHA=$(git rev-parse --verify --quiet "${COMMIT}^{commit}") || {
+              echo "❌ Error: could not resolve commit '$COMMIT'"
+              exit 1
+            }
+            if ! git merge-base --is-ancestor "$SHA" "origin/$REF"; then
+              echo "❌ Error: commit $SHA is not on branch '$REF'"
+              exit 1
+            fi
+          else
+            SHA=$(git rev-parse --verify "origin/$REF^{commit}")
           fi
-          echo "✅ Branch check passed: running on master branch"
+
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "✅ Target commit: $SHA (branch $REF)"
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -37,8 +70,8 @@ jobs:
 
       - name: Wait for build images to be available
         run: |
-          IMAGE="${{ env.REGISTRY_URL }}:${{ github.sha }}"
-          AIRLOCK_IMAGE="${{ env.AIRLOCK_REGISTRY_URL }}:${{ github.sha }}"
+          IMAGE="${{ env.REGISTRY_URL }}:${{ steps.resolve.outputs.sha }}"
+          AIRLOCK_IMAGE="${{ env.AIRLOCK_REGISTRY_URL }}:${{ steps.resolve.outputs.sha }}"
           WAIT_INTERVAL=10
 
           # The app image is required.
@@ -78,10 +111,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: deploy
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.wait-for-build.outputs.sha }}
+          fetch-depth: 0
 
       - name: Setup SSH
         uses: webfactory/ssh-agent@v0.9.0
@@ -125,7 +161,7 @@ jobs:
         run: npm install
 
       - name: Deploy via npm script
-        run: npm run deploy-node -- ${{ github.sha }}
+        run: npm run deploy-node -- ${{ needs.wait-for-build.outputs.sha }}
         env:
           # Skip branch check since we're in CI and may be checking out a specific commit
           SKIP_BRANCH_CHECK: true
@@ -137,5 +173,6 @@ jobs:
           echo "=========================================="
           echo "Deployment Summary"
           echo "=========================================="
-          echo "Commit SHA: ${{ github.sha }}"
+          echo "Branch:     ${{ needs.wait-for-build.outputs.ref }}"
+          echo "Commit SHA: ${{ needs.wait-for-build.outputs.sha }}"
           echo "Deployment completed successfully! 🚀"


### PR DESCRIPTION
## What

The **Deploy to EC2** workflow (`workflow_dispatch`) always deployed `github.sha` — the tip of master at dispatch time. This adds two optional inputs so you can deploy a specific commit:

| Input | Default | Meaning |
|-------|---------|---------|
| `ref` | `master` | Branch to deploy from |
| `commit` | *(empty)* | A full commit hash or short code on that branch. Empty = tip of `ref`. |

## How

- New **Resolve target commit** step in `wait-for-build`:
  - resolves `commit` (or the branch tip) to a full SHA via `git rev-parse`
  - verifies with `git merge-base --is-ancestor` that the SHA is actually on `ref` — a commit that isn't on the branch fails the job
  - publishes `sha` / `ref` as job outputs
- The image-wait step, the `deploy` job's checkout, the `deploy-node` argument, and the summary all consume `needs.wait-for-build.outputs.sha` instead of `github.sha`.
- Checkout uses `fetch-depth: 0` (was shallow) so older commits / short codes can be resolved.
- `scripts/deploy/util/getGitCommit.js` already accepts a hash/short-code argument, so no script changes were needed.

## Behaviour change

- **No inputs:** unchanged — deploys the current tip of `master`.
- The previous hard `github.ref == refs/heads/master` guard is removed; deploy target is now governed by the `ref` input + the on-branch verification, and the `deploy` environment gate still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)