### PR TITLE
Harden payment webhooks (opt-in signature verification) and PayPal signup

### DIFF
--- a/app/dashboard/sign-up/paypal.js
+++ b/app/dashboard/sign-up/paypal.js
@@ -29,7 +29,28 @@ paypal.get("/", async (req, res, next) => {
       }
     );
 
+    if (!response.ok) {
+      return next(new Error("Could not verify subscription with PayPal"));
+    }
+
     const json = await response.json();
+
+    // Only accept an active subscription on a plan Blot actually sells - a
+    // cancelled, suspended or legacy-plan subscription id must not create an
+    // account.
+    const configuredPlans = Object.values(config.paypal.plans || {}).filter(
+      Boolean
+    );
+    if (
+      !["ACTIVE", "APPROVED"].includes(json.status) ||
+      (configuredPlans.length && !configuredPlans.includes(json.plan_id))
+    ) {
+      return next(new Error("Subscription is not active on a valid plan"));
+    }
+
+    if (!json.subscriber || !json.subscriber.email_address) {
+      return next(new Error("No subscriber email from PayPal"));
+    }
 
     req.session.paypal = json;
     req.session.email = json.subscriber.email_address;

--- a/app/dashboard/webhooks/paypal_webhook.js
+++ b/app/dashboard/webhooks/paypal_webhook.js
@@ -18,16 +18,78 @@ const SUBSCRIPTION_EVENTS = [
 
 const prefix = () => `${clfdate()} PayPal Webhook:`;
 
+// Verify an incoming PayPal webhook via PayPal's verify-webhook-signature API.
+// Returns true when verification succeeds - or when no webhook id is configured,
+// in which case verification is skipped and the previous behaviour preserved,
+// so this is safe to deploy before BLOT_PAYPAL_WEBHOOK_ID is set.
+const verifyPayPalWebhook = async req => {
+  const webhookId = config.paypal.webhook_id;
+
+  if (!webhookId) {
+    console.warn(
+      prefix(),
+      "signature NOT verified - set BLOT_PAYPAL_WEBHOOK_ID to enable"
+    );
+    return true;
+  }
+
+  const response = await fetch(
+    `${config.paypal.api_base}/v1/notifications/verify-webhook-signature`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Basic ${Buffer.from(
+          `${config.paypal.client_id}:${config.paypal.secret}`
+        ).toString("base64")}`
+      },
+      body: JSON.stringify({
+        auth_algo: req.headers["paypal-auth-algo"],
+        cert_url: req.headers["paypal-cert-url"],
+        transmission_id: req.headers["paypal-transmission-id"],
+        transmission_sig: req.headers["paypal-transmission-sig"],
+        transmission_time: req.headers["paypal-transmission-time"],
+        webhook_id: webhookId,
+        webhook_event: req.body
+      })
+    }
+  );
+
+  const json = await response.json();
+
+  return json.verification_status === "SUCCESS";
+};
+
 paypal.post("/", parser.json(), async (req, res) => {
-  // if the webhook is for a subscription-related event
-  // update the subscription
-  if (SUBSCRIPTION_EVENTS.includes(req.body.event_type)) {
-    // pass the subscription ID to the updateSubscription function
-    console.log(prefix(), req.body.event_type, req.body.resource.id);
+  // Verify the webhook signature when a webhook id is configured (see above).
+  try {
+    const verified = await verifyPayPalWebhook(req);
+    if (!verified) {
+      console.log(prefix(), "signature verification failed");
+      return res.status(400).send("Invalid signature");
+    }
+  } catch (err) {
+    console.log(prefix(), "signature verification error", err);
+    return res.sendStatus(400);
+  }
+
+  const eventType = req.body && req.body.event_type;
+  // resource.id used to be read unconditionally, which threw - and crashed the
+  // process via an unhandled rejection - on any request without a resource.
+  const subscriptionID =
+    req.body && req.body.resource && req.body.resource.id;
+
+  // if the webhook is for a subscription-related event, update the subscription
+  if (SUBSCRIPTION_EVENTS.includes(eventType)) {
+    if (!subscriptionID) {
+      console.log(prefix(), "missing resource.id for", eventType);
+      return res.sendStatus(400);
+    }
+
+    console.log(prefix(), eventType, subscriptionID);
 
     try {
-      console.log(prefix(), "Updating subscriptionID=", req.body.resource.id);
-      await updateSubscription(req.body.resource.id);
+      await updateSubscription(subscriptionID);
       console.log(prefix(), "Updated subscription successfully");
     } catch (err) {
       console.log(prefix(), err);

--- a/app/dashboard/webhooks/stripe_webhook.js
+++ b/app/dashboard/webhooks/stripe_webhook.js
@@ -79,14 +79,64 @@ function getStripeClient() {
 //   state from Stripe.
 // - There are probably other things I'm missing....
 
-webhooks.post("/", parser.json(), function (req, res) {
+// If a signing secret is configured we verify Stripe's signature over the raw
+// request body and construct the event via the Stripe SDK. If it is not
+// configured we fall back to parsing the (unverified) body, so this change is
+// safe to deploy before BLOT_STRIPE_WEBHOOK_SECRET is set. Returns the event,
+// or null after already sending an error response.
+function verifyStripeEvent(req, res) {
+  var rawBody = req.body;
+  var signingSecret = config.stripe && config.stripe.webhook_secret;
+
+  if (signingSecret) {
+    var stripe = getStripeClient();
+
+    if (!stripe || !stripe.webhooks || !stripe.webhooks.constructEvent) {
+      console.error(NO_STRIPE_CLIENT);
+      res.sendStatus(500);
+      return null;
+    }
+
+    try {
+      return stripe.webhooks.constructEvent(
+        rawBody,
+        req.headers["stripe-signature"],
+        signingSecret
+      );
+    } catch (err) {
+      console.error("Stripe webhook signature verification failed:", err.message);
+      res.sendStatus(400);
+      return null;
+    }
+  }
+
+  // No signing secret configured: preserve the previous, unverified behaviour.
+  console.warn(
+    "Stripe webhook signature NOT verified - set BLOT_STRIPE_WEBHOOK_SECRET to enable"
+  );
+
+  try {
+    return Buffer.isBuffer(rawBody)
+      ? JSON.parse(rawBody.toString("utf8"))
+      : rawBody;
+  } catch (err) {
+    console.error("Stripe webhook body is not valid JSON");
+    res.sendStatus(400);
+    return null;
+  }
+}
+
+webhooks.post("/", parser.raw({ type: "application/json" }), function (req, res) {
   // Down for maintenance, Stripe should
   // back off and try again later.
   if (config.maintenance) return res.sendStatus(503);
 
-  var event = req.body;
+  var event = verifyStripeEvent(req, res);
 
-  if (!event || !event.type) {
+  // verifyStripeEvent has already sent a response if it returned null.
+  if (!event) return;
+
+  if (!event.type) {
     console.error("Stripe webhook missing event type");
     return res.sendStatus(400);
   }

--- a/config/index.js
+++ b/config/index.js
@@ -115,6 +115,10 @@ module.exports = {
   stripe: {
     key: process.env.BLOT_STRIPE_KEY,
     secret: process.env.BLOT_STRIPE_SECRET,
+    // When set, incoming Stripe webhooks are verified against this signing
+    // secret (see app/dashboard/webhooks/stripe_webhook). Leave it unset to
+    // skip verification, preserving the previous behaviour.
+    webhook_secret: process.env.BLOT_STRIPE_WEBHOOK_SECRET,
     // Ensure that each monthly plan has a corresponding
     // annual plan, and vice versa, and that these IDs
     // correspond to plans on Stripe in both live and
@@ -167,6 +171,10 @@ module.exports = {
   paypal: {
     client_id: process.env.BLOT_PAYPAL_CLIENT_ID,
     secret: process.env.BLOT_PAYPAL_SECRET,
+    // When set, incoming PayPal webhooks are verified via PayPal's
+    // verify-webhook-signature API (see app/dashboard/webhooks/paypal_webhook).
+    // Leave it unset to skip verification, preserving the previous behaviour.
+    webhook_id: process.env.BLOT_PAYPAL_WEBHOOK_ID,
 
     plan: process.env.BLOT_PAYPAL_MONTHLY_6,
 


### PR DESCRIPTION
Hi, it's Claude (Opus 4.8; Effort: Low), following up on the security report — this covers the two remaining webhook items from report 5: **"Stripe & PayPal webhooks are not signature-verified"** and **"Unauthenticated webhook process crash + no PayPal signup validation"**.

### Designed to be safe to merge first
Signature verification is **opt-in and fail-safe**: it activates only when a secret is configured, and otherwise preserves the current (unverified) behaviour. So merging and deploying this changes **nothing functional** until you set the env vars — you can enable enforcement on your own schedule.

- `BLOT_STRIPE_WEBHOOK_SECRET` → verify Stripe events over the raw body via `stripe.webhooks.constructEvent`.
- `BLOT_PAYPAL_WEBHOOK_ID` → verify PayPal events via the `verify-webhook-signature` API.

Both are wired through `config` (`config.stripe.webhook_secret`, `config.paypal.webhook_id`).

### The three changes
1. **Webhook signature verification** (opt-in, as above). The Stripe route switches to `express.raw` so the signature can be checked over the exact bytes; when no secret is set it JSON-parses the same body, so downstream logic is unchanged.
2. **PayPal crash guard.** `req.body.resource.id` was read unconditionally in an `async` handler, so a `POST /paypal-webhook` with no `resource` threw and took the process down via an unhandled rejection. It now returns `400` for a subscription event missing an id.
3. **PayPal signup validation.** `sign-up/paypal.js` now requires `response.ok`, an `ACTIVE`/`APPROVED` status and a configured `plan_id`, and guards the `subscriber` dereference — so an arbitrary (cancelled/suspended/legacy-plan) subscription id can no longer create an account.

### Notes / things to check on your side
- `stripe.webhooks.constructEvent` requires a Stripe SDK that exposes `.webhooks` (your pin is `6.36.0` — it's there, but worth a sanity check); if it's ever missing the code returns `500` rather than crashing.
- The PayPal `verify-webhook-signature` call passes the parsed event as `webhook_event`, per PayPal's documented flow — worth confirming against a real signed webhook in your environment before you flip `BLOT_PAYPAL_WEBHOOK_ID` on.
- **Not run against a live server.** Verified control flow and syntax only.

I split these from the free-sites fix (#1733) so each is reviewable on its own. Glad the reports were useful — thank you for the thoughtful responses.
