### PR TITLE
CI: skip the image build+push jobs on fork PRs (fixes the red builds)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,13 @@ env:
 
 jobs:
   build:
+    # A PR from a fork runs with a read-only GITHUB_TOKEN and cannot push to
+    # this repo's container registry ("denied: installation not allowed to
+    # Write organization package"), so skip the image build+push for forks.
+    # This still runs on pushes to master and on PRs from branches of this
+    # repo; the manifest job below is skipped automatically because it needs
+    # this one. (Tests in the other workflows still run for fork PRs.)
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     strategy:
       matrix:
         include:
@@ -142,6 +149,9 @@ jobs:
   # scripts/deploy/index.js expects a manifest for every commit's SHA to
   # exist, same as the app image.
   build-airlock:
+    # Skipped for fork PRs for the same reason as the build job above; the
+    # manifest-airlock job needs this one and is skipped automatically.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Hi, it's Claude (Opus 4.8; Effort: Low) again — this is the small CI fix I offered for the red builds on my other two PRs (#1733, #1734), sent separately so it's easy to take or leave.

### Why those builds go red
The `build` and `build-airlock` jobs push images to `ghcr.io/davidmerfield/blot`. A PR **from a fork** runs with a read-only `GITHUB_TOKEN`, so the push step fails:

```
#29 ERROR: failed to push ghcr.io/davidmerfield/blot:...-amd64:
denied: installation not allowed to Write organization package
```

The image builds fine — it only fails at the final registry push. (The `test` jobs all pass, which is why #1733/#1734 are otherwise green.)

### This change
Gates `build` and `build-airlock` on the run being a push, or a PR from a branch of this repo:

```yaml
if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
```

- **Your push-to-master and same-repo PR builds are unchanged** — the condition is `true` for them, so those jobs run exactly as before.
- Fork PRs **skip** these jobs (skipped ≠ failed), so they stop showing a red ✗. The `manifest` / `manifest-airlock` jobs `need:` the builds, so they skip automatically.
- Test workflows still run for fork PRs.

### One caveat, and an alternative
I picked the low-risk option: skipping means a fork PR gets **no** Docker-build validation (it gets none today either, since it fails). If you'd rather **keep** the build + health-check on forks and only skip the push, the alternative is `push: false` + `load: true` (so the health check runs against the locally-built image) with the registry `cache-to`/manifest steps gated the same way. Happy to send that version instead if you prefer it — I went with the simpler one because I can't run Actions locally to fully verify the more involved change.

I couldn't validate this against your live Actions setup (only that the YAML parses and the condition logic is right), so give it a sanity check before merging.
