### PR TITLE
Exclude pages and menu entries from tag indexes

### DIFF
--- a/TODO
+++ b/TODO
@@ -235,8 +235,6 @@ Fix bug with [~/gitbug folder](https://mail.google.com/mail/u/0/#inbox/KtbxLxgKJ
 
 Fix bug with auto heading injector and tell [Chuck](https://mail.google.com/mail/u/0/#inbox/FMfcgzQgKvJFLPslvxmlmMBnmcQQTqzq)
 
-Fix bug where pages where appearing in the list of posts filtered by path_prefix AND tag – e.g. /work/tagged/automotive and tell Chuck
-
 Fix bug with huge draft crashing the sync server /a327ex/drafts/it_follows.txt
 - Chunk large drafts into multiple messages to avoid memory issues? 
 

--- a/app/blog/render/retrieve/tests/tagged.js
+++ b/app/blog/render/retrieve/tests/tagged.js
@@ -112,7 +112,7 @@ describe("tagged block", function () {
         locals: {
           path_prefix: "/blog/",
         },
-      }
+      },
     );
 
     const res = await this.get("/tagged/foo");
@@ -122,7 +122,39 @@ describe("tagged block", function () {
     expect(body.trim()).toEqual("<ul><li>Three</li><li>One</li></ul>");
   });
 
+  it("excludes pages from tagged listings and pagination totals", async function () {
+    await this.write({
+      path: "/work/post.txt",
+      content: "Title: Car post\nTags: automotive\n\nPost body",
+    });
+    await this.write({
+      path: "/work/page.txt",
+      content: "Title: Car page\nTags: automotive\nPage: yes\n\nPage body",
+    });
 
+    await this.template(
+      {
+        "tagged.html": `{{#tagged}}{{total}}|{{pagination.total}}|{{#entries}}{{title}}{{/entries}}{{/tagged}}`,
+      },
+      {
+        views: {
+          "tagged.html": {
+            url: ["/work/tagged/:tag", "/work/tagged/:tag/page/:page"],
+          },
+        },
+        locals: {
+          path_prefix: "/work/",
+          tagged_page_size: 1,
+        },
+      },
+    );
+
+    const res = await this.get("/work/tagged/automotive");
+    const body = await res.text();
+
+    expect(res.status).toEqual(200);
+    expect(body.trim()).toEqual("1|1|Car post");
+  });
 
   it("treats empty and whitespace path_prefix as disabled filtering", async function () {
     await this.write({
@@ -142,7 +174,7 @@ describe("tagged block", function () {
         locals: {
           path_prefix: "   ",
         },
-      }
+      },
     );
 
     const res = await this.get("/tagged/foo");
@@ -170,7 +202,7 @@ describe("tagged block", function () {
         locals: {
           path_prefix: "blog/",
         },
-      }
+      },
     );
 
     const res = await this.get("/tagged/foo");
@@ -198,7 +230,7 @@ describe("tagged block", function () {
         locals: {
           path_prefix: "/blog/",
         },
-      }
+      },
     );
 
     const res = await this.get("/tagged/foo");
@@ -264,7 +296,7 @@ describe("tagged block", function () {
           path_prefix: "/blog/",
           tagged_page_size: 1,
         },
-      }
+      },
     );
 
     const res = await this.get("/tagged/foo/page/2");
@@ -296,7 +328,7 @@ describe("tagged block", function () {
         locals: {
           tagged_page_size: 1,
         },
-      }
+      },
     );
 
     const res = await this.get("/tagged/foo/page/2?tag=foo&tag=bar");
@@ -329,7 +361,7 @@ describe("tagged block", function () {
           path_prefix: "/blog/",
           tagged_page_size: 1,
         },
-      }
+      },
     );
 
     const res = await this.get("/tagged/foo/page/2?tag=foo&tag=bar");

--- a/app/models/tags/set.js
+++ b/app/models/tags/set.js
@@ -91,7 +91,10 @@ module.exports = function (blogID, entry, callback) {
         }
 
         multi.set(key.name(blogID, tag), prettyTags[i]);
-        multi.zAdd(key.sortedTag(blogID, tag), { score: score, value: entry.id });
+        multi.zAdd(key.sortedTag(blogID, tag), {
+          score: score,
+          value: entry.id,
+        });
       });
 
       // For each tagName in the list of tags which the
@@ -129,6 +132,8 @@ function shouldHide(entry) {
     entry.deleted ||
     entry.draft ||
     entry.scheduled ||
+    entry.page ||
+    entry.menu ||
     entry.path.split("/").filter(function (i) {
       return i[0] === "_";
     }).length

--- a/app/models/tags/tests/set.js
+++ b/app/models/tags/tests/set.js
@@ -1,21 +1,76 @@
 describe("tags.set", function () {
-    
-    const set = require("../set");
+  const set = require("../set");
+  const get = require("../get");
 
-    // Create a test user and blog before each spec
-    global.test.blog();
+  // Create a test user and blog before each spec
+  global.test.blog();
 
-    it("can be invoked without error", function (done) {
-        const entry = {
-            id: "entry1",
-            blogID: "blog1",
-            path: "/entry1",
-            tags: ["tag1"],
-        };
+  it("can be invoked without error", function (done) {
+    const entry = {
+      id: "entry1",
+      blogID: "blog1",
+      path: "/entry1",
+      tags: ["tag1"],
+    };
 
-        set(this.blog.id, entry, function (err, entryIDs, tag) {
-            expect(err).toBeUndefined();
-            done();
-        });
+    set(this.blog.id, entry, function (err) {
+      expect(err).toBeUndefined();
+      done();
     });
+  });
+
+  ["page", "menu"].forEach(function (property) {
+    it(
+      "does not index a newly created tagged " + property + " entry",
+      function (done) {
+        const entry = {
+          id: property + "-entry",
+          blogID: this.blog.id,
+          path: "/" + property + "-entry",
+          tags: ["automotive"],
+        };
+        entry[property] = true;
+
+        set(this.blog.id, entry, (err) => {
+          if (err) return done.fail(err);
+
+          get(this.blog.id, "automotive", (err, entryIDs) => {
+            if (err) return done.fail(err);
+            expect(entryIDs).toEqual([]);
+            done();
+          });
+        });
+      },
+    );
+  });
+
+  it("removes tag associations when an existing post becomes a page", function (done) {
+    const entry = {
+      id: "work-entry",
+      blogID: this.blog.id,
+      path: "/work/entry",
+      tags: ["automotive", "featured"],
+      dateStamp: 1,
+    };
+
+    set(this.blog.id, entry, (err) => {
+      if (err) return done.fail(err);
+
+      entry.page = true;
+      set(this.blog.id, entry, (err) => {
+        if (err) return done.fail(err);
+
+        get(this.blog.id, "automotive", (err, automotiveIDs) => {
+          if (err) return done.fail(err);
+          expect(automotiveIDs).toEqual([]);
+
+          get(this.blog.id, "featured", (err, featuredIDs) => {
+            if (err) return done.fail(err);
+            expect(featuredIDs).toEqual([]);
+            done();
+          });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Motivation
- Tag indexes were including entries marked as `page` (and menu links), causing pages to appear in tag-based post listings and polluting pagination totals.
- The intent is to make tag indexing follow the same visibility rules used for post listings so pages and menu-only links are never shown in tag result sets.

### Description
- Updated `app/models/tags/set.js` so `shouldHide(entry)` returns true for `entry.page` and `entry.menu`, preventing pages and menu entries from being added to the tag index.  
- Added focused unit tests in `app/models/tags/tests/set.js` to assert that newly created tagged pages and menu entries are not indexed and that converting an existing tagged post into a page removes its tag associations.  
- Added an integration regression in `app/blog/render/retrieve/tests/tagged.js` that creates a tagged post and a tagged page under the same `path_prefix`, requests the corresponding tagged route (e.g. `/work/tagged/automotive`) and asserts only the post appears and pagination totals exclude the page.  
- Removed the resolved TODO line from the repository root `TODO` file.

### Testing
- Ran static checks with `node --check app/models/tags/set.js && node --check app/models/tags/tests/set.js && node --check app/blog/render/retrieve/tests/tagged.js` which completed without syntax errors.  
- Verified repository consistency with `git diff --check`.  
- Attempted to run the package tests `npm test -- app/models/tags/tests/set.js` but the environment lacks Docker, so the full test harness could not be executed here.  
- Attempted a local test runner fallback (`NODE_PATH=app node scripts/tests/index.js ...`) which started but could not complete end-to-end due to no running Redis instance in this environment; the added tests remain runnable in CI or a developer environment with Docker/Redis.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa12c54c4fc83299279ef21c27459b6)