### PR TITLE
Fix minute-rollover flake in dates timezone test

### DIFF
--- a/app/blog/tests/dates.js
+++ b/app/blog/tests/dates.js
@@ -243,28 +243,34 @@ describe("dates", function () {
     });
     await this.blog.update({ timeZone: "Asia/Tokyo" });
 
-    // When you remove date from metadata, it should use created date adjusted for timezone
+    // When you remove date from metadata, it should use the created date
+    // adjusted for timezone. The "created" timestamp is assigned during the
+    // build, some time after createTime, so the minute can roll over between
+    // the two - accept any minute in the [createTime, afterCreateTime] window.
     const createTime = Date.now();
     await this.write({ path: "/a.txt", content: "Foo" });
+    const afterCreateTime = Date.now();
+
+    const acceptableMinutes = (zone) => {
+      const values = [];
+      for (
+        let t = moment.utc(createTime).startOf("minute");
+        t.valueOf() <= afterCreateTime;
+        t.add(1, "minute")
+      ) {
+        values.push(t.clone().tz(zone).format("YYYY-MM-DD HH:mm"));
+      }
+      return values;
+    };
 
     // In Tokyo timezone, created date should be adjusted accordingly
-    const createdDateTokyo = moment
-      .utc(createTime)
-      .tz("Asia/Tokyo")
-      .format("YYYY-MM-DD HH:mm");
-
-    expect(await this.text("/")).toBe(createdDateTokyo);
+    expect(acceptableMinutes("Asia/Tokyo")).toContain(await this.text("/"));
 
     // Change timezone to America/New_York
     await this.blog.update({ timeZone: "America/New_York" });
     await this.blog.rebuild();
 
-    const createdDateNY = moment
-      .utc(createTime)
-      .tz("America/New_York")
-      .format("YYYY-MM-DD HH:mm");
-
-    expect(await this.text("/")).toBe(createdDateNY);
+    expect(acceptableMinutes("America/New_York")).toContain(await this.text("/"));
 
     // However, when you use a date in metadata, it should remain constant regardless of timezone
     await this.write({


### PR DESCRIPTION
## Problem

CI failure on master ([run 34453785616](https://github.com/davidmerfield/blot/actions/runs/34453785616/job/102795453912)):

```
1) dates respects the blog's timezone setting when rendering dates
   Expected '2026-09-10 17:13' to be '2026-09-10 17:12'.
   Expected '2026-09-10 04:13' to be '2026-09-10 04:12'.
```

Both assertions are the same instant rendered in `Asia/Tokyo` and `America/New_York`.

## Cause — flaky, not a real regression

The spec writes an entry with no `Date:` metadata, so its displayed date comes from the `created` timestamp, which is assigned **during the build** triggered by `this.write()` — a few milliseconds after the test captures `createTime = Date.now()`. The format precision is minutes (`HH:mm`). When a minute boundary falls in that window (here at `08:12:59.9xx` UTC), the build records `08:13` while the assertion expects `08:12`. Both assertions fail together because they derive from the same `createTime`. Nothing timezone-specific.

## Fix

Bracket the write with `createTime` / `afterCreateTime` and assert the rendered value is any minute within that window rather than one exact string. The later `America/New_York` rebuild re-renders the same stored `created` value, so the same window applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)