### PR TITLE
Shrink prod image and speed up the deploy checkout

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,9 @@ package-lock.json
 app/views-built/
 data/
 config/openresty/tests/data/
+
+# Test and benchmark fixtures (~45MB) are never used at runtime. The dev/CI
+# image bind-mounts the working tree instead of copying it, so these are still
+# present for the test matrix - this only trims the prod build context.
+app/**/tests/
+app/**/benchmarks/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,9 +26,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Need full history so an older commit or short code can be
-          # resolved and verified against master.
+          # Need full commit history so an older commit or short code can be
+          # resolved and verified against master. blob:none makes this a
+          # treeless partial clone: all commits/trees, but file contents are
+          # fetched on demand - this repo's blob history is multiple GB and
+          # the deploy only needs rev-parse / merge-base / a single checkout.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Check branch
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -159,10 +159,14 @@ WORKDIR /usr/src/app
 # Runtime dependencies only (no devDependencies, no toolchain).
 COPY --from=deps /usr/src/app/node_modules ./node_modules
 
-# Copy files and set ownership for non-root user
+# Copy files and set ownership for non-root user.
+# `app` is chown'd at COPY time rather than with a later `RUN chown -R`: a
+# recursive chown rewrites every inode, so it would duplicate the whole ~380MB
+# `app` tree into an extra layer that every deploy then has to pull. config,
+# scripts and node_modules stay root-owned (the app only reads them).
 COPY ./config ./config
 COPY ./scripts ./scripts
-COPY ./app ./app
+COPY --chown=1000:1000 ./app ./app
 COPY ./TODO ./TODO
 
 ## Stage 6 (default, production)
@@ -172,12 +176,10 @@ FROM source AS prod
 HEALTHCHECK --interval=10s --timeout=5s --start-period=120s --start-interval=5s --retries=3 \
   CMD curl --fail http://localhost:8080/health || exit 1
 
-# Ensure the data directory exists
-# In production we mount the shared data directory to this location
-RUN mkdir -p /usr/src/app/data
-
-# Give the non-root user ownership of the app directory and data directory
-RUN chown -R 1000:1000 /usr/src/app/app && chown -R 1000:1000 /usr/src/app/data
+# Ensure the data directory exists (empty; in production the shared data
+# directory is mounted over this location). `app` is already owned by 1000:1000
+# from the COPY --chown above, so no recursive chown is needed here.
+RUN mkdir -p /usr/src/app/data && chown 1000:1000 /usr/src/app/data
 
 # Change to the non-root user for the rest of the Dockerfile (ec2-user)
 USER 1000


### PR DESCRIPTION
Three independent, low-risk changes that cut how many bytes a deploy has to move. Part of the image-size investigation; the big font-format reduction is being handled separately.

## 1. Dockerfile — `COPY --chown` instead of `RUN chown -R` on `app/`

`RUN chown -R 1000:1000 /usr/src/app/app` rewrites every inode in the tree, so overlayfs writes a **second full copy** of the ~380 MB `app/` directory into that layer. Doing the ownership change at `COPY` time removes the duplicate layer entirely. `config/`, `scripts/` and `node_modules/` stay root-owned exactly as before (the app only reads them). The `data/` chown stays but no longer needs `-R` — the dir is empty at build time.

## 2. `.dockerignore` — drop test/benchmark fixtures from the prod context

`app/**/tests/` and `app/**/benchmarks/` are ~45 MB of fixtures (`car.heic`, sample gifs, converter corpora, …). Verified nothing under `app/` `require()`s them outside test files. The `dev`/CI image bind-mounts the working tree rather than copying the build context (see `scripts/tests/invoke.sh`), so the test matrix is unaffected — this only trims the `prod` build.

## 3. `deploy.yml` — treeless partial clone for the checkout

The deploy checkout keeps `fetch-depth: 0` (it must resolve/verify an arbitrary commit or short code against `master`) but adds `filter: blob:none`. The deploy only runs `rev-parse` / `merge-base --is-ancestor` / a single `git checkout --detach` and then drives everything over SSH — it never needs the repo's multi-GB blob history, which the partial clone now fetches on demand.

## Risk / verification

- `build.yml` builds `target: prod` on both arches and runs the container health check — exercises the chown and dockerignore changes end to end.
- No application code touched.
- Prod still runs `node app/documentation/build` as UID 1000; `app/` is writable by 1000 via the `COPY --chown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)