### PR TITLE
Require a paid PayPal seat before creating a site via /inform-paypal

### DIFF
--- a/app/dashboard/account/create-site.js
+++ b/app/dashboard/account/create-site.js
@@ -65,7 +65,7 @@ CreateBlog.route("/inform-paypal")
     });
   })
 
-  .post(saveBlog, (req, res) => {
+  .post(requirePaidPayPalSeat, saveBlog, (req, res) => {
     res.message('/sites/' + req.blog.handle, 'Created site');
   });
 
@@ -199,6 +199,48 @@ function validateSubscription (req, res, next) {
 }
 
 
+
+function getUserById (uid) {
+  return new Promise(function (resolve, reject) {
+    User.getById(uid, function (err, user) {
+      if (err) return reject(err);
+      resolve(user);
+    });
+  });
+}
+
+// The /inform-paypal page is shown precisely when the user has NOT yet paid
+// for the seat they're trying to create. Its POST used to call saveBlog with
+// no further check, so a PayPal user could create unlimited sites for free by
+// POSTing here directly (bypassing the PayPal "revise" step). Before creating
+// the site, refetch the live subscription from PayPal and require the paid
+// quantity to actually exceed the current blog count - the same entitlement
+// the main create-site route enforces. If they still haven't paid, send them
+// back to the pay page instead of creating the site.
+async function requirePaidPayPalSeat (req, res, next) {
+  // The blog count is stable for the duration of this request.
+  var blogCount = req.user.blogs.length;
+
+  try {
+    if (req.user.paypal && req.user.paypal.id) {
+      // updatePayPalSubscription refetches from PayPal and persists it.
+      await updatePayPalSubscription(req.user.paypal.id);
+      // Reload so we read the freshly-persisted quantity, not the stale one.
+      var fresh = await getUserById(req.user.uid);
+      if (fresh && fresh.paypal) req.user.paypal = fresh.paypal;
+    }
+  } catch (err) {
+    return next(err);
+  }
+
+  var paidQuantity = req.user.paypal
+    ? parseInt(req.user.paypal.quantity, 10)
+    : 0;
+
+  if (paidQuantity > blogCount) return next();
+
+  res.redirect(req.baseUrl + "/inform-paypal");
+}
 
 function saveBlog (req, res, next) {
   var title, handle;


### PR DESCRIPTION
Hi, it's Claude (Opus 4.8; Effort: Low), following up on the security report you kindly invited PRs for — this addresses **"Unlimited free sites for PayPal customers"** from report 5.

### The problem
`/sites/account/create-site/inform-paypal` is shown only when a PayPal user has **not** yet paid for the extra seat. Its `POST` handler called `saveBlog` unconditionally, so a PayPal user could create additional sites without paying by POSTing to it directly, bypassing the PayPal "revise" step. (The main `create-site` route does gate on the paid quantity; this route didn't.)

### The fix
Adds a `requirePaidPayPalSeat` middleware before `saveBlog` on that POST. It refetches the live subscription from PayPal (reusing the existing `updatePayPalSubscription` helper), reloads the persisted quantity, and requires it to exceed the current blog count — the same entitlement the main route enforces. If the user still hasn't paid, they're redirected back to the pay page instead of a site being created.

### Notes
- Only PayPal users reach `/inform-paypal` (Stripe users are redirected upstream), and `blogCount` is captured before the refetch, so the check can't be raced by its own mutation. Both `await`s are inside a `try` → `next(err)`, so there's no unhandled rejection.
- **Not run against a live server** — I don't have your PayPal environment. I verified the control flow and syntax; a quick check against a real revise flow would be worth doing, since it depends on PayPal reflecting the new quantity by the time the refetch runs (a lag there is a fail-closed "please retry", not a bypass).

Happy to adjust the approach if you'd rather enforce this differently.
