### PR TITLE
CI: build images on fork PRs without pushing to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,12 @@ permissions:
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/blot
   AIRLOCK_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/blot-airlock
+  # True for push builds and PRs from a branch of this repo; false for PRs
+  # from a fork, whose GITHUB_TOKEN is read-only and cannot write to GHCR.
+  # Fork PRs still build the images and run the health checks locally
+  # (push: false, load: true) - they just skip the registry push, the
+  # registry cache export, and the manifest jobs.
+  PUSH_IMAGES: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
 jobs:
   build:
@@ -53,20 +59,24 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       # Per-arch registry cache. Keeps layers hot on each native runner.
-      - name: Build and push (${{ matrix.arch }})
+      - name: Build ${{ env.PUSH_IMAGES == 'true' && 'and push' || '(local only)' }} (${{ matrix.arch }})
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           target: prod
           platforms: ${{ matrix.platform }}          # native, no QEMU
-          push: true
+          # Fork PRs cannot push to GHCR - build locally and load into the
+          # runner's Docker so the health check below still has an image.
+          push: ${{ env.PUSH_IMAGES == 'true' }}
+          load: ${{ env.PUSH_IMAGES != 'true' }}
           tags: |
             ${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: |
             type=registry,ref=${{ env.IMAGE_NAME }}:cache-${{ matrix.arch }}
-          cache-to: |
-            type=registry,ref=${{ env.IMAGE_NAME }}:cache-${{ matrix.arch }},mode=max
+          # Registry cache export needs write access, which fork PRs lack -
+          # skip it there rather than fail the build.
+          cache-to: ${{ env.PUSH_IMAGES == 'true' && format('type=registry,ref={0}:cache-{1},mode=max', env.IMAGE_NAME, matrix.arch) || '' }}
 
       - name: Verify health check (${{ matrix.arch }})
         env:
@@ -105,7 +115,8 @@ jobs:
   manifest:
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ always() && needs.build.result == 'success' }}
+    # Nothing was pushed on a fork PR, so there is no manifest to assemble.
+    if: ${{ always() && needs.build.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -167,18 +178,22 @@ jobs:
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push airlock (${{ matrix.arch }})
+      - name: Build ${{ env.PUSH_IMAGES == 'true' && 'and push' || '(local only)' }} airlock (${{ matrix.arch }})
         uses: docker/build-push-action@v6
         with:
           context: config/airlock
           platforms: ${{ matrix.platform }}
-          push: true
+          # Fork PRs cannot push to GHCR - build locally and load into the
+          # runner's Docker so the egress-filter check below still has an image.
+          push: ${{ env.PUSH_IMAGES == 'true' }}
+          load: ${{ env.PUSH_IMAGES != 'true' }}
           tags: |
             ${{ env.AIRLOCK_IMAGE_NAME }}:${{ github.sha }}-${{ matrix.arch }}
           cache-from: |
             type=registry,ref=${{ env.AIRLOCK_IMAGE_NAME }}:cache-${{ matrix.arch }}
-          cache-to: |
-            type=registry,ref=${{ env.AIRLOCK_IMAGE_NAME }}:cache-${{ matrix.arch }},mode=max
+          # Registry cache export needs write access, which fork PRs lack -
+          # skip it there rather than fail the build.
+          cache-to: ${{ env.PUSH_IMAGES == 'true' && format('type=registry,ref={0}:cache-{1},mode=max', env.AIRLOCK_IMAGE_NAME, matrix.arch) || '' }}
 
       - name: Verify egress filter (${{ matrix.arch }})
         env:
@@ -286,7 +301,8 @@ jobs:
   manifest-airlock:
     needs: build-airlock
     runs-on: ubuntu-latest
-    if: ${{ always() && needs.build-airlock.result == 'success' }}
+    # Nothing was pushed on a fork PR, so there is no manifest to assemble.
+    if: ${{ always() && needs.build-airlock.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
       - name: Login to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
## Problem

`build` and `build-airlock` in [`.github/workflows/build.yml`](.github/workflows/build.yml) push images to `ghcr.io/davidmerfield/blot`. A `pull_request` **from a fork** runs with a read-only `GITHUB_TOKEN` (GitHub caps this for untrusted forks regardless of the `permissions:` block), so the final push fails:

```
denied: installation not allowed to Write organization package
```

The image builds fine — only the registry push fails — but the PR still shows a red ✗. This is what's reddening #1733 / #1734. See #1735 for the original report.

## Approach

Rather than skipping the build jobs on fork PRs (which loses build + health-check validation), keep building and only gate the registry writes.

A new `PUSH_IMAGES` flag is `true` for pushes and same-repo PRs, `false` for fork PRs:

```yaml
PUSH_IMAGES: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
```

- **Push builds and same-repo PRs are unchanged** — the condition is `true`, so `push: true`, registry `cache-to`, and the manifest jobs all run exactly as before.
- **Fork PRs** build with `push: false` + `load: true`, so the per-arch image is loaded into the runner's Docker and the existing `Verify health check` / `Verify egress filter` steps run against it. They skip the registry cache export and the `manifest` / `manifest-airlock` jobs (skipped ≠ failed).
- `test` workflows are untouched.

| fork PR | before | after |
|---|---|---|
| image builds | ✗ (fails at push) | ✓ builds, loaded locally |
| health / egress checks | not reached | ✓ run against loaded image |
| pushed to GHCR | — | — (skipped, green) |

## Notes

- `load: true` is safe here because each matrix leg is a single native platform (`ubuntu-latest` / `ubuntu-24.04-arm`).
- YAML parses; the expression logic is verified by hand. Couldn't exercise it against live Actions — worth a sanity check that a same-repo PR run is byte-for-byte identical.
- Keep first-time-contributor workflow approval on; it's an orthogonal safety gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)