### PR TITLE
Migration: repair templates with a divergent stored slug

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,16 @@
-resolve cloudflare fail2ban issuye 
+Remove the template slug-divergence migration once PR #1775 is merged and
+`node scripts/template/fix-divergent-slugs.js --apply` has run against every
+blog — including disabled ones, after they are re-enabled (the script reports
+these separately and prints the rerun command). Then delete
+scripts/template/fix-divergent-slugs.js,
+app/models/template/util/repairDivergentSlug.js and its spec
+app/models/template/tests/repairDivergentSlug.js. Nothing else imports them.
+The #1749 forward fix (models/template/create.js + util/slugForName.js) stays
+— it is what stops new divergent records being created.
+
+---
+
+resolve cloudflare fail2ban issuye
 
 ---
 
@@ -157,69 +169,6 @@ iCloud:
 - Investigate setting up paralell server with 'Advanced Data Protection' enabled so users with this setting can sync to Blot as well
 
 ---
-
-Fix bug with local editing and template slugs
-- Forward fix landed in PR #1749: models/template/create.js now keeps a
-  template's stored slug in step with its id (makeID), and newTemplate.js /
-  fork-if-needed.js / create-template-with-unique-name.js derive the slug via
-  the new models/template/util/slugForName.js helper. No template created from
-  now on can be stored with a slug that makeID maps to a different id.
-- STILL TODO: a one-off migration for records created *before* that fix. A
-  draft script (scripts/template/fix-divergent-slugs.js) was dropped from
-  #1749 because getting the on-disk folder move right (under the sync lock,
-  losslessly, across every provider) is its own piece of work. Agent prompt to
-  do it properly:
-
-    Write scripts/template/fix-divergent-slugs.js: a one-off, dry-run-by-default
-    migration that repairs every existing template whose stored slug no longer
-    resolves to its id, i.e. makeID(blog.id, template.slug) !== template.id.
-    Read models/template/{create,writeToFolder,readFromFolder,buildFromFolder,
-    determineTemplateFolder}.js and util/{makeID,slugForName}.js first, plus
-    scripts/dropbox/resync.js and scripts/icloud/resync.js for the
-    establishSyncLock(blog.id) / syncLock.done() pattern, and scripts/each/blog
-    + scripts/get/blog for iteration. Requirements:
-      * CLI: `node scripts/template/fix-divergent-slugs.js [--apply] [<blog>]`.
-        Dry run prints every change it WOULD make and an accurate count
-        (increment the would-repair counter before any early return — the
-        earlier draft always printed "would repair 0"). <blog> is anything
-        scripts/get/blog accepts.
-      * The target slug is the id's own suffix, but ONLY when
-        makeID(blog.id, suffix) === template.id. A legacy id that does not
-        round-trip (a non-ASCII name from before any makeID cap) cannot be
-        repaired here — report it for a manual rename and skip.
-      * Do the whole per-blog repair inside establishSyncLock(blog.id) so no
-        buildFromFolder can run against a half-migrated state (that cleanup
-        drops any local template whose stored slug is absent from the folder).
-        Release the lock in a finally.
-      * Persist the corrected slug (setMetadata) only AFTER the folder is
-        durable under the new name — a failed folder step must leave the stored
-        slug untouched so a rerun retries identically rather than skipping the
-        record.
-      * MOVE the on-disk directory, never delete-and-regenerate: copy every
-        file under Templates/<oldSlug>/ (or templates/<oldSlug>/ — check BOTH
-        roots, buildFromFolder scans both) to Templates/<newSlug>/ through the
-        blog's client (require("clients")[blog.client]; fall back to fs for a
-        blog with no client), walking the real directory so nested, dotfile and
-        shouldIgnoreFile-ignored local-only files are preserved, then remove
-        the old files/dir through the client. Propagate any copy/remove error,
-        do not count the record as repaired, and leave it for a rerun.
-      * Constrain the stale slug as a path component before touching the
-        filesystem: reject "." / ".." / anything that resolves outside the
-        blog's template root.
-      * If the stale slug resolves (via makeID) to a *different* real template
-        that owns Templates/<oldSlug>/, do not move or delete it — report the
-        collision and skip, leaving both records for manual handling.
-      * Handle localEditing === false too: a divergent record can still have a
-        stale folder (the disable route sets the flag even when removeFromFolder
-        failed). Reconcile an actual on-disk directory independently of the flag.
-      * Bump blog.cacheID after a successful repair. Print a per-blog and a
-        grand-total summary (blogs, templates, divergent, repaired, skipped,
-        collisions).
-    Add a spec under app/models/template/tests/ or scripts/tests/ that seeds a
-    divergent locally-edited template with an extra ignored/nested file, runs
-    the script with --apply against a test blog, and asserts: the stored slug
-    now round-trips, the folder moved to the new name, and the extra file
-    survived the move.
 
 Fix bugs with templates:
 - Fix responsive thumbnail component on photo template (it loads large thumbnail every time)

--- a/app/models/template/tests/repairDivergentSlug.js
+++ b/app/models/template/tests/repairDivergentSlug.js
@@ -99,4 +99,47 @@ describe("template", function () {
       fs.existsSync(join(this.blogDirectory, root, fixed.slug, ".DS_Store"))
     ).toBe(true);
   });
+
+  it("refuses a template directory that contains a symlink and touches nothing", async function () {
+    var blog = this.blog;
+    var templateID = this.template.id;
+
+    await call(setView, templateID, { name: "entry.html", content: "<h1>hi</h1>" });
+    await call(setMetadata, templateID, { localEditing: true });
+    await call(writeToFolder, blog.id, templateID);
+
+    var goodSlug = (await call(getMetadata, templateID)).slug;
+    var root = fs.existsSync(this.blogDirectory + "/Templates")
+      ? "Templates"
+      : "templates";
+
+    var staleSlug =
+      "another-deliberately-divergent-slug-that-is-really-quite-long";
+    fs.moveSync(
+      join(this.blogDirectory, root, goodSlug),
+      join(this.blogDirectory, root, staleSlug)
+    );
+    await call(setMetadata, templateID, { slug: staleSlug });
+
+    fs.symlinkSync(
+      "entry.html",
+      join(this.blogDirectory, root, staleSlug, "link.html")
+    );
+
+    var divergent = await call(getMetadata, templateID);
+    var syncLock = await establishSyncLock(blog.id);
+    var result;
+    try {
+      result = await repairDivergentSlug(blog, divergent, { apply: true });
+    } finally {
+      await syncLock.done();
+    }
+
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toContain("symlink");
+    // The stored slug and the folder are untouched, so a rerun retries.
+    expect((await call(getMetadata, templateID)).slug).toEqual(staleSlug);
+    expect(fs.existsSync(join(this.blogDirectory, root, staleSlug))).toBe(true);
+    expect(fs.existsSync(join(this.blogDirectory, root, divergent.id.split(":").slice(1).join(":")))).toBe(false);
+  });
 });

--- a/app/models/template/tests/repairDivergentSlug.js
+++ b/app/models/template/tests/repairDivergentSlug.js
@@ -1,0 +1,102 @@
+describe("template", function () {
+  var fs = require("fs-extra");
+  var { join } = require("path");
+
+  var makeID = require("../index").makeID;
+  var setView = require("../index").setView;
+  var setMetadata = require("../index").setMetadata;
+  var getMetadata = require("../index").getMetadata;
+  var writeToFolder = require("../index").writeToFolder;
+  var establishSyncLock = require("sync/establishSyncLock");
+  var repairDivergentSlug = require("../util/repairDivergentSlug");
+
+  require("./setup")({ createTemplate: true });
+
+  afterEach(function () {
+    fs.removeSync(this.blogDirectory + "/Templates");
+    fs.removeSync(this.blogDirectory + "/templates");
+  });
+
+  var call = function (fn) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    return new Promise(function (resolve, reject) {
+      fn.apply(null, args.concat(function (err, value) {
+        if (err) return reject(err);
+        resolve(value);
+      }));
+    });
+  };
+
+  it("repairs a divergent locally-edited template: slug round-trips, folder moves, local-only files survive", async function () {
+    var blog = this.blog;
+    var templateID = this.template.id;
+
+    // A locally edited template with a view on disk.
+    await call(setView, templateID, { name: "entry.html", content: "<h1>hi</h1>" });
+    await call(setMetadata, templateID, { localEditing: true });
+    await call(writeToFolder, blog.id, templateID);
+
+    var goodSlug = (await call(getMetadata, templateID)).slug;
+    var root = fs.existsSync(this.blogDirectory + "/Templates")
+      ? "Templates"
+      : "templates";
+    expect(fs.existsSync(join(this.blogDirectory, root, goodSlug))).toBe(true);
+
+    // Force divergence: a stored slug long enough that makeID's 30-character
+    // cap shortens it to something other than the id, plus the on-disk folder
+    // renamed to match that stale slug.
+    var staleSlug =
+      "a-deliberately-divergent-slug-that-is-really-quite-long-indeed";
+    expect(makeID(blog.id, staleSlug)).not.toEqual(templateID);
+
+    fs.moveSync(
+      join(this.blogDirectory, root, goodSlug),
+      join(this.blogDirectory, root, staleSlug)
+    );
+    await call(setMetadata, templateID, { slug: staleSlug });
+
+    // An ignored file and a nested local-only file the move must preserve.
+    fs.outputFileSync(
+      join(this.blogDirectory, root, staleSlug, ".DS_Store"),
+      "junk"
+    );
+    fs.outputFileSync(
+      join(this.blogDirectory, root, staleSlug, "partials/head.html"),
+      "<meta>"
+    );
+
+    var divergent = await call(getMetadata, templateID);
+    expect(makeID(blog.id, divergent.slug)).not.toEqual(templateID);
+
+    // Run the repair the way the script does — under a real sync lock.
+    var syncLock = await establishSyncLock(blog.id);
+    var result;
+    try {
+      result = await repairDivergentSlug(blog, divergent, { apply: true });
+    } finally {
+      await syncLock.done();
+    }
+
+    expect(result.repaired).toBe(true);
+
+    // The stored slug now round-trips to the id.
+    var fixed = await call(getMetadata, templateID);
+    expect(makeID(blog.id, fixed.slug)).toEqual(templateID);
+    expect(fixed.slug).toEqual(templateID.split(":").slice(1).join(":"));
+
+    // The folder moved to the new name; the stale directory is gone.
+    expect(fs.existsSync(join(this.blogDirectory, root, fixed.slug))).toBe(true);
+    expect(fs.existsSync(join(this.blogDirectory, root, staleSlug))).toBe(false);
+
+    // Nested and ignored local-only files came across with it.
+    expect(
+      fs.readFileSync(
+        join(this.blogDirectory, root, fixed.slug, "partials/head.html"),
+        "utf8"
+      )
+    ).toEqual("<meta>");
+    expect(
+      fs.existsSync(join(this.blogDirectory, root, fixed.slug, ".DS_Store"))
+    ).toBe(true);
+  });
+});

--- a/app/models/template/util/repairDivergentSlug.js
+++ b/app/models/template/util/repairDivergentSlug.js
@@ -5,6 +5,7 @@ var { promisify } = require("util");
 var makeID = require("./makeID");
 var localPath = require("helper/localPath");
 var setMetadata = require("../setMetadata");
+var getMetadata = require("../getMetadata");
 var getTemplateList = require("../getTemplateList");
 var Blog = require("models/blog");
 var shouldIgnoreFile = require("clients/util/shouldIgnoreFile");
@@ -91,85 +92,85 @@ function classify(blogID, template) {
   return { divergent: true, repairable: true, target: target };
 }
 
-// List every regular file under absDir (relative, "/"-joined). Directories
-// themselves are skipped; dotfiles and shouldIgnoreFile-ignored local-only
-// files are kept so the move is lossless. Symlinks are handled separately
-// (containsSymlink) — a tree with one is refused rather than silently losing
-// it, so they never reach here.
-function walkFiles(absDir) {
-  var out = [];
+// Walk absDir asynchronously (so the sync-lock heartbeat keeps running on very
+// large trees) and report what it holds. Returns:
+//   { files, hasSymlink, hasExecutable, empty }
+// files are "/"-joined paths relative to absDir, regular files only. dotfiles
+// are included; symlinks and executables are flagged, not listed — a tree with
+// either is refused rather than moved lossily (the copy cannot reproduce them
+// and the subsequent client.remove would commit their deletion).
+async function scanTree(absDir) {
+  var files = [];
+  var hasSymlink = false;
+  var hasExecutable = false;
 
-  (function walk(dir, rel) {
+  async function walk(dir, rel) {
     var entries;
     try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
+      entries = await fs.readdir(dir, { withFileTypes: true });
     } catch (e) {
       if (e.code === "ENOENT" || e.code === "ENOTDIR") return;
       throw e;
     }
 
-    entries.forEach(function (entry) {
-      var childRel = rel ? rel + "/" + entry.name : entry.name;
-      if (entry.isSymbolicLink()) return;
-      if (entry.isDirectory()) return walk(path.join(dir, entry.name), childRel);
-      if (entry.isFile()) out.push(childRel);
-    });
-  })(absDir, "");
-
-  return out;
-}
-
-// True if any entry anywhere under absDir is a symlink. writeToFolder leaves
-// symlinks out of reconciliation without deleting them; this migration deletes
-// the whole source directory through the client, so a tracked symlink would be
-// lost. Refuse such a directory instead.
-function containsSymlink(absDir) {
-  var found = false;
-
-  (function walk(dir) {
-    if (found) return;
-    var entries;
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch (e) {
-      if (e.code === "ENOENT" || e.code === "ENOTDIR") return;
-      throw e;
-    }
     for (var i = 0; i < entries.length; i++) {
-      if (found) return;
       var entry = entries[i];
-      if (entry.isSymbolicLink()) {
-        found = true;
-        return;
-      }
-      if (entry.isDirectory()) walk(path.join(dir, entry.name));
-    }
-  })(absDir);
+      var childAbs = path.join(dir, entry.name);
+      var childRel = rel ? rel + "/" + entry.name : entry.name;
 
-  return found;
+      if (entry.isSymbolicLink()) {
+        hasSymlink = true;
+        continue;
+      }
+      if (entry.isDirectory()) {
+        await walk(childAbs, childRel);
+        continue;
+      }
+      if (entry.isFile()) {
+        files.push(childRel);
+        try {
+          var st = await fs.stat(childAbs);
+          if (st.mode & 0o111) hasExecutable = true;
+        } catch (e) {
+          if (e.code !== "ENOENT") throw e;
+        }
+      }
+    }
+  }
+
+  await walk(absDir, "");
+
+  return {
+    files: files,
+    hasSymlink: hasSymlink,
+    hasExecutable: hasExecutable,
+    empty: files.length === 0,
+  };
 }
 
-// Copy each file from srcAbs/<rel> to <destRelClient>/<rel>. Real template
-// files go through the blog's client so the move propagates to the provider;
-// ignored local-only files (which client.write refuses) are written straight
-// to disk.
+// Copy each listed file from srcAbs/<rel> to <destRelClient>/<rel> through the
+// blog's client (so the move reaches the provider); fall back to a plain disk
+// write for a blog with no client. Only reached for trees scanTree accepted,
+// so no symlinks or executables are in play. shouldIgnoreFile entries are
+// local-only for every non-git client (client.write refuses them and Blot
+// never syncs them out), and git blogs are refused wholesale upstream, so
+// those are written straight to disk.
 async function copyFiles(blogID, client, files, srcAbs, destRelClient) {
   for (var i = 0; i < files.length; i++) {
     var rel = files[i];
     var destFileRel = destRelClient + "/" + rel;
     var contents = await fs.readFile(path.join(srcAbs, rel));
 
-    if (!client || shouldIgnoreFile(destFileRel)) {
-      await fs.outputFile(localPath(blogID, destFileRel), contents);
-    } else {
+    if (client && !shouldIgnoreFile(destFileRel)) {
       await promisify(client.write)(blogID, destFileRel, contents);
+    } else {
+      await fs.outputFile(localPath(blogID, destFileRel), contents);
     }
   }
 }
 
-// Remove the stale directory: through the client first (so the provider drops
-// the tracked files), then a plain fs.remove to sweep up any local-only
-// leftovers and the now-empty directory shell.
+// Remove the stale directory through the client (so the provider drops it),
+// then fs.remove the now-empty local shell.
 async function removeDir(blogID, client, oldRelClient, oldAbs) {
   if (client) {
     try {
@@ -187,16 +188,16 @@ async function removeDir(blogID, client, oldRelClient, oldAbs) {
 // so no buildFromFolder runs against a half-migrated state.
 //
 // Returns one of:
-//   { skipped: true, reason }              not divergent / manual rename / unsafe
+//   { skipped: true, reason }              nothing to do / needs a manual hand
 //   { skipped: true, collision: true, reason }
 //   { wouldRepair: true }                  dry run, a repair is available
 //   { repaired: true }                     applied
 //
-// Throws on a folder / metadata error — the record is then left untouched so a
-// rerun retries it identically rather than skipping it. If the metadata write
-// fails after the folder was moved, the move is rolled back first so the
-// buildFromFolder that syncLock.done() runs does not see a folder whose name
-// no longer matches the still-stored slug (and drop the template).
+// Throws only on an unexpected folder / metadata error. When the folder was
+// already moved and the metadata write then fails, the stored slug is checked:
+// if it did persist the move stands, otherwise the move is rolled back so a
+// rerun retries identically and the lock's buildFromFolder never sees the
+// folder name and the stored slug disagree.
 async function repairDivergentSlug(blog, template, options) {
   options = options || {};
   var apply = options.apply === true;
@@ -210,15 +211,18 @@ async function repairDivergentSlug(blog, template, options) {
   var oldSlug = template.slug;
   var target = info.target;
 
-  // Constrain the stale slug as a path component before any filesystem access.
+  // Constrain both slugs as path components before any filesystem access.
   var unsafe = TEMPLATE_ROOTS.some(function (root) {
-    return safeDir(blog.id, root, oldSlug) === null;
+    return (
+      safeDir(blog.id, root, oldSlug) === null ||
+      safeDir(blog.id, root, target) === null
+    );
   });
   if (unsafe) {
     return {
       skipped: true,
       reason:
-        "stored slug " + JSON.stringify(oldSlug) +
+        "slug " + JSON.stringify(oldSlug) + " or " + JSON.stringify(target) +
         " is not a safe path component",
     };
   }
@@ -228,13 +232,14 @@ async function repairDivergentSlug(blog, template, options) {
     return t.owner === blog.id;
   });
 
-  // If the stale slug resolves (via makeID) to a *different* real template, or
-  // another owned record stores the *same* stale slug (so both claim the same
-  // physical directory), leave every record involved for manual handling.
+  // Leave every record involved for manual handling when another owned template
+  // resolves to the stale id, stores the same stale slug, or already stores the
+  // target slug — in each case two records would claim one physical directory.
   var staleID = makeID(blog.id, oldSlug);
   var collidesWith = owned.find(function (t) {
     return (
-      t.id !== template.id && (t.id === staleID || t.slug === oldSlug)
+      t.id !== template.id &&
+      (t.id === staleID || t.slug === oldSlug || t.slug === target)
     );
   });
   if (collidesWith) {
@@ -242,43 +247,116 @@ async function repairDivergentSlug(blog, template, options) {
       skipped: true,
       collision: true,
       reason:
-        "stale slug " + JSON.stringify(oldSlug) + " is also claimed by " +
-        collidesWith.id + " — resolve by hand",
+        "the " + JSON.stringify(oldSlug) + " / " + JSON.stringify(target) +
+        " directory is also claimed by " + collidesWith.id + " — resolve by hand",
     };
   }
+
+  // A git-backed blog needs `git mv` to relocate a tracked subtree: writing the
+  // files at the new path and removing the old one through the client loses
+  // tracked ignored files, changes 100755 modes to 100644, and rewrites history
+  // needlessly. Refuse and leave it for a manual `git mv`.
+  if (blog.client === "git") {
+    return {
+      skipped: true,
+      reason:
+        "git-backed blog: `git mv " + TEMPLATE_ROOTS[0] + "/" + oldSlug + " " +
+        TEMPLATE_ROOTS[0] + "/" + target + "` by hand, then rerun",
+    };
+  }
+
+  var client = require("clients")[blog.client] || null;
 
   // Find the stale directory under either root. A divergent record can have a
   // stale folder even with localEditing === false (the disable route sets the
   // flag even when removeFromFolder failed), so key off the actual directory,
   // not the flag.
-  var client = require("clients")[blog.client] || null;
   var found = [];
 
   for (var r = 0; r < TEMPLATE_ROOTS.length; r++) {
     var root = TEMPLATE_ROOTS[r];
-    var oldAbs = safeDir(blog.id, root, oldSlug);
+    var fromAbs = safeDir(blog.id, root, oldSlug);
+    var toAbs = safeDir(blog.id, root, target);
     var stat = null;
 
     try {
-      stat = await fs.lstat(oldAbs);
+      stat = await fs.lstat(fromAbs);
     } catch (e) {
       if (e.code !== "ENOENT") throw e;
     }
 
-    if (stat && stat.isDirectory()) found.push({ root: root, oldAbs: oldAbs });
-  }
+    if (!stat) continue;
 
-  // A tracked symlink would be dropped by the copy and then committed as a
-  // deletion by removeDir — refuse the directory rather than lose it.
-  for (var s = 0; s < found.length; s++) {
-    if (containsSymlink(found[s].oldAbs)) {
+    // The stale entry must be a real directory. A symlink here would be left
+    // in place by the move and then followed by buildFromFolder.
+    if (!stat.isDirectory()) {
       return {
         skipped: true,
         reason:
-          found[s].root + "/" + oldSlug +
-          " contains a symlink — reconcile by hand",
+          root + "/" + oldSlug + " is not a real directory — reconcile by hand",
       };
     }
+
+    var scan = await scanTree(fromAbs);
+
+    if (scan.hasSymlink) {
+      return {
+        skipped: true,
+        reason: root + "/" + oldSlug + " contains a symlink — reconcile by hand",
+      };
+    }
+    if (scan.hasExecutable) {
+      return {
+        skipped: true,
+        reason:
+          root + "/" + oldSlug +
+          " contains an executable file — reconcile by hand",
+      };
+    }
+    if (scan.empty) {
+      return {
+        skipped: true,
+        reason: root + "/" + oldSlug + " is empty — reconcile by hand",
+      };
+    }
+
+    // An existing destination must be a real directory too (never a symlink or
+    // file) before we treat it as a resumable prior move and write into it.
+    var destStat = null;
+    try {
+      destStat = await fs.lstat(toAbs);
+    } catch (e) {
+      if (e.code !== "ENOENT") throw e;
+    }
+    if (destStat && !destStat.isDirectory()) {
+      return {
+        skipped: true,
+        collision: true,
+        reason:
+          root + "/" + target + " exists and is not a real directory — " +
+          "resolve by hand",
+      };
+    }
+
+    found.push({
+      root: root,
+      fromAbs: fromAbs,
+      toAbs: toAbs,
+      files: scan.files,
+      resuming: !!destStat,
+    });
+  }
+
+  // A locally edited template with no folder on disk is already headed for
+  // buildFromFolder's cleanup regardless of its slug — don't report it as
+  // repaired, flag it for a look.
+  if (!found.length && template.localEditing) {
+    return {
+      skipped: true,
+      reason:
+        "localEditing template has no folder under Templates/ or templates/ " +
+        "— reconcile by hand",
+    };
   }
 
   log(
@@ -289,7 +367,7 @@ async function repairDivergentSlug(blog, template, options) {
     (found.length
       ? found
           .map(function (f) {
-            return f.root;
+            return f.root + (f.resuming ? " (resuming)" : "");
           })
           .join("+")
       : "none") +
@@ -298,72 +376,81 @@ async function repairDivergentSlug(blog, template, options) {
 
   if (!apply) return { wouldRepair: true };
 
-  // Move every stale directory, then persist the slug. If anything in this
-  // sequence fails, roll the moves back so a rerun retries identically and the
-  // lock's buildFromFolder never sees folder/metadata disagreement.
   var moved = [];
 
-  try {
-    for (var f = 0; f < found.length; f++) {
-      var fromRoot = found[f].root;
-      var fromAbs = found[f].oldAbs;
-      var oldRelClient = clientPath(fromRoot, oldSlug);
-      var newRelClient = clientPath(fromRoot, target);
-      var newAbs = safeDir(blog.id, fromRoot, target);
-
-      if (newAbs === null) {
-        throw new Error(
-          "refusing to move " + oldRelClient + " into unsafe path " +
-          newRelClient
-        );
-      }
-
-      // No other template can legitimately own <root>/<target>: target is this
-      // template's own id suffix. A directory already there is a leftover from
-      // an interrupted run — overwrite it and continue.
-      var destStat = null;
-      try {
-        destStat = await fs.lstat(newAbs);
-      } catch (e) {
-        if (e.code !== "ENOENT") throw e;
-      }
-      if (destStat) {
-        log("  " + newRelClient + " already present — resuming a prior move");
-      }
-
-      // Record the move before starting it so a mid-copy failure is rolled
-      // back too (copying the partial destination back over the intact
-      // source is a harmless overwrite).
-      moved.push({
-        oldRelClient: oldRelClient,
-        oldAbs: fromAbs,
-        newRelClient: newRelClient,
-        newAbs: newAbs,
-      });
-
-      var files = walkFiles(fromAbs);
-      await copyFiles(blog.id, client, files, fromAbs, newRelClient);
-      await removeDir(blog.id, client, oldRelClient, fromAbs);
-    }
-
-    // The folder is durable under the new name (or there was no folder) — only
-    // now correct the stored slug.
-    await promisify(setMetadata)(template.id, { slug: target });
-  } catch (e) {
+  async function rollback() {
     for (var m = moved.length - 1; m >= 0; m--) {
       var mv = moved[m];
       try {
-        var backFiles = walkFiles(mv.newAbs);
-        await copyFiles(blog.id, client, backFiles, mv.newAbs, mv.oldRelClient);
-        await removeDir(blog.id, client, mv.newRelClient, mv.newAbs);
+        var back = await scanTree(mv.toAbs);
+        await copyFiles(
+          blog.id,
+          client,
+          back.files,
+          mv.toAbs,
+          clientPath(mv.root, oldSlug)
+        );
+        await removeDir(
+          blog.id,
+          client,
+          clientPath(mv.root, target),
+          mv.toAbs
+        );
       } catch (rollbackErr) {
         log(
-          "  ROLLBACK FAILED " + mv.newRelClient + " -> " + mv.oldRelClient +
-          ": " + rollbackErr.message + " — reconcile by hand"
+          "  ROLLBACK FAILED " + mv.root + "/" + target + " -> " + mv.root +
+          "/" + oldSlug + ": " + rollbackErr.message + " — reconcile by hand"
         );
       }
     }
+  }
+
+  // Move every stale directory before persisting the slug.
+  try {
+    for (var f = 0; f < found.length; f++) {
+      var fromRoot = found[f].root;
+      moved.push({ root: fromRoot, toAbs: found[f].toAbs });
+      await copyFiles(
+        blog.id,
+        client,
+        found[f].files,
+        found[f].fromAbs,
+        clientPath(fromRoot, target)
+      );
+      await removeDir(
+        blog.id,
+        client,
+        clientPath(fromRoot, oldSlug),
+        found[f].fromAbs
+      );
+    }
+  } catch (e) {
+    await rollback();
     throw e;
+  }
+
+  // The folder is durable under the new name (or there was no folder) — only
+  // now correct the stored slug.
+  try {
+    await promisify(setMetadata)(template.id, { slug: target });
+  } catch (e) {
+    // setMetadata writes the hash before its own fallible follow-ups
+    // (cacheID bump, CDN manifest). If the slug did persist, the folder
+    // already matches it — keep the move. Otherwise roll back.
+    var current = null;
+    try {
+      current = await promisify(getMetadata)(template.id);
+    } catch (readErr) {
+      current = null;
+    }
+    if (!current || current.slug !== target) {
+      await rollback();
+      throw e;
+    }
+    log(
+      "  setMetadata errored after persisting the slug (" + e.message +
+      ") — folder already matches, keeping the move"
+    );
   }
 
   // setMetadata already bumps cacheID for a blog-owned template; do it

--- a/app/models/template/util/repairDivergentSlug.js
+++ b/app/models/template/util/repairDivergentSlug.js
@@ -41,6 +41,15 @@ function safeDir(blogID, root, slug) {
   return abs;
 }
 
+// A blot-folder-relative path for a client call. Always leading-slashed:
+// git and dropbox strip the slash themselves, but google-drive's write adds
+// one (so its file-id database is keyed with it) while its remove does not —
+// pass the slashed form so removals actually match. See clients/google-drive.
+function clientPath() {
+  var parts = Array.prototype.slice.call(arguments).filter(Boolean);
+  return "/" + parts.join("/");
+}
+
 // Pure classification of a template's stored slug against its id.
 //   { divergent: false }
 //   { divergent: true, repairable: false, reason }   -> needs a manual rename
@@ -82,9 +91,11 @@ function classify(blogID, template) {
   return { divergent: true, repairable: true, target: target };
 }
 
-// List every regular file under absDir (relative, "/"-joined). Symlinks and
-// directories themselves are skipped; dotfiles and shouldIgnoreFile-ignored
-// local-only files are kept so the move is lossless.
+// List every regular file under absDir (relative, "/"-joined). Directories
+// themselves are skipped; dotfiles and shouldIgnoreFile-ignored local-only
+// files are kept so the move is lossless. Symlinks are handled separately
+// (containsSymlink) — a tree with one is refused rather than silently losing
+// it, so they never reach here.
 function walkFiles(absDir) {
   var out = [];
 
@@ -108,13 +119,44 @@ function walkFiles(absDir) {
   return out;
 }
 
-// Copy each file from srcAbs/<rel> to <destRel>/<rel>. Real template files go
-// through the blog's client so the move propagates to the provider; ignored
-// local-only files (which client.write refuses) are written straight to disk.
-async function copyFiles(blogID, client, files, srcAbs, destRel) {
+// True if any entry anywhere under absDir is a symlink. writeToFolder leaves
+// symlinks out of reconciliation without deleting them; this migration deletes
+// the whole source directory through the client, so a tracked symlink would be
+// lost. Refuse such a directory instead.
+function containsSymlink(absDir) {
+  var found = false;
+
+  (function walk(dir) {
+    if (found) return;
+    var entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (e) {
+      if (e.code === "ENOENT" || e.code === "ENOTDIR") return;
+      throw e;
+    }
+    for (var i = 0; i < entries.length; i++) {
+      if (found) return;
+      var entry = entries[i];
+      if (entry.isSymbolicLink()) {
+        found = true;
+        return;
+      }
+      if (entry.isDirectory()) walk(path.join(dir, entry.name));
+    }
+  })(absDir);
+
+  return found;
+}
+
+// Copy each file from srcAbs/<rel> to <destRelClient>/<rel>. Real template
+// files go through the blog's client so the move propagates to the provider;
+// ignored local-only files (which client.write refuses) are written straight
+// to disk.
+async function copyFiles(blogID, client, files, srcAbs, destRelClient) {
   for (var i = 0; i < files.length; i++) {
     var rel = files[i];
-    var destFileRel = path.join(destRel, rel);
+    var destFileRel = destRelClient + "/" + rel;
     var contents = await fs.readFile(path.join(srcAbs, rel));
 
     if (!client || shouldIgnoreFile(destFileRel)) {
@@ -128,10 +170,10 @@ async function copyFiles(blogID, client, files, srcAbs, destRel) {
 // Remove the stale directory: through the client first (so the provider drops
 // the tracked files), then a plain fs.remove to sweep up any local-only
 // leftovers and the now-empty directory shell.
-async function removeDir(blogID, client, oldRel, oldAbs) {
+async function removeDir(blogID, client, oldRelClient, oldAbs) {
   if (client) {
     try {
-      await promisify(client.remove)(blogID, oldRel);
+      await promisify(client.remove)(blogID, oldRelClient);
     } catch (e) {
       if (!e || e.code !== "ENOENT") throw e;
     }
@@ -151,7 +193,10 @@ async function removeDir(blogID, client, oldRel, oldAbs) {
 //   { repaired: true }                     applied
 //
 // Throws on a folder / metadata error — the record is then left untouched so a
-// rerun retries it identically rather than skipping it.
+// rerun retries it identically rather than skipping it. If the metadata write
+// fails after the folder was moved, the move is rolled back first so the
+// buildFromFolder that syncLock.done() runs does not see a folder whose name
+// no longer matches the still-stored slug (and drop the template).
 async function repairDivergentSlug(blog, template, options) {
   options = options || {};
   var apply = options.apply === true;
@@ -178,20 +223,27 @@ async function repairDivergentSlug(blog, template, options) {
     };
   }
 
-  // If the stale slug resolves (via makeID) to a *different* real template,
-  // that template may own the directory — leave both for manual handling.
   var list = await promisify(getTemplateList)(blog.id);
+  var owned = (list || []).filter(function (t) {
+    return t.owner === blog.id;
+  });
+
+  // If the stale slug resolves (via makeID) to a *different* real template, or
+  // another owned record stores the *same* stale slug (so both claim the same
+  // physical directory), leave every record involved for manual handling.
   var staleID = makeID(blog.id, oldSlug);
-  var collidesWith = (list || []).find(function (t) {
-    return t.id === staleID && t.id !== template.id;
+  var collidesWith = owned.find(function (t) {
+    return (
+      t.id !== template.id && (t.id === staleID || t.slug === oldSlug)
+    );
   });
   if (collidesWith) {
     return {
       skipped: true,
       collision: true,
       reason:
-        "stale slug " + JSON.stringify(oldSlug) + " resolves to " + staleID +
-        " (another template) — resolve by hand",
+        "stale slug " + JSON.stringify(oldSlug) + " is also claimed by " +
+        collidesWith.id + " — resolve by hand",
     };
   }
 
@@ -216,6 +268,19 @@ async function repairDivergentSlug(blog, template, options) {
     if (stat && stat.isDirectory()) found.push({ root: root, oldAbs: oldAbs });
   }
 
+  // A tracked symlink would be dropped by the copy and then committed as a
+  // deletion by removeDir — refuse the directory rather than lose it.
+  for (var s = 0; s < found.length; s++) {
+    if (containsSymlink(found[s].oldAbs)) {
+      return {
+        skipped: true,
+        reason:
+          found[s].root + "/" + oldSlug +
+          " contains a symlink — reconcile by hand",
+      };
+    }
+  }
+
   log(
     (apply ? "FIX  " : "WOULD FIX ") + blog.id + " " + template.id +
     "  " + JSON.stringify(oldSlug) + " -> " + JSON.stringify(target) +
@@ -233,42 +298,73 @@ async function repairDivergentSlug(blog, template, options) {
 
   if (!apply) return { wouldRepair: true };
 
-  // Move every stale directory before persisting the slug: a failed folder
-  // step must leave the stored slug untouched so a rerun retries identically.
-  for (var f = 0; f < found.length; f++) {
-    var fromRoot = found[f].root;
-    var fromAbs = found[f].oldAbs;
-    var oldRel = path.join(fromRoot, oldSlug);
-    var newRel = path.join(fromRoot, target);
-    var newAbs = safeDir(blog.id, fromRoot, target);
+  // Move every stale directory, then persist the slug. If anything in this
+  // sequence fails, roll the moves back so a rerun retries identically and the
+  // lock's buildFromFolder never sees folder/metadata disagreement.
+  var moved = [];
 
-    if (newAbs === null) {
-      throw new Error(
-        "refusing to move " + oldRel + " into unsafe path " + newRel
-      );
+  try {
+    for (var f = 0; f < found.length; f++) {
+      var fromRoot = found[f].root;
+      var fromAbs = found[f].oldAbs;
+      var oldRelClient = clientPath(fromRoot, oldSlug);
+      var newRelClient = clientPath(fromRoot, target);
+      var newAbs = safeDir(blog.id, fromRoot, target);
+
+      if (newAbs === null) {
+        throw new Error(
+          "refusing to move " + oldRelClient + " into unsafe path " +
+          newRelClient
+        );
+      }
+
+      // No other template can legitimately own <root>/<target>: target is this
+      // template's own id suffix. A directory already there is a leftover from
+      // an interrupted run — overwrite it and continue.
+      var destStat = null;
+      try {
+        destStat = await fs.lstat(newAbs);
+      } catch (e) {
+        if (e.code !== "ENOENT") throw e;
+      }
+      if (destStat) {
+        log("  " + newRelClient + " already present — resuming a prior move");
+      }
+
+      // Record the move before starting it so a mid-copy failure is rolled
+      // back too (copying the partial destination back over the intact
+      // source is a harmless overwrite).
+      moved.push({
+        oldRelClient: oldRelClient,
+        oldAbs: fromAbs,
+        newRelClient: newRelClient,
+        newAbs: newAbs,
+      });
+
+      var files = walkFiles(fromAbs);
+      await copyFiles(blog.id, client, files, fromAbs, newRelClient);
+      await removeDir(blog.id, client, oldRelClient, fromAbs);
     }
 
-    // No other template can legitimately own <root>/<target>: target is this
-    // template's own id suffix. A directory already there is a leftover from
-    // an interrupted run — overwrite it and continue.
-    var destStat = null;
-    try {
-      destStat = await fs.lstat(newAbs);
-    } catch (e) {
-      if (e.code !== "ENOENT") throw e;
+    // The folder is durable under the new name (or there was no folder) — only
+    // now correct the stored slug.
+    await promisify(setMetadata)(template.id, { slug: target });
+  } catch (e) {
+    for (var m = moved.length - 1; m >= 0; m--) {
+      var mv = moved[m];
+      try {
+        var backFiles = walkFiles(mv.newAbs);
+        await copyFiles(blog.id, client, backFiles, mv.newAbs, mv.oldRelClient);
+        await removeDir(blog.id, client, mv.newRelClient, mv.newAbs);
+      } catch (rollbackErr) {
+        log(
+          "  ROLLBACK FAILED " + mv.newRelClient + " -> " + mv.oldRelClient +
+          ": " + rollbackErr.message + " — reconcile by hand"
+        );
+      }
     }
-    if (destStat) {
-      log("  " + newRel + " already present — resuming an interrupted move");
-    }
-
-    var files = walkFiles(fromAbs);
-    await copyFiles(blog.id, client, files, fromAbs, newRel);
-    await removeDir(blog.id, client, oldRel, fromAbs);
+    throw e;
   }
-
-  // The folder is durable under the new name (or there was no folder) — only
-  // now correct the stored slug.
-  await promisify(setMetadata)(template.id, { slug: target });
 
   // setMetadata already bumps cacheID for a blog-owned template; do it
   // explicitly too so the repair is self-contained.

--- a/app/models/template/util/repairDivergentSlug.js
+++ b/app/models/template/util/repairDivergentSlug.js
@@ -1,0 +1,286 @@
+var path = require("path");
+var fs = require("fs-extra");
+var { promisify } = require("util");
+
+var makeID = require("./makeID");
+var localPath = require("helper/localPath");
+var setMetadata = require("../setMetadata");
+var getTemplateList = require("../getTemplateList");
+var Blog = require("models/blog");
+var shouldIgnoreFile = require("clients/util/shouldIgnoreFile");
+
+// buildFromFolder scans both of these; writeToFolder writes to whichever
+// determineTemplateFolder picks. A stale directory could be under either.
+var TEMPLATE_ROOTS = ["Templates", "templates"];
+
+function idSuffix(id) {
+  var i = String(id).indexOf(":");
+  return i === -1 ? "" : String(id).slice(i + 1);
+}
+
+// A slug is safe to use as a single on-disk path component only if it has no
+// separators and does not climb out of its directory.
+function isSafeComponent(slug) {
+  return (
+    typeof slug === "string" &&
+    slug.length > 0 &&
+    slug !== "." &&
+    slug !== ".." &&
+    slug.indexOf("/") === -1 &&
+    slug.indexOf("\\") === -1
+  );
+}
+
+// Resolve <root>/<slug> and confirm it lands directly inside <root> of the
+// blog's folder. Returns the absolute path, or null when the slug is unsafe.
+function safeDir(blogID, root, slug) {
+  if (!isSafeComponent(slug)) return null;
+  var rootAbs = localPath(blogID, root);
+  var abs = localPath(blogID, path.join(root, slug));
+  if (path.dirname(abs) !== rootAbs) return null;
+  return abs;
+}
+
+// Pure classification of a template's stored slug against its id.
+//   { divergent: false }
+//   { divergent: true, repairable: false, reason }   -> needs a manual rename
+//   { divergent: true, repairable: true, target }    -> target is the new slug
+function classify(blogID, template) {
+  var slug = template && template.slug;
+  var resolved;
+
+  try {
+    resolved = makeID(blogID, slug);
+  } catch (e) {
+    return {
+      divergent: true,
+      repairable: false,
+      reason:
+        "stored slug " + JSON.stringify(slug) + " is not a usable name (" +
+        e.message + ")",
+    };
+  }
+
+  if (resolved === template.id) return { divergent: false };
+
+  // The slug we want is the id's own suffix — but only when makeID maps it
+  // straight back to the id. A legacy id minted from a non-ASCII name (before
+  // makeID capped length / percent-encoded it) will not round-trip and cannot
+  // be repaired safely here.
+  var target = idSuffix(template.id);
+
+  if (!target || makeID(blogID, target) !== template.id) {
+    return {
+      divergent: true,
+      repairable: false,
+      reason:
+        "id " + template.id + " has no suffix that makeID maps back to it — " +
+        "rename the template by hand",
+    };
+  }
+
+  return { divergent: true, repairable: true, target: target };
+}
+
+// List every regular file under absDir (relative, "/"-joined). Symlinks and
+// directories themselves are skipped; dotfiles and shouldIgnoreFile-ignored
+// local-only files are kept so the move is lossless.
+function walkFiles(absDir) {
+  var out = [];
+
+  (function walk(dir, rel) {
+    var entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (e) {
+      if (e.code === "ENOENT" || e.code === "ENOTDIR") return;
+      throw e;
+    }
+
+    entries.forEach(function (entry) {
+      var childRel = rel ? rel + "/" + entry.name : entry.name;
+      if (entry.isSymbolicLink()) return;
+      if (entry.isDirectory()) return walk(path.join(dir, entry.name), childRel);
+      if (entry.isFile()) out.push(childRel);
+    });
+  })(absDir, "");
+
+  return out;
+}
+
+// Copy each file from srcAbs/<rel> to <destRel>/<rel>. Real template files go
+// through the blog's client so the move propagates to the provider; ignored
+// local-only files (which client.write refuses) are written straight to disk.
+async function copyFiles(blogID, client, files, srcAbs, destRel) {
+  for (var i = 0; i < files.length; i++) {
+    var rel = files[i];
+    var destFileRel = path.join(destRel, rel);
+    var contents = await fs.readFile(path.join(srcAbs, rel));
+
+    if (!client || shouldIgnoreFile(destFileRel)) {
+      await fs.outputFile(localPath(blogID, destFileRel), contents);
+    } else {
+      await promisify(client.write)(blogID, destFileRel, contents);
+    }
+  }
+}
+
+// Remove the stale directory: through the client first (so the provider drops
+// the tracked files), then a plain fs.remove to sweep up any local-only
+// leftovers and the now-empty directory shell.
+async function removeDir(blogID, client, oldRel, oldAbs) {
+  if (client) {
+    try {
+      await promisify(client.remove)(blogID, oldRel);
+    } catch (e) {
+      if (!e || e.code !== "ENOENT") throw e;
+    }
+  }
+  await fs.remove(oldAbs);
+}
+
+// Reconcile one template whose stored slug no longer resolves to its id.
+//
+// The caller is responsible for holding establishSyncLock(blog.id) around this
+// so no buildFromFolder runs against a half-migrated state.
+//
+// Returns one of:
+//   { skipped: true, reason }              not divergent / manual rename / unsafe
+//   { skipped: true, collision: true, reason }
+//   { wouldRepair: true }                  dry run, a repair is available
+//   { repaired: true }                     applied
+//
+// Throws on a folder / metadata error — the record is then left untouched so a
+// rerun retries it identically rather than skipping it.
+async function repairDivergentSlug(blog, template, options) {
+  options = options || {};
+  var apply = options.apply === true;
+  var log = typeof options.log === "function" ? options.log : function () {};
+
+  var info = classify(blog.id, template);
+
+  if (!info.divergent) return { skipped: true, reason: "slug already resolves" };
+  if (!info.repairable) return { skipped: true, reason: info.reason };
+
+  var oldSlug = template.slug;
+  var target = info.target;
+
+  // Constrain the stale slug as a path component before any filesystem access.
+  var unsafe = TEMPLATE_ROOTS.some(function (root) {
+    return safeDir(blog.id, root, oldSlug) === null;
+  });
+  if (unsafe) {
+    return {
+      skipped: true,
+      reason:
+        "stored slug " + JSON.stringify(oldSlug) +
+        " is not a safe path component",
+    };
+  }
+
+  // If the stale slug resolves (via makeID) to a *different* real template,
+  // that template may own the directory — leave both for manual handling.
+  var list = await promisify(getTemplateList)(blog.id);
+  var staleID = makeID(blog.id, oldSlug);
+  var collidesWith = (list || []).find(function (t) {
+    return t.id === staleID && t.id !== template.id;
+  });
+  if (collidesWith) {
+    return {
+      skipped: true,
+      collision: true,
+      reason:
+        "stale slug " + JSON.stringify(oldSlug) + " resolves to " + staleID +
+        " (another template) — resolve by hand",
+    };
+  }
+
+  // Find the stale directory under either root. A divergent record can have a
+  // stale folder even with localEditing === false (the disable route sets the
+  // flag even when removeFromFolder failed), so key off the actual directory,
+  // not the flag.
+  var client = require("clients")[blog.client] || null;
+  var found = [];
+
+  for (var r = 0; r < TEMPLATE_ROOTS.length; r++) {
+    var root = TEMPLATE_ROOTS[r];
+    var oldAbs = safeDir(blog.id, root, oldSlug);
+    var stat = null;
+
+    try {
+      stat = await fs.lstat(oldAbs);
+    } catch (e) {
+      if (e.code !== "ENOENT") throw e;
+    }
+
+    if (stat && stat.isDirectory()) found.push({ root: root, oldAbs: oldAbs });
+  }
+
+  log(
+    (apply ? "FIX  " : "WOULD FIX ") + blog.id + " " + template.id +
+    "  " + JSON.stringify(oldSlug) + " -> " + JSON.stringify(target) +
+    "  (localEditing=" + !!template.localEditing +
+    ", onDisk=" +
+    (found.length
+      ? found
+          .map(function (f) {
+            return f.root;
+          })
+          .join("+")
+      : "none") +
+    ")"
+  );
+
+  if (!apply) return { wouldRepair: true };
+
+  // Move every stale directory before persisting the slug: a failed folder
+  // step must leave the stored slug untouched so a rerun retries identically.
+  for (var f = 0; f < found.length; f++) {
+    var fromRoot = found[f].root;
+    var fromAbs = found[f].oldAbs;
+    var oldRel = path.join(fromRoot, oldSlug);
+    var newRel = path.join(fromRoot, target);
+    var newAbs = safeDir(blog.id, fromRoot, target);
+
+    if (newAbs === null) {
+      throw new Error(
+        "refusing to move " + oldRel + " into unsafe path " + newRel
+      );
+    }
+
+    // No other template can legitimately own <root>/<target>: target is this
+    // template's own id suffix. A directory already there is a leftover from
+    // an interrupted run — overwrite it and continue.
+    var destStat = null;
+    try {
+      destStat = await fs.lstat(newAbs);
+    } catch (e) {
+      if (e.code !== "ENOENT") throw e;
+    }
+    if (destStat) {
+      log("  " + newRel + " already present — resuming an interrupted move");
+    }
+
+    var files = walkFiles(fromAbs);
+    await copyFiles(blog.id, client, files, fromAbs, newRel);
+    await removeDir(blog.id, client, oldRel, fromAbs);
+  }
+
+  // The folder is durable under the new name (or there was no folder) — only
+  // now correct the stored slug.
+  await promisify(setMetadata)(template.id, { slug: target });
+
+  // setMetadata already bumps cacheID for a blog-owned template; do it
+  // explicitly too so the repair is self-contained.
+  try {
+    await promisify(Blog.set)(blog.id, { cacheID: Date.now() });
+  } catch (e) {
+    // non-fatal: the slug and folder are already consistent
+  }
+
+  return { repaired: true };
+}
+
+module.exports = repairDivergentSlug;
+module.exports.classify = classify;
+module.exports.TEMPLATE_ROOTS = TEMPLATE_ROOTS;

--- a/scripts/template/fix-divergent-slugs.js
+++ b/scripts/template/fix-divergent-slugs.js
@@ -39,6 +39,7 @@ var totals = {
   skipped: 0,
   collisions: 0,
   disabled: 0,
+  failed: 0,
 };
 
 function getList(blogID) {
@@ -56,6 +57,7 @@ async function processBlog(blog) {
   try {
     list = await getList(blog.id);
   } catch (e) {
+    totals.failed++;
     console.error("  " + blog.id + ": getTemplateList failed: " + e.message);
     return;
   }
@@ -77,7 +79,13 @@ async function processBlog(blog) {
 
   if (!pending.length) return;
 
-  var per = { divergent: pending.length, repaired: 0, skipped: 0, collisions: 0 };
+  var per = {
+    divergent: pending.length,
+    repaired: 0,
+    skipped: 0,
+    collisions: 0,
+    failed: 0,
+  };
 
   // establishSyncLock delegates to Sync, which refuses a disabled blog, so a
   // divergent template on one cannot be repaired here. Report it distinctly:
@@ -99,12 +107,12 @@ async function processBlog(blog) {
     try {
       syncLock = await establishSyncLock(blog.id);
     } catch (e) {
+      per.failed += pending.length;
+      totals.failed += pending.length;
       console.error(
         "  " + blog.id + ": could not acquire sync lock: " + e.message +
-        " (skipping this blog)"
+        " (" + pending.length + " template(s) left for a rerun)"
       );
-      per.skipped += pending.length;
-      totals.skipped += pending.length;
       return;
     }
   }
@@ -122,8 +130,8 @@ async function processBlog(blog) {
           },
         });
       } catch (e) {
-        per.skipped++;
-        totals.skipped++;
+        per.failed++;
+        totals.failed++;
         console.error(
           "  FAIL " + blog.id + " " + template.id + ": " + e.message +
           " (left for a rerun)"
@@ -155,6 +163,7 @@ async function processBlog(blog) {
       try {
         await syncLock.done();
       } catch (e) {
+        totals.failed++;
         console.error(
           "  " + blog.id + ": failed to release sync lock: " + e.message
         );
@@ -167,7 +176,8 @@ async function processBlog(blog) {
     "divergent " + per.divergent +
     (APPLY ? "  repaired " : "  would repair ") + per.repaired +
     "  skipped " + per.skipped +
-    "  collisions " + per.collisions
+    "  collisions " + per.collisions +
+    "  failed " + per.failed
   );
 }
 
@@ -180,7 +190,8 @@ function printGrandTotal() {
     (APPLY ? "  repaired " : "  would repair ") + totals.repaired +
     "  skipped " + totals.skipped +
     "  collisions " + totals.collisions +
-    "  disabled " + totals.disabled
+    "  disabled " + totals.disabled +
+    "  failed " + totals.failed
   );
 
   if (!APPLY && totals.divergent) {
@@ -194,6 +205,13 @@ function printGrandTotal() {
       "rerun this script for those blogs once they are re-enabled."
     );
   }
+
+  if (totals.failed) {
+    console.log(
+      "\n" + totals.failed +
+      " template(s) hit an error and were left for a rerun — exiting non-zero."
+    );
+  }
 }
 
 if (require.main === module) {
@@ -205,6 +223,7 @@ if (require.main === module) {
     run = new Promise(function (resolve) {
       require("../get/blog")(IDENTIFIER, function (err, user, blog) {
         if (err || !blog) {
+          totals.failed++;
           console.error(
             "No blog for " + JSON.stringify(IDENTIFIER) + ": " +
             ((err && err.message) || "not found")
@@ -213,6 +232,7 @@ if (require.main === module) {
         }
         totals.blogs = 1;
         processBlog(blog).then(resolve, function (e) {
+          totals.failed++;
           console.error("Fatal: " + e.message);
           resolve();
         });
@@ -228,6 +248,7 @@ if (require.main === module) {
               nextBlog();
             },
             function (e) {
+              totals.failed++;
               console.error("  " + blog.id + ": " + e.message);
               nextBlog();
             }
@@ -242,7 +263,7 @@ if (require.main === module) {
 
   run.then(function () {
     printGrandTotal();
-    process.exit(0);
+    process.exit(totals.failed > 0 ? 1 : 0);
   });
 }
 

--- a/scripts/template/fix-divergent-slugs.js
+++ b/scripts/template/fix-divergent-slugs.js
@@ -1,0 +1,224 @@
+// One-off repair for template records whose stored slug no longer resolves to
+// the template's id through makeID.
+//
+// writeToFolder names a locally edited template's on-disk directory after its
+// stored slug, and readFromFolder turns that directory name back into an id
+// with makeID. When the two disagree, a template written to a folder is read
+// back as a *different* template and overwrites it. New templates are kept
+// consistent in models/template/create.js (and the slugForName helper); this
+// is the pass for records created before that fix — duplicated / forked /
+// added-from-shared templates with long names, mostly.
+//
+//   node scripts/template/fix-divergent-slugs.js                 dry run, every blog
+//   node scripts/template/fix-divergent-slugs.js <blog>          dry run, one blog
+//   node scripts/template/fix-divergent-slugs.js --apply         apply, every blog
+//   node scripts/template/fix-divergent-slugs.js --apply <blog>  apply, one blog
+//
+// <blog> is anything scripts/get/blog accepts (id, handle, domain, id prefix).
+//
+// The per-blog repair runs inside establishSyncLock(blog.id) so no
+// buildFromFolder can run against a half-migrated state. The corrected slug is
+// persisted only after the folder is durable under the new name, so a failed
+// run leaves the record untouched and a rerun retries it identically. The
+// actual reconciliation lives in models/template/util/repairDivergentSlug.js.
+
+var getTemplateList = require("models/template/getTemplateList");
+var establishSyncLock = require("sync/establishSyncLock");
+var repairDivergentSlug = require("models/template/util/repairDivergentSlug");
+
+var APPLY = process.argv.indexOf("--apply") > -1;
+var IDENTIFIER = process.argv.slice(2).filter(function (a) {
+  return a !== "--apply";
+})[0];
+
+var totals = {
+  blogs: 0,
+  templates: 0,
+  divergent: 0,
+  repaired: 0,
+  skipped: 0,
+  collisions: 0,
+};
+
+function getList(blogID) {
+  return new Promise(function (resolve, reject) {
+    getTemplateList(blogID, function (err, list) {
+      if (err) return reject(err);
+      resolve(list || []);
+    });
+  });
+}
+
+async function processBlog(blog) {
+  var list;
+
+  try {
+    list = await getList(blog.id);
+  } catch (e) {
+    console.error("  " + blog.id + ": getTemplateList failed: " + e.message);
+    return;
+  }
+
+  var owned = list.filter(function (t) {
+    return t.owner === blog.id;
+  });
+
+  // Classify first (no filesystem writes) so the sync lock is only taken when
+  // there is at least one divergent record to repair.
+  var pending = [];
+  owned.forEach(function (t) {
+    totals.templates++;
+    var info = repairDivergentSlug.classify(blog.id, t);
+    if (!info.divergent) return;
+    totals.divergent++;
+    pending.push(t);
+  });
+
+  if (!pending.length) return;
+
+  var per = { divergent: pending.length, repaired: 0, skipped: 0, collisions: 0 };
+
+  var syncLock = null;
+  if (APPLY) {
+    try {
+      syncLock = await establishSyncLock(blog.id);
+    } catch (e) {
+      console.error(
+        "  " + blog.id + ": could not acquire sync lock: " + e.message +
+        " (skipping this blog)"
+      );
+      per.skipped += pending.length;
+      totals.skipped += pending.length;
+      return;
+    }
+  }
+
+  try {
+    for (var i = 0; i < pending.length; i++) {
+      var template = pending[i];
+      var result;
+
+      try {
+        result = await repairDivergentSlug(blog, template, {
+          apply: APPLY,
+          log: function (line) {
+            console.log("  " + line);
+          },
+        });
+      } catch (e) {
+        per.skipped++;
+        totals.skipped++;
+        console.error(
+          "  FAIL " + blog.id + " " + template.id + ": " + e.message +
+          " (left for a rerun)"
+        );
+        continue;
+      }
+
+      // Count the would-repair before any early return: a repair that is
+      // merely available in a dry run still shows up in the totals.
+      if (result.repaired || result.wouldRepair) {
+        per.repaired++;
+        totals.repaired++;
+      } else if (result.collision) {
+        per.collisions++;
+        totals.collisions++;
+        console.log(
+          "  COLLISION " + blog.id + " " + template.id + ": " + result.reason
+        );
+      } else {
+        per.skipped++;
+        totals.skipped++;
+        console.log(
+          "  SKIP " + blog.id + " " + template.id + ": " + result.reason
+        );
+      }
+    }
+  } finally {
+    if (syncLock) {
+      try {
+        await syncLock.done();
+      } catch (e) {
+        console.error(
+          "  " + blog.id + ": failed to release sync lock: " + e.message
+        );
+      }
+    }
+  }
+
+  console.log(
+    "  blog " + blog.id + " (" + (blog.handle || "no handle") + "): " +
+    "divergent " + per.divergent +
+    (APPLY ? "  repaired " : "  would repair ") + per.repaired +
+    "  skipped " + per.skipped +
+    "  collisions " + per.collisions
+  );
+}
+
+function printGrandTotal() {
+  console.log("\n" + "=".repeat(60));
+  console.log(
+    "blogs " + totals.blogs +
+    "  templates " + totals.templates +
+    "  divergent " + totals.divergent +
+    (APPLY ? "  repaired " : "  would repair ") + totals.repaired +
+    "  skipped " + totals.skipped +
+    "  collisions " + totals.collisions
+  );
+
+  if (!APPLY && totals.divergent) {
+    console.log("\nRe-run with --apply to make these changes.");
+  }
+}
+
+if (require.main === module) {
+  if (!APPLY) console.log("DRY RUN — no changes will be written.\n");
+
+  var run;
+
+  if (IDENTIFIER) {
+    run = new Promise(function (resolve) {
+      require("../get/blog")(IDENTIFIER, function (err, user, blog) {
+        if (err || !blog) {
+          console.error(
+            "No blog for " + JSON.stringify(IDENTIFIER) + ": " +
+            ((err && err.message) || "not found")
+          );
+          return resolve();
+        }
+        totals.blogs = 1;
+        processBlog(blog).then(resolve, function (e) {
+          console.error("Fatal: " + e.message);
+          resolve();
+        });
+      });
+    });
+  } else {
+    run = new Promise(function (resolve) {
+      require("../each/blog")(
+        function (user, blog, nextBlog) {
+          totals.blogs++;
+          processBlog(blog).then(
+            function () {
+              nextBlog();
+            },
+            function (e) {
+              console.error("  " + blog.id + ": " + e.message);
+              nextBlog();
+            }
+          );
+        },
+        function () {
+          resolve();
+        }
+      );
+    });
+  }
+
+  run.then(function () {
+    printGrandTotal();
+    process.exit(0);
+  });
+}
+
+module.exports = { processBlog: processBlog };

--- a/scripts/template/fix-divergent-slugs.js
+++ b/scripts/template/fix-divergent-slugs.js
@@ -38,6 +38,7 @@ var totals = {
   repaired: 0,
   skipped: 0,
   collisions: 0,
+  disabled: 0,
 };
 
 function getList(blogID) {
@@ -77,6 +78,21 @@ async function processBlog(blog) {
   if (!pending.length) return;
 
   var per = { divergent: pending.length, repaired: 0, skipped: 0, collisions: 0 };
+
+  // establishSyncLock delegates to Sync, which refuses a disabled blog, so a
+  // divergent template on one cannot be repaired here. Report it distinctly:
+  // it stays vulnerable to the original overwrite bug and must be rerun once
+  // the blog is re-enabled.
+  if (blog.isDisabled) {
+    totals.disabled += pending.length;
+    console.log(
+      "  blog " + blog.id + " (" + (blog.handle || "no handle") + "): " +
+      "DISABLED — " + pending.length + " divergent template(s) left; " +
+      "rerun `node scripts/template/fix-divergent-slugs.js " +
+      (APPLY ? "--apply " : "") + blog.id + "` after re-enabling"
+    );
+    return;
+  }
 
   var syncLock = null;
   if (APPLY) {
@@ -163,11 +179,20 @@ function printGrandTotal() {
     "  divergent " + totals.divergent +
     (APPLY ? "  repaired " : "  would repair ") + totals.repaired +
     "  skipped " + totals.skipped +
-    "  collisions " + totals.collisions
+    "  collisions " + totals.collisions +
+    "  disabled " + totals.disabled
   );
 
   if (!APPLY && totals.divergent) {
     console.log("\nRe-run with --apply to make these changes.");
+  }
+
+  if (totals.disabled) {
+    console.log(
+      "\n" + totals.disabled +
+      " divergent template(s) are on disabled blogs and were not repaired — " +
+      "rerun this script for those blogs once they are re-enabled."
+    );
   }
 }
 


### PR DESCRIPTION
## Background

PR #1749 landed the forward fix: `models/template/create.js` now keeps a
template's stored slug in step with its id (`makeID`), and the dashboard
create paths derive the slug via `models/template/util/slugForName.js`. No
template created from now on can be stored with a slug that `makeID` maps to a
different id.

This PR is the **still-TODO one-off migration** for records created *before*
that fix — mostly duplicated / forked / added-from-shared templates with long
names, where `makeID(blog.id, template.slug) !== template.id`. When the stored
slug and id disagree, `writeToFolder` names the on-disk directory after the
stale slug and `readFromFolder` turns it back into a *different* id, so a
locally edited template can be read from its folder as another template and
overwrite it.

## What's here

### `models/template/util/repairDivergentSlug.js` (testable core)

Reconciles one template whose stored slug no longer resolves to its id:

- **Target slug** is the id's own suffix, but only when `makeID(blog.id, suffix) === template.id`. A legacy non-ASCII id that does not round-trip is reported for a manual rename and skipped.
- **Folder move, never delete-and-regenerate.** Checks *both* template roots (`Templates/` and `templates/` — `buildFromFolder` scans both), walks the real directory so nested, dotfile and `shouldIgnoreFile`-ignored local-only files are preserved, copies through the blog's client (`require("clients")[blog.client]`, `fs` fallback for a client-less blog), then removes the old dir through the client. Ignored files (which `client.write` refuses) go straight to disk. Any copy/remove error propagates — the record is not counted as repaired and is left for a rerun.
- **Ordering.** The corrected slug is persisted with `setMetadata` only *after* the folder is durable under the new name, so a failed run leaves the stored slug untouched and a rerun retries identically.
- **Path safety.** The stale slug is constrained as a single path component (rejects `.`, `..`, separators, anything resolving outside the blog's template root) before any filesystem access.
- **Collisions.** If the stale slug resolves via `makeID` to a *different* real template, both records are left for manual handling.
- **`localEditing === false`** is handled — an actual on-disk directory is reconciled independently of the flag.
- Bumps `blog.cacheID` after a successful repair.

### `scripts/template/fix-divergent-slugs.js` (CLI)

```
node scripts/template/fix-divergent-slugs.js [--apply] [<blog>]
```

Dry-run by default. `<blog>` is anything `scripts/get/blog` accepts. Classifies
first so `establishSyncLock(blog.id)` is only taken when there is something to
repair; the whole per-blog repair runs inside the lock (released in a
`finally`) so no `buildFromFolder` sees a half-migrated state. Prints every
change it would make — the would-repair counter is incremented in dry runs too
— plus per-blog and grand-total summaries (blogs, templates, divergent,
repaired, skipped, collisions).

### Spec — `app/models/template/tests/repairDivergentSlug.js`

Seeds a divergent locally-edited template with an extra ignored (`.DS_Store`)
and nested (`partials/head.html`) file, runs the repair with `--apply`
semantics under a real sync lock against a test blog, and asserts: the stored
slug now round-trips to the id, the folder moved to the new name (old name
gone), and both extra files survived the move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)