### PR TITLE
Add regression test for unresolved same-page anchor wikilinks

### DIFF
--- a/app/build/tests/plugins/wikilinks.js
+++ b/app/build/tests/plugins/wikilinks.js
@@ -122,6 +122,20 @@ Heading Here
     this.buildAndCheck({ path, contents }, { html }, done);
   });
 
+  // Regression test for https://blot.im/questions/2670 - a wikilink to a
+  // same-page anchor with no matching heading used to be reported as
+  // breaking the build ("File is not a post or page"). The build should
+  // succeed and the unresolved link should be left in place.
+  it("will not break the build for an unresolved same-page anchor", function (done) {
+    const contents = "Hello world\n\nSee [[#missing-heading]] and [[#text]] here.";
+    const path = "/hello.txt";
+    const html =
+      '<p>Hello world</p>\n<p>See <a href="#missing-heading" class="wikilink">#missing-heading</a> and <a href="#text" class="wikilink">#text</a> here.</p>';
+
+    this.blog.plugins.wikilinks = { enabled: true, options: {} };
+    this.buildAndCheck({ path, contents }, { html }, done);
+  });
+
   it("will convert wikilinks next to ignored nodes", function (done) {
     const contents =
       "<script>console.log('hey');</script>\n\nA **[[wikilink elsewhere]]** ";


### PR DESCRIPTION
## What

Adds one test to `app/build/tests/plugins/wikilinks.js` covering a wikilink to a same-page heading anchor that has **no matching heading** (e.g. `[[#missing-heading]]`).

## Why

Victor reported ([blot.im/questions/2670](https://blot.im/questions/2670), TODO item) that `[[#xxxx]]` in a post "breaks the backend" — the synced file wouldn't publish and the dashboard showed *"File is not a post or page"* (i.e. the build threw and no entry was saved).

I could not reproduce this on current code, nor after rolling the wikilinks plugin + resolvers back to the July 2024 version, nor with pandoc 3.1.1 vs 3.6.1. The plugin was rewritten in Oct 2025 (`0d95a765a`, `81e0430cb`) to support heading-anchor links as a real feature, and the no-match case now falls through gracefully — the build succeeds and the link is left in place as `<a href="#missing-heading" class="wikilink">`.

There was test coverage for anchors that *resolve*, but none for the unresolved case that was originally reported. This locks in the current behaviour.

## Test

`npm test app/build/tests/plugins/wikilinks.js` — 36 specs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)