### PR TITLE
[benchmark] Baseline CI test-suite timing (do not merge)

### DIFF
--- a/README
+++ b/README
@@ -20,3 +20,5 @@ npm start
 The dashboard is https://local.blot and the example site is https://example.local.blot. For the full setup, see:
 
 https://blot.im/developers/guides/run-blot-locally
+
+(Force a CI run to benchmark the test suite. This commit will be reverted.)


### PR DESCRIPTION
Temporary PR to capture a **baseline** of how long the `node.yml` test matrix takes on a pull request, before the Jasmine upgrade + spec-sharding work in the companion PR.

- Only change is one line appended to `README`.
- I'll record per-suite and total wall-clock timings from this run, then close this PR unmerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)