### PR TITLE
Add nested progress indicator to scripts/each/* iterators

### DIFF
--- a/scripts/each/blog.js
+++ b/scripts/each/blog.js
@@ -3,6 +3,7 @@ var Blog = require("models/blog");
 var async = require("async");
 var type = require("helper/type");
 var ensure = require("helper/ensure");
+var progress = require("./progress");
 
 module.exports = function (doThis, allDone, options) {
   options = options || {};
@@ -62,9 +63,16 @@ module.exports = function (doThis, allDone, options) {
       forEach = async.each;
     }
 
+    var bar = progress.push("Blog", blogIDs.length);
+
     forEach(
       blogIDs,
-      function (blogID, nextBlog) {
+      function (blogID, done) {
+        var nextBlog = function (err) {
+          bar.tick();
+          done(err);
+        };
+
         Blog.get({ id: blogID }, function (err, blog) {
           if (err || !blog) {
             return nextBlog();
@@ -82,7 +90,10 @@ module.exports = function (doThis, allDone, options) {
           });
         });
       },
-      allDone
+      function (err) {
+        bar.pop();
+        allDone(err);
+      }
     );
   });
 };

--- a/scripts/each/entry.js
+++ b/scripts/each/entry.js
@@ -1,6 +1,7 @@
 var ensure = require("helper/ensure");
 var Entries = require("models/entries");
 var eachBlog = require("./blog");
+var progress = require("./progress");
 
 module.exports = function (doThis, allDone, options) {
   options = options || {};
@@ -9,12 +10,21 @@ module.exports = function (doThis, allDone, options) {
 
   eachBlog(
     function (user, blog, nextBlog) {
+      // Entries.each streams ids, so the per-blog total is not known up
+      // front - the frame shows the running count as "(123/?)". Skipped
+      // under options.p: parallel blogs would share one global frame stack.
+      var bar = options.p ? null : progress.push("Entry", null);
+
       Entries.each(
         blog.id,
         function (entry, nextEntry) {
+          if (bar) bar.tick();
           doThis(user, blog, entry, nextEntry);
         },
-        nextBlog
+        function (err) {
+          if (bar) bar.pop();
+          nextBlog(err);
+        }
       );
     },
     allDone,

--- a/scripts/each/progress.js
+++ b/scripts/each/progress.js
@@ -1,0 +1,178 @@
+"use strict";
+
+// Nested progress indicator for the scripts/each/* iterators.
+//
+// Each iterator pushes a frame before its loop and pops it in the loop's
+// final callback, ticking once per item:
+//
+//   var bar = progress.push("Blog", blogIDs.length);
+//   ... bar.tick() per blog ...
+//   bar.pop();
+//
+// Because template.js -> blog.js and view.js -> template.js, the frames
+// nest on their own and the status line reads
+//
+//   Blog (23/1500)  Template (1/4)  View (7/12)
+//
+// On a TTY the line is pinned to the bottom and redrawn after anything the
+// script logs, so it survives stdout scrolling past. When stdout is not a
+// TTY (CI, a pipe, a log file) it falls back to a throttled plain line so
+// the output stays greppable. Set PROGRESS=0 / NO_PROGRESS=1 to silence it;
+// it is silent under NODE_ENV=test regardless.
+
+var CLEAR_LINE = "\x1b[2K";
+var REDRAW_THROTTLE_MS = 80;
+var FALLBACK_THROTTLE_MS = 3000;
+
+var frames = [];
+
+var disabled =
+  process.env.PROGRESS === "0" ||
+  process.env.NO_PROGRESS === "1" ||
+  process.env.NODE_ENV === "test";
+var sticky = !disabled && !!process.stdout.isTTY;
+var fallback = !disabled && !process.stdout.isTTY;
+
+var realStdoutWrite = null;
+var realStderrWrite = null;
+var realLog = console.log.bind(console);
+
+var patched = false;
+var exitHooked = false;
+var lineOnScreen = false;
+// True when real output is sitting mid-line (last chunk had no trailing
+// newline), so the status line must break to its own line first.
+var pendingNewline = false;
+var redrawTimer = null;
+var lastFallback = 0;
+
+function format() {
+  return frames
+    .map(function (f) {
+      return (
+        f.label + " (" + f.index + "/" + (f.total == null ? "?" : f.total) + ")"
+      );
+    })
+    .join("  ");
+}
+
+function writeRaw(str) {
+  realStdoutWrite.call(process.stdout, str);
+}
+
+function eraseLine() {
+  if (!lineOnScreen) return;
+  writeRaw("\r" + CLEAR_LINE);
+  lineOnScreen = false;
+  pendingNewline = false;
+}
+
+function drawLine() {
+  if (!frames.length) return;
+  if (pendingNewline) writeRaw("\n");
+  writeRaw(format());
+  pendingNewline = false;
+  lineOnScreen = true;
+}
+
+function scheduleRedraw() {
+  if (!sticky || redrawTimer) return;
+  redrawTimer = setTimeout(function () {
+    redrawTimer = null;
+    eraseLine();
+    drawLine();
+  }, REDRAW_THROTTLE_MS);
+  if (redrawTimer.unref) redrawTimer.unref();
+}
+
+function makePatchedWrite(stream, real) {
+  return function (chunk) {
+    eraseLine();
+    var ret = real.apply(stream, arguments);
+    var str = typeof chunk === "string" ? chunk : String(chunk);
+    pendingNewline = str.length > 0 && str.charAt(str.length - 1) !== "\n";
+    drawLine();
+    return ret;
+  };
+}
+
+function install() {
+  if (!sticky || patched) return;
+  patched = true;
+  realStdoutWrite = process.stdout.write;
+  realStderrWrite = process.stderr.write;
+  process.stdout.write = makePatchedWrite(process.stdout, realStdoutWrite);
+  process.stderr.write = makePatchedWrite(process.stderr, realStderrWrite);
+  if (!exitHooked) {
+    exitHooked = true;
+    process.on("exit", teardown);
+  }
+}
+
+function teardown() {
+  if (!patched) return;
+  eraseLine();
+  process.stdout.write = realStdoutWrite;
+  process.stderr.write = realStderrWrite;
+  patched = false;
+}
+
+function maybeFallbackLog(force) {
+  if (!fallback || !frames.length) return;
+  var now = Date.now();
+  if (!force && now - lastFallback < FALLBACK_THROTTLE_MS) return;
+  lastFallback = now;
+  realLog("progress: " + format());
+}
+
+function onChange(force) {
+  if (sticky) scheduleRedraw();
+  else if (fallback) maybeFallbackLog(force);
+}
+
+// push(label[, total]) -> handle. total may be null/undefined when unknown;
+// call handle.setTotal(n) later once it is known.
+function push(label, total) {
+  var frame = { label: label, index: 0, total: total == null ? null : total };
+  frames.push(frame);
+  install();
+
+  var handle = {
+    tick: function (n) {
+      frame.index += n || 1;
+      onChange(false);
+      return handle;
+    },
+    setIndex: function (n) {
+      frame.index = n;
+      onChange(false);
+      return handle;
+    },
+    setTotal: function (n) {
+      frame.total = n;
+      onChange(false);
+      return handle;
+    },
+    pop: function () {
+      var i = frames.indexOf(frame);
+      if (i !== -1) frames.splice(i, 1);
+      // Time-throttled in fallback mode: a long run pops a frame per view,
+      // which must not mean a log line per view.
+      onChange(false);
+      if (!frames.length) {
+        if (sticky) {
+          if (redrawTimer) {
+            clearTimeout(redrawTimer);
+            redrawTimer = null;
+          }
+          teardown();
+        }
+      }
+      return handle;
+    },
+  };
+
+  return handle;
+}
+
+module.exports = { push: push };

--- a/scripts/each/progress.js
+++ b/scripts/each/progress.js
@@ -64,14 +64,16 @@ function eraseLine() {
   if (!lineOnScreen) return;
   writeRaw("\r" + CLEAR_LINE);
   lineOnScreen = false;
-  pendingNewline = false;
 }
 
 function drawLine() {
   if (!frames.length) return;
-  if (pendingNewline) writeRaw("\n");
+  // Real output is sitting mid-line (a write with no trailing newline).
+  // Don't pin the status line over it - wait for the next newline-
+  // terminated write, so a logical line emitted as write("foo");
+  // write("bar\n") stays "foobar" rather than being split in two.
+  if (pendingNewline) return;
   writeRaw(format());
-  pendingNewline = false;
   lineOnScreen = true;
 }
 
@@ -90,7 +92,7 @@ function makePatchedWrite(stream, real) {
     eraseLine();
     var ret = real.apply(stream, arguments);
     var str = typeof chunk === "string" ? chunk : String(chunk);
-    pendingNewline = str.length > 0 && str.charAt(str.length - 1) !== "\n";
+    if (str.length) pendingNewline = str.charAt(str.length - 1) !== "\n";
     drawLine();
     return ret;
   };
@@ -136,6 +138,9 @@ function push(label, total) {
   var frame = { label: label, index: 0, total: total == null ? null : total };
   frames.push(frame);
   install();
+  // Show the 0/N state right away, so a slow or hanging first item still
+  // renders an indicator before it calls tick().
+  onChange(false);
 
   var handle = {
     tick: function (n) {
@@ -155,19 +160,30 @@ function push(label, total) {
     },
     pop: function () {
       var i = frames.indexOf(frame);
-      if (i !== -1) frames.splice(i, 1);
-      // Time-throttled in fallback mode: a long run pops a frame per view,
-      // which must not mean a log line per view.
-      onChange(false);
-      if (!frames.length) {
-        if (sticky) {
-          if (redrawTimer) {
-            clearTimeout(redrawTimer);
-            redrawTimer = null;
-          }
-          teardown();
+      if (i === -1) return handle;
+
+      // When the outermost frame finishes, emit one final line so a
+      // completed run's last record reads N/N - even when the whole run
+      // fit inside the fallback throttle window. Inner frames stay
+      // throttled: a long run pops one frame per view.
+      var outermost = frames.length === 1;
+      var finalLine = outermost ? format() : null;
+
+      frames.splice(i, 1);
+
+      if (outermost) {
+        if (fallback && finalLine) realLog("progress: " + finalLine);
+        if (sticky && redrawTimer) {
+          clearTimeout(redrawTimer);
+          redrawTimer = null;
         }
+        teardown();
+      } else {
+        // Time-throttled in fallback mode: a long run pops a frame per
+        // view, which must not mean a log line per view.
+        onChange(false);
       }
+
       return handle;
     },
   };

--- a/scripts/each/template.js
+++ b/scripts/each/template.js
@@ -2,17 +2,26 @@ var eachBlog = require("./blog");
 var Template = require("models/template");
 var async = require("async");
 var config = require("../../config");
+var progress = require("./progress");
 
 module.exports = function (doThis, callback) {
   eachBlog(function (user, blog, nextBlog) {
     Template.getTemplateList(blog.id, function (err, templates) {
       if (err) throw err;
 
+      var owned = (templates || []).filter(function (template) {
+        return template.owner === blog.id;
+      });
+
+      var bar = progress.push("Template", owned.length);
+
       async.eachSeries(
-        templates,
-        function (template, nextTemplate) {
-          // Only manipulate templates owned by the blog
-          if (template.owner !== blog.id) return nextTemplate();
+        owned,
+        function (template, done) {
+          var nextTemplate = function (err) {
+            bar.tick();
+            done(err);
+          };
 
           // console.log();
           // console.log(
@@ -30,7 +39,10 @@ module.exports = function (doThis, callback) {
 
           doThis(user, blog, template, nextTemplate);
         },
-        nextBlog
+        function (err) {
+          bar.pop();
+          nextBlog(err);
+        }
       );
     });
   }, callback);

--- a/scripts/each/user.js
+++ b/scripts/each/user.js
@@ -1,13 +1,21 @@
 var User = require("models/user");
 var async = require("async");
+var progress = require("./progress");
 
 module.exports = function (fn, callback) {
   User.getAllIds(function (err, uids) {
     if (err || !uids) return callback(err || new Error("No uids"));
 
+    var bar = progress.push("User", uids.length);
+
     async.eachSeries(
       uids,
-      function (uid, next) {
+      function (uid, done) {
+        var next = function (err) {
+          bar.tick();
+          done(err);
+        };
+
         User.getById(uid, function (err, user) {
           if (err) return next(err);
 
@@ -21,7 +29,10 @@ module.exports = function (fn, callback) {
           fn(user, next);
         });
       },
-      callback
+      function (err) {
+        bar.pop();
+        callback(err);
+      }
     );
   });
 };

--- a/scripts/each/view.js
+++ b/scripts/each/view.js
@@ -1,18 +1,29 @@
 var eachTemplate = require("./template");
 var Template = require("models/template");
 var async = require("async");
+var progress = require("./progress");
 
 module.exports = function (doThis, callback) {
   eachTemplate(function (user, blog, template, nextTemplate) {
     Template.getAllViews(template.id, function (err, views) {
       if (err) throw err;
 
+      var bar = progress.push("View", Object.keys(views || {}).length);
+
       async.eachOfSeries(
         views,
-        function (view, name, nextView) {
+        function (view, name, done) {
+          var nextView = function (err) {
+            bar.tick();
+            done(err);
+          };
+
           doThis(user, blog, template, view, nextView);
         },
-        nextTemplate
+        function (err) {
+          bar.pop();
+          nextTemplate(err);
+        }
       );
     });
   }, callback);

--- a/scripts/template/recalculate-retrieve.js
+++ b/scripts/template/recalculate-retrieve.js
@@ -317,7 +317,10 @@ function eachSiteView(iterator, done) {
             async.eachOfSeries(
               views || {},
               function (view, name, nextView) {
-                iterator(templateID, view, nextView);
+                iterator(templateID, view, function (err) {
+                  viewBar.tick();
+                  nextView(err);
+                });
               },
               function (err) {
                 viewBar.pop();

--- a/scripts/template/recalculate-retrieve.js
+++ b/scripts/template/recalculate-retrieve.js
@@ -1,4 +1,5 @@
 var eachBlog = require("../each/blog");
+var progress = require("../each/progress");
 var async = require("async");
 var Template = require("models/template");
 var templateKey = require("models/template/key");
@@ -123,12 +124,14 @@ function recalcBlog(blogID, stats, done) {
     });
 
     var changedTemplateIDs = [];
+    var bar = progress.push("Template", owned.length);
 
     async.eachSeries(
       owned,
       function (template, nextTemplate) {
         recalcTemplateViews(template.id, stats, function (err, changed) {
           if (changed) changedTemplateIDs.push(template.id);
+          bar.tick();
           // Stop the blog loop on a genuine setView error, but keep the
           // partial `changed` set so finalizeBlog still flushes the views
           // that were rewritten before the failure.
@@ -136,6 +139,7 @@ function recalcBlog(blogID, stats, done) {
         });
       },
       function (err) {
+        bar.pop();
         finalizeBlog(blogID, changedTemplateIDs, function (flushErr) {
           done(err || flushErr);
         });
@@ -150,6 +154,7 @@ function recalcTemplateViews(templateID, stats, done) {
 
     var changed = false;
     var firstErr = null;
+    var bar = progress.push("View", Object.keys(views || {}).length);
 
     async.eachOfSeries(
       views || {},
@@ -157,10 +162,12 @@ function recalcTemplateViews(templateID, stats, done) {
         recalcView(templateID, view, stats, function (err, viewChanged) {
           if (viewChanged) changed = true;
           if (err && !firstErr) firstErr = err;
+          bar.tick();
           nextView(err);
         });
       },
       function (err) {
+        bar.pop();
         done(firstErr || err || null, changed);
       }
     );
@@ -289,22 +296,40 @@ function eachSiteView(iterator, done) {
   redis
     .sMembers(templateKey.blogTemplates("SITE"))
     .then(function (templateIDs) {
+      var templateBar = progress.push("Template", (templateIDs || []).length);
+
       async.eachSeries(
         templateIDs || [],
-        function (templateID, nextTemplate) {
+        function (templateID, nextItem) {
+          var nextTemplate = function (err) {
+            templateBar.tick();
+            nextItem(err);
+          };
+
           Template.getAllViews(templateID, function (err, views) {
             if (err) return nextTemplate(err);
+
+            var viewBar = progress.push(
+              "View",
+              Object.keys(views || {}).length
+            );
 
             async.eachOfSeries(
               views || {},
               function (view, name, nextView) {
                 iterator(templateID, view, nextView);
               },
-              nextTemplate
+              function (err) {
+                viewBar.pop();
+                nextTemplate(err);
+              }
             );
           });
         },
-        done
+        function (err) {
+          templateBar.pop();
+          done(err);
+        }
       );
     })
     .catch(done);


### PR DESCRIPTION
## What

Adds progress indicators to the `scripts/each/*` iterators (and therefore to every script that iterates blogs / users / templates / views / entries, including `scripts/template/recalculate-retrieve.js`).

New helper **`scripts/each/progress.js`**: a nested frame stack. Each iterator does `progress.push(label, total)` before its loop, `bar.tick()` per item, `bar.pop()` in the loop's final callback. Because `template.js → blog.js` and `view.js → template.js`, the frames nest on their own:

```
Blog (23/1500)  Template (1/4)  View (7/12)
```

- **TTY**: the line is pinned to the bottom and redrawn after anything the script logs to stdout/stderr, so it survives output scrolling past (via `\r` + `\x1b[2K`, no dependency, `process.stdout.write` wrapped only while frames are active and restored on exit).
- **Non-TTY** (CI, pipe, log file): degrades to a time-throttled `progress: Blog (23/1500)  Template (1/4)` line so logs stay greppable.
- Silent under `NODE_ENV=test`, or with `PROGRESS=0` / `NO_PROGRESS=1`.

## Wiring

- `scripts/each/blog.js`, `user.js`, `template.js`, `view.js`, `entry.js` — push/tick/pop around their existing loops. Transparent to callers; the `next()` contract is unchanged.
  - `template.js` now pre-filters to blog-owned templates (it already skipped the rest with a no-op `nextTemplate()`), so the `Template` count is meaningful.
  - `entry.js` shows `(123/?)` — `Entries.each` streams ids so the per-blog total isn't known up front; the per-blog frame is skipped under `options.p` (parallel blogs would share one global stack).
- `scripts/template/recalculate-retrieve.js` — adds explicit `Template` / `View` frames since it rolls its own template/view iteration (inc. the `SITE:*` pass). The `Blog` frame comes for free from `each/blog.js`.

## Testing

- Syntax-checked all touched files.
- Smoke-tested the helper under a pseudo-tty (sticky line clears/redraws correctly, no leftover line on exit) and piped (throttled fallback lines, silent under `NODE_ENV=test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)