### PR TITLE
Use crypto for session secret, document BLOT_SESSION_SECRET, and clarify guid safety

### DIFF
--- a/app/dashboard/util/session.js
+++ b/app/dashboard/util/session.js
@@ -1,5 +1,5 @@
 const config = require("config");
-const guid = require("helper/guid");
+const crypto = require("crypto");
 const session = require("express-session");
 const { RedisStore } = require("connect-redis");
 const redis = require("redis");
@@ -16,13 +16,25 @@ sessionClient.connect().catch((err) => {
   console.error("Session Redis connect error:", err);
 });
 
+// Hosted production sets BLOT_SESSION_SECRET. Self-hosted and development
+// installs may omit it, so keep those installs usable with a process-local,
+// cryptographically secure secret and make the resulting session invalidation
+// on restart explicit. Never use helper/guid here: it is an identifier helper,
+// uses Math.random, and is not suitable for signing or other security purposes.
+const sessionSecret =
+  config.session.secret || crypto.randomBytes(32).toString("hex");
+
+if (!config.session.secret) {
+  console.warn(
+    "BLOT_SESSION_SECRET is not set; using a secure ephemeral secret. " +
+      "Dashboard sessions will be invalidated when this process restarts.",
+  );
+}
+
 // Session settings. It is important that session
 // comes before the cache so we know what to serve
 module.exports = session({
-  // If no session secret is set we use a random GUID
-  // this will mean that sessions will only be valid
-  // for as long as the process is running.
-  secret: config.session.secret || guid(),
+  secret: sessionSecret,
   saveUninitialized: false,
   resave: false,
   proxy: true,
@@ -35,5 +47,3 @@ module.exports = session({
   },
   store: new RedisStore({ client: sessionClient }),
 });
-
-

--- a/app/helper/guid.js
+++ b/app/helper/guid.js
@@ -5,6 +5,10 @@
  **/
 
 function generate() {
+  // This produces convenient, non-security-sensitive identifiers only. It is
+  // Math.random-based and must not be used for secrets, tokens, signatures, or
+  // any value whose unpredictability is a security requirement. Use crypto's
+  // randomBytes/randomUUID APIs for those purposes instead.
   var d = Date.now();
 
   //use high-precision timer if available
@@ -13,7 +17,7 @@ function generate() {
   }
 
   var guid = "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx".replace(/[xy]/g, function (c) {
-    var r = (d + Math.random() * 16) % 16 | 0;
+    var r = ((d + Math.random() * 16) % 16) | 0;
     d = Math.floor(d / 16);
     return (c == "x" ? r : (r & 0x3) | 0x8).toString(16);
   });

--- a/app/views/developers/guides/run-blot-locally.html
+++ b/app/views/developers/guides/run-blot-locally.html
@@ -42,3 +42,8 @@ sudo bash -c 'echo "nameserver 127.0.0.1" > /etc/resolver/blot'</code></pre>
 <h2>6. Edit the example blog</h2>
 <p>The example blog folder is inside <code>data</code>:</p>
 <pre><code>./data/blogs/blog_$ID</code></pre>
+
+<h2>7. Configure the session secret</h2>
+<p>Production deployments should set <code>BLOT_SESSION_SECRET</code> to a stable random value, for example, the output of:</p>
+<pre class="bash"><code>openssl rand -hex 32</code></pre>
+<p>If it is not set, Blot logs a warning and uses a cryptographically secure process-local fallback. This is safe for signing, but existing dashboard sessions expire whenever the process restarts.</p>

--- a/config/environment.sh
+++ b/config/environment.sh
@@ -49,6 +49,10 @@ export PUPPETEER_EXECUTABLE_PATH=
 #               S E C R E T S               #
 #############################################
 
+# Set this to a stable, randomly generated secret in production, for example:
+#   openssl rand -hex 32
+# If omitted, Blot warns and generates a secure process-local fallback; because
+# that fallback changes at each restart, all existing dashboard sessions expire.
 export BLOT_SESSION_SECRET=
 export BLOT_BACKUP_SECRET=
 export BLOT_WEBHOOKS_SECRET=


### PR DESCRIPTION
### Motivation
- Ensure session signing uses a cryptographically secure secret rather than a Math.random-based identifier to avoid weak secrets and accidental misuse.
- Make the deployment expectation explicit by documenting the `BLOT_SESSION_SECRET` environment variable so production installs provide a stable secret.
- Prevent accidental use of the `guid` helper in security-sensitive contexts by clarifying its non-cryptographic nature.

### Description
- Replace use of the `guid` helper for session signing with Node's `crypto.randomBytes(32)` fallback and prefer `config.session.secret` when provided, and log a warning when falling back.
- Update `app/helper/guid.js` to add a clear comment that the generator is Math.random-based and must not be used for secrets, and apply a minor expression formatting fix.
- Add documentation to `app/views/developers/guides/run-blot-locally.html` describing `BLOT_SESSION_SECRET` and an example `openssl rand -hex 32` command, and update `config/environment.sh` with guidance for setting `BLOT_SESSION_SECRET`.
- Keep Redis session store and session cookie settings unchanged aside from the secret handling.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa152f982ec832992910c25f9bf4c6f)