### PR TITLE
Add Redis deployment diagnostics

### DIFF
--- a/app/dashboard/log-in/rateLimit.js
+++ b/app/dashboard/log-in/rateLimit.js
@@ -2,15 +2,19 @@ const { rateLimit}  = require("express-rate-limit");
 const { RedisStore } = require('rate-limit-redis')
 const redis = require("redis");
 const config = require("config");
+const instrumentRedis = require("helper/instrumentRedis");
+
+const redisUrl = `redis://${config.redis.host}:${config.redis.port}`;
 
 // rate-limit-redis uses the promise API (get/set/del with options), so use
 // a native redis client, not the shared application singleton from models/client.
 const client = redis.createClient({
-  url: `redis://${config.redis.host}:${config.redis.port}`,
+  url: redisUrl,
   RESP: 2,
   commandOptions: { timeout: undefined },
   socket: { keepAliveInitialDelay: 5000 },
 });
+instrumentRedis("dashboard-login-rate-limit", client, redisUrl);
 client.connect().catch((err) => {
   console.error("Rate limit Redis connect error:", err);
 });

--- a/app/dashboard/util/session.js
+++ b/app/dashboard/util/session.js
@@ -3,15 +3,19 @@ const guid = require("helper/guid");
 const session = require("express-session");
 const { RedisStore } = require("connect-redis");
 const redis = require("redis");
+const instrumentRedis = require("helper/instrumentRedis");
+
+const redisUrl = `redis://${config.redis.host}:${config.redis.port}`;
 
 // connect-redis 9 uses the promise API (get/set/del with options), so use
 // a native redis client, not the shared application singleton from models/client.
 const sessionClient = redis.createClient({
-  url: `redis://${config.redis.host}:${config.redis.port}`,
+  url: redisUrl,
   RESP: 2,
   commandOptions: { timeout: undefined },
   socket: { keepAliveInitialDelay: 5000 },
 });
+instrumentRedis("dashboard-session", sessionClient, redisUrl);
 sessionClient.connect().catch((err) => {
   console.error("Session Redis connect error:", err);
 });
@@ -35,5 +39,4 @@ module.exports = session({
   },
   store: new RedisStore({ client: sessionClient }),
 });
-
 

--- a/app/helper/instrumentRedis.js
+++ b/app/helper/instrumentRedis.js
@@ -1,0 +1,44 @@
+const clfdate = require("helper/clfdate");
+
+// node-redis deliberately exposes only lifecycle events, not its underlying
+// socket. Keep this at that public boundary so diagnostic logging cannot alter
+// connection behaviour or depend on node-redis internals.
+module.exports = function instrumentRedis(name, client, endpoint) {
+  const startedAt = Date.now();
+
+  function context() {
+    return {
+      client: name,
+      endpoint,
+      pid: process.pid,
+      uptimeMs: Date.now() - startedAt,
+      isOpen: client.isOpen,
+      isReady: client.isReady,
+    };
+  }
+
+  client.on("connect", () => {
+    console.log(clfdate(), "Redis lifecycle connect", context());
+  });
+
+  client.on("ready", () => {
+    console.log(clfdate(), "Redis lifecycle ready", context());
+  });
+
+  client.on("reconnecting", () => {
+    console.warn(clfdate(), "Redis lifecycle reconnecting", context());
+  });
+
+  client.on("end", () => {
+    console.warn(clfdate(), "Redis lifecycle end", context());
+  });
+
+  // An error listener is required by Node's EventEmitter contract. Log the
+  // complete Error object so errno/code/syscall and its stack survive in the
+  // container logs, rather than converting it to a lossy string.
+  client.on("error", (error) => {
+    console.error(clfdate(), "Redis lifecycle error", context(), error);
+  });
+
+  return client;
+};

--- a/app/index.js
+++ b/app/index.js
@@ -1,5 +1,17 @@
 const config = require("config");
 const clfdate = require("helper/clfdate");
+
+// Observes fatal exceptions without installing an uncaughtException handler:
+// Node still follows its normal exit path. This is a last-resort breadcrumb
+// when a crash happens before a subsystem can identify itself.
+process.on("uncaughtExceptionMonitor", (error, origin) => {
+  console.error(clfdate(), "Uncaught exception", {
+    origin,
+    pid: process.pid,
+    release: process.env.BLOT_RELEASE_ID || process.env.GIT_SHA,
+  }, error);
+});
+
 const email = require("helper/email");
 const redis = require("models/client");
 const setup = require("./setup");

--- a/app/models/redis.js
+++ b/app/models/redis.js
@@ -1,5 +1,6 @@
 const config = require("config");
 const redis = require("redis");
+const instrumentRedis = require("helper/instrumentRedis");
 
 const url = `redis://${config.redis.host}:${config.redis.port}`;
 const clientSideCaches = new WeakMap();
@@ -22,14 +23,7 @@ function createRedisClient() {
 
   clientSideCaches.set(client, clientSideCache);
 
-  client.on("error", function (err) {
-    console.log("Redis Error:");
-    console.log(err);
-    if (err.trace) console.log(err.trace);
-    if (err.stack) console.log(err.stack);
-  });
-
-  return client;
+  return instrumentRedis("models", client, url);
 }
 
 // Only expose an immutable stats snapshot, rather than the controllable cache.


### PR DESCRIPTION
## Summary
- log Redis lifecycle events and complete socket errors for the shared, session, and login rate-limit clients
- add a non-interfering uncaught-exception monitor with release and PID context
- preserve existing Redis reconnect and queue behavior while collecting evidence for the post-deploy timeout

## Deployment log collection

Run these immediately after deployment (or after an incident) to collect the relevant entries from every application container:

```sh
docker logs --timestamps --since 15m blot-container-yellow 2>&1 | grep -E 'Redis lifecycle|Uncaught exception|ETIMEDOUT|Starting server'
docker logs --timestamps --since 15m blot-container-blue 2>&1 | grep -E 'Redis lifecycle|Uncaught exception|ETIMEDOUT|Starting server'
docker logs --timestamps --since 15m blot-container-green 2>&1 | grep -E 'Redis lifecycle|Uncaught exception|ETIMEDOUT|Starting server'
```

Increase `--since` if the deployment or incident started earlier. Preserve the output from all three containers; the timestamps, PID, release ID, client name, and readiness state establish the connection-failure sequence.

## Verification
- exercised the instrumentation with a lifecycle/error smoke test
- ran git diff --check