### PR TITLE
Fix template-editor redirect loop when installed template slug is "default"

### DIFF
--- a/app/dashboard/site/template/index.js
+++ b/app/dashboard/site/template/index.js
@@ -12,7 +12,12 @@ const writeChangeToFolder = require('./save/writeChangeToFolder');
 // so docs can deep link to e.g. /sites/gitt/template/default/links
 TemplateEditor.use("/default", (req, res, next) => {
   const slug = res.locals.template?.slug;
-  if (!slug) return next();
+  // When the installed template's own slug is literally "default" (the user
+  // named a local template "default") there is nothing to disambiguate: fall
+  // through to the /:templateSlug route, which loads it directly. Redirecting
+  // here would point /template/default at itself and loop until the browser
+  // bails with ERR_TOO_MANY_REDIRECTS.
+  if (!slug || slug === "default") return next();
   const pathSuffix = req.path || "";
   res.redirect(`${res.locals.base}/template/${slug}${pathSuffix}`);
 });

--- a/app/dashboard/site/template/tests/default-slug-redirect.js
+++ b/app/dashboard/site/template/tests/default-slug-redirect.js
@@ -1,0 +1,111 @@
+describe("/default template-editor shim", function () {
+  const router = require("../index");
+
+  // The shim is registered with TemplateEditor.use("/default", fn). Pick it
+  // out of the router stack by the "default" fragment in its compiled path
+  // regexp so we can exercise it in isolation, the way install.js does.
+  const defaultShim = router.stack
+    .filter(function (layer) {
+      return !layer.route && layer.regexp && layer.regexp.source.includes("default");
+    })
+    .map(function (layer) {
+      return layer.handle;
+    })[0];
+
+  it("is registered", function () {
+    expect(typeof defaultShim).toEqual("function");
+  });
+
+  function run({ slug, base, path, originalUrl }) {
+    return new Promise(function (resolve) {
+      const req = { method: "GET", path: path, originalUrl: originalUrl };
+      const res = {
+        locals: { base: base },
+        redirect: jasmine.createSpy("redirect"),
+      };
+
+      if (slug !== undefined) res.locals.template = { slug: slug };
+
+      const next = jasmine.createSpy("next");
+
+      Promise.resolve(defaultShim(req, res, next)).then(function () {
+        resolve({
+          redirect: res.redirect,
+          next: next,
+          redirectedTo: res.redirect.calls.any()
+            ? res.redirect.calls.mostRecent().args.slice(-1)[0]
+            : null,
+        });
+      });
+    });
+  }
+
+  it("redirects /default to the installed template's slug", async function () {
+    const { redirect, redirectedTo } = await run({
+      slug: "cleanwhite",
+      base: "/sites/example",
+      path: "/",
+      originalUrl: "/sites/example/template/default/",
+    });
+
+    expect(redirect).toHaveBeenCalled();
+    expect(redirectedTo).toEqual("/sites/example/template/cleanwhite/");
+  });
+
+  it("preserves the sub-path when redirecting", async function () {
+    const { redirectedTo } = await run({
+      slug: "cleanwhite",
+      base: "/sites/example",
+      path: "/links",
+      originalUrl: "/sites/example/template/default/links",
+    });
+
+    expect(redirectedTo).toEqual("/sites/example/template/cleanwhite/links");
+  });
+
+  it("falls through when there is no installed template slug", async function () {
+    const { redirect, next } = await run({
+      slug: undefined,
+      base: "/sites/example",
+      path: "/",
+      originalUrl: "/sites/example/template/default/",
+    });
+
+    expect(redirect).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  // Regression: a local template whose own slug is literally "default"
+  // (the user named it "default") made the shim redirect /template/default
+  // to /template/default - the same URL - looping until the browser gave up
+  // with ERR_TOO_MANY_REDIRECTS.
+  it("does not redirect /default to itself when the installed slug is 'default'", async function () {
+    const originalUrl = "/sites/example/template/default/";
+
+    const { redirect, next, redirectedTo } = await run({
+      slug: "default",
+      base: "/sites/example",
+      path: "/",
+      originalUrl: originalUrl,
+    });
+
+    expect(redirectedTo).not.toEqual(originalUrl);
+    expect(redirect).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("does not loop on a sub-path when the installed slug is 'default'", async function () {
+    const originalUrl = "/sites/example/template/default/links";
+
+    const { redirect, next, redirectedTo } = await run({
+      slug: "default",
+      base: "/sites/example",
+      path: "/links",
+      originalUrl: originalUrl,
+    });
+
+    expect(redirectedTo).not.toEqual(originalUrl);
+    expect(redirect).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The bug

Opening the template editor for a site whose installed template has the slug `default` (a local template the user named "default") loops forever — the browser eventually shows `ERR_TOO_MANY_REDIRECTS`. Reported for site `arzoriac` on its `default` template: `https://blot.im/sites/arzoriac/template/default/`.

## Cause

The shim at the top of `app/dashboard/site/template/index.js` exists so docs can deep-link `/sites/<handle>/template/default/<view>` to whichever template is installed:

```js
TemplateEditor.use("/default", (req, res, next) => {
  const slug = res.locals.template?.slug;
  if (!slug) return next();
  const pathSuffix = req.path || "";
  res.redirect(`${res.locals.base}/template/${slug}${pathSuffix}`);
});
```

`res.locals.template.slug` is the installed template's own slug (`blog.template.split(":").slice(1).join(":")`, set in `app/dashboard/util/load-blog.js`). When that slug is literally `default`, the shim redirects `/sites/<handle>/template/default/` to `/sites/<handle>/template/default/` — the same URL — on every hit.

There is no stock `SITE:default` template, which is why this only affects sites running a *local* template named "default".

## Fix

Fall through to the `/:templateSlug` route when the resolved slug is `default`. That route (`load/template.js`) loads the template by slug directly, so no rewrite is needed and every `/template/default*` path resolves normally.

## Tests

Added `app/dashboard/site/template/tests/default-slug-redirect.js`, which exercises the shim in isolation (same pattern as `tests/install.js`):

- redirects `/default` to the installed slug, preserving sub-paths (unchanged behaviour)
- falls through when there is no installed slug
- **regression:** does not redirect `/default` (or `/default/links`) to itself when the installed slug is `default`

The two regression specs fail before the change and pass after; full `app/dashboard/site/template` suite: 90 specs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)