### PR TITLE
Regression coverage: reset post date when Date metadata is removed

### DIFF
--- a/TODO
+++ b/TODO
@@ -1257,9 +1257,6 @@ Adjust length of slug to use as few words as possible until collision and tell [
 
 --- 
 
-Metadata parser
-- Removing Date metadata from a post should reset its date to the file's creation date. Currently nothing changes.
-
 Improve 404 log page on Dashboard
 - Make the 404 page more useful (see Netlify site)
 - Add button to clear 404 log and tell [Jamie](https://mail.google.com/mail/u/0/#inbox/FMfcgxwBVDLzTVpVZHfgwRgcmtGXFHXx)

--- a/app/sync/tests/dateStamp.js
+++ b/app/sync/tests/dateStamp.js
@@ -1,0 +1,50 @@
+describe("dateStamp", function () {
+  // Set up a test blog before each test
+  global.test.blog();
+
+  it("resets a post's date to its created date when Date metadata is removed", async function (done) {
+    const path = "/dated-post.txt";
+    const metadataDate = 1577836800000; // 2020-01-01T00:00:00Z
+
+    // Publish the post with an explicit Date in its metadata
+    await this.blog.write({ path, content: "Date: 2020-01-01\n\nHello" });
+    await this.blog.rebuild();
+
+    const withDate = await this.blog.check({ path });
+    expect(withDate.dateStamp).toEqual(metadataDate);
+
+    // Remove the Date metadata and rebuild the same file
+    await this.blog.write({ path, content: "Hello" });
+    await this.blog.rebuild();
+
+    const withoutDate = await this.blog.check({ path });
+
+    // The stale date from the removed metadata must not linger
+    expect(withoutDate.dateStamp).not.toEqual(metadataDate);
+
+    // With no date in the metadata or the path, the post falls back
+    // to the date it was first created on
+    expect(withoutDate.dateStamp).toEqual(withoutDate.created);
+
+    done();
+  });
+
+  it("recovers the Date metadata timestamp when it is added back", async function (done) {
+    const path = "/toggled-date-post.txt";
+    const metadataDate = 1577836800000; // 2020-01-01T00:00:00Z
+
+    await this.blog.write({ path, content: "Hello" });
+    await this.blog.rebuild();
+
+    const withoutDate = await this.blog.check({ path });
+    expect(withoutDate.dateStamp).toEqual(withoutDate.created);
+
+    await this.blog.write({ path, content: "Date: 2020-01-01\n\nHello" });
+    await this.blog.rebuild();
+
+    const withDate = await this.blog.check({ path });
+    expect(withDate.dateStamp).toEqual(metadataDate);
+
+    done();
+  });
+});


### PR DESCRIPTION
## What

Adds an integration regression test for the TODO item _"Removing Date metadata from a post should reset its date to the file's creation date"_ and removes that item from `TODO`.

## Why

Investigating the TODO, the behaviour it describes ("Currently nothing changes") is already fixed:

- `app/build/index.js` sets `dateStampWasRemoved` when the date helper returns `undefined` (no `Date:` metadata and no date in the path).
- `app/models/entry/set.js` sees that flag, deletes the stale `dateStamp` carried over from the previous build, and falls back to `entry.created`.

The date helper (`app/build/prepare/dateStamp`) correctly falls back, and the entry state is not stale across a rebuild. What was missing was a test exercising the **full sync → rebuild → `Entry.set`** path, so a future change can't silently reintroduce the stale date.

## Test

`app/sync/tests/dateStamp.js`:

1. Publish a post with `Date: 2020-01-01`, rebuild, assert `dateStamp` is the 2020 timestamp.
2. Remove the `Date:` line, rebuild, assert the stale 2020 timestamp is gone and `dateStamp === created`.
3. Add the `Date:` line back, rebuild, assert the 2020 timestamp is recovered.

Both specs pass (`npm test app/sync/tests/dateStamp.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)