### PR TITLE
Preserve encoded separators when matching view routes

### DIFF
--- a/app/blog/render/retrieve/tests/tagged.js
+++ b/app/blog/render/retrieve/tests/tagged.js
@@ -156,6 +156,44 @@ describe("tagged block", function () {
     expect(body.trim()).toEqual("1|1|Car post");
   });
 
+  it("matches encoded separators inside custom tagged-route parameters", async function () {
+    await this.write({
+      path: "/work/first.txt",
+      content: "Title: First design post\nTags: Design/UI\n\nFirst body",
+    });
+    await this.write({
+      path: "/work/second.txt",
+      content: "Title: Second design post\nTags: Design/UI\n\nSecond body",
+    });
+
+    await this.template(
+      {
+        "tagged.html": `{{#tagged}}{{tag}}|{{pagination.current}}|{{#entries}}{{title}}{{/entries}}{{/tagged}}`,
+      },
+      {
+        views: {
+          "tagged.html": {
+            url: ["/work/tagged/:tag", "/work/tagged/:tag/page/:page"],
+          },
+        },
+        locals: {
+          path_prefix: "/work/",
+          tagged_page_size: 1,
+        },
+      },
+    );
+
+    const firstPage = await this.get("/work/tagged/design%2Fui");
+    const firstPageBody = await firstPage.text();
+    const secondPage = await this.get("/work/tagged/design%2Fui/page/2");
+    const secondPageBody = await secondPage.text();
+
+    expect(firstPage.status).toEqual(200);
+    expect(firstPageBody.trim()).toEqual("Design/UI|1|Second design post");
+    expect(secondPage.status).toEqual(200);
+    expect(secondPageBody.trim()).toEqual("Design/UI|2|First design post");
+  });
+
   it("treats empty and whitespace path_prefix as disabled filtering", async function () {
     await this.write({
       path: "/blog/one.txt",

--- a/app/blog/view.js
+++ b/app/blog/view.js
@@ -5,17 +5,7 @@ module.exports = function (req, res, next) {
 
   if (!template) return next();
 
-  // If you don't decode the URL here, you'll see issues
-  // with URLs containing special characters e.g. %20 or %2F
-  // We intentionally do minimal processing in getViewsByURL
-  let url = req.url;
-  try {
-    url = decodeURIComponent(req.url);
-  } catch (e) {
-    url = req.url;
-  }
-
-  getViewByURL(template, url, function (err, viewName, params) {
+  getViewByURL(template, req.url, function (err, viewName, params) {
     if (err) return next(err);
 
     if (!viewName) return next();

--- a/app/models/template/tests/getViewByURL.js
+++ b/app/models/template/tests/getViewByURL.js
@@ -155,6 +155,33 @@ describe("template", function () {
     expect(viewName).toEqual(view.name);
   });
 
+  it("decodes parameters after matching encoded path separators", async function () {
+    const view = {
+      name: "tagged.html",
+      url: ["/work/tagged/:tag"],
+    };
+
+    await this.setView(view);
+    const { viewName, params } = await this.getViewByURL(
+      "/work/tagged/design%2Fui"
+    );
+
+    expect(viewName).toEqual(view.name);
+    expect(params).toEqual({ tag: "design/ui" });
+  });
+
+  it("keeps malformed percent escapes in parameters non-fatal", async function () {
+    const view = {
+      name: "tagged.html",
+      url: ["/tagged/:tag"],
+    };
+
+    await this.setView(view);
+    const { viewName, params } = await this.getViewByURL("/tagged/design%ZZ");
+
+    expect(viewName).toEqual(view.name);
+    expect(params).toEqual({ tag: "design%zz" });
+  });
 
   it("returns an error for a non-existent URL", async function () {
     try {

--- a/app/models/template/viewURLPatterns.js
+++ b/app/models/template/viewURLPatterns.js
@@ -41,7 +41,21 @@ function safeMatch(rawPattern, normalizedPathname) {
   // Use path-to-regexp to create a matching function
   const matchPattern = match(normalizedPattern, { decode: false });
 
-  return matchPattern(normalizedPathname);
+  const matchResult = matchPattern(normalizedPathname);
+
+  if (!matchResult) return null;
+
+  for (const key of Object.keys(matchResult.params)) {
+    const value = matchResult.params[key];
+
+    try {
+      matchResult.params[key] = decodeURIComponent(value);
+    } catch (err) {
+      // Keep malformed percent escapes as-is rather than failing the route.
+    }
+  }
+
+  return matchResult;
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Prevent premature decoding of path separators so route-pattern matching preserves segment boundaries for patterns like `/work/tagged/:tag`.
- Ensure route parameters containing encoded separators (e.g. `%2F`) are exposed as their pretty form (e.g. `Design/UI`) to templates while keeping malformed percent escapes non-fatal.

### Description
- Stop decoding `req.url` in `app/blog/view.js` and pass the raw request URL into `getViewByURL`. 
- Keep `{ decode: false }` when matching patterns in `app/models/template/viewURLPatterns.js`, then safely `decodeURIComponent` each captured param after a successful match, ignoring decoding errors for malformed escapes. 
- Add model-level tests in `app/models/template/tests/getViewByURL.js` to verify decoded parameters and non-fatal malformed escapes. 
- Add an integration regression test in `app/blog/render/retrieve/tests/tagged.js` that configures `tagged.html` with `/work/tagged/:tag` (and paginated variant), publishes entries tagged `Design/UI`, requests `/work/tagged/design%2Fui` and `/work/tagged/design%2Fui/page/2`, and asserts rendering and exposed pretty tag.

### Testing
- `node --check` on the modified files succeeded. 
- `git diff --check` reported no problems. 
- Targeted Node assertions exercising `safeMatch` and post-match decoding passed. 
- Attempt to run the full containerized Jasmine test (`./scripts/tests/invoke.sh app/models/template/tests/getViewByURL.js`) failed due to Docker not being available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa155df13b4832994c25d1e837d4ede)