### PR TITLE
Preserve Redis crash behavior while logging errors

### DIFF
--- a/app/helper/instrumentRedis.js
+++ b/app/helper/instrumentRedis.js
@@ -1,4 +1,5 @@
 const clfdate = require("helper/clfdate");
+const { errorMonitor } = require("node:events");
 
 // node-redis deliberately exposes only lifecycle events, not its underlying
 // socket. Keep this at that public boundary so diagnostic logging cannot alter
@@ -33,10 +34,10 @@ module.exports = function instrumentRedis(name, client, endpoint) {
     console.warn(clfdate(), "Redis lifecycle end", context());
   });
 
-  // An error listener is required by Node's EventEmitter contract. Log the
-  // complete Error object so errno/code/syscall and its stack survive in the
-  // container logs, rather than converting it to a lossy string.
-  client.on("error", (error) => {
+  // errorMonitor observes an EventEmitter error before its regular error
+  // listeners run, but is not itself an error handler. This records the full
+  // error without preventing Node's original unhandled-error crash behavior.
+  client.on(errorMonitor, (error) => {
     console.error(clfdate(), "Redis lifecycle error", context(), error);
   });
 

--- a/app/models/redis.js
+++ b/app/models/redis.js
@@ -23,6 +23,15 @@ function createRedisClient() {
 
   clientSideCaches.set(client, clientSideCache);
 
+  // This client handled errors before the diagnostic work. Retain that
+  // existing behavior; dashboard clients deliberately have no such handler.
+  client.on("error", function (err) {
+    console.log("Redis Error:");
+    console.log(err);
+    if (err.trace) console.log(err.trace);
+    if (err.stack) console.log(err.stack);
+  });
+
   return instrumentRedis("models", client, url);
 }
 


### PR DESCRIPTION
## Why
PR #1727 unintentionally changed the dashboard clients' behavior: attaching a normal `error` listener prevented Node from crashing on their Redis socket failures. That removed the existing restart behavior and let requests remain queued while clients reconnect.

## Change
- use Node's `errorMonitor` symbol for Redis error diagnostics; it observes every emitted error but does not handle it
- restore the shared models client's pre-existing normal `error` listener
- leave the dashboard clients without normal `error` listeners, preserving their pre-#1727 crash behavior

Lifecycle logging and the process-level `uncaughtExceptionMonitor` remain diagnostic-only.

## Verification
- verified `errorMonitor` logs an error before a normal listener runs
- verified separately that an emitter with only `errorMonitor` still terminates with Node's normal unhandled-error path
- ran `git diff --check`