### PR TITLE
Add contextual status to blog iteration progress

### DIFF
--- a/scripts/each/blog.js
+++ b/scripts/each/blog.js
@@ -43,6 +43,9 @@ module.exports = function (doThis, allDone, options) {
     }
 
     if (options.o) {
+      // Unlike scripts/get/blog.js (and therefore eachBlogOrOneBlog.js), this
+      // option does not resolve shortened IDs, handles, or domains. Callers
+      // must provide complete blog IDs.
       if (type(options.o, "array")) {
         blogIDs = options.o.map(function (id) {
           return id + "";
@@ -58,9 +61,11 @@ module.exports = function (doThis, allDone, options) {
     }
 
     var forEach = async.eachSeries;
+    var parallel = false;
 
     if (options.p) {
       forEach = async.each;
+      parallel = true;
     } else if (options.c && parseInt(options.c, 10) > 1) {
       // Bounded concurrency: overlap the per-blog Redis reads without the
       // unbounded fan-out of options.p. The nested progress line (Blog x
@@ -69,16 +74,34 @@ module.exports = function (doThis, allDone, options) {
       // one-off migration where throughput matters more than a tidy status
       // line.
       var limit = parseInt(options.c, 10);
+      parallel = true;
       forEach = function (items, iterator, cb) {
         async.eachLimit(items, limit, iterator, cb);
       };
     }
 
-    var bar = progress.push("Blog", blogIDs.length);
+    // A concurrent run has several equally current blogs. In that case show
+    // only aggregate completed progress rather than a misleading ID, ordinal,
+    // or active-item percentage.
+    var bar = progress.push("Blog", blogIDs.length, {
+      percentage: !parallel,
+    });
+    var activeOrdinal = 0;
 
     forEach(
       blogIDs,
       function (blogID, done) {
+        if (!parallel) {
+          activeOrdinal += 1;
+          // Set this before Blog.get so slow reads still identify the blog
+          // currently being processed. Keep it separate from bar.tick(),
+          // which counts only completed (including skipped) blogs.
+          bar.setContext({
+            detail: blogID.slice(0, 12),
+            index: activeOrdinal,
+          });
+        }
+
         var nextBlog = function (err) {
           bar.tick();
           done(err);

--- a/scripts/each/eachBlogOrOneBlog.js
+++ b/scripts/each/eachBlogOrOneBlog.js
@@ -13,7 +13,8 @@ module.exports = function eachBlogOrOneBlog(processBlog) {
   const identifier = process.argv[2];
 
   if (identifier) {
-    // Process a single blog
+    // Process a single blog. getBlog owns identifier resolution, including
+    // shortened IDs; in contrast, each/blog.js's -o option requires full IDs.
     return new Promise((resolve, reject) => {
       getBlog(identifier, (err, _user, blog) => {
         if (err || !blog) {
@@ -74,4 +75,3 @@ module.exports = function eachBlogOrOneBlog(processBlog) {
     });
   }
 };
-

--- a/scripts/each/progress.js
+++ b/scripts/each/progress.js
@@ -12,7 +12,12 @@
 // Because template.js -> blog.js and view.js -> template.js, the frames
 // nest on their own and the status line reads
 //
-//   Blog (23/1500)  Template (1/4)  View (7/12)
+//   42%  Blog blog_1234567 (23/55)  Template (1/4)  View (7/12)
+//
+// A frame may opt into the leading percentage and may set contextual display
+// data (the item currently in flight and its one-based index) independently of
+// its completed-item index. Percentages are rounded to the nearest whole
+// number with Math.round; an empty total is displayed as 0%.
 //
 // On a TTY the line is pinned to the bottom and redrawn after anything the
 // script logs, so it survives stdout scrolling past. When stdout is not a
@@ -47,10 +52,35 @@ var redrawTimer = null;
 var lastFallback = 0;
 
 function format() {
-  return frames
+  var percentageFrame = frames.filter(function (f) {
+    return f.percentage;
+  })[0];
+  var prefix = "";
+
+  if (percentageFrame) {
+    var percentageIndex =
+      percentageFrame.context.index == null
+        ? percentageFrame.index
+        : percentageFrame.context.index;
+    var percentage = percentageFrame.total
+      ? Math.round((percentageIndex / percentageFrame.total) * 100)
+      : 0;
+    prefix = percentage + "%  ";
+  }
+
+  return prefix + frames
     .map(function (f) {
+      var displayIndex =
+        f.context.index == null ? f.index : f.context.index;
+      var detail = f.context.detail ? " " + f.context.detail : "";
       return (
-        f.label + " (" + f.index + "/" + (f.total == null ? "?" : f.total) + ")"
+        f.label +
+        detail +
+        " (" +
+        displayIndex +
+        "/" +
+        (f.total == null ? "?" : f.total) +
+        ")"
       );
     })
     .join("  ");
@@ -132,10 +162,20 @@ function onChange(force) {
   else if (fallback) maybeFallbackLog(force);
 }
 
-// push(label[, total]) -> handle. total may be null/undefined when unknown;
-// call handle.setTotal(n) later once it is known.
-function push(label, total) {
-  var frame = { label: label, index: 0, total: total == null ? null : total };
+// push(label[, total[, options]]) -> handle. total may be null/undefined when
+// unknown; call handle.setTotal(n) later once it is known. Pass
+// { percentage: true } to prefix the whole nested status with this frame's
+// progress. setContext({ detail, index }) identifies an active item without
+// changing the completed-item count advanced by tick().
+function push(label, total, options) {
+  options = options || {};
+  var frame = {
+    label: label,
+    index: 0,
+    total: total == null ? null : total,
+    percentage: !!options.percentage,
+    context: {},
+  };
   frames.push(frame);
   install();
   // Show the 0/N state right away, so a slow or hanging first item still
@@ -155,6 +195,11 @@ function push(label, total) {
     },
     setTotal: function (n) {
       frame.total = n;
+      onChange(false);
+      return handle;
+    },
+    setContext: function (context) {
+      frame.context = context || {};
       onChange(false);
       return handle;
     },


### PR DESCRIPTION
### Motivation
- Improve progress output so nested progress lines can show which blog is actively being processed and surface contextual display data without disturbing completed-item counts.
- Avoid misleading single-current-blog output during parallel runs by providing aggregate-only semantics in concurrent modes and document where shortened-ID resolution is handled.

### Description
- Extend `scripts/each/progress.js` `push` API to accept an `options` object and added `setContext({ detail, index })` to carry an active-item one-based index and an optional detail string, while preserving `tick()`, `setIndex()`, and `setTotal()` behavior.
- Add a leading percentage prefix computed with `Math.round` (and showing `0%` for empty totals) derived from the frame that opts into `percentage: true`, and render the context-aware display index and detail in the formatted line.
- Update `scripts/each/blog.js` to set the blog frame's context (short ID via `blogID.slice(0, 12)` and a one-based ordinal) at the start of each serial iteration (before `Blog.get`), and suppress percentage/ID prefixes when running with parallel or bounded-concurrency modes to avoid misleading current-blog output.
- Document the distinction that shortened-ID resolution is implemented in `scripts/get/blog.js` and therefore available via `scripts/each/eachBlogOrOneBlog.js`, while `scripts/each/blog.js -o` continues to require full IDs.

### Testing
- Ran `git diff --check` to validate the workspace diff had no whitespace or obvious errors and it succeeded.
- Per request did a manual code review of serial, filtered, nested, empty-list, skipped-blog, bounded-parallel, and unbounded-parallel control flows to validate behavior changes.
- Did not add or run automated tests as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa2a46c94288329bf90c43a11dadaa0)