### PR TITLE
Fix backlinks when the linking entry is a page

### DIFF
--- a/TODO
+++ b/TODO
@@ -399,8 +399,6 @@ Fix bug parsing ISO8601 date format and tell [Thomas](https://mail.google.com/ma
 
 Fix bug with Client.write which does not propogate sync errors... to demonstrate this, revoke dropbox token then try to enable local editing.
 
-Fix bug with pages not appearing in backlinks and [tell questioner](https://blot.im/questions/2913)
-
 Fix bug with magic text in posts which breaks backend and tell [Victor](https://mail.google.com/mail/u/0/#inbox/FMfcgzQVxRMzjBtRWVwLWtlBcFGsSVCQ)
 
 Fix bug with Google Drive client and [Stephen's large blog](https://mail.google.com/mail/u/0/#inbox/QgrcJHsBsbkNkMkkkMmLWBxRfnGnWPVwLHl)

--- a/app/blog/tests/backlinks.js
+++ b/app/blog/tests/backlinks.js
@@ -6,6 +6,47 @@ describe("backlinks", function () {
       "{{#entry}}{{#backlinks.length}}Backlinks: {{#backlinks}}{{title}}{{/backlinks}}{{/backlinks.length}}{{/entry}}",
   };
 
+  it("renders a backlink when a page links to another page", async function () {
+    // Pages have no entry.permalink (only posts and entries with an
+    // explicit Permalink/Link/Url do), so the linking page has to be
+    // attributed by its entry.url instead or it never registers as
+    // the source of a backlink.
+    await this.write({
+      path: "/pages/target.txt",
+      content: "Page: yes\nTitle: Target Page\n\nContent.",
+    });
+    await this.write({
+      path: "/pages/linker.txt",
+      content: "Page: yes\nTitle: Linker Page\n\n[see target](/target-page)",
+    });
+    await this.template(backlinksTemplate);
+
+    const body = await this.text("/target-page");
+    expect(body).toContain("Backlinks:");
+    expect(body).toContain("Linker Page");
+  });
+
+  it("renders multiple backlinks when several pages link to the same page", async function () {
+    await this.write({
+      path: "/pages/target.txt",
+      content: "Page: yes\nTitle: Target Page\n\nContent.",
+    });
+    await this.write({
+      path: "/pages/linker-a.txt",
+      content: "Page: yes\nTitle: Linker A\n\n[target](/target-page)",
+    });
+    await this.write({
+      path: "/pages/linker-b.txt",
+      content: "Page: yes\nTitle: Linker B\n\n[target](/target-page)",
+    });
+    await this.template(backlinksTemplate);
+
+    const body = await this.text("/target-page");
+    expect(body).toContain("Backlinks:");
+    expect(body).toContain("Linker A");
+    expect(body).toContain("Linker B");
+  });
+
   it("renders backlinks when another post links via markdown", async function () {
     await this.write({ path: "/target.txt", content: "Title: Target\n\nContent." });
     await this.write({

--- a/app/models/entry/_backlinksToUpdate.js
+++ b/app/models/entry/_backlinksToUpdate.js
@@ -17,8 +17,21 @@ function backlinksToUpdate(
 	entry,
 	previousInternalLinks,
 	previousPermalink,
+	previousUrl,
 	callback
 ) {
+	if (typeof previousUrl === "function") {
+		callback = previousUrl;
+		previousUrl = undefined;
+	}
+
+	// The value we record on other entries' backlinks lists to point back
+	// at this entry. Pages (and any entry without an explicit Permalink/
+	// Link/Url in their metadata) have an empty entry.permalink, so fall
+	// back to entry.url - the URL the entry is actually served from - or
+	// they can never appear as the *source* of a backlink.
+	const permalink = entry.permalink || entry.url;
+	const formerPermalink = previousPermalink || previousUrl;
 	// Since this post is no longer available, none of its current or former
 	// links are present. Remove everything.
 	// Since this post exists, we need to work out which dependencies were
@@ -64,18 +77,17 @@ function backlinksToUpdate(
 				.filter((link) => validInternalLinks.indexOf(link) > -1)
 				.forEach((link) => {
 					changes[link].backlinks = changes[link].backlinks.filter(
-						(link) =>
-							link !== entry.permalink && link !== entry.previousPermalink
+						(link) => link !== permalink && link !== formerPermalink
 					);
 				});
 
 			currentInternalLinks
 				.filter((link) => validInternalLinks.indexOf(link) > -1)
 				.forEach((link) => {
-					changes[link].backlinks.push(entry.permalink);
-					if (entry.permalink !== previousPermalink) {
+					if (permalink) changes[link].backlinks.push(permalink);
+					if (permalink !== formerPermalink) {
 						changes[link].backlinks = changes[link].backlinks.filter(
-							(link) => link !== previousPermalink
+							(link) => link !== formerPermalink
 						);
 					}
 				});

--- a/app/models/entry/set.js
+++ b/app/models/entry/set.js
@@ -196,6 +196,7 @@ module.exports = function set (blogID, path, updates, callback) {
                 entry,
                 previousInternalLinks,
                 previousPermalink,
+                previousUrl,
                 function (err, changes) {
                   if (err) return callback(err);
 


### PR DESCRIPTION
## Problem

Reported in [blot.im/questions/2913](https://blot.im/questions/2913). A user building a Zettelkasten out of **pages**:

- A **post** linking to a page produces a backlink. ✅
- A **page** linking to another page produces **no** backlink. ❌
- `{{#backlinks}}` "suddenly" returns only one link instead of all matches.

## Root cause

`_backlinksToUpdate.js` records the linking entry on its targets' `backlinks` lists using `entry.permalink`. But `entry.permalink` is only populated for posts and for entries with an explicit `Permalink:` / `Link:` / `Url:` in their metadata — for a plain page it is `""` (`app/build/prepare/index.js`: `entry.permalink = permalinkCandidates.shift() || ""`).

So every page-sourced backlink is pushed as `""`. `_.uniq()` collapses all of them to a single `""`, and `augment.js` discards it at render time (`getByUrl(blogID, "")` resolves to nothing). That is also why a page-based Zettelkasten sees "only one backlink" — all page links dedupe to one dead entry, leaving only post links.

The entry's real served URL (`entry.url`) is already resolved at this point; it just wasn't the value being used.

## Fix

- `_backlinksToUpdate.js`: attribute by `entry.permalink || entry.url`, and prune stale backlinks on rename by `previousPermalink || previousUrl`. Guard against pushing a falsy value.
- `set.js`: pass the already-computed `previousUrl` through. New arg sits before the callback with a `typeof` guard for any direct caller still using the old arity.

## Tests

`app/blog/tests/backlinks.js` — two new specs:

- `renders a backlink when a page links to another page`
- `renders multiple backlinks when several pages link to the same page`

Both fail on `master` and pass with this change. Full `app/blog/tests/backlinks.js` (19 specs) and `app/models/entry/tests/backlinks.js` (8 specs) pass.

## Not included

Ray also asked for a per-page frontmatter opt-out to suppress backlinks on pages where they aren't wanted. That is a separate feature and is not addressed here.

## Migration note

Stale `""` values already stored in existing blogs' backlink arrays are harmless (filtered at render) and clear on the next rebuild of each target; a full site rebuild removes them immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)