### PR TITLE
Skip already-current views in recalculate-retrieve

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,6 +1,92 @@
 Run this in prod: node scripts/template/recalculate-retrieve.js
 Run this as well: node scripts/template/migrate-font-urls.js
 
+---
+
+Clean up retrieve-metadata migration code once recalculate-retrieve has run
+
+Context: "Store entry fields in template retrieve metadata" (00d195709) taught
+parseTemplate to record which entry fields a view references, as
+retrieve.<local>.fields.<field>. scripts/template/recalculate-retrieve.js
+backfills that onto every stored view. Several pieces of code exist only to
+tolerate stored views that have NOT been backfilled yet (projected-entry
+locals stored as a bare `true` instead of `{}` / `{ fields: {...} }`). Once
+the script has run to completion in prod - confirm with
+`node scripts/template/recalculate-retrieve.js --dry-run` reporting 0 views
+to update - the following can go.
+
+Available immediately once PR #1768 merges (independent of the prod run),
+do as its own follow-up PR:
+
+1. Remove the `deferCacheBump` option - it is now orphaned. PR #1768 rewrote
+   recalcView to write the single `retrieve` hash field directly with
+   redis.hSet instead of calling Template.setView, so nothing passes
+   deferCacheBump any more.
+   - app/models/template/setView.js: drop `deferCacheBump` and the
+     `{ deferCacheBump }` thread into setMetadata. Keep the
+     options-position-or-callback shim only if some other caller passes an
+     options object - grep `setView(` across app/ and scripts/ first; if the
+     script is still the only options caller, revert setView's signature to
+     `(templateID, updates, callback)`. The `clearErrorsIfNeeded` refactor
+     from #1761 can stay (it is a tidy-up) or be inlined back.
+   - app/models/template/setMetadata.js: revert to
+     `(id, updates, callback)` - the `options` / `deferCacheBump` parameter
+     (added by #1761) has no other caller.
+   - Drop the matching assertions in app/models/template/tests/setView.js and
+     tests/setMetadata.js.
+   - This effectively reverts the app/models/template/* half of #1761; keep
+     #1768's script.
+
+After the prod run is confirmed complete:
+
+2. Retire scripts/template/recalculate-retrieve.js. It is a one-shot backfill.
+   Options: (a) delete it (precedent: most scripts/template/*.js one-shots are
+   kept, so this is a judgement call), or (b) keep it as a dormant maintenance
+   tool - the exact-equality skip added in #1768 makes a re-run cheap and
+   idempotent, which is useful the next time parseTemplate's retrieve output
+   changes. If keeping it, leave a note here instead of in the file header.
+   If deleting it, also check whether `options.c` on scripts/each/blog.js has
+   any other user (grep `\bc:\s` / `options.c`); it is a harmless generic
+   knob so probably keep it, but it was added for this script.
+
+3. Simplify mergeRetrieve.reconcileBooleans
+   (app/models/template/util/mergeRetrieve.js). The two projection-specific
+   swaps - `sourceVal === true && isProjectionMetadata(targetVal)` and the
+   mirror - exist for the window where a view has backfilled metadata but one
+   of its partials (merged at render time by getFullView / getPartials) still
+   stores `allEntries: true`, or vice versa. Once every stored view is
+   backfilled, no projected-entry local is ever a bare `true`, so those two
+   branches are unreachable from stored data. Risk: a single view missed by
+   the migration would then have a heavy field projected away that it
+   actually renders. Mitigation: before deleting, land a change that logs
+   (or asserts, behind a flag) when reconcileBooleans hits a projection
+   boolean, run for a release, confirm it never fires, then remove. The
+   generic non-projection `targetVal === true && object` promotion (plugin:
+   true + plugin.katex.css) is permanent - keep it. Update the
+   tests/mergeRetrieve.js specs that cover the removed branches.
+
+Not removable - reword stale comments only:
+
+4. app/blog/render/retrieve/helpers/projectEntryFields.js: resolveFields()
+   returns null (skip projection) whenever a local lacks a `fields` map. That
+   is still correct forever for the current parser's own output -
+   `retrieve.posts = {}` (list references no heavy field) and
+   `retrieve.allEntries = { length: true }` (non-field access) both hit it.
+   Only the header comment ("Views whose retrieve metadata has not been
+   recalculated yet still store `allEntries: true`") and the "legacy boolean
+   metadata" aside in resolveFields' doc comment are now misleading - reword
+   to describe the `{}` / `.length` cases instead.
+
+5. app/models/template/parseTemplate.js:54 and setView.js:34 mention
+   recalculate-retrieve by name in comments; adjust if the script is deleted.
+
+migrate-font-urls.js is also a one-shot (retire after its prod run) but
+introduced no backward-compat branches to unwind - rewriteContent is a pure
+content rewrite, idempotent on re-run, so there is nothing else to clean up
+for it.
+
+---
+
 Proxy container (OpenResty) - deferred work after the build-only scaffolding PR
 
 The `proxy/` directory is build-only scaffolding: the image builds, the

--- a/app/models/template/setView.js
+++ b/app/models/template/setView.js
@@ -16,6 +16,7 @@ var ERROR = require("../../blog/render/error");
 var updateCdnManifest = require("./util/updateCdnManifest");
 var serializeRedisHashValues = require("models/redisHashSerializer");
 var clfdate = require("helper/clfdate");
+var applyUserRetrieveOptions = require("./util/applyUserRetrieveOptions");
 const MAX_VIEW_PAYLOAD_SIZE = 2 * 1024 * 1024;
 
 module.exports = function setView(templateID, updates, options, callback) {
@@ -390,65 +391,6 @@ module.exports = function setView(templateID, updates, options, callback) {
 		}).catch(callback);
 	});
 };
-
-var USER_RETRIEVE_KEYS = ["includeDraft", "filters"];
-
-function applyUserRetrieveOptions(parsedRetrieve, requestedRetrieve, existingRetrieve) {
-	var result = {};
-
-	extend(result).and(parsedRetrieve || {});
-
-	// The parser is authoritative for locals it can see in the content, but it
-	// can't see a dependency reached indirectly - e.g. a view whose
-	// locals.snippet is "{{latest_entry.title}}" and content is "{{{snippet}}}"
-	// still needs retrieve.latest_entry. Carry over any real retrieve local
-	// (one blot knows how to fetch) that the caller or the stored view asked
-	// for. Non-local keys (stale output from an older parser, internal
-	// __sentinels) are dropped - they fetch nothing.
-	[requestedRetrieve, existingRetrieve].forEach(function (source) {
-		if (!source) return;
-		Object.keys(source).forEach(function (key) {
-			if (key.indexOf("__") === 0) return;
-			if (!parseTemplate.isSystemRetrieveLocal(key)) return;
-
-			var sourceVal = source[key];
-
-			if (result[key] === undefined) {
-				result[key] = sourceVal;
-			} else if (type(result[key], "array") && type(sourceVal, "array")) {
-				// `cdn` is an array dependency - union the targets so an
-				// explicit/stored entry (e.g. a target reached indirectly)
-				// survives alongside the parser's. updateCdnManifest builds
-				// the manifest purely from this persisted array.
-				result[key] = [...new Set(result[key].concat(sourceVal))].sort();
-			} else if (type(result[key], "object") && type(sourceVal, "object")) {
-				// Both structured (e.g. plugin.katex.css from content plus an
-				// explicit plugin.zoom.js needed by a local): keep the parser's
-				// leaves, fold in the extra nested requests.
-				extend(result[key]).and(sourceVal);
-			}
-			// else: parser produced a value and the explicit one is a bare
-			// boolean (or vice versa) - the parser wins (see the setView
-			// stale-boolean tests).
-		});
-	});
-
-	USER_RETRIEVE_KEYS.forEach(function (key) {
-		var value;
-
-		if (requestedRetrieve && requestedRetrieve[key] !== undefined) {
-			value = requestedRetrieve[key];
-		} else if (existingRetrieve && existingRetrieve[key] !== undefined) {
-			value = existingRetrieve[key];
-		}
-
-		if (value !== undefined) {
-			result[key] = value;
-		}
-	});
-
-	return result;
-}
 
 function detectInfinitePartialDependency(
 	templateID,

--- a/app/models/template/tests/applyUserRetrieveOptions.js
+++ b/app/models/template/tests/applyUserRetrieveOptions.js
@@ -1,0 +1,88 @@
+describe("applyUserRetrieveOptions", function () {
+  var applyUserRetrieveOptions = require("../util/applyUserRetrieveOptions");
+
+  it("returns the parser output when nothing else is supplied", function () {
+    expect(
+      applyUserRetrieveOptions(
+        { posts: { fields: { title: true } } },
+        undefined,
+        {}
+      )
+    ).toEqual({ posts: { fields: { title: true } } });
+  });
+
+  it("does not mutate the parser output it was given", function () {
+    var parsed = { posts: { fields: { title: true } } };
+    applyUserRetrieveOptions(parsed, undefined, { includeDraft: true });
+    expect(parsed).toEqual({ posts: { fields: { title: true } } });
+  });
+
+  it("carries over a real retrieve local the parser could not see", function () {
+    // e.g. locals.snippet = "{{latest_entry.title}}", content = "{{{snippet}}}"
+    expect(
+      applyUserRetrieveOptions({}, undefined, { latest_entry: true })
+    ).toEqual({ latest_entry: true });
+  });
+
+  it("drops __ sentinels and non-system keys from the stored retrieve", function () {
+    expect(
+      applyUserRetrieveOptions(
+        {},
+        { __recalculateRetrieve: 123 },
+        { foo: true, __stale: 1 }
+      )
+    ).toEqual({});
+  });
+
+  it("keeps includeDraft / filters, with the request winning over the stored value", function () {
+    expect(
+      applyUserRetrieveOptions(
+        { posts: { fields: { title: true } } },
+        { includeDraft: true },
+        { includeDraft: false, filters: [{ tag: "x" }] }
+      )
+    ).toEqual({
+      posts: { fields: { title: true } },
+      includeDraft: true,
+      filters: [{ tag: "x" }],
+    });
+  });
+
+  it("lets the parser's projection object win over a stored bare boolean", function () {
+    expect(
+      applyUserRetrieveOptions(
+        { allEntries: { fields: { html: true } } },
+        undefined,
+        { allEntries: true }
+      )
+    ).toEqual({ allEntries: { fields: { html: true } } });
+  });
+
+  it("unions and sorts cdn targets from the stored retrieve", function () {
+    expect(
+      applyUserRetrieveOptions({ cdn: ["b.js"] }, undefined, {
+        cdn: ["a.js", "b.js"],
+      })
+    ).toEqual({ cdn: ["a.js", "b.js"] });
+  });
+
+  it("is idempotent: re-applying its own output changes nothing", function () {
+    var parseTemplate = require("../parseTemplate");
+    var content =
+      "{{{appCSS}}}{{#posts}}{{title}}{{{html}}}{{/posts}}" +
+      "{{#latest_entry}}{{summary}}{{/latest_entry}}";
+
+    var first = applyUserRetrieveOptions(
+      parseTemplate(content).retrieve || {},
+      undefined,
+      {}
+    );
+    var second = applyUserRetrieveOptions(
+      parseTemplate(content).retrieve || {},
+      undefined,
+      first
+    );
+
+    expect(second).toEqual(first);
+  });
+});

--- a/app/models/template/util/applyUserRetrieveOptions.js
+++ b/app/models/template/util/applyUserRetrieveOptions.js
@@ -1,0 +1,73 @@
+var extend = require("helper/extend");
+var type = require("helper/type");
+var parseTemplate = require("../parseTemplate");
+
+// The parser is the source of truth for retrieve locals it can see in a view's
+// content. This folds back the two things the parser can't derive from content
+// alone:
+//
+//   1. Real retrieve locals (ones blot knows how to fetch) that the caller or
+//      the previously stored view asked for - e.g. a dependency reached only
+//      through a string local. Non-local keys (stale output from an older
+//      parser, internal __sentinels) are dropped: they fetch nothing.
+//   2. User-set options on the retrieve object (includeDraft, filters).
+//
+// setView persists exactly what this returns, so scripts that recalculate
+// retrieve metadata in bulk compare a view's stored retrieve against a fresh
+// run of this to decide whether a rewrite is needed.
+
+var USER_RETRIEVE_KEYS = ["includeDraft", "filters"];
+
+module.exports = function applyUserRetrieveOptions(
+	parsedRetrieve,
+	requestedRetrieve,
+	existingRetrieve
+) {
+	var result = {};
+
+	extend(result).and(parsedRetrieve || {});
+
+	[requestedRetrieve, existingRetrieve].forEach(function (source) {
+		if (!source) return;
+		Object.keys(source).forEach(function (key) {
+			if (key.indexOf("__") === 0) return;
+			if (!parseTemplate.isSystemRetrieveLocal(key)) return;
+
+			var sourceVal = source[key];
+
+			if (result[key] === undefined) {
+				result[key] = sourceVal;
+			} else if (type(result[key], "array") && type(sourceVal, "array")) {
+				// `cdn` is an array dependency - union the targets so an
+				// explicit/stored entry (e.g. a target reached indirectly)
+				// survives alongside the parser's. updateCdnManifest builds
+				// the manifest purely from this persisted array.
+				result[key] = [...new Set(result[key].concat(sourceVal))].sort();
+			} else if (type(result[key], "object") && type(sourceVal, "object")) {
+				// Both structured (e.g. plugin.katex.css from content plus an
+				// explicit plugin.zoom.js needed by a local): keep the parser's
+				// leaves, fold in the extra nested requests.
+				extend(result[key]).and(sourceVal);
+			}
+			// else: parser produced a value and the explicit one is a bare
+			// boolean (or vice versa) - the parser wins (see the setView
+			// stale-boolean tests).
+		});
+	});
+
+	USER_RETRIEVE_KEYS.forEach(function (key) {
+		var value;
+
+		if (requestedRetrieve && requestedRetrieve[key] !== undefined) {
+			value = requestedRetrieve[key];
+		} else if (existingRetrieve && existingRetrieve[key] !== undefined) {
+			value = existingRetrieve[key];
+		}
+
+		if (value !== undefined) {
+			result[key] = value;
+		}
+	});
+
+	return result;
+};

--- a/scripts/each/blog.js
+++ b/scripts/each/blog.js
@@ -61,6 +61,17 @@ module.exports = function (doThis, allDone, options) {
 
     if (options.p) {
       forEach = async.each;
+    } else if (options.c && parseInt(options.c, 10) > 1) {
+      // Bounded concurrency: overlap the per-blog Redis reads without the
+      // unbounded fan-out of options.p. The nested progress line (Blog x
+      // Template x View) assumes one blog in flight at a time, so with
+      // options.c it only tracks the blog frame reliably - acceptable for a
+      // one-off migration where throughput matters more than a tidy status
+      // line.
+      var limit = parseInt(options.c, 10);
+      forEach = function (items, iterator, cb) {
+        async.eachLimit(items, limit, iterator, cb);
+      };
     }
 
     var bar = progress.push("Blog", blogIDs.length);

--- a/scripts/template/recalculate-retrieve.js
+++ b/scripts/template/recalculate-retrieve.js
@@ -5,82 +5,84 @@ var Template = require("models/template");
 var templateKey = require("models/template/key");
 var redis = require("models/client");
 var Blog = require("models/blog");
+var parseTemplate = require("models/template/parseTemplate");
+var applyUserRetrieveOptions = require("models/template/util/applyUserRetrieveOptions");
 var updateCdnManifest = require("models/template/util/updateCdnManifest");
 
+// How many blogs to process concurrently. 1 keeps the nested progress line
+// accurate; raise it (via --concurrency=N) when the per-blog Redis reads are
+// the bottleneck on a full-fleet run.
+var DEFAULT_CONCURRENCY = 1;
+
 if (require.main === module) {
-  main(function (err, stats) {
+  var options = parseArgs(process.argv.slice(2));
+
+  main(options, function (err, stats) {
     if (err) {
       console.error(err);
       process.exit(1);
     }
 
     console.log(
-      "Done. Recalculated retrieve metadata for",
+      options.dryRun ? "Dry run complete." : "Done.",
+      options.dryRun ? "Would recalculate" : "Recalculated",
+      "retrieve metadata for",
       stats.updated,
       "views",
       "(skipped",
       stats.skipped,
       "invalid,",
       stats.alreadyMigrated,
-      "already migrated)"
+      "already current)"
     );
 
     process.exit(0);
   });
 }
 
-// Projected-entry retrieve locals. parseTemplate records references to a heavy
-// entry field under `retrieve.<local>.fields.<field>`; the old parser stored
-// these locals as a bare `true`. A stored view whose retrieve already carries
-// that `fields` projection metadata was therefore written by the new parser,
-// and setView persists retrieve atomically, so recalculating it would be a
-// no-op. Skipping those views makes an interrupted run cheap to resume.
-var PROJECTED_ENTRY_LOCALS = [
-  "allEntries",
-  "all_entries",
-  "recentEntries",
-  "recent_entries",
-  "latestEntry",
-  "latest_entry",
-  "posts",
-  "search_results",
-  "tagged",
-  "archives",
-];
+function parseArgs(argv) {
+  var options = { dryRun: false, concurrency: DEFAULT_CONCURRENCY };
 
-function hasProjectionMetadata(retrieve) {
-  if (!retrieve || typeof retrieve !== "object") return false;
-
-  return PROJECTED_ENTRY_LOCALS.some(function (local) {
-    var value = retrieve[local];
-    return (
-      !!value &&
-      typeof value === "object" &&
-      !Array.isArray(value) &&
-      !!value.fields &&
-      typeof value.fields === "object"
-    );
+  (argv || []).forEach(function (arg) {
+    if (arg === "--dry-run" || arg === "-n") {
+      options.dryRun = true;
+    } else if (arg.indexOf("--concurrency=") === 0) {
+      var n = parseInt(arg.slice("--concurrency=".length), 10);
+      if (n > 0) options.concurrency = n;
+    }
   });
+
+  return options;
 }
 
-function main(callback) {
+function main(options, callback) {
+  if (typeof options === "function") {
+    callback = options;
+    options = {};
+  }
+
+  options = options || {};
+
+  var dryRun = options.dryRun === true;
+  var concurrency = options.concurrency > 0 ? options.concurrency : DEFAULT_CONCURRENCY;
+
   var stats = {
     updated: 0,
     skipped: 0,
     alreadyMigrated: 0,
   };
 
-  // Blog-owned templates. Recalculate every view of every template with the
-  // per-view cache work deferred (see recalcView), then, once per blog whose
-  // templates changed, bump that blog's cacheID a single time and rebuild the
-  // CDN manifest of each changed template.
+  // Blog-owned templates. Recalculate every view of every template, then, once
+  // per blog whose templates actually changed, bump that blog's cacheID a
+  // single time and rebuild the CDN manifest of each changed template.
   //
-  // setView would otherwise bump the owner blog's cacheID and rebuild the CDN
-  // manifest once per changed view, for every template the blog owns - needless
-  // repetition of a fleet-wide cache flush.
+  // recalcView reparses each view in-process and only writes (just the
+  // `retrieve` hash field) when the stored metadata differs from what the
+  // parser now produces - so a view that is already current costs one parse
+  // and no Redis write, and a blog with nothing stale is never flushed.
   eachBlog(
     function (user, blog, nextBlog) {
-      recalcBlog(blog.id, stats, nextBlog);
+      recalcBlog(blog.id, stats, dryRun, nextBlog);
     },
     function (err) {
       if (err) return callback(err, stats);
@@ -92,7 +94,7 @@ function main(callback) {
 
       eachSiteView(
         function (templateID, view, next) {
-          recalcView(templateID, view, stats, function (err, changed) {
+          recalcView(templateID, view, stats, dryRun, function (err, changed) {
             if (changed) touchedSiteTemplates[templateID] = true;
             next(err);
           });
@@ -103,6 +105,8 @@ function main(callback) {
           // caches of every blog whose active template we just rewrote so the
           // new retrieve metadata takes effect - even if iteration stopped on
           // an error, so a partial run still flushes what it did rewrite.
+          if (dryRun) return callback(err, stats);
+
           invalidateBlogsUsing(
             Object.keys(touchedSiteTemplates),
             function (flushErr) {
@@ -111,11 +115,12 @@ function main(callback) {
           );
         }
       );
-    }
+    },
+    { c: concurrency }
   );
 }
 
-function recalcBlog(blogID, stats, done) {
+function recalcBlog(blogID, stats, dryRun, done) {
   Template.getTemplateList(blogID, function (err, templates) {
     if (err) return done(err);
 
@@ -129,17 +134,20 @@ function recalcBlog(blogID, stats, done) {
     async.eachSeries(
       owned,
       function (template, nextTemplate) {
-        recalcTemplateViews(template.id, stats, function (err, changed) {
+        recalcTemplateViews(template.id, stats, dryRun, function (err, changed) {
           if (changed) changedTemplateIDs.push(template.id);
           bar.tick();
-          // Stop the blog loop on a genuine setView error, but keep the
-          // partial `changed` set so finalizeBlog still flushes the views
-          // that were rewritten before the failure.
+          // Stop the blog loop on a genuine write error, but keep the partial
+          // `changed` set so finalizeBlog still flushes the views that were
+          // rewritten before the failure.
           nextTemplate(err);
         });
       },
       function (err) {
         bar.pop();
+
+        if (dryRun) return done(err);
+
         finalizeBlog(blogID, changedTemplateIDs, function (flushErr) {
           done(err || flushErr);
         });
@@ -148,7 +156,7 @@ function recalcBlog(blogID, stats, done) {
   });
 }
 
-function recalcTemplateViews(templateID, stats, done) {
+function recalcTemplateViews(templateID, stats, dryRun, done) {
   Template.getAllViews(templateID, function (err, views) {
     if (err) return done(err, false);
 
@@ -159,7 +167,7 @@ function recalcTemplateViews(templateID, stats, done) {
     async.eachOfSeries(
       views || {},
       function (view, name, nextView) {
-        recalcView(templateID, view, stats, function (err, viewChanged) {
+        recalcView(templateID, view, stats, dryRun, function (err, viewChanged) {
           if (viewChanged) changed = true;
           if (err && !firstErr) firstErr = err;
           bar.tick();
@@ -208,54 +216,98 @@ function finalizeBlog(blogID, changedTemplateIDs, done) {
   });
 }
 
-function recalcView(templateID, view, stats, next) {
+function recalcView(templateID, view, stats, dryRun, next) {
   if (!view || !view.name || !view.content) {
     stats.skipped++;
     return next(null, false);
   }
 
-  // Idempotency: a view whose stored retrieve already carries field-projection
-  // metadata was rewritten by the new parser on an earlier run. Skip it so an
-  // interrupted run can be restarted without redoing completed work.
-  if (hasProjectionMetadata(view.retrieve)) {
+  var expectedRetrieve;
+
+  try {
+    var parsed = parseTemplate(view.content);
+    // setView persists exactly applyUserRetrieveOptions(parser output, the
+    // update's retrieve, the stored retrieve). The recalculation passes no
+    // real retrieve options, so a full setView run would store precisely
+    // this. Compute it here without any Redis round-trip.
+    expectedRetrieve = applyUserRetrieveOptions(
+      parsed.retrieve || {},
+      undefined,
+      view.retrieve || {}
+    );
+  } catch (e) {
+    // The parser choked on this view's content. Leave it untouched rather
+    // than guessing - a genuinely broken view is a pre-existing problem and
+    // rewriting its metadata blind could make things worse.
+    console.error(
+      "Skipping unparseable view",
+      templateID,
+      view.name,
+      "-",
+      e && e.message
+    );
+    stats.skipped++;
+    return next(null, false);
+  }
+
+  // Idempotent: the stored retrieve already matches the parser. No write, and
+  // - because this view reports no change - no cache flush for its blog.
+  if (
+    stableStringify(expectedRetrieve) === stableStringify(view.retrieve || {})
+  ) {
     stats.alreadyMigrated++;
     return next(null, false);
   }
 
-  // Force setView to re-parse template content and rewrite retrieve
-  // metadata. setView short-circuits when content and retrieve are
-  // unchanged, so pass a sentinel retrieve object. setView drops the
-  // sentinel and rebuilds retrieve from the parser, preserving user
-  // options such as includeDraft and filters.
-  //
-  // deferCacheBump: skip setView's per-view cacheID bump and CDN manifest
-  // rebuild - the caller does that once per blog / template instead.
-  Template.setView(
-    templateID,
-    {
-      name: view.name,
-      content: view.content,
-      retrieve: {
-        __recalculateRetrieve: Date.now(),
-      },
-    },
-    { deferCacheBump: true },
-    function (err) {
-      if (err) {
-        // setView commits the view hash (multi.exec) before the steps that
-        // can still fail here - the deferred error-entry cleanup, or in
-        // non-deferred callers the cache bump / manifest rebuild. So an
-        // error does not mean the retrieve metadata was left untouched.
-        // Report the view as changed anyway so the caller still flushes
-        // this template's caches before the error stops the run.
-        return next(err, true);
-      }
+  if (dryRun) {
+    stats.updated++;
+    console.log("Would update", templateID, view.name);
+    return next(null, true);
+  }
 
+  // Only the parser-derived retrieve metadata is changing. Write just that
+  // one hash field: no content validation, no infinite-partial detection, no
+  // rewrite of the (potentially megabyte) content field, no per-view cacheID
+  // bump. finalizeBlog / invalidateBlogsUsing flush the owner blog once.
+  redis
+    .hSet(
+      templateKey.view(templateID, view.name),
+      "retrieve",
+      JSON.stringify(expectedRetrieve)
+    )
+    .then(function () {
       stats.updated++;
       console.log("Updated", templateID, view.name);
       next(null, true);
-    }
-  );
+    })
+    .catch(function (err) {
+      // Report the view as changed so the caller still flushes this
+      // template's caches before the error stops the run.
+      next(err, true);
+    });
+}
+
+// Deterministic JSON: object keys sorted at every level so two structurally
+// equal retrieve objects (parsed fresh vs. round-tripped through Redis)
+// stringify identically. Array order is left alone - it is meaningful for
+// `cdn`, which applyUserRetrieveOptions already sorts.
+function stableStringify(value) {
+  return JSON.stringify(sortKeysDeep(value));
+}
+
+function sortKeysDeep(value) {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+
+  if (value && typeof value === "object") {
+    return Object.keys(value)
+      .sort()
+      .reduce(function (acc, key) {
+        acc[key] = sortKeysDeep(value[key]);
+        return acc;
+      }, {});
+  }
+
+  return value;
 }
 
 // Mirror app/templates/index.js:emptyCacheForBlogsUsing - bump the cacheID of

--- a/scripts/template/recalculate-retrieve.js
+++ b/scripts/template/recalculate-retrieve.js
@@ -1,6 +1,7 @@
 var eachBlog = require("../each/blog");
 var progress = require("../each/progress");
 var async = require("async");
+var Mustache = require("mustache");
 var Template = require("models/template");
 var templateKey = require("models/template/key");
 var redis = require("models/client");
@@ -13,6 +14,17 @@ var updateCdnManifest = require("models/template/util/updateCdnManifest");
 // accurate; raise it (via --concurrency=N) when the per-blog Redis reads are
 // the bottleneck on a full-fleet run.
 var DEFAULT_CONCURRENCY = 1;
+
+// A retrieve write commits before its blog's cache is flushed. If the process
+// stops (or a flush fails) in that window the metadata now looks current, so a
+// re-run's equality check would skip the blog and never retry the flush. These
+// keys record "this blog still needs a flush" so the next run drains them
+// first. PENDING_FLUSH_KEY is a hash blogID -> JSON(changed template ids) for
+// blog-owned templates (cacheID bump + manifest rebuild); PENDING_SITE_FLUSH
+// is a plain set of blog ids that use a rewritten SITE template (cacheID bump
+// only, matching invalidateBlogsUsing).
+var PENDING_FLUSH_KEY = "template:recalculate-retrieve:pending-flush";
+var PENDING_SITE_FLUSH_KEY = "template:recalculate-retrieve:pending-site-flush";
 
 if (require.main === module) {
   var options = parseArgs(process.argv.slice(2));
@@ -36,6 +48,23 @@ if (require.main === module) {
       "already current)"
     );
 
+    if (stats.recovered) {
+      console.log(
+        "Recovered",
+        stats.recovered,
+        "pending cache flush(es) from a previous run"
+      );
+    }
+
+    if (stats.errors.length) {
+      console.error("\n" + stats.errors.length + " error(s):");
+      stats.errors.forEach(function (e) {
+        var where = [e.blogID, e.templateID, e.viewName].filter(Boolean).join(" / ");
+        console.error("  -", where || "(global)", ":", e.error);
+      });
+      process.exit(1);
+    }
+
     process.exit(0);
   });
 }
@@ -55,6 +84,14 @@ function parseArgs(argv) {
   return options;
 }
 
+function recordError(stats, entry) {
+  stats.errors.push(entry);
+  var where = [entry.blogID, entry.templateID, entry.viewName]
+    .filter(Boolean)
+    .join(" / ");
+  console.error("Error:", where || "(global)", "-", entry.error);
+}
+
 function main(options, callback) {
   if (typeof options === "function") {
     callback = options;
@@ -64,12 +101,15 @@ function main(options, callback) {
   options = options || {};
 
   var dryRun = options.dryRun === true;
-  var concurrency = options.concurrency > 0 ? options.concurrency : DEFAULT_CONCURRENCY;
+  var concurrency =
+    options.concurrency > 0 ? options.concurrency : DEFAULT_CONCURRENCY;
 
   var stats = {
     updated: 0,
     skipped: 0,
     alreadyMigrated: 0,
+    recovered: 0,
+    errors: [],
   };
 
   // Blog-owned templates. Recalculate every view of every template, then, once
@@ -80,49 +120,84 @@ function main(options, callback) {
   // `retrieve` hash field) when the stored metadata differs from what the
   // parser now produces - so a view that is already current costs one parse
   // and no Redis write, and a blog with nothing stale is never flushed.
-  eachBlog(
-    function (user, blog, nextBlog) {
-      recalcBlog(blog.id, stats, dryRun, nextBlog);
-    },
-    function (err) {
-      if (err) return callback(err, stats);
+  //
+  // Per-blog and per-view failures are collected in stats.errors and the run
+  // continues: a single unreadable blog must not abort a fleet-wide migration,
+  // and - with --concurrency > 1 - must not let async's eachLimit fire its
+  // final callback (and the process exit) while other blogs are mid-write.
+  function runIteration() {
+    eachBlog(
+      function (user, blog, nextBlog) {
+        recalcBlog(blog.id, stats, dryRun, function () {
+          nextBlog();
+        });
+      },
+      function (err) {
+        // Only a failure to enumerate blogs at all reaches here.
+        if (err) return callback(err, stats);
 
-      // Bundled SITE:* templates are used directly by blogs but are skipped
-      // by scripts/each - iterate them explicitly so their views also pick
-      // up field projection metadata.
-      var touchedSiteTemplates = {};
+        // Bundled SITE:* templates are used directly by blogs but are skipped
+        // by scripts/each - iterate them explicitly so their views also pick
+        // up field projection metadata.
+        var touchedSiteTemplates = {};
 
-      eachSiteView(
-        function (templateID, view, next) {
-          recalcView(templateID, view, stats, dryRun, function (err, changed) {
-            if (changed) touchedSiteTemplates[templateID] = true;
-            next(err);
-          });
-        },
-        function (err) {
-          // setView's cacheID bump is deferred for these, and their owner is
-          // the synthetic "SITE" anyway. Flush the full-view / rendered-output
-          // caches of every blog whose active template we just rewrote so the
-          // new retrieve metadata takes effect - even if iteration stopped on
-          // an error, so a partial run still flushes what it did rewrite.
-          if (dryRun) return callback(err, stats);
+        eachSiteView(
+          function (templateID, view, next) {
+            recalcView(templateID, view, stats, dryRun, function (vErr, changed) {
+              if (changed) touchedSiteTemplates[templateID] = true;
+              if (vErr)
+                recordError(stats, {
+                  templateID: templateID,
+                  viewName: view && view.name,
+                  error: "site view write: " + vErr.message,
+                });
+              next();
+            });
+          },
+          function (err) {
+            if (err)
+              recordError(stats, {
+                error: "SITE template iteration: " + err.message,
+              });
 
-          invalidateBlogsUsing(
-            Object.keys(touchedSiteTemplates),
-            function (flushErr) {
-              callback(err || flushErr, stats);
-            }
-          );
-        }
-      );
-    },
-    { c: concurrency }
-  );
+            if (dryRun) return callback(null, stats);
+
+            // Flush the full-view / rendered-output caches of every blog whose
+            // active template we just rewrote so the new retrieve metadata
+            // takes effect.
+            invalidateBlogsUsing(
+              Object.keys(touchedSiteTemplates),
+              stats,
+              function (flushErr) {
+                if (flushErr)
+                  recordError(stats, {
+                    error: "SITE cache invalidation: " + flushErr.message,
+                  });
+                callback(null, stats);
+              }
+            );
+          }
+        );
+      },
+      { c: concurrency }
+    );
+  }
+
+  if (dryRun) return runIteration();
+
+  recoverPendingFlushes(stats, function (err) {
+    if (err)
+      recordError(stats, { error: "pending-flush recovery: " + err.message });
+    runIteration();
+  });
 }
 
 function recalcBlog(blogID, stats, dryRun, done) {
   Template.getTemplateList(blogID, function (err, templates) {
-    if (err) return done(err);
+    if (err) {
+      recordError(stats, { blogID: blogID, error: "getTemplateList: " + err.message });
+      return done();
+    }
 
     var owned = (templates || []).filter(function (template) {
       return template.owner === blogID;
@@ -134,22 +209,32 @@ function recalcBlog(blogID, stats, dryRun, done) {
     async.eachSeries(
       owned,
       function (template, nextTemplate) {
-        recalcTemplateViews(template.id, stats, dryRun, function (err, changed) {
+        recalcTemplateViews(template.id, stats, dryRun, function (tErr, changed) {
           if (changed) changedTemplateIDs.push(template.id);
+          if (tErr)
+            recordError(stats, {
+              blogID: blogID,
+              templateID: template.id,
+              error: tErr.message,
+            });
           bar.tick();
-          // Stop the blog loop on a genuine write error, but keep the partial
-          // `changed` set so finalizeBlog still flushes the views that were
-          // rewritten before the failure.
-          nextTemplate(err);
+          // Keep going: one bad template must not skip the blog's others, and
+          // finalizeBlog still flushes whatever did change.
+          nextTemplate();
         });
       },
-      function (err) {
+      function () {
         bar.pop();
 
-        if (dryRun) return done(err);
+        if (dryRun) return done();
 
         finalizeBlog(blogID, changedTemplateIDs, function (flushErr) {
-          done(err || flushErr);
+          if (flushErr)
+            recordError(stats, {
+              blogID: blogID,
+              error: "finalize: " + flushErr.message,
+            });
+          done();
         });
       }
     );
@@ -171,12 +256,13 @@ function recalcTemplateViews(templateID, stats, dryRun, done) {
           if (viewChanged) changed = true;
           if (err && !firstErr) firstErr = err;
           bar.tick();
-          nextView(err);
+          // Don't abort the template's remaining views on one failed write.
+          nextView();
         });
       },
-      function (err) {
+      function () {
         bar.pop();
-        done(firstErr || err || null, changed);
+        done(firstErr || null, changed);
       }
     );
   });
@@ -188,36 +274,76 @@ function recalcTemplateViews(templateID, stats, dryRun, done) {
 // active template and every preview-of-my-* template alike. Bump before
 // rebuilding any manifest so updateCdnManifest renders CDN targets against the
 // new cacheID, matching the order setView and clone use.
+//
+// The PENDING_FLUSH_KEY entry is written before the bump and cleared only once
+// the manifest rebuilds finish, so a crash or failure anywhere in between is
+// retried by recoverPendingFlushes on the next run.
 function finalizeBlog(blogID, changedTemplateIDs, done) {
-  if (!changedTemplateIDs.length) return done();
+  if (!changedTemplateIDs || !changedTemplateIDs.length) return done();
 
-  // Re-read the blog: this script is long-running and the owner may have
-  // switched active template while we worked through their other templates.
-  Blog.get({ id: blogID }, function (err, blog) {
-    if (err) return done(err);
-    if (!blog) return done();
+  Promise.resolve(
+    redis.hSet(PENDING_FLUSH_KEY, blogID, JSON.stringify(changedTemplateIDs))
+  )
+    .then(function () {
+      // Re-read the blog: this script is long-running and the owner may have
+      // switched active template while we worked through their other templates.
+      Blog.get({ id: blogID }, function (err, blog) {
+        if (err) return done(err);
+        if (!blog) return clearPending();
 
-    Blog.set(blogID, { cacheID: Date.now() }, function (err) {
-      if (err) return done(err);
+        Blog.set(blogID, { cacheID: Date.now() }, function (err) {
+          if (err) return done(err);
 
-      console.log("Flushed cache for", blog.handle || blogID);
+          console.log("Flushed cache for", blog.handle || blogID);
 
-      // Rebuild the CDN manifest once per changed template. updateCdnManifest
-      // no-ops for templates that aren't installed on their owner blog, so an
-      // inactive template costs only a metadata lookup here.
-      async.eachSeries(
-        changedTemplateIDs,
-        function (templateID, next) {
-          updateCdnManifest(templateID, next);
-        },
-        done
-      );
-    });
-  });
+          // Rebuild the CDN manifest once per changed template.
+          // updateCdnManifest no-ops for templates that aren't installed on
+          // their owner blog, so an inactive template costs only a metadata
+          // lookup here.
+          async.eachSeries(
+            changedTemplateIDs,
+            function (templateID, next) {
+              updateCdnManifest(templateID, next);
+            },
+            function (err) {
+              if (err) return done(err);
+              clearPending();
+            }
+          );
+        });
+      });
+    })
+    .catch(done);
+
+  function clearPending() {
+    Promise.resolve(redis.hDel(PENDING_FLUSH_KEY, blogID))
+      .then(function () {
+        done();
+      })
+      .catch(done);
+  }
 }
 
 function recalcView(templateID, view, stats, dryRun, next) {
   if (!view || !view.name || !view.content) {
+    stats.skipped++;
+    return next(null, false);
+  }
+
+  // parseTemplate swallows a malformed-Mustache parse and just returns empty
+  // metadata, so it can't tell us the content is broken. Match setView's own
+  // guard (Mustache.render(content, {})) and leave a genuinely invalid view
+  // untouched rather than writing metadata derived from a failed parse.
+  try {
+    Mustache.render(view.content, {});
+  } catch (e) {
+    console.error(
+      "Skipping view with invalid Mustache",
+      templateID,
+      view.name,
+      "-",
+      e && e.message
+    );
     stats.skipped++;
     return next(null, false);
   }
@@ -233,14 +359,11 @@ function recalcView(templateID, view, stats, dryRun, next) {
     expectedRetrieve = applyUserRetrieveOptions(
       parsed.retrieve || {},
       undefined,
-      view.retrieve || {}
+      view.retrieve && typeof view.retrieve === "object" ? view.retrieve : {}
     );
   } catch (e) {
-    // The parser choked on this view's content. Leave it untouched rather
-    // than guessing - a genuinely broken view is a pre-existing problem and
-    // rewriting its metadata blind could make things worse.
     console.error(
-      "Skipping unparseable view",
+      "Skipping view; retrieve computation failed",
       templateID,
       view.name,
       "-",
@@ -250,10 +373,17 @@ function recalcView(templateID, view, stats, dryRun, next) {
     return next(null, false);
   }
 
-  // Idempotent: the stored retrieve already matches the parser. No write, and
-  // - because this view reports no change - no cache flush for its blog.
+  // Only skip when the stored value is actually a retrieve object that already
+  // matches. A legacy view whose hash omits `retrieve` (or stores null) is
+  // materialised with an explicit object here - getFullView -> retrieve()
+  // asserts an object, so leaving the field absent could break rendering.
+  var stored = view.retrieve;
+  var storedIsObject =
+    !!stored && typeof stored === "object" && !Array.isArray(stored);
+
   if (
-    stableStringify(expectedRetrieve) === stableStringify(view.retrieve || {})
+    storedIsObject &&
+    stableStringify(expectedRetrieve) === stableStringify(stored)
   ) {
     stats.alreadyMigrated++;
     return next(null, false);
@@ -269,21 +399,22 @@ function recalcView(templateID, view, stats, dryRun, next) {
   // one hash field: no content validation, no infinite-partial detection, no
   // rewrite of the (potentially megabyte) content field, no per-view cacheID
   // bump. finalizeBlog / invalidateBlogsUsing flush the owner blog once.
-  redis
-    .hSet(
+  Promise.resolve(
+    redis.hSet(
       templateKey.view(templateID, view.name),
       "retrieve",
       JSON.stringify(expectedRetrieve)
     )
+  )
     .then(function () {
       stats.updated++;
       console.log("Updated", templateID, view.name);
       next(null, true);
     })
     .catch(function (err) {
-      // Report the view as changed so the caller still flushes this
-      // template's caches before the error stops the run.
-      next(err, true);
+      // The hSet is atomic - on failure nothing was written, so report the
+      // view as unchanged. The error is surfaced via stats.errors.
+      next(err, false);
     });
 }
 
@@ -313,8 +444,10 @@ function sortKeysDeep(value) {
 // Mirror app/templates/index.js:emptyCacheForBlogsUsing - bump the cacheID of
 // every blog whose active template is one we just rewrote. Used for SITE:*
 // templates, whose owner is the literal "SITE" so no real blog's cacheID is
-// touched by the recalculation itself.
-function invalidateBlogsUsing(templateIDs, done) {
+// touched by the recalculation itself. Each blog id is recorded in
+// PENDING_SITE_FLUSH_KEY before its bump and removed after, so a failed or
+// interrupted flush is retried by recoverPendingFlushes.
+function invalidateBlogsUsing(templateIDs, stats, done) {
   if (!templateIDs || !templateIDs.length) return done();
 
   var touched = {};
@@ -329,14 +462,42 @@ function invalidateBlogsUsing(templateIDs, done) {
       ids || [],
       function (blogID, next) {
         Blog.get({ id: blogID }, function (err, blog) {
-          if (err) return next(err);
+          if (err) {
+            recordError(stats, {
+              blogID: blogID,
+              error: "SITE flush get: " + err.message,
+            });
+            return next();
+          }
           if (!blog || !blog.template || !touched[blog.template]) return next();
 
-          Blog.set(blogID, { cacheID: Date.now() }, function (err) {
-            if (err) return next(err);
-            console.log("Flushed cache for", blog.handle || blogID);
-            next();
-          });
+          Promise.resolve(redis.sAdd(PENDING_SITE_FLUSH_KEY, blogID))
+            .then(function () {
+              Blog.set(blogID, { cacheID: Date.now() }, function (err) {
+                if (err) {
+                  recordError(stats, {
+                    blogID: blogID,
+                    error: "SITE flush set: " + err.message,
+                  });
+                  return next();
+                }
+                console.log("Flushed cache for", blog.handle || blogID);
+                Promise.resolve(redis.sRem(PENDING_SITE_FLUSH_KEY, blogID))
+                  .then(function () {
+                    next();
+                  })
+                  .catch(function () {
+                    next();
+                  });
+              });
+            })
+            .catch(function (markErr) {
+              recordError(stats, {
+                blogID: blogID,
+                error: "SITE flush mark: " + markErr.message,
+              });
+              next();
+            });
         });
       },
       done
@@ -344,22 +505,129 @@ function invalidateBlogsUsing(templateIDs, done) {
   });
 }
 
+// Retry the cache flushes a previous run recorded but did not confirm, before
+// this run's equality checks skip those blogs for good.
+function recoverPendingFlushes(stats, callback) {
+  Promise.resolve(redis.hGetAll(PENDING_FLUSH_KEY))
+    .then(function (pending) {
+      pending = pending || {};
+      var blogIDs = Object.keys(pending);
+
+      Promise.resolve(redis.sMembers(PENDING_SITE_FLUSH_KEY))
+        .then(function (siteBlogIDs) {
+          siteBlogIDs = siteBlogIDs || [];
+
+          if (!blogIDs.length && !siteBlogIDs.length) return callback();
+
+          console.log(
+            "Recovering",
+            blogIDs.length + siteBlogIDs.length,
+            "pending cache flush(es) from a previous run"
+          );
+
+          async.eachSeries(
+            blogIDs,
+            function (blogID, next) {
+              var templateIDs;
+              try {
+                templateIDs = JSON.parse(pending[blogID]);
+              } catch (e) {
+                templateIDs = [];
+              }
+
+              if (!Array.isArray(templateIDs) || !templateIDs.length) {
+                return Promise.resolve(redis.hDel(PENDING_FLUSH_KEY, blogID))
+                  .then(function () {
+                    next();
+                  })
+                  .catch(function () {
+                    next();
+                  });
+              }
+
+              finalizeBlog(blogID, templateIDs, function (err) {
+                if (err)
+                  recordError(stats, {
+                    blogID: blogID,
+                    error: "recover finalize: " + err.message,
+                  });
+                else stats.recovered++;
+                next();
+              });
+            },
+            function () {
+              async.eachSeries(
+                siteBlogIDs,
+                function (blogID, next) {
+                  Blog.get({ id: blogID }, function (err, blog) {
+                    if (err || !blog) {
+                      return Promise.resolve(
+                        redis.sRem(PENDING_SITE_FLUSH_KEY, blogID)
+                      )
+                        .then(function () {
+                          next();
+                        })
+                        .catch(function () {
+                          next();
+                        });
+                    }
+
+                    Blog.set(blogID, { cacheID: Date.now() }, function (err) {
+                      if (err) {
+                        recordError(stats, {
+                          blogID: blogID,
+                          error: "recover SITE flush: " + err.message,
+                        });
+                        return next();
+                      }
+                      console.log(
+                        "Recovered cache flush for",
+                        blog.handle || blogID
+                      );
+                      stats.recovered++;
+                      Promise.resolve(redis.sRem(PENDING_SITE_FLUSH_KEY, blogID))
+                        .then(function () {
+                          next();
+                        })
+                        .catch(function () {
+                          next();
+                        });
+                    });
+                  });
+                },
+                callback
+              );
+            }
+          );
+        })
+        .catch(callback);
+    })
+    .catch(callback);
+}
+
 function eachSiteView(iterator, done) {
-  redis
-    .sMembers(templateKey.blogTemplates("SITE"))
+  Promise.resolve(redis.sMembers(templateKey.blogTemplates("SITE")))
     .then(function (templateIDs) {
       var templateBar = progress.push("Template", (templateIDs || []).length);
 
       async.eachSeries(
         templateIDs || [],
         function (templateID, nextItem) {
-          var nextTemplate = function (err) {
+          var nextTemplate = function () {
             templateBar.tick();
-            nextItem(err);
+            nextItem();
           };
 
           Template.getAllViews(templateID, function (err, views) {
-            if (err) return nextTemplate(err);
+            if (err) {
+              console.error(
+                "Skipping SITE template; getAllViews failed",
+                templateID,
+                "-",
+                err && err.message
+              );
+              return nextTemplate();
+            }
 
             var viewBar = progress.push(
               "View",
@@ -369,14 +637,14 @@ function eachSiteView(iterator, done) {
             async.eachOfSeries(
               views || {},
               function (view, name, nextView) {
-                iterator(templateID, view, function (err) {
+                iterator(templateID, view, function () {
                   viewBar.tick();
-                  nextView(err);
+                  nextView();
                 });
               },
-              function (err) {
+              function () {
                 viewBar.pop();
-                nextTemplate(err);
+                nextTemplate();
               }
             );
           });


### PR DESCRIPTION
## Problem

`node scripts/template/recalculate-retrieve.js` is extraordinarily slow in production. It's not one hot spot — the script **force-rewrites every view of every template of every blog**:

- `recalcView` passes a sentinel `retrieve: { __recalculateRetrieve: Date.now() }` to defeat `setView`'s short-circuit (`retrieveUnchanged=false` in every log line).
- Each forced `setView` re-runs `Mustache.render` content validation, `detectInfinitePartialDependency` (a Redis read + parse **per partial dependency**), and rewrites the **entire** view hash — vendored `js-jquery.js` / `js-moment.js` / `css-tachyons.css` content included.
- `finalizeBlog` then bumps `cacheID` + rebuilds the CDN manifest once per changed template — and since every template has a "changed" view, that's a `cacheID` bump + `flushCache` HTTP purge for **~all 1779 blogs** (every `flushCache: fetching …/purge` line in the logs).
- The only skip (`hasProjectionMetadata`) never matched non-entry views (`style.css`, `header.html`, `robots.txt`, …), so they were reprocessed on every run and every resume.

## Fix

`recalcView` now reparses each view **in-process** and computes exactly what `setView` would persist — `applyUserRetrieveOptions(parseTemplate(content).retrieve, …, storedRetrieve)`. If that already equals the stored `retrieve`:

- no Redis write, and
- the view reports no change, so its blog is never flushed.

Only views whose stored metadata is genuinely stale are written, and only the single `retrieve` hash field — not the whole view, no content validation, no infinite-partial recursion, no per-view cache bump. The fleet-wide purge storm disappears on its own: `finalizeBlog` / `invalidateBlogsUsing` only fire for blogs with a genuinely stale entry view.

### Changes

- **`app/models/template/util/applyUserRetrieveOptions.js`** — extracted from `setView.js` so `setView` and the script derive the stored `retrieve` identically. Unit-tested (`tests/applyUserRetrieveOptions.js`, pure, no Redis).
- **`scripts/template/recalculate-retrieve.js`**
  - in-process parse + exact-equality skip (replaces the leaky `hasProjectionMetadata` / `PROJECTED_ENTRY_LOCALS` heuristic — exact equality is a strictly better idempotency guard, so a re-run / resume now skips everything already done)
  - direct `hSet(viewKey, "retrieve", …)` for the views that do change
  - `--dry-run` / `-n`: report how many views would change, write nothing
  - `--concurrency=N`: opt-in bounded parallelism across blogs
- **`scripts/each/blog.js`** — new `options.c` (bounded `async.eachLimit`). Default `1`, so existing callers and the nested progress line are unchanged.

### `migrate-font-urls.js`

`master` merged in (fast-forward). Reviewed `scripts/template/migrate-font-urls.js` — it **already** has the equivalent guard: `rewriteContent` is a pure in-process transform, `setView` is only called on an actual regex match (a rare customer-pasted `/fonts/…` URL), and it's idempotent on re-run. No change needed. It could take `options.c` too, but that needs threading `options` through `each/template.js` + `each/view.js`, which isn't worth the blast radius for a one-off script.

## Testing

- `app/models/template/tests/applyUserRetrieveOptions.js` — 8 specs, pass locally.
- Full suite via CI (Docker/Redis).
- Suggest running `node scripts/template/recalculate-retrieve.js --dry-run` in production first to confirm how few views actually need rewriting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)