### PR TITLE
Fix RFC 3339 date metadata regression coverage

### DIFF
--- a/app/build/prepare/dateStamp/fromMetadata.js
+++ b/app/build/prepare/dateStamp/fromMetadata.js
@@ -39,15 +39,20 @@ function fromMetadata(dateString, userFormat) {
   } catch (e) {}
 
   try {
+    // Blot deliberately supports an RFC 3339-style subset here rather than
+    // every ISO 8601 representation. In addition to RFC 3339 timestamps, the
+    // enumerated formats accept the same timestamps without a timezone and
+    // interpret them as UTC. Date-only, reduced-precision, ordinal-date, and
+    // week-date forms are not handled by this parser.
     let rfcNormalized = moment.utc(
       dateString,
       [
         "YYYY-MM-DD[T]HH:mm:ssZ",
+        "YYYY-MM-DD[T]HH:mm:ss",
         "YYYY-MM-DD[T]HH:mm:ss.SSSZ",
         "YYYY-MM-DD[T]HH:mm:ss.SSS",
-        "YYYY-MM-DD[T]HH:mm:ssZ[Z]",
       ],
-      true
+      true,
     );
 
     if (rfcNormalized.isValid()) {

--- a/app/build/prepare/dateStamp/tests/fromMetadata.js
+++ b/app/build/prepare/dateStamp/tests/fromMetadata.js
@@ -1,4 +1,3 @@
-var moment = require("moment");
 var fromMetadata = require("../fromMetadata");
 
 // Blot parses dates according to the 'dateFormat' of the blog.
@@ -12,33 +11,39 @@ var fromMetadata = require("../fromMetadata");
 // metadata inputs, regardless of the blog's dateFormat.
 // For example, the date "2019-01-01T00:00:00Z"
 // should be parsed from "2019", "2019-01-01" etc...
-var supportedByAllFormats = {
-  "2019-01-01T00:00:00Z": ["2019", "2019-01-01", "2019 01 01"],
-  "2017-02-14T00:00:00Z": ["2017-02-14", "2017/02/14"],
-  "2018-01-15T00:00:00Z": ["January 15th, 2018", "JANUARY 15th 2018"],
-  "2017-05-15T00:00:00Z": ['"2017-05-15"', "'2017-05-15'"], // surrounded by quote marks
-  "2019-04-03T12:33:15Z": ["2019-04-03 12:33:15"],
-  "2018-12-17T17:29:00Z": ["2018-12-17 17:29"],
-  "2019-11-15T14:45:00Z": ["11/15/2019 14:45"],
-  "2018-03-29T00:00:00Z": ["March 29, 2018", "March.29.2018"],
-  "2015-02-10T07:26:00Z": ["February 10th, 2015 07:26"],
-  "2019-01-18T00:00:00Z": ["18 january, 2019"], // lowercase month name
-  "2018-04-18T00:00:00Z": ["Apr 18, 2018"],
-  "2019-04-16T14:50:00Z": ["2019-04-16 02:50 PM"], // AM/PM
-  "2018-06-24T14:59:27Z": ["June 24th 2018, 2:59:27 pm"], // am/pm
-  "2015-01-04T05:08:00Z": ["January 4th, 2015 05:08"],
-  "2015-02-04T21:14:18Z": ["Wed Feb  4 21:14:18 EST 2015"], // timezone ignored
-  "2012-05-30T14:45:44Z": ["Wed May 30 2012 14:45:44 GMT+0000 (UTC)"], // timezone ignored
-  "2011-07-12T21:00:36Z": ["2011-07-12T21:00:36Z", "2011-07-12T21:00:36"], // RFC 3339 with and without trailing 'Z'
-  "2011-07-12T21:00:36Z": [
-    "2011-07-12T21:00:36.443Z",
-    "2011-07-12T21:00:36.443",
-  ], // RFC 3339 with milliseconds and 'Z'
-  "2011-07-13T04:00:36Z": [
-    "2011-07-12T21:00:36-07:00Z",
-    "2011-07-12T21:00:36-07:00",
-  ], // RFC 3339 with timezone
-};
+var supportedByAllFormats = [
+  record(Date.UTC(2019, 0, 1), ["2019", "2019-01-01", "2019 01 01"]),
+  record(Date.UTC(2017, 1, 14), ["2017-02-14", "2017/02/14"]),
+  record(Date.UTC(2018, 0, 15), ["January 15th, 2018", "JANUARY 15th 2018"]),
+  record(Date.UTC(2017, 4, 15), ['"2017-05-15"', "'2017-05-15'"]),
+  record(Date.UTC(2019, 3, 3, 12, 33, 15), ["2019-04-03 12:33:15"]),
+  record(Date.UTC(2018, 11, 17, 17, 29), ["2018-12-17 17:29"]),
+  record(Date.UTC(2019, 10, 15, 14, 45), ["11/15/2019 14:45"]),
+  record(Date.UTC(2018, 2, 29), ["March 29, 2018", "March.29.2018"]),
+  record(Date.UTC(2015, 1, 10, 7, 26), ["February 10th, 2015 07:26"]),
+  record(Date.UTC(2019, 0, 18), ["18 january, 2019"]),
+  record(Date.UTC(2018, 3, 18), ["Apr 18, 2018"]),
+  record(Date.UTC(2019, 3, 16, 14, 50), ["2019-04-16 02:50 PM"]),
+  record(Date.UTC(2018, 5, 24, 14, 59, 27), ["June 24th 2018, 2:59:27 pm"]),
+  record(Date.UTC(2015, 0, 4, 5, 8), ["January 4th, 2015 05:08"]),
+  record(Date.UTC(2015, 1, 4, 21, 14, 18), ["Wed Feb  4 21:14:18 EST 2015"]),
+  record(Date.UTC(2012, 4, 30, 14, 45, 44), [
+    "Wed May 30 2012 14:45:44 GMT+0000 (UTC)",
+  ]),
+  // RFC 3339 timestamps and Blot's timezone-less UTC extension.
+  record(1310504436000, ["2011-07-12T21:00:36Z"], true),
+  record(1310504436000, ["2011-07-12T21:00:36"], true),
+  record(1310504436443, ["2011-07-12T21:00:36.443Z"], true),
+  record(1310504436443, ["2011-07-12T21:00:36.443"], true),
+  record(1310529636000, ["2011-07-12T21:00:36-07:00"], true),
+];
+
+function record(created, inputs, adjusted) {
+  return {
+    expected: { created: created, adjusted: adjusted || false },
+    inputs: inputs,
+  };
+}
 
 // The following date strings can only be parsed from blogs
 // with specific date formats. This is neccessary due to ambiguity
@@ -56,23 +61,19 @@ var supportedBySpecficFormat = {
 describe("date metadata", function () {
   // Test the metadata which should be parsed correctly
   // regardless of the dateFormat (e.g. M/D/YYYY) of the blog
-  Object.keys(supportedByAllFormats).forEach(function (result) {
-    supportedByAllFormats[result].forEach(function (metadata) {
+  supportedByAllFormats.forEach(function (testCase) {
+    testCase.inputs.forEach(function (metadata) {
       Object.keys(supportedBySpecficFormat).forEach(function (format) {
         it(
           'parses "' + metadata + '" using date format ' + format,
           function () {
-            expect(
-              moment.utc(fromMetadata(metadata, format).created).format()
-            ).toEqual(result);
-          }
+            expect(fromMetadata(metadata, format)).toEqual(testCase.expected);
+          },
         );
       });
 
       it('parses "' + metadata + '" without passing a format', function () {
-        expect(moment.utc(fromMetadata(metadata).created).format()).toEqual(
-          result
-        );
+        expect(fromMetadata(metadata)).toEqual(testCase.expected);
       });
     });
   });
@@ -85,10 +86,11 @@ describe("date metadata", function () {
         it(
           'parses "' + metadata + '" using date format ' + format,
           function () {
-            expect(
-              moment.utc(fromMetadata(metadata, format).created).format()
-            ).toEqual(result);
-          }
+            expect(fromMetadata(metadata, format)).toEqual({
+              created: Date.parse(result),
+              adjusted: false,
+            });
+          },
         );
       });
     });


### PR DESCRIPTION
### Motivation
- Prevent silent overwrites from duplicate keys in the ISO/RFC3339 test fixtures by using a representation that preserves every case. 
- Ensure tests verify exact millisecond timestamps and the `adjusted` flag so precision and offset handling cannot be hidden by moment formatting. 

### Description
- Replace the duplicate-key fixture object with an ordered array of `{ expected, inputs }` records and add a small `record()` helper used by the tests in `app/build/prepare/dateStamp/tests/fromMetadata.js`. 
- Update assertions to compare the full `fromMetadata` return (`{ created, adjusted }`) instead of reformatting via Moment, and add explicit cases for `2011-07-12T21:00:36Z`, `2011-07-12T21:00:36`, `2011-07-12T21:00:36.443Z`, `2011-07-12T21:00:36.443`, and `2011-07-12T21:00:36-07:00`. 
- Document that Blot intentionally supports an RFC 3339–style subset (with a timezone-less UTC extension) and adjust the stricter RFC/ISO parsing list in `app/build/prepare/dateStamp/fromMetadata.js` to include the timezone-less second form while removing the nonstandard offset-plus-`Z` syntax. 

### Testing
- Ran `npx jasmine app/build/prepare/dateStamp/tests/fromMetadata.js` and all specs passed (111 specs, 0 failures). 
- Ran `npx prettier --write` on the modified files to normalize formatting and `git diff --check` to validate no whitespace errors. 
- The updated tests exercise the five RFC 3339 cases explicitly and validate both exact millisecond `created` values and the `adjusted` boolean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa1560252dc8329a9099b27efaff0db)