### PR TITLE
Entry hashes, stage 2.5: read from the hash by default

### DIFF
--- a/app/models/entry/README
+++ b/app/models/entry/README
@@ -2,7 +2,7 @@
 
 This module is the authoritative data layer for blog entries in Blot. It handles persistence, URL assignment, list membership, backlink tracking, dependency graph maintenance, scheduled publication, and full-text search for individual entries within a blog.
 
-All storage is backed by Redis. **Migration in progress:** each entry is now written twice, in one `MULTI` — to the legacy JSON string key and to a Redis hash (`key.entryHash`). Reads still come from the JSON string; the hash is dormant until `config.redis.readEntriesFromHash` is turned on (per environment, once `scripts/entry/backfill-hashes.js` has populated every entry). `get` can then fetch individual fields with `HMGET` instead of loading and parsing the whole entry, and falls back to the string for any entry the backfill has not reached. Relationships (URL-to-path mappings, sorted membership lists, dependency sets) are maintained as separate Redis keys updated atomically alongside each write.
+All storage is backed by Redis. **Migration in progress:** each entry is written twice, in one `MULTI` — to the legacy JSON string key and to a Redis hash (`key.entryHash`). `get` now reads from the hash by default (`config.redis.readEntriesFromHash`, on unless `BLOT_REDIS_READ_ENTRIES_FROM_HASH=false`), fetching individual fields with `HMGET` instead of loading and parsing the whole entry, and falls back to the string for any entry the backfill (`scripts/entry/backfill-hashes.js`) has not reached. The string keys stay as that fallback until a later migration stage stops writing them and expires them. Relationships (URL-to-path mappings, sorted membership lists, dependency sets) are maintained as separate Redis keys updated atomically alongside each write.
 
 ---
 
@@ -75,8 +75,8 @@ Defined in `key.js`.
 
 | Key pattern | Type | Contains |
 |-------------|------|---------|
-| `blog:{blogID}:entry:{normalizedPath}` | string | JSON-serialised entry object. Authoritative; still the read source by default. |
-| `blog:{blogID}:entry:hash:{normalizedPath}` | hash | One field per entry property. Dual-written in the same `MULTI` as the string key; read only when `config.redis.readEntriesFromHash` is on. |
+| `blog:{blogID}:entry:{normalizedPath}` | string | JSON-serialised entry object. Dual-written; now only a fallback for un-backfilled entries (and a rollback target via `BLOT_REDIS_READ_ENTRIES_FROM_HASH=false`). |
+| `blog:{blogID}:entry:hash:{normalizedPath}` | hash | One field per entry property. Dual-written in the same `MULTI` as the string key; the default read source. |
 | `blog:{blogID}:url:{url}` | string | The `id` (normalised path) of the entry claiming that URL |
 | `blog:{blogID}:dependents:{path}` | set | Paths of entries that depend on this path |
 | `blog:{blogID}:search` | — | Referenced but not written by this module directly |
@@ -107,12 +107,12 @@ Retrieves one or more entries from Redis.
 - When passed an array, calls back with an array of `Entry` instances. Missing entries are omitted from the result. An empty input array calls back with an empty array immediately.
 - Results are instances of the `Entry` constructor defined in `instance.js`.
 
-**Default (`config.redis.readEntriesFromHash` off):** one `MGET` over the JSON string keys, exactly as before. `fields` is ignored.
-
-**Hash mode (`config.redis.readEntriesFromHash` on):** reads `HGETALL`/`HMGET` from `key.entryHash`, falling back to the JSON string for any entry with no hash yet. `fields` (optional) then restricts which properties are read:
+**Default (`config.redis.readEntriesFromHash` on):** reads `HGETALL`/`HMGET` from `key.entryHash`, falling back to the JSON string for any entry with no hash yet. `fields` (optional) then restricts which properties are read:
   - `"title"` — a single field name. For a single-entry lookup the raw value is passed to the callback instead of an `Entry`.
   - `["title", "url"]` — an array of field names. Each result is an `Entry` carrying only those fields plus `id`.
   - omitted — the whole entry.
+
+**Rollback (`BLOT_REDIS_READ_ENTRIES_FROM_HASH=false`):** one `MGET` over the JSON string keys, exactly as before the migration. `fields` is ignored.
 
 ### `getByUrl(blogID, entryUrl, callback)`
 

--- a/config/environment.sh
+++ b/config/environment.sh
@@ -19,6 +19,11 @@ export BLOT_PROTOCOL=https
 # Redis configuration
 export BLOT_REDIS_HOST=127.0.0.1
 
+# Entry reads come from the per-entry Redis hash by default. Set this to
+# "false" to force reads back onto the legacy JSON string key (migration
+# rollback). Remove once the string keys have been purged.
+# export BLOT_REDIS_READ_ENTRIES_FROM_HASH=false
+
 # Name of linux user who runs the blot server
 export BLOT_USER=
 

--- a/config/index.js
+++ b/config/index.js
@@ -98,13 +98,12 @@ module.exports = {
     port: 6379,
     host: process.env.BLOT_REDIS_HOST || "127.0.0.1",
 
-    // Migration flag (see app/models/entry). When "true", models/entry/get
-    // reads each entry from its Redis hash, falling back to the legacy JSON
-    // string key. Default (any other value) keeps reads on the JSON string,
-    // so the hash can be dual-written and backfilled with zero read-path
-    // risk; flip this per environment only once the backfill is verified.
+    // Migration flag (see app/models/entry). models/entry/get reads each entry
+    // from its Redis hash, falling back to the legacy JSON string key. This is
+    // now on by default; set BLOT_REDIS_READ_ENTRIES_FROM_HASH=false to force
+    // reads back onto the JSON string (rollback, no code change needed).
     readEntriesFromHash:
-      process.env.BLOT_REDIS_READ_ENTRIES_FROM_HASH === "true",
+      process.env.BLOT_REDIS_READ_ENTRIES_FROM_HASH !== "false",
   },
 
   admin: {


### PR DESCRIPTION
Flips `config.redis.readEntriesFromHash` **on by default** — entry reads now come from the per-entry Redis hash (with the JSON-string fallback for any entry the backfill hasn't reached). Stages 1 (#1758) and 2 (#1771) built and verified that read path behind the flag; this is the cutover.

## Change

```js
// before: off unless explicitly enabled
readEntriesFromHash: process.env.BLOT_REDIS_READ_ENTRIES_FROM_HASH === "true"
// after: on unless explicitly disabled
readEntriesFromHash: process.env.BLOT_REDIS_READ_ENTRIES_FROM_HASH !== "false"
```

Plus a documented line in `config/environment.sh` and README updates.

## Rollback — no code change

Set `BLOT_REDIS_READ_ENTRIES_FROM_HASH=false` in `/etc/blot/environment.sh` and restart/redeploy. `get.js` goes back to a single `MGET` over the JSON string keys (still dual-written), exactly as before the migration. Reverting this PR works too.

## Prerequisite

`scripts/entry/backfill-hashes.js` must have completed cleanly (exit 0, no "blogs skipped" warning) on every environment before this deploys — otherwise un-backfilled entries lean on the per-read string fallback, which works but defeats the point.

## What changes at runtime

- Single-entry reads: `HGETALL` instead of `MGET` + `JSON.parse`.
- List reads (`allEntries`, `archives`, `recentEntries`, `tagged`): narrowed `HMGET` of just the fields the template renders — a list/archive page fetches ~1–2 KB per entry instead of the whole ~12 KB entry. `withEntryFields` refetches in full for the rare entry whose own content contains Mustache.
- `latest_entry`, `posts`, search: unchanged (whole-entry path).

Next: stage 3 stops writing the JSON string and expires it (7-day grace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)