### PR TITLE
fix: fix security issue in replaceCssAndScriptUrls.js

### DIFF
--- a/scripts/template/replaceCssAndScriptUrls.js
+++ b/scripts/template/replaceCssAndScriptUrls.js
@@ -1,5 +1,7 @@
 const { promisify } = require("util");
 const url = require("url");
+const net = require("net");
+const dns = require("dns");
 const fetch = require("node-fetch");
 const eachView = require("../each/view");
 const Template = require("models/template");
@@ -77,6 +79,30 @@ function isValidUrl(urlString) {
 }
 
 /**
+ * Determine whether an IP address falls within a loopback, link-local,
+ * or private range. Used to block SSRF requests to internal services
+ * (e.g. localhost, 169.254.169.254 cloud metadata, 10.0.0.0/8, etc).
+ */
+function isPrivateIp(ip) {
+  if (net.isIPv4(ip)) {
+    const parts = ip.split(".").map(Number);
+    return (
+      parts[0] === 0 ||
+      parts[0] === 10 ||
+      parts[0] === 127 ||
+      (parts[0] === 169 && parts[1] === 254) ||
+      (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+      (parts[0] === 192 && parts[1] === 168)
+    );
+  }
+  if (net.isIPv6(ip)) {
+    const lower = ip.toLowerCase();
+    return lower === "::1" || lower.startsWith("fc") || lower.startsWith("fd") || lower.startsWith("fe80");
+  }
+  return true;
+}
+
+/**
  * Fetch an asset from a URL and return the buffer
  */
 async function fetchAsset(assetUrl) {
@@ -85,6 +111,15 @@ async function fetchAsset(assetUrl) {
   const timer = setTimeout(() => controller.abort(), 10000); // 10 second timeout
 
   try {
+    const parsed = url.parse(assetUrl.startsWith("//") ? "https:" + assetUrl : assetUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error(`Blocked request with disallowed protocol: ${parsed.protocol}`);
+    }
+    const { address } = await dns.promises.lookup(parsed.hostname);
+    if (isPrivateIp(address)) {
+      throw new Error(`Blocked request to internal address: ${address}`);
+    }
+
     const response = await fetch(assetUrl, { signal });
 
     clearTimeout(timer);


### PR DESCRIPTION
## Summary
Fix high severity security issue in `scripts/template/replaceCssAndScriptUrls.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `scripts/template/replaceCssAndScriptUrls.js:82` |
| **Assessment** | Likely exploitable |

**Description**: The fetchAsset function fetches external URLs without URL validation, allowlisting, or blocking of private IP ranges. The assetUrl parameter is derived from user-controlled template configuration (extendedBlog.cssURL and extendedBlog.scriptURL). While isValidUrl() validates URL format, it does not validate the destination - allowing localhost, AWS metadata endpoints (169.254.169.254), and internal IP ranges.

## Evidence

**Exploitation scenario**: An attacker who can influence template configuration sets cssURL to 'http://169.254.169.254/latest/meta-data/iam/security-credentials/' or 'http://localhost:6379/' (Redis).

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `scripts/template/replaceCssAndScriptUrls.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

## Security Invariant
> **Property**: The security boundary is maintained under adversarial input

<details>
<summary>Regression test</summary>

```javascript
const { fetchAsset } = require("../../scripts/template/replaceCssAndScriptUrls.js");

describe("fetchAsset blocks SSRF attacks against internal/private IP ranges", () => {
  const payloads = [
    ["localhost SSRF", "http://localhost/admin"],
    ["AWS metadata endpoint", "http://169.254.169.254/latest/meta-data/"],
    ["private IP range", "http://10.0.0.1/secret"],
    ["valid public URL", "https://example.com/style.css"],
  ];

  test.each(payloads)("%s", async (name, url) => {
    if (name === "valid public URL") {
      // Valid public URLs should be allowed (or fail for network reasons, not blocked)
      await expect(fetchAsset(url)).resolves.toBeDefined();
    } else {
      // SSRF payloads targeting internal resources must be rejected
      await expect(fetchAsset(url)).rejects.toThrow(/blocked|forbidden|invalid|not allowed/i);
    }
  });
});
```

</details>

This test guards against regressions — it's useful independent of the code change above.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
