### PR TITLE
Encode filesystem paths in rewritten dependency URLs

### DIFF
--- a/app/build/dependencies/index.js
+++ b/app/build/dependencies/index.js
@@ -18,9 +18,19 @@ var metadataCaseInsensitive = require("helper/metadataCaseInsensitive");
 //     unchanged instead of being double-encoded;
 //   - spaces, control characters and the HTML-significant < > " ` .
 //
-// Everything else - "/" separators, sub-delimiters like : @ + = that are
-// legal in a path, and non-ASCII characters - is left untouched so the
-// value still decodes back to the exact path recorded as a dependency.
+// Everything else - "/" separators, reserved characters that are still
+// legal inside a path segment (: @ + = & ; ,), and non-ASCII
+// characters - is left untouched so the value still decodes back to the
+// exact path recorded as a dependency.
+//
+// Two accepted edge cases. First: static asset requests are decoded
+// with decodeURIComponent (app/blog/assets.js), which restores every
+// escape, but Entry.getByUrl and the image transformer use decodeURI,
+// which leaves "%23"/"%3F" encoded - so a folder whose name literally
+// contains "#" or "?" is still served as a static file but misses
+// image-cache optimization. Second: an existing "%HH" is assumed to be
+// pre-encoding rather than a literal "%", so a file literally named
+// e.g. "50%FF.png" would need its "%" doubled by hand.
 function serializePath (path) {
   // eslint-disable-next-line no-control-regex
   return path.replace(/%(?![0-9A-Fa-f]{2})|[\x00-\x20"#<>?\x60]/g, function (char) {
@@ -159,14 +169,7 @@ function dependencies (path, html, metadata) {
     // Strip it before resolving and reattach it, untouched, after - so
     // the suffix keeps its literal ? / # rather than being encoded into
     // the path.
-    var cutIndex = -1;
-    var hashIndex = value.indexOf("#");
-    var queryIndex = value.indexOf("?");
-
-    if (hashIndex > -1) cutIndex = hashIndex;
-    if (queryIndex > -1 && (cutIndex === -1 || queryIndex < cutIndex))
-      cutIndex = queryIndex;
-
+    var cutIndex = value.search(/[#?]/);
     var pathPart = cutIndex === -1 ? value : value.slice(0, cutIndex);
 
     suffix = cutIndex === -1 ? "" : value.slice(cutIndex);
@@ -244,7 +247,10 @@ function dependencies (path, html, metadata) {
     // target text, including deliberately leaving it untouched when
     // it can't find a match.
     if (!isWikilink) {
-      $el.attr(attribute, serializePath(resolved_value) + suffix);
+      var serialized = serializePath(resolved_value);
+      if (serialized !== resolved_value)
+        debug(path, attribute, resolved_value, "encoded to", serialized);
+      $el.attr(attribute, serialized + suffix);
     }
 
     if (isSelfReference) {

--- a/app/build/dependencies/index.js
+++ b/app/build/dependencies/index.js
@@ -6,12 +6,26 @@ var is_path = require("./is_path");
 var extname = require("path").extname;
 var metadataCaseInsensitive = require("helper/metadataCaseInsensitive");
 
-// Encode filesystem paths for use in HTML attributes one segment at a time.
-// Encoding the entire path would also encode its slash separators, while
-// writing the decoded path directly would let characters such as # and ? be
-// interpreted as URL delimiters by the browser.
+// Make a resolved filesystem path safe to drop into an HTML attribute
+// without changing which file it points at. We only percent-encode the
+// characters a browser would otherwise read as URL syntax or that can't
+// appear in an attribute value at all:
+//
+//   - "#" and "?", which would start a fragment or query;
+//   - a "%" that isn't already the start of a valid "%HH" escape, so
+//     paths that already contain percent-encoding (e.g. "%20", "%C3%A9"
+//     from the Markdown converter or a hand-written link) round-trip
+//     unchanged instead of being double-encoded;
+//   - spaces, control characters and the HTML-significant < > " ` .
+//
+// Everything else - "/" separators, sub-delimiters like : @ + = that are
+// legal in a path, and non-ASCII characters - is left untouched so the
+// value still decodes back to the exact path recorded as a dependency.
 function serializePath (path) {
-  return path.split("/").map(encodeURIComponent).join("/");
+  // eslint-disable-next-line no-control-regex
+  return path.replace(/%(?![0-9A-Fa-f]{2})|[\x00-\x20"#<>?\x60]/g, function (char) {
+    return encodeURIComponent(char);
+  });
 }
 
 // The purpose of this module is to take the HTML for
@@ -117,7 +131,6 @@ function dependencies (path, html, metadata) {
   // links to any local file.
   $("link[href], a[href], [src]").each(function () {
     var $el = $(this);
-    var isAnchor = $el.is("a");
     var isWikilink = $el.attr("title") === "wikilink";
     var suffix = "";
 
@@ -139,46 +152,50 @@ function dependencies (path, html, metadata) {
       return;
     }
 
-    if (isAnchor) {
-      // Anchors are also used for in-page navigation (footnotes,
-      // tables of contents), which isn't a file path – strip any
-      // #fragment or ?query before resolving and reattach it after.
-      var cutIndex = -1;
-      var hashIndex = value.indexOf("#");
-      var queryIndex = value.indexOf("?");
+    // A #fragment or ?query is URL syntax, never part of the filesystem
+    // path: <a href> uses it for in-page navigation (footnotes, tables
+    // of contents), while <img src>/<link href> use it for cache-
+    // busters ("photo.jpg?v=2") or SVG sprite ids ("icons.svg#home").
+    // Strip it before resolving and reattach it, untouched, after - so
+    // the suffix keeps its literal ? / # rather than being encoded into
+    // the path.
+    var cutIndex = -1;
+    var hashIndex = value.indexOf("#");
+    var queryIndex = value.indexOf("?");
 
-      if (hashIndex > -1) cutIndex = hashIndex;
-      if (queryIndex > -1 && (cutIndex === -1 || queryIndex < cutIndex))
-        cutIndex = queryIndex;
+    if (hashIndex > -1) cutIndex = hashIndex;
+    if (queryIndex > -1 && (cutIndex === -1 || queryIndex < cutIndex))
+      cutIndex = queryIndex;
 
-      var pathPart = cutIndex === -1 ? value : value.slice(0, cutIndex);
+    var pathPart = cutIndex === -1 ? value : value.slice(0, cutIndex);
 
-      suffix = cutIndex === -1 ? "" : value.slice(cutIndex);
+    suffix = cutIndex === -1 ? "" : value.slice(cutIndex);
 
-      // Browsers treat a backslash the same as a forward slash when
-      // parsing a URL for an http(s) page - e.g. "\Files\report.pdf"
-      // is root-relative ("/Files/report.pdf") and "\\host\report.pdf"
-      // is an external network-path reference ("//host/report.pdf").
-      // Normalizing here means the existing is_url/absolute-path
-      // checks below already handle both cases correctly.
-      pathPart = pathPart.replace(/\\/g, "/");
+    // Browsers treat a backslash the same as a forward slash when
+    // parsing a URL for an http(s) page - e.g. "\Files\report.pdf"
+    // is root-relative ("/Files/report.pdf") and "\\host\report.pdf"
+    // is an external network-path reference ("//host/report.pdf").
+    // Normalizing here means the existing is_url/absolute-path checks
+    // below already handle both cases correctly, and (for a local path)
+    // that serializePath never emits a "%5C" the asset handler and the
+    // transformer's backslash fallback would then fail to match.
+    pathPart = pathPart.replace(/\\/g, "/");
 
-      if (!pathPart) {
-        debug(path, attribute, value, "is a fragment or query only");
-        return;
-      }
-
-      // Anchors are also used for URI schemes we don't otherwise
-      // recognize (javascript:, geo:, magnet:, etc.) - treat any
-      // recognizable URI scheme as non-local, not just the specific
-      // ones is_url knows about.
-      if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(pathPart) && !is_url(pathPart)) {
-        debug(path, attribute, value, "has an unrecognized URI scheme");
-        return;
-      }
-
-      value = pathPart;
+    if (!pathPart) {
+      debug(path, attribute, value, "is a fragment or query only");
+      return;
     }
+
+    // Attributes are also used for URI schemes we don't otherwise
+    // recognize (javascript:, geo:, magnet:, etc.) - treat any
+    // recognizable URI scheme as non-local, not just the specific
+    // ones is_url knows about.
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(pathPart) && !is_url(pathPart)) {
+      debug(path, attribute, value, "has an unrecognized URI scheme");
+      return;
+    }
+
+    value = pathPart;
 
     if (is_url(value)) {
       debug(path, attribute, value, "is a URL");

--- a/app/build/dependencies/index.js
+++ b/app/build/dependencies/index.js
@@ -6,6 +6,14 @@ var is_path = require("./is_path");
 var extname = require("path").extname;
 var metadataCaseInsensitive = require("helper/metadataCaseInsensitive");
 
+// Encode filesystem paths for use in HTML attributes one segment at a time.
+// Encoding the entire path would also encode its slash separators, while
+// writing the decoded path directly would let characters such as # and ? be
+// interpreted as URL delimiters by the browser.
+function serializePath (path) {
+  return path.split("/").map(encodeURIComponent).join("/");
+}
+
 // The purpose of this module is to take the HTML for
 // a given blog post and work out if it references any
 // files in the user's folder. For example, this image
@@ -219,7 +227,7 @@ function dependencies (path, html, metadata) {
     // target text, including deliberately leaving it untouched when
     // it can't find a match.
     if (!isWikilink) {
-      $el.attr(attribute, resolved_value + suffix);
+      $el.attr(attribute, serializePath(resolved_value) + suffix);
     }
 
     if (isSelfReference) {

--- a/app/build/dependencies/tests/index.js
+++ b/app/build/dependencies/tests/index.js
@@ -162,6 +162,39 @@ describe("dependencies", function () {
     },
   });
 
+  // Filesystem path segments must be URL-encoded in rewritten attributes,
+  // without changing the decoded paths used for dependency bookkeeping.
+  should_get_dependencies({
+    html:
+      '<a href="report.pdf">Report</a><img src="cover image.png"><link rel="stylesheet" href="print.css">',
+    path: "/folder#1/post.txt",
+    metadata: {},
+    result: {
+      html:
+        '<a href="/folder%231/report.pdf">Report</a><img src="/folder%231/cover%20image.png"><link rel="stylesheet" href="/folder%231/print.css">',
+      metadata: {},
+      dependencies: [
+        "/folder#1/report.pdf",
+        "/folder#1/cover image.png",
+        "/folder#1/print.css",
+      ],
+    },
+  });
+
+  // A genuine anchor suffix is appended after the resolved filesystem path is
+  // encoded; the suffix itself retains its URL query/fragment delimiters.
+  should_get_dependencies({
+    html: '<a href="report.pdf?download=1#page=3">Report</a>',
+    path: "/folder?draft/post.txt",
+    metadata: {},
+    result: {
+      html:
+        '<a href="/folder%3Fdraft/report.pdf?download=1#page=3">Report</a>',
+      metadata: {},
+      dependencies: ["/folder?draft/report.pdf"],
+    },
+  });
+
   // Should not touch fragment-only hrefs, e.g. footnotes and
   // tables of contents
   should_get_dependencies({

--- a/app/build/dependencies/tests/index.js
+++ b/app/build/dependencies/tests/index.js
@@ -211,6 +211,19 @@ describe("dependencies", function () {
     },
   });
 
+  // A "%" that does not begin a valid "%HH" escape is a literal percent
+  // sign in the filename and must be encoded so it round-trips.
+  should_get_dependencies({
+    html: '<a href="100%done.pdf">done</a>',
+    path: "/notes/post.txt",
+    metadata: {},
+    result: {
+      html: '<a href="/notes/100%25done.pdf">done</a>',
+      metadata: {},
+      dependencies: ["/notes/100%done.pdf"],
+    },
+  });
+
   // Characters that are legal in a URL path (sub-delimiters such as
   // : ; @ + = ,) are left untouched, so the rewritten value still
   // resolves to the same entry/file. getByUrl / the asset handler

--- a/app/build/dependencies/tests/index.js
+++ b/app/build/dependencies/tests/index.js
@@ -195,6 +195,66 @@ describe("dependencies", function () {
     },
   });
 
+  // Paths that already contain percent-encoding (from the Markdown
+  // converter, Pandoc, or a hand-written link) must round-trip
+  // unchanged rather than being encoded a second time.
+  should_get_dependencies({
+    html:
+      '<a href="caf%C3%A9.pdf">Report</a><img src="my%20photo.png">',
+    path: "/notes/post.txt",
+    metadata: {},
+    result: {
+      html:
+        '<a href="/notes/caf%C3%A9.pdf">Report</a><img src="/notes/my%20photo.png">',
+      metadata: {},
+      dependencies: ["/notes/caf%C3%A9.pdf", "/notes/my%20photo.png"],
+    },
+  });
+
+  // Characters that are legal in a URL path (sub-delimiters such as
+  // : ; @ + = ,) are left untouched, so the rewritten value still
+  // resolves to the same entry/file. getByUrl / the asset handler
+  // only decodeURI once and would not decode these if we encoded them.
+  should_get_dependencies({
+    html: '<a href="/notes:2024/draft+final,v2@home">link</a>',
+    path: "/post.txt",
+    metadata: {},
+    result: {
+      html: '<a href="/notes:2024/draft+final,v2@home">link</a>',
+      metadata: {},
+      dependencies: ["/notes:2024/draft+final,v2@home"],
+    },
+  });
+
+  // A query string or fragment on a non-anchor attribute (cache-buster,
+  // SVG sprite id) is split off and reattached, not encoded into the
+  // resolved path.
+  should_get_dependencies({
+    html: '<img src="photo.jpg?v=2"><img src="icons.svg#home">',
+    path: "/assets/post.txt",
+    metadata: {},
+    result: {
+      html:
+        '<img src="/assets/photo.jpg?v=2"><img src="/assets/icons.svg#home">',
+      metadata: {},
+      dependencies: ["/assets/photo.jpg", "/assets/icons.svg"],
+    },
+  });
+
+  // Backslash separators are normalized to forward slashes for every
+  // attribute (browsers do the same on http(s) pages), so the value is
+  // never encoded as "%5C".
+  should_get_dependencies({
+    html: '<img src="images\\photo.jpg">',
+    path: "/post.txt",
+    metadata: {},
+    result: {
+      html: '<img src="/images/photo.jpg">',
+      metadata: {},
+      dependencies: ["/images/photo.jpg"],
+    },
+  });
+
   // Should not touch fragment-only hrefs, e.g. footnotes and
   // tables of contents
   should_get_dependencies({


### PR DESCRIPTION
### Motivation
- When `app/build/dependencies` resolves a relative `<a href>` / `<img src>` / `<link href>` against the post's folder, the folder name is spliced into the attribute. If that folder (or the file) contains `#`, `?`, a space or a bare `%`, the browser reads it as URL syntax and the link points somewhere else than the file on disk.
- Dependency tracking, self-reference detection and debug output must keep working with the original decoded filesystem paths.

### Description
- Added `serializePath(path)` in `app/build/dependencies/index.js`. It percent-encodes **only** the characters that a browser would otherwise treat as URL syntax or that are invalid in an attribute value — `#`, `?`, space, control characters, `< > " ` `` ` `` — and encodes a `%` only when it does not already begin a valid `%HH` escape. Slashes, path sub-delimiters (`: @ + = ; ,`) and non-ASCII characters are left untouched, so the rewritten value still decodes back to the exact path recorded as a dependency, image-cache key and backlink target.
- When rewriting an attribute the code now writes `serializePath(resolved_value) + suffix`; `resolved_value` itself is unchanged for dependency lists and self-reference checks.
- The `#fragment` / `?query` split and the backslash→slash normalization, previously done only for `<a>`, now run for every element, so a cache-buster like `<img src="photo.jpg?v=2">` keeps its suffix and a Windows-separator `src` still resolves via the transformer's backslash fallback.
- Kept the wikilink exception (`title="wikilink"`) — those attributes are tracked as dependencies but not rewritten.
- Regression tests in `app/build/dependencies/tests/index.js` cover: directories containing `#` / `?`, a real query/fragment suffix left unencoded, already-encoded paths not being double-encoded, sub-delimiters preserved, non-anchor query/fragment suffixes, and backslash normalization.

### Testing
- `app/build/dependencies` — 74 specs, 0 failures.
- Full `app/build` suite — passes (previously failed on the quoted / accented image filename specs).
- `app/blog/tests/backlinks.js` — 17 specs, 0 failures (previously failed on umlaut / double-encoded / accented-slug backlinks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa12c64d9c48329b6824ff2211da923)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
