### PR TITLE
Add -s/--start and -r/--reverse flags to recalculate-retrieve

### DIFF
--- a/scripts/template/recalculate-retrieve.js
+++ b/scripts/template/recalculate-retrieve.js
@@ -72,14 +72,29 @@ if (require.main === module) {
 function parseArgs(argv) {
   var options = { dryRun: false, concurrency: DEFAULT_CONCURRENCY };
 
-  (argv || []).forEach(function (arg) {
+  argv = argv || [];
+
+  for (var i = 0; i < argv.length; i++) {
+    var arg = argv[i];
+
     if (arg === "--dry-run" || arg === "-n") {
       options.dryRun = true;
     } else if (arg.indexOf("--concurrency=") === 0) {
       var n = parseInt(arg.slice("--concurrency=".length), 10);
       if (n > 0) options.concurrency = n;
+    } else if (arg === "-r" || arg === "--reverse") {
+      // Walk blogs newest-first (see scripts/each/blog.js option `r`).
+      options.reverse = true;
+    } else if (arg === "-s" || arg === "--start") {
+      // Skip ahead to the Nth blog - 1-based position in the id list, matching
+      // scripts/each/blog.js option `s` - so an interrupted run can resume.
+      var s = parseInt(argv[++i], 10);
+      if (s > 0) options.start = s;
+    } else if (arg.indexOf("--start=") === 0) {
+      var sEq = parseInt(arg.slice("--start=".length), 10);
+      if (sEq > 0) options.start = sEq;
     }
-  });
+  }
 
   return options;
 }
@@ -103,6 +118,13 @@ function main(options, callback) {
   var dryRun = options.dryRun === true;
   var concurrency =
     options.concurrency > 0 ? options.concurrency : DEFAULT_CONCURRENCY;
+
+  // Passed straight through to scripts/each/blog.js: `s` starts at the Nth blog
+  // (1-based), `r` reverses the iteration order. SITE:* templates are always
+  // processed in full afterwards regardless of these.
+  var eachBlogOptions = { c: concurrency };
+  if (options.start > 0) eachBlogOptions.s = options.start;
+  if (options.reverse) eachBlogOptions.r = true;
 
   var stats = {
     updated: 0,
@@ -179,7 +201,7 @@ function main(options, callback) {
           }
         );
       },
-      { c: concurrency }
+      eachBlogOptions
     );
   }
 


### PR DESCRIPTION
## What

Adds two command-line flags to `scripts/template/recalculate-retrieve.js`:

- `-s N` / `--start N` (also `--start=N`) — begin at the Nth blog (1-based position in the id list)
- `-r` / `--reverse` — walk blogs newest-first

```bash
node scripts/template/recalculate-retrieve.js -s 400
node scripts/template/recalculate-retrieve.js -r
```

## Why

The recalculate-retrieve migration is slow over the full fleet. `-s` lets an interrupted run resume partway through; `-r` lets the fleet be worked from both ends at once.

## How

Both options are handed straight to `scripts/each/blog.js`, which already implements `s` (slice from position) and `r` (reverse). `main` now builds an `eachBlogOptions` object (`{ c: concurrency }` plus `s`/`r` when set) instead of the inline literal.

`parseArgs` was switched from a `forEach` to an index-based loop so `-s` can consume a space-separated value.

## Notes for reviewers

- Flags compose with each other and with the existing `--dry-run` / `--concurrency=N`.
- SITE:* templates are still processed in full after the blog pass, unaffected by these flags.
- `node -c` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)