### PR TITLE
Fix settings save bouncing user to homepage (typeset & other plugin options)

### DIFF
--- a/app/dashboard/site/save/finish.js
+++ b/app/dashboard/site/save/finish.js
@@ -16,7 +16,10 @@ var dictionary = {
 
 module.exports = function (req, res, next) {
   var updates = req.updates || {};
-  var redirect = req.body.redirect || req.path;
+  // req.path is relative to the router mount, so fall back to the full
+  // dashboard path (req.baseUrl + req.path) rather than "/", which would
+  // bounce the user out to the site homepage.
+  var redirect = req.body.redirect || (req.baseUrl || "") + req.path;
 
   Blog.set(req.blog.id, updates, function (errors, changes) {
     if (errors)

--- a/app/dashboard/tests/save.js
+++ b/app/dashboard/tests/save.js
@@ -22,4 +22,35 @@ describe("dashboard site settings save", function () {
     expect(Object.keys(updates)).not.toContain("owner");
     expect(Object.keys(updates)).not.toContain("cacheID");
   });
+
+  // Regression: saving a plugin option (e.g. typeset) from a settings
+  // sub-page used to bounce the user out to the site homepage because the
+  // form omitted the `redirect` field and save/finish.js fell back to a
+  // router-relative req.path of "/".
+  ["settings", "settings/images", "settings/links"].forEach((page) => {
+    it(
+      `keeps the redirect on /${page} pointed back at itself`,
+      async function () {
+        const $ = await this.parse(`/sites/${this.blog.handle}/${page}`);
+        const redirect = $('input[name="redirect"]').attr("value");
+        expect(redirect).toBe(`/sites/${this.blog.handle}/${page}`);
+      },
+      30000
+    );
+  });
+
+  it(
+    "does not redirect to the homepage when the form omits a redirect field",
+    async function () {
+      const res = await this.submit(`/sites/${this.blog.handle}/settings`, {
+        "plugins.typeset.options.punctuation": "on",
+      });
+
+      const path = new URL(res.url).pathname;
+
+      expect(path).not.toBe("/");
+      expect(path.startsWith(`/sites/${this.blog.handle}`)).toBe(true);
+    },
+    30000
+  );
 });

--- a/app/views/dashboard/site/settings/images.html
+++ b/app/views/dashboard/site/settings/images.html
@@ -2,6 +2,8 @@
 
 <h1>Images</h1>
 
+<input type="hidden" name="redirect" value="{{{base}}}/settings/images" />
+
 {{#categories.Images}}
 {{> plugin-row}}
 {{/categories.Images}}

--- a/app/views/dashboard/site/settings/index.html
+++ b/app/views/dashboard/site/settings/index.html
@@ -2,6 +2,8 @@
 
 <h1>General</h1>
 
+<input type="hidden" name="redirect" value="{{{base}}}/settings" />
+
 <h2>Headings</h2>
 {{#categories.Headings}}
 {{> plugin-row}}

--- a/app/views/dashboard/site/settings/links.html
+++ b/app/views/dashboard/site/settings/links.html
@@ -2,6 +2,8 @@
 
 <h1>Links</h1>
 
+<input type="hidden" name="redirect" value="{{{base}}}/settings/links" />
+
 {{#categories.Links}}
 {{> plugin-row}}
 {{/categories.Links}}


### PR DESCRIPTION
## The bug

From `TODO`: *"Hitting the save changes button under typeset settings spits you back out to homepage! Bug!"*

The Typeset **Substitution** plugin lives on the **General** settings page (`app/views/dashboard/site/settings/index.html`, under *Typography*). Clicking **Save changes** there submits the shared settings form, which posts to `{{{base}}}` = `/sites/:handle` and ends in `app/dashboard/site/save/finish.js`:

```js
var redirect = req.body.redirect || req.path;
```

Inside the mounted site router `req.path` is just `/` (the mount `/sites/:handle` is in `req.baseUrl`), so with no `redirect` field in the body the user is redirected to the site root / homepage.

## Why only some pages

Before the Nov 2025 "Settings reorganization" (`3aa01ed88`) the settings UI *was* the site dashboard home page, so redirecting to `/` landed you back where you started. The reorg split settings into sub-pages and added a hidden `redirect` field to **embeds, date, services, flags, redirects** — but missed **General (`index.html`), Images, and Links**. General is where Typeset lives → the reported symptom.

## Fix

- Add `<input type="hidden" name="redirect" value="{{{base}}}/settings…">` to `index.html`, `images.html`, `links.html`, matching the other sub-pages.
- Harden `save/finish.js` to fall back to `req.baseUrl + req.path` (as `util/message.js` already does) so any future page missing the field returns to the site dashboard rather than the marketing homepage.
- Regression tests in `app/dashboard/tests/save.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)