### PR TITLE
Attach the airlock network before starting app containers

### DIFF
--- a/config/airlock/README.md
+++ b/config/airlock/README.md
@@ -188,21 +188,35 @@ it".
    bad airlock build can't leave nothing running at all.
 
 3. **Connecting app containers.** Deliberately **not** `--network blotnet`
-   on the app containers at creation - that would move them off the default
-   `bridge` network entirely, changing their gateway from `172.17.0.1` to
-   `blotnet`'s gateway, which could silently break a hardcoded
-   `BLOT_REDIS_HOST` or `BLOT_REVERSE_PROXY_URLS` on the live host (neither
-   is visible from this repo). Instead, after each app container starts (or
-   is confirmed already up to date), `connectToAirlockNetwork()` checks
-   `blotnet`'s membership first and only runs `docker network connect
-   blotnet <container>` if it isn't already a member - Docker's supported
-   way to give a running container a *second* network interface. Checking
-   membership first (rather than attempting the connect and swallowing
-   "already exists" with `|| true`) means a genuine attach failure - a
-   missing network, a renamed container - surfaces in the deploy log
-   instead of looking identical to success. The container keeps its
-   original bridge network and gateway untouched, and gains the ability to
-   resolve and reach `blot-airlock` via `blotnet`'s embedded DNS.
+   on the app containers - that would move them off the default `bridge`
+   network entirely, changing their gateway from `172.17.0.1` to `blotnet`'s
+   gateway, which could silently break a hardcoded `BLOT_REDIS_HOST` or
+   `BLOT_REVERSE_PROXY_URLS` on the live host (neither is visible from this
+   repo). Instead, each app container is created stopped (`docker create`),
+   `connectToAirlockNetwork()` runs `docker network connect blotnet
+   <container>`, and only then is it started (`docker start`) - so the app
+   process starts up with `blotnet` already in place and opens its Redis
+   connections once, against the final network shape.
+
+   This attach step used to run *after* `docker run`, on the
+   already-running container. Connecting a network to a running container
+   reprograms its routing table and drops in-flight conntrack entries: it
+   was tearing down the app's established connections to the off-box Redis
+   instance a few seconds into every deploy, which node-redis surfaced as an
+   unhandled `read ETIMEDOUT` `error` event that crash-restarted each
+   container exactly once per deploy. The restart "fixed" it only because
+   the restarted container came up already attached to both networks - which
+   is now what a first start does too.
+
+   `connectToAirlockNetwork()` checks `blotnet`'s membership first and only
+   connects if the container isn't already a member - Docker's supported way
+   to give a container a *second* network interface. Checking membership
+   first (rather than attempting the connect and swallowing "already exists"
+   with `|| true`) means a genuine attach failure - a missing network, a
+   renamed container - surfaces in the deploy log instead of looking
+   identical to success. The container keeps its original bridge network and
+   gateway untouched, and gains the ability to resolve and reach
+   `blot-airlock` via `blotnet`'s embedded DNS.
    `generateDockerCommand.js` sets `BLOT_AIRLOCK_BROWSER_URL` /
    `BLOT_AIRLOCK_PROXY_URL` to `http://blot-airlock:9222` / `:8888` on
    every app container - see "Configuration" above.

--- a/scripts/deploy/constants.js
+++ b/scripts/deploy/constants.js
@@ -53,12 +53,17 @@ module.exports = {
   // fetching untrusted, user-supplied URLs. See config/airlock/README.md.
   //
   // Deployed as a single, standalone container - not blue/green/yellow -
-  // on its own Docker network. App containers are NOT switched onto this
-  // network at creation (that would move their default gateway off the
-  // bridge they're on today - see config/airlock/README.md's production
+  // on its own Docker network. App containers are NOT given `--network
+  // blotnet` at `docker create` (that would move their default gateway off
+  // the bridge they're on today - see config/airlock/README.md's production
   // note); instead the deploy script `docker network connect`s each app
-  // container to it after it starts, so they keep their original network
-  // and gain a second interface that can reach `blot-airlock`.
+  // container to it between `docker create` and `docker start`, so they keep
+  // their original bridge network and gateway and gain a second interface
+  // that can reach `blot-airlock`. Attaching the network before start (not
+  // after, as originally written) matters: connecting a network to an
+  // already-running container drops its in-flight connections - it was
+  // killing the app's established connections to the off-box Redis instance
+  // seconds after each deploy, one crash-restart per container.
   //
   // memory is deliberately tight. Idle (nginx + tinyproxy + a headless
   // Chromium with no page open) this sits under ~300m; it held up in

--- a/scripts/deploy/index.js
+++ b/scripts/deploy/index.js
@@ -159,7 +159,7 @@ async function getCurrentImageHash(containerName) {
 }
 
 async function deployContainer(container, platform, imageHash) {
-  const dockerRunCommand = await generateDockerCommand(
+  const dockerCreateCommand = await generateDockerCommand(
     container,
     platform,
     imageHash
@@ -167,7 +167,7 @@ async function deployContainer(container, platform, imageHash) {
 
   console.log(`Deploying ${container.name}... with command:`);
   console.log();
-  console.log(dockerRunCommand);
+  console.log(dockerCreateCommand);
   console.log();
 
   console.log("Pulling new image...");
@@ -194,8 +194,19 @@ async function deployContainer(container, platform, imageHash) {
     );
   }
   await removeContainer(container.name);
+
+  // Create the container stopped, attach the airlock network, THEN start it -
+  // so the app process finds its network in final shape and opens its Redis
+  // connections once. Connecting a network to an already-running container
+  // (the previous behaviour) dropped the app's in-flight connections to the
+  // off-box Redis instance, which surfaced as an unhandled `read ETIMEDOUT`
+  // that crash-restarted every container once per deploy. See
+  // generateDockerCommand.js and the AIRLOCK comment in ./constants.js.
+  console.log("Creating new container...");
+  await sshCommand(dockerCreateCommand);
+  await connectToAirlockNetwork(container.name);
   console.log("Starting new container...");
-  await sshCommand(dockerRunCommand);
+  await sshCommand(`docker start ${container.name}`);
   console.log("Checking health of new container...");
   await checkHealth(container.name, container.port);
 }
@@ -455,7 +466,11 @@ async function main() {
           `Image for ${container.name} is already deployed. Skipping...`
         );
         // Still ensure the network hookup exists even when we skip
-        // redeploying the container itself (e.g. a re-run of this script).
+        // redeploying the container itself (e.g. a re-run of this script, or a
+        // container whose create-time attach failed on the previous deploy).
+        // This is the one path that may attach the network to an
+        // already-running container; a normal deploy attaches it between
+        // `docker create` and `docker start` (see deployContainer).
         await connectToAirlockNetwork(container.name);
         continue;
       }
@@ -467,8 +482,8 @@ async function main() {
       }
 
       try {
+        // deployContainer attaches AIRLOCK.network between create and start.
         await deployContainer(container, platform, imageHash);
-        await connectToAirlockNetwork(container.name);
       } catch (error) {
         console.error(`Deployment failed for ${container.name}`);
 
@@ -489,7 +504,6 @@ async function main() {
         console.error("Rolling back...");
         try {
           await deployContainer(container, platform, rollbackHash);
-          await connectToAirlockNetwork(container.name);
           console.error("Rollback succeeded.");
         } catch (rollbackError) {
           console.error("Rollback failed:", rollbackError);

--- a/scripts/deploy/util/generateDockerCommand.js
+++ b/scripts/deploy/util/generateDockerCommand.js
@@ -171,11 +171,19 @@ async function generateDockerCommand(container, platform, commitHash) {
   // Sanitize inputs for command construction
   const sanitizedName = sanitizeString(containerName);
 
-  // Construct command string
+  // Construct command string.
+  //
+  // `docker create`, not `docker run`: the container is created stopped so the
+  // deploy script can attach it to AIRLOCK.network (see connectToAirlockNetwork
+  // in ../index.js) *before* it is started. Attaching a second network to an
+  // already-running container reprograms its routing table and drops in-flight
+  // conntrack entries - which killed the app's established connections to the
+  // off-box Redis instance seconds after every deploy, surfacing as an
+  // unhandled `read ETIMEDOUT` that crash-restarted each container exactly once.
+  // Creating stopped, connecting the network, then starting means the app opens
+  // its Redis connections once, after the network is already in its final shape.
   return [
-    "docker run",
-    // Run the container in the background
-    "-d",
+    "docker create",
     // If the container stops, restart it unless explicitly stopped
     "--restart unless-stopped",
     `--name ${sanitizedName}`,
@@ -198,9 +206,9 @@ async function generateDockerCommand(container, platform, commitHash) {
     // Routes bookmark-link screenshots (helper/screenshot) and remote-image
     // downloads (helper/transformer/download) through the airlock - see
     // config/airlock/README.md. This container is connected to
-    // AIRLOCK.network after it starts (see deployContainer/
-    // connectToAirlockNetwork in ../index.js), not via --network here - see
-    // the comment on AIRLOCK in ../constants.js for why.
+    // AIRLOCK.network between `docker create` and `docker start` (see
+    // deployContainer/connectToAirlockNetwork in ../index.js), not via
+    // --network here - see the comment on AIRLOCK in ../constants.js for why.
     `-e BLOT_AIRLOCK_BROWSER_URL=http://${AIRLOCK.name}:9222`,
     `-e BLOT_AIRLOCK_PROXY_URL=http://${AIRLOCK.name}:8888`,
     // Mount the data directory on the host to the container


### PR DESCRIPTION
## The problem

Right after every deploy, each app container crashes and restarts exactly once with an unhandled node-redis `error`:

```
Error: read ETIMEDOUT
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20)
Emitted 'error' event on Class instance at:
    ... #onSocketError (@redis/client/dist/lib/client/socket.js:286:14)
  errno: -110, code: 'ETIMEDOUT', syscall: 'read'
```

Key clue: this only happens **on a deploy**, never on a later `docker restart` or a monit-triggered restart — and it only started once the **airlock** landed.

## Cause

`deployContainer()` started the container (`docker run`), waited for its health check to pass, and *then* `connectToAirlockNetwork()` ran `docker network connect blotnet <container>` on the **already-running** container.

Attaching a second network to a running container reprograms its routing table and drops in-flight conntrack entries. The app had already opened long-lived connections to the **off-box Redis instance** (separate EC2 box, reached over the VPC — see `config/redis/scripts/setup.sh`). Those flows broke; ~110s later the kernel gave up (`errno -110`), node-redis emitted `error` on the dashboard clients in `app/dashboard/util/session.js` and `app/dashboard/log-in/rateLimit.js` (neither has an `error` listener), Node rethrew it, the process exited, and `--restart unless-stopped` brought it back — now dual-homed from the first instant, so it stayed healthy.

A later restart never reproduces it because nothing mutates the container's network after PID 1 is up. The two reverted Redis commits (`7c2593fe1`, `f836effcd`) suppressed the crash with an `error` listener but, with no command timeout and an unbounded offline queue, converted a one-restart blip into every dashboard/site request hanging on a client that wasn't reconnecting.

## The fix

Give the container its final network shape **before the app process starts**:

1. **`generateDockerCommand.js`** emits `docker create` instead of `docker run` (drops the run-only `-d`).
2. **`deployContainer()`** now does: `docker create` → `connectToAirlockNetwork()` → `docker start` → health check.
3. The redundant post-`deployContainer` `connectToAirlockNetwork()` calls in the deploy and rollback paths are removed. The "already deployed, skip" branch keeps its call — now the only path that may attach the network to a running container, and only as a recovery step.

End state is identical to today's steady state: bridge stays the primary network (gateway `172.17.0.1` untouched, so a hardcoded `BLOT_REDIS_HOST` / `BLOT_REVERSE_PROXY_URLS` is unaffected — the concern documented in `config/airlock/README.md`), `blotnet` is a second interface. It's just in place before the app opens a socket, so nothing is disrupted mid-flight.

Comments in `constants.js`, `generateDockerCommand.js`, and `config/airlock/README.md` step 3 are updated — they described "connect after start" as intentional.

## Not in this PR (deliberately)

An `error` listener on the two dashboard Redis clients is still worth adding as defence in depth against unrelated Redis blips — but paired with `disableOfflineQueue: true` + a `socket.connectTimeout` so it fails fast instead of hanging (the thing the reverted commits got wrong). Also worth a follow-up: a Redis-touching readiness route so `scripts/deploy/util/checkHealth.js` would actually catch a wedged container instead of green-lighting `res.send("OK")`.

## Testing

- `node -c` on both changed JS files; smoke-tested `generateDockerCommand()` output (starts with `docker create`, no `-d`, keeps `--restart unless-stopped`).
- No automated tests exist for `scripts/deploy`.
- **Needs a real deploy to confirm** — the deploy plumbing can't be exercised without the live host. Watch the container logs for the absence of the post-deploy `ETIMEDOUT` crash, and confirm `docker inspect <container>` shows both `bridge` and `blotnet` from first start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)