### PR TITLE
Fix active tag matching for encoded slashes

### DIFF
--- a/app/blog/render/retrieve/active.js
+++ b/app/blog/render/retrieve/active.js
@@ -1,18 +1,31 @@
+function canonicalize(url) {
+  var segments = url.split("/").map(function (segment) {
+    return decodeURIComponent(segment);
+  });
+
+  // Match the previous behavior, which trimmed after decoding the URL.
+  segments[0] = segments[0].trimStart();
+  segments[segments.length - 1] = segments[segments.length - 1].trimEnd();
+
+  // Decode and re-encode each path segment independently. In particular, this
+  // keeps an encoded slash inside a tag slug rather than turning it into a path
+  // separator.
+  return segments.map(encodeURIComponent).join("/");
+}
+
 module.exports = function (req, res, callback) {
   return callback(null, function () {
     var url;
     var link;
 
     try {
-      url = decodeURI(req.url);
+      url = req.url;
       link = this.url;
 
-      // it's neccessary to decodeURI
-      // in order for tag slugs with accents to work
-      if (!link && this.slug) link = "/tagged/" + decodeURIComponent(this.slug);
+      if (!link && this.slug) link = "/tagged/" + this.slug;
 
-      url = url.trim();
-      link = link.trim();
+      url = canonicalize(url);
+      link = canonicalize(link);
     } catch (e) {
       return false;
     }

--- a/app/blog/render/retrieve/active.js
+++ b/app/blog/render/retrieve/active.js
@@ -1,4 +1,17 @@
 function canonicalize(url) {
+  // Split off the query string and/or fragment so their delimiters are treated
+  // as structural URL syntax rather than being folded into path-segment
+  // encoding. Otherwise a slug containing an encoded "?" (e.g. `foo%3Fbar`)
+  // would canonicalize to the same value as a distinct link with a real query
+  // string (`foo?bar`).
+  var suffixIndex = url.search(/[?#]/);
+  var suffix = "";
+
+  if (suffixIndex !== -1) {
+    suffix = url.slice(suffixIndex);
+    url = url.slice(0, suffixIndex);
+  }
+
   var segments = url.split("/").map(function (segment) {
     return decodeURIComponent(segment);
   });
@@ -10,7 +23,7 @@ function canonicalize(url) {
   // Decode and re-encode each path segment independently. In particular, this
   // keeps an encoded slash inside a tag slug rather than turning it into a path
   // separator.
-  return segments.map(encodeURIComponent).join("/");
+  return segments.map(encodeURIComponent).join("/") + suffix;
 }
 
 module.exports = function (req, res, callback) {

--- a/app/blog/render/retrieve/tests/active.js
+++ b/app/blog/render/retrieve/tests/active.js
@@ -1,6 +1,39 @@
 describe("active property", function () {
   require("blog/tests/util/setup")();
 
+  function active(url, local) {
+    var helper;
+
+    require("../active")({ url: url }, {}, function (err, value) {
+      expect(err).toBeNull();
+      helper = value;
+    });
+
+    return helper.call(local);
+  }
+
+  it("compares encoded tag slugs without treating encoded slashes as separators", function () {
+    expect(active("/tagged/design%2Fui", { slug: "design%2Fui" })).toEqual(
+      "active"
+    );
+    expect(active("/tagged/design/ui", { slug: "design%2Fui" })).toEqual("");
+  });
+
+  it("retains active matching for ordinary, spaced, and accented tag slugs", function () {
+    expect(active("/tagged/design", { slug: "design" })).toEqual("active");
+    expect(active("/tagged/web%20design", { slug: "web%20design" })).toEqual(
+      "active"
+    );
+    expect(active("/tagged/caf%C3%A9", { slug: "caf%C3%A9" })).toEqual(
+      "active"
+    );
+  });
+
+  it("retains complete local URL matching and rejects malformed escapes", function () {
+    expect(active("/caf%C3%A9", { url: "/café" })).toEqual("active");
+    expect(active("/tagged/bad%escape", { slug: "bad%escape" })).toBe(false);
+  });
+
   it("renders an 'active' property for each entry", async function () {
     await this.write({ path: "/1.txt", content: "Link: /1\n\nA" });
     await this.write({ path: "/2.txt", content: "Link: /2\n\nB" });

--- a/app/blog/render/retrieve/tests/active.js
+++ b/app/blog/render/retrieve/tests/active.js
@@ -29,6 +29,13 @@ describe("active property", function () {
     );
   });
 
+  it("does not conflate an encoded query delimiter in a slug with a real query string", function () {
+    expect(active("/tagged/foo%3Fbar", { slug: "foo%3Fbar" })).toEqual(
+      "active"
+    );
+    expect(active("/tagged/foo?bar", { slug: "foo%3Fbar" })).toEqual("");
+  });
+
   it("retains complete local URL matching and rejects malformed escapes", function () {
     expect(active("/caf%C3%A9", { url: "/café" })).toEqual("active");
     expect(active("/tagged/bad%escape", { slug: "bad%escape" })).toBe(false);


### PR DESCRIPTION
### Motivation
- Ensure the `active` helper compares the current request URL and generated tag links in the same canonical encoded form so encoded slashes (e.g. `%2F`) inside tag slugs are not treated as route separators.
- Avoid applying `decodeURIComponent` to the whole tag slug during comparison while preserving existing handling for spaces, accented characters, malformed escapes, and template locals that provide a full `url` rather than a `slug`.

### Description
- Add a `canonicalize` helper to `app/blog/render/retrieve/active.js` that decodes and then re-encodes each path segment independently, preserving encoded slashes inside segments and trimming as before.
- Change the `active` helper to compare `req.url` and `this.url`/`this.slug` after segment-wise canonicalization and stop decoding the entire slug with `decodeURIComponent`.
- Add focused tests in `app/blog/render/retrieve/tests/active.js` covering encoded slashes (`/tagged/design%2Fui`), encoded-vs-real-slash distinction, ordinary/spaced/accented tags, complete local `url` values, and malformed escape handling.

### Testing
- Ran focused `node` assertions exercising the `active` helper (7 cases) which passed locally. 
- Ran `node --check` on `app/blog/render/retrieve/active.js` and the updated `tests/active.js` which reported no syntax errors. 
- Attempted `npm test -- app/blog/render/retrieve/tests/active.js` but the test harness could not run in this environment because Docker is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa155ecc1248329b8f333a9365976f3)