### PR TITLE
Add maximal benchmark template profile and deterministic maximal fixture

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,6 +37,9 @@ on:
       iterations:
         description: "Iterations to run and aggregate"
         default: "3"
+      template_profile:
+        description: "Template workload profile (default or maximal)"
+        default: "maximal"
 
 permissions:
   contents: read
@@ -92,6 +95,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # The commit actually being benchmarked (PR head, not the merge commit).
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      TEMPLATE_PROFILE: ${{ github.event.inputs.template_profile || 'maximal' }}
 
     steps:
       - name: Checkout code
@@ -165,6 +169,7 @@ jobs:
               -e GITHUB_SHA=${{ github.sha }} \
               -e SITES_ARG="${{ github.event.inputs.sites }}" \
               -e FILES_ARG="${{ github.event.inputs.files }}" \
+              -e TEMPLATE_PROFILE="$TEMPLATE_PROFILE" \
               -v ${{ github.workspace }}/app:/usr/src/app/app \
               -v ${{ github.workspace }}/scripts:/usr/src/app/scripts \
               -v ${{ github.workspace }}/config:/usr/src/app/config \
@@ -175,6 +180,7 @@ jobs:
                 ARGS="--output /benchmarks/runs/run-'"$i"'.json"
                 [ -n "$SITES_ARG" ] && ARGS="$ARGS --sites $SITES_ARG"
                 [ -n "$FILES_ARG" ] && ARGS="$ARGS --files $FILES_ARG"
+                ARGS="$ARGS --template-profile $TEMPLATE_PROFILE"
                 npm run benchmark:ci -- $ARGS
               '
             echo "::endgroup::"

--- a/app/blog/benchmarks/benchmarks.js
+++ b/app/blog/benchmarks/benchmarks.js
@@ -9,6 +9,7 @@ const { expandSitemapUrls } = require("./util/sitemap");
 const { runWithConcurrency } = require("./util/concurrency");
 const { parseBenchmarkConfig } = require("./util/config");
 const { buildBenchmarkResult } = require("./util/result");
+const { readTemplateProfile } = require("./util/templateProfile");
 
 describe("blog benchmarks", function () {
   require("./util/setup")();
@@ -17,23 +18,36 @@ describe("blog benchmarks", function () {
 
   it("measures build and render performance", async function () {
     const benchmarkConfig = parseBenchmarkConfig(
-      global.__BLOT_BENCHMARK_CONFIG || {}
+      global.__BLOT_BENCHMARK_CONFIG || {},
     );
 
-    const blogs = Array.isArray(this.blogs) && this.blogs.length
-      ? this.blogs
-      : this.blog
-      ? [this.blog]
-      : [];
+    const blogs =
+      Array.isArray(this.blogs) && this.blogs.length
+        ? this.blogs
+        : this.blog
+          ? [this.blog]
+          : [];
 
     if (blogs.length !== benchmarkConfig.sites) {
       throw new Error(
-        `Expected ${benchmarkConfig.sites} benchmark sites but got ${blogs.length}`
+        `Expected ${benchmarkConfig.sites} benchmark sites but got ${blogs.length}`,
       );
     }
 
     const rng = seedrandom(benchmarkConfig.seed);
     const workload = buildWorkload(benchmarkConfig, blogs, rng);
+    const templateProfile = readTemplateProfile(
+      benchmarkConfig.templateProfile,
+    );
+
+    if (templateProfile) {
+      const originalBlog = this.blog;
+      for (const blog of blogs) {
+        this.blog = blog;
+        await this.template(templateProfile.views, templateProfile.packageJSON);
+      }
+      this.blog = originalBlog;
+    }
 
     const buildPhaseMonitor = new PhaseMonitor({
       sampleIntervalMs: benchmarkConfig.cpuSampleIntervalMs,
@@ -48,24 +62,28 @@ describe("blog benchmarks", function () {
 
     buildPhaseMonitor.start();
 
-    await runWithConcurrency(writeTasks, benchmarkConfig.writeConcurrency, async (task) => {
-      if (task.sourcePath != null) {
-        let blogDir = localPath(task.blog.id, "/");
-        if (blogDir.endsWith("/")) blogDir = blogDir.slice(0, -1);
-        const destPath = blogDir + task.path;
-        await fs.ensureDir(path.dirname(destPath));
-        await fs.copy(task.sourcePath, destPath);
-      } else {
-        await task.blog.write({ path: task.path, content: task.content });
-      }
-    });
+    await runWithConcurrency(
+      writeTasks,
+      benchmarkConfig.writeConcurrency,
+      async (task) => {
+        if (task.sourcePath != null) {
+          let blogDir = localPath(task.blog.id, "/");
+          if (blogDir.endsWith("/")) blogDir = blogDir.slice(0, -1);
+          const destPath = blogDir + task.path;
+          await fs.ensureDir(path.dirname(destPath));
+          await fs.copy(task.sourcePath, destPath);
+        } else {
+          await task.blog.write({ path: task.path, content: task.content });
+        }
+      },
+    );
 
     await Promise.all(
       blogs.map(async (blog, index) => {
         const startedAt = performance.now();
         await blog.rebuild();
         buildSiteDurations[index] = performance.now() - startedAt;
-      })
+      }),
     );
 
     const buildPhaseMetrics = buildPhaseMonitor.stop();
@@ -89,7 +107,7 @@ describe("blog benchmarks", function () {
 
       if (sitemapRes.status !== 200) {
         throw new Error(
-          `Failed to fetch sitemap.xml for ${blog.handle}: status=${sitemapRes.status}`
+          `Failed to fetch sitemap.xml for ${blog.handle}: status=${sitemapRes.status}`,
         );
       }
 
@@ -97,7 +115,7 @@ describe("blog benchmarks", function () {
       const sitemapPaths = await expandSitemapUrls(
         blog,
         sitemapXML,
-        this.getForBlog.bind(this)
+        this.getForBlog.bind(this),
       );
 
       if (!sitemapPaths.length) {
@@ -110,7 +128,7 @@ describe("blog benchmarks", function () {
         blog.handle,
         `${sitemapPaths.length} sitemap pages × ${n} =>`,
         sitemapPaths.length * n,
-        "render tasks"
+        "render tasks",
       );
 
       siteSummaries.push({
@@ -129,7 +147,7 @@ describe("blog benchmarks", function () {
 
     console.log(
       "[benchmark] total render tasks (Total requests):",
-      renderTasks.length
+      renderTasks.length,
     );
 
     renderPhaseMonitor.start();
@@ -149,7 +167,7 @@ describe("blog benchmarks", function () {
         if (res.status >= 400) {
           renderFailures.push({ blogIndex, path, status: res.status });
         }
-      }
+      },
     );
 
     const renderPhaseMetrics = renderPhaseMonitor.stop();
@@ -157,15 +175,31 @@ describe("blog benchmarks", function () {
 
     siteSummaries.forEach((summary, index) => {
       summary.rendered_pages = renderTasks.filter(
-        (task) => task.blog.id === summary.blog_id
+        (task) => task.blog.id === summary.blog_id,
       ).length;
       summary.non_2xx = renderFailures.filter(
-        (failure) => blogs[failure.blogIndex].id === summary.blog_id
+        (failure) => blogs[failure.blogIndex].id === summary.blog_id,
       ).length;
       summary.rendered_bytes = bytesPerSite[index] || 0;
     });
 
     const renderBytesTotal = bytesPerSite.reduce((sum, n) => sum + n, 0);
+
+    if (benchmarkConfig.templateProfile === "maximal") {
+      for (const blog of blogs) {
+        const [entriesBody, archivesBody, taggedBody] = await Promise.all([
+          this.textForBlog(blog, "/"),
+          this.textForBlog(blog, "/archives"),
+          this.textForBlog(blog, "/tagged/benchmark"),
+        ]);
+
+        expect(entriesBody).toContain("MAXIMAL_PROFILE_INSTALLED");
+        expect(entriesBody).toContain("MAXIMAL_ALL_ENTRIES");
+        expect(archivesBody).toContain("MAXIMAL_ARCHIVES");
+        expect(taggedBody).toContain("MAXIMAL_TAGS");
+        expect(taggedBody).toContain("MAXIMAL_POPULAR_TAGS");
+      }
+    }
 
     const result = buildBenchmarkResult({
       benchmarkConfig,
@@ -184,7 +218,7 @@ describe("blog benchmarks", function () {
     global.__BLOT_BENCHMARK_RESULT = result;
 
     expect(workload.files.length).toEqual(
-      benchmarkConfig.files + workload.fixtureCount * blogs.length
+      benchmarkConfig.files + workload.fixtureCount * blogs.length,
     );
     expect(renderTasks.length).toBeGreaterThan(0);
     expect(renderFailures.length).toEqual(0);
@@ -200,33 +234,41 @@ describe("blog benchmarks", function () {
       totalWallMs > 0 ? (totalCpuMs / totalWallMs) * 100 : 0;
     const totalMemoryMb = Math.max(
       result.build.memory_mb.peak_rss,
-      result.render.memory_mb.peak_rss
+      result.render.memory_mb.peak_rss,
     );
     const totalSeconds = totalWallMs / 1000;
     const label = (s) => ("  " + s).padEnd(26);
     const num = (n, width = 10) => String(n).padStart(width);
 
     console.log("");
-    console.log(label("Requests per page") + num(benchmarkConfig.requestsPerPage, 8));
+    console.log(
+      label("Requests per page") + num(benchmarkConfig.requestsPerPage, 8),
+    );
     console.log(label("Total CPU") + num(totalCpuPercent.toFixed(2), 8) + " %");
-    console.log(label("Total Memory") + num(Math.round(totalMemoryMb), 8) + " mb");
-    console.log(label("Total requests") + num(result.render.sitemap_pages_total, 8));
+    console.log(
+      label("Total Memory") + num(Math.round(totalMemoryMb), 8) + " mb",
+    );
+    console.log(
+      label("Total requests") + num(result.render.sitemap_pages_total, 8),
+    );
     console.log("");
-    console.log(label("Total time") + num(totalSeconds.toFixed(1), 8) + " seconds");
+    console.log(
+      label("Total time") + num(totalSeconds.toFixed(1), 8) + " seconds",
+    );
     console.log(
       label("Mean build time") +
         num(result.build.timing_ms.mean.toFixed(0), 8) +
-        " ms per site"
+        " ms per site",
     );
     console.log(
       label("Mean blog render time") +
         num(result.render.timing_ms.mean.toFixed(0), 8) +
-        " ms per page"
+        " ms per page",
     );
     console.log(
       label("Mean output size") +
         num((result.render.bytes.mean_per_page / 1024).toFixed(1), 8) +
-        " kb per page"
+        " kb per page",
     );
     console.log("");
   });

--- a/app/blog/benchmarks/fixtures/templates/maximal/_entry-fields.html
+++ b/app/blog/benchmarks/fixtures/templates/maximal/_entry-fields.html
@@ -1,0 +1,14 @@
+<article data-entry="{{id}}">
+  <a href="{{{url}}}">{{title}}</a>
+  <span
+    >{{date}}|{{dateStamp}}|{{path}}|{{name}}|{{slug}}|{{guid}}|{{created}}|{{updated}}</span
+  >
+  {{#first}}
+  <div>{{{html}}}|{{{body}}}|{{{teaser}}}|{{{teaserBody}}}|{{summary}}</div>
+  {{/first}}
+  {{#encode_xml}}{{{html}}}{{/encode_xml}}{{#encodeXML}}{{{body}}}{{/encodeXML}}
+  {{#encode_json}}{{{teaser}}}{{/encode_json}}{{#encodeJSON}}{{{teaserBody}}}{{/encodeJSON}}
+  {{#encode_uri_component}}{{summary}}{{/encode_uri_component}}{{#encodeURIComponent}}{{summary}}{{/encodeURIComponent}}
+  {{#absolute_urls}}{{{html}}}{{/absolute_urls}}{{#absoluteURLs}}{{{body}}}{{/absoluteURLs}}
+  {{#tags}}<i>{{name}}/{{slug}}</i>{{/tags}}
+</article>

--- a/app/blog/benchmarks/fixtures/templates/maximal/_repeated.html
+++ b/app/blog/benchmarks/fixtures/templates/maximal/_repeated.html
@@ -1,0 +1,3 @@
+<aside>
+  {{#all_entries}}{{title}}/{{summary}}{{/all_entries}}{{#popular_tags}}{{name}}{{/popular_tags}}{{#cdn}}benchmark.css{{/cdn}}
+</aside>

--- a/app/blog/benchmarks/fixtures/templates/maximal/_stress.html
+++ b/app/blog/benchmarks/fixtures/templates/maximal/_stress.html
@@ -1,0 +1,44 @@
+<div id="maximal-profile-installed">MAXIMAL_PROFILE_INSTALLED</div>
+<section id="all-entries">
+  MAXIMAL_ALL_ENTRIES{{#all_entries}}{{>
+  entry-fields}}{{/all_entries}}{{#allEntries}}{{> entry-fields}}{{/allEntries}}
+</section>
+<section id="recent">
+  {{#recent_entries}}{{> entry-fields}}{{/recent_entries}}{{#recentEntries}}{{>
+  entry-fields}}{{/recentEntries}}
+</section>
+<section id="latest">
+  {{#latest_entry}}{{> entry-fields}}{{/latest_entry}}{{#latestEntry}}{{>
+  entry-fields}}{{/latestEntry}}
+</section>
+<section id="posts">{{#posts}}{{> entry-fields}}{{/posts}}</section>
+<section id="archives">
+  MAXIMAL_ARCHIVES{{#archives}}{{year}}/{{total}}{{#months}}{{month}}/{{year}}/{{entries.length}}{{#entries}}{{>
+  entry-fields}}{{/entries}}{{/months}}{{/archives}}
+</section>
+<section id="tags">
+  MAXIMAL_TAGS{{#all_tags}}{{name}}/{{tag}}/{{slug}}/{{total}}{{/all_tags}}{{#allTags}}{{name}}/{{tag}}/{{slug}}/{{total}}{{/allTags}}
+</section>
+<section id="popular-tags">
+  MAXIMAL_POPULAR_TAGS{{#popular_tags}}{{name}}/{{tag}}/{{slug}}/{{total}}{{#entries}}{{.}}{{/entries}}{{/popular_tags}}
+</section>
+<section id="tagged">
+  {{#tagged}}{{tag}}/{{slug}}{{#entries}}{{>
+  entry-fields}}{{/entries}}{{/tagged}}
+</section>
+<div>
+  {{updated}}|{{total_posts}}|{{feed_url}}|{{avatar_url}}|{{css_url}}|{{script_url}}|{{search_query}}
+</div>
+<div>
+  {{app_css}}{{appCSS}}{{app_js}}{{appJS}}{{plugin_css}}{{plugin_js}}{{is_active}}{{isActive}}{{active}}
+</div>
+<div>
+  {{#folder}}{{parent}}/{{parentURI}}{{#contents}}{{name}}/{{path}}/{{pathURI}}/{{isDirectory}}/{{isFile}}/{{updated}}{{/contents}}{{/folder}}
+</div>
+<div>
+  {{#rgb}}#123456{{/rgb}}|{{#is.benchmark_mode.maximal}}is-maximal{{/is.benchmark_mode.maximal}}|{{plugin}}
+</div>
+<div>
+  {{#asset}}benchmark.css{{/asset}}|{{cdn}}|{{#cdn}}benchmark.css{{/cdn}}|{{#cdn}}benchmark.js{{/cdn}}
+</div>
+{{> repeated}}{{> repeated}}

--- a/app/blog/benchmarks/fixtures/templates/maximal/archives.html
+++ b/app/blog/benchmarks/fixtures/templates/maximal/archives.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <body data-view="archives">
+    {{> stress}} {{#entry}}{{> entry-fields}}{{/entry}} {{#search_results}}{{>
+    entry-fields}}{{/search_results}} {{#error}}
+    <h1>{{title}}</h1>
+    <p>{{message}}</p>
+    {{/error}}
+  </body>
+</html>

--- a/app/blog/benchmarks/fixtures/templates/maximal/benchmark.css
+++ b/app/blog/benchmarks/fixtures/templates/maximal/benchmark.css
@@ -1,0 +1,4 @@
+/* deterministic maximal benchmark asset */
+.maximal {
+  display: block;
+}

--- a/app/blog/benchmarks/fixtures/templates/maximal/benchmark.js
+++ b/app/blog/benchmarks/fixtures/templates/maximal/benchmark.js
@@ -1,0 +1,1 @@
+window.MAXIMAL_BENCHMARK = true;

--- a/app/blog/benchmarks/fixtures/templates/maximal/entries.html
+++ b/app/blog/benchmarks/fixtures/templates/maximal/entries.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <body data-view="entries">
+    {{> stress}} {{#entry}}{{> entry-fields}}{{/entry}} {{#search_results}}{{>
+    entry-fields}}{{/search_results}} {{#error}}
+    <h1>{{title}}</h1>
+    <p>{{message}}</p>
+    {{/error}}
+  </body>
+</html>

--- a/app/blog/benchmarks/fixtures/templates/maximal/entry.html
+++ b/app/blog/benchmarks/fixtures/templates/maximal/entry.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <body data-view="entry">
+    {{> stress}} {{#entry}}{{> entry-fields}}{{/entry}} {{#search_results}}{{>
+    entry-fields}}{{/search_results}} {{#error}}
+    <h1>{{title}}</h1>
+    <p>{{message}}</p>
+    {{/error}}
+  </body>
+</html>

--- a/app/blog/benchmarks/fixtures/templates/maximal/error.html
+++ b/app/blog/benchmarks/fixtures/templates/maximal/error.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <body data-view="error">
+    {{> stress}} {{#entry}}{{> entry-fields}}{{/entry}} {{#search_results}}{{>
+    entry-fields}}{{/search_results}} {{#error}}
+    <h1>{{title}}</h1>
+    <p>{{message}}</p>
+    {{/error}}
+  </body>
+</html>

--- a/app/blog/benchmarks/fixtures/templates/maximal/package.json
+++ b/app/blog/benchmarks/fixtures/templates/maximal/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "Benchmark Maximal",
+  "locals": {
+    "page_size": 100,
+    "benchmark_mode": "maximal"
+  },
+  "views": {
+    "entries.html": {},
+    "entry.html": {},
+    "tagged.html": {},
+    "archives.html": {
+      "url": "/archives"
+    },
+    "search.html": {
+      "url": "/search"
+    },
+    "error.html": {}
+  }
+}

--- a/app/blog/benchmarks/fixtures/templates/maximal/search.html
+++ b/app/blog/benchmarks/fixtures/templates/maximal/search.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <body data-view="search">
+    {{> stress}} {{#entry}}{{> entry-fields}}{{/entry}} {{#search_results}}{{>
+    entry-fields}}{{/search_results}} {{#error}}
+    <h1>{{title}}</h1>
+    <p>{{message}}</p>
+    {{/error}}
+  </body>
+</html>

--- a/app/blog/benchmarks/fixtures/templates/maximal/tagged.html
+++ b/app/blog/benchmarks/fixtures/templates/maximal/tagged.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <body data-view="tagged">
+    {{> stress}} {{#entry}}{{> entry-fields}}{{/entry}} {{#search_results}}{{>
+    entry-fields}}{{/search_results}} {{#error}}
+    <h1>{{title}}</h1>
+    <p>{{message}}</p>
+    {{/error}}
+  </body>
+</html>

--- a/app/blog/benchmarks/util/config.js
+++ b/app/blog/benchmarks/util/config.js
@@ -9,29 +9,40 @@ function num(value, fallback) {
 }
 
 function parseBenchmarkConfig(raw = {}) {
+  const templateProfile = String(
+    raw.templateProfile || BENCHMARK_DEFAULTS.templateProfile,
+  );
+
+  if (!["default", "maximal"].includes(templateProfile)) {
+    throw new Error(
+      `templateProfile must be one of: default, maximal (got ${templateProfile})`,
+    );
+  }
+
   return {
     sites: num(raw.sites, BENCHMARK_DEFAULTS.sites),
     files: num(raw.files, BENCHMARK_DEFAULTS.files),
     seed: String(raw.seed || BENCHMARK_DEFAULTS.seed),
+    templateProfile,
     renderConcurrency: num(
       raw.renderConcurrency,
-      BENCHMARK_DEFAULTS.renderConcurrency
+      BENCHMARK_DEFAULTS.renderConcurrency,
     ),
     writeConcurrency: num(
       raw.writeConcurrency,
-      BENCHMARK_DEFAULTS.writeConcurrency
+      BENCHMARK_DEFAULTS.writeConcurrency,
     ),
     cpuSampleIntervalMs: num(
       raw.cpuSampleIntervalMs,
-      BENCHMARK_DEFAULTS.cpuSampleIntervalMs
+      BENCHMARK_DEFAULTS.cpuSampleIntervalMs,
     ),
     regressionThresholdPercent: num(
       raw.regressionThresholdPercent,
-      BENCHMARK_DEFAULTS.regressionThresholdPercent
+      BENCHMARK_DEFAULTS.regressionThresholdPercent,
     ),
     requestsPerPage: num(
       raw.requestsPerPage,
-      BENCHMARK_DEFAULTS.requestsPerPage
+      BENCHMARK_DEFAULTS.requestsPerPage,
     ),
   };
 }

--- a/app/blog/benchmarks/util/defaults.js
+++ b/app/blog/benchmarks/util/defaults.js
@@ -14,6 +14,8 @@ const BENCHMARK_DEFAULTS = Object.freeze({
   files: 1000,
   // Deterministic seed for workload generation.
   seed: "blot-benchmark-seed",
+  // Template workload installed on every benchmark blog.
+  templateProfile: "default",
   // Concurrency used when replaying sitemap URLs during the render phase.
   renderConcurrency: 8,
   // Concurrency used when writing the generated workload to disk.

--- a/app/blog/benchmarks/util/result.js
+++ b/app/blog/benchmarks/util/result.js
@@ -24,6 +24,7 @@ function buildBenchmarkResult(options) {
       files: benchmarkConfig.files,
       fixture_files_per_site: workload.fixtureCount,
       seed: benchmarkConfig.seed,
+      template_profile: benchmarkConfig.templateProfile,
       render_concurrency: benchmarkConfig.renderConcurrency,
       requests_per_page: benchmarkConfig.requestsPerPage,
       regression_threshold_percent: benchmarkConfig.regressionThresholdPercent,

--- a/app/blog/benchmarks/util/templateProfile.js
+++ b/app/blog/benchmarks/util/templateProfile.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const PROFILE_ROOT = path.resolve(__dirname, "../fixtures/templates");
+
+function readTemplateProfile(profile) {
+  if (profile === "default") return null;
+
+  const directory = path.join(PROFILE_ROOT, profile);
+  const packageJSON = JSON.parse(
+    fs.readFileSync(path.join(directory, "package.json"), "utf8"),
+  );
+  const views = {};
+
+  for (const name of fs.readdirSync(directory).sort()) {
+    if (name === "package.json") continue;
+    const file = path.join(directory, name);
+    if (fs.statSync(file).isFile()) views[name] = fs.readFileSync(file, "utf8");
+  }
+
+  return { packageJSON, views };
+}
+
+module.exports = { readTemplateProfile };

--- a/app/blog/benchmarks/util/workload.js
+++ b/app/blog/benchmarks/util/workload.js
@@ -51,6 +51,7 @@ function makeEntryContent({ rng, slug, blogIndex, index }) {
   return [
     `Title: Benchmark ${blogIndex}-${index}`,
     `Link: /${slug}`,
+    `Tags: benchmark, site-${blogIndex}`,
     "",
     sentences.join(" "),
     "",

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -9,10 +9,10 @@ One run creates `--sites` blogs, writes `--files` generated text entries plus a
 fixed set of converter fixtures (markdown, docx, rtf, odt, org, images, gdoc —
 reused from `app/build/converters/*/tests`), then:
 
-| Phase      | What happens                                                    | Headline metrics |
-|------------|----------------------------------------------------------------|------------------|
-| **build**  | write the workload to disk, then `blog.rebuild()` every site   | per-site wall time p50 / p95, peak RSS, CPU % |
-| **render** | fetch every URL in each blog's sitemap and read the full body  | per-page wall time p50 / p95, peak RSS, CPU %, output bytes/page |
+| Phase      | What happens                                                  | Headline metrics                                                 |
+| ---------- | ------------------------------------------------------------- | ---------------------------------------------------------------- |
+| **build**  | write the workload to disk, then `blog.rebuild()` every site  | per-site wall time p50 / p95, peak RSS, CPU %                    |
+| **render** | fetch every URL in each blog's sitemap and read the full body | per-page wall time p50 / p95, peak RSS, CPU %, output bytes/page |
 
 Everything is seeded (`--seed`, default `blot-benchmark-seed`) so the generated
 workload is identical from run to run. The full result is written as JSON; the
@@ -41,8 +41,26 @@ Lower-level knobs (passed through to [`index.js`](index.js)):
 ```bash
 node scripts/benchmarks --help
 node scripts/benchmarks --sites 3 --files 500 --output /tmp/result.json
+node scripts/benchmarks --template-profile maximal
 BENCHMARK_DEBUG=1 node scripts/benchmarks        # verbose sitemap expansion
 ```
+
+### Template profiles
+
+`--template-profile` selects the template installed on every generated blog
+before build or render measurement. `default` preserves the normal test-blog
+template; `maximal` installs the deterministic fixture in
+`app/blog/benchmarks/fixtures/templates/maximal/` (and is the CI profile).
+
+The maximal profile is intentionally a worst-case retrieval and rendering
+workload, not a realistic theme. Every route renders all-entry, archive, tag,
+popular-tag, recent/latest-entry, and projected heavy entry fields. It repeats
+dependencies through snake_case and camelCase aliases, nested sections,
+transparent helpers, partials, and multiple CDN targets. Expensive locals are
+kept in live sections so the benchmark measures their retrieval and output,
+rather than merely making the template parser discover unreachable work. The
+selected profile is stored as `config.template_profile` in result JSON, keeping
+comparisons auditable.
 
 Defaults for every knob live in one place:
 [`app/blog/benchmarks/util/defaults.js`](../../app/blog/benchmarks/util/defaults.js).
@@ -52,7 +70,7 @@ Defaults for every knob live in one place:
 `.github/workflows/benchmarks.yml`. GitHub-hosted runners are noisy, so nothing
 here blocks a merge — the signal comes from trends, not single runs.
 
-### On a pull request (once it's marked *ready for review*)
+### On a pull request (once it's marked _ready for review_)
 
 - runs on **amd64 only**, `2` iterations, aggregated to medians
   ([`aggregate.js`](aggregate.js))
@@ -117,18 +135,18 @@ PR comment still shows deltas but marks them information-only, and
 
 ## File map
 
-| File | Runs where | Purpose |
-|------|-----------|---------|
-| `index.js` | container | run the spec once, write result JSON |
-| `app/blog/benchmarks/benchmarks.js` | container | the Jasmine spec itself |
-| `invoke.sh` | host | run `index.js` in Docker + throwaway Redis |
-| `compare.js` / `format-diff.js` | host | local branch-vs-branch comparison |
-| `aggregate.js` | host | merge N iteration JSONs into one (median per metric) |
-| `update-history.js` | host | append a master result, recompute baseline |
-| `detect-regression.js` | host | open an issue on sustained master drift |
-| `pr-comment.js` | host | post / update the PR comparison comment |
-| `seed-history.js` | host | restore history from an artifact on cache miss |
-| `lib/*.js` | host | shared stats / metric definitions / history / report |
+| File                                | Runs where | Purpose                                              |
+| ----------------------------------- | ---------- | ---------------------------------------------------- |
+| `index.js`                          | container  | run the spec once, write result JSON                 |
+| `app/blog/benchmarks/benchmarks.js` | container  | the Jasmine spec itself                              |
+| `invoke.sh`                         | host       | run `index.js` in Docker + throwaway Redis           |
+| `compare.js` / `format-diff.js`     | host       | local branch-vs-branch comparison                    |
+| `aggregate.js`                      | host       | merge N iteration JSONs into one (median per metric) |
+| `update-history.js`                 | host       | append a master result, recompute baseline           |
+| `detect-regression.js`              | host       | open an issue on sustained master drift              |
+| `pr-comment.js`                     | host       | post / update the PR comparison comment              |
+| `seed-history.js`                   | host       | restore history from an artifact on cache miss       |
+| `lib/*.js`                          | host       | shared stats / metric definitions / history / report |
 
 ## Ideas not yet built
 

--- a/scripts/benchmarks/index.js
+++ b/scripts/benchmarks/index.js
@@ -48,6 +48,7 @@ var benchmarkConfig = {
   sites: args.sites,
   files: args.files,
   seed: args.seed,
+  templateProfile: args.templateProfile,
   renderConcurrency: args.renderConcurrency,
   writeConcurrency: args.writeConcurrency,
   cpuSampleIntervalMs: args.cpuSampleIntervalMs,
@@ -71,7 +72,7 @@ jasmine.addReporter({
 
     if (result.overallStatus === "passed" && !benchmarkResult) {
       console.error(
-        "[benchmark] Missing benchmark result payload from spec run"
+        "[benchmark] Missing benchmark result payload from spec run",
       );
       exitCode = 1;
     }
@@ -82,7 +83,7 @@ jasmine.addReporter({
       console.log(
         clfdate(),
         "Wrote benchmark result",
-        colors.cyan(args.output)
+        colors.cyan(args.output),
       );
     }
 
@@ -118,6 +119,7 @@ function parseArgs(argv) {
     sites: BENCHMARK_DEFAULTS.sites,
     files: BENCHMARK_DEFAULTS.files,
     seed: BENCHMARK_DEFAULTS.seed,
+    templateProfile: BENCHMARK_DEFAULTS.templateProfile,
     renderConcurrency: BENCHMARK_DEFAULTS.renderConcurrency,
     writeConcurrency: BENCHMARK_DEFAULTS.writeConcurrency,
     cpuSampleIntervalMs: BENCHMARK_DEFAULTS.cpuSampleIntervalMs,
@@ -154,6 +156,12 @@ function parseArgs(argv) {
 
     if (arg === "--seed" && next) {
       parsed.seed = String(next);
+      i += 1;
+      continue;
+    }
+
+    if (arg === "--template-profile" && next) {
+      parsed.templateProfile = String(next);
       i += 1;
       continue;
     }
@@ -197,6 +205,9 @@ function parseArgs(argv) {
   ensurePositiveInt(parsed.writeConcurrency, "--write-concurrency");
   ensurePositiveInt(parsed.cpuSampleIntervalMs, "--cpu-sample-interval-ms");
   ensurePositiveInt(parsed.requestsPerPage, "--requests-per-page");
+  if (!["default", "maximal"].includes(parsed.templateProfile)) {
+    throw new Error("--template-profile must be one of: default, maximal");
+  }
 
   return parsed;
 }
@@ -222,6 +233,9 @@ function printHelp() {
       "  --seed <value>                 Deterministic seed (default: " +
         BENCHMARK_DEFAULTS.seed +
         ")",
+      "  --template-profile <name>      Template workload: default or maximal (default: " +
+        BENCHMARK_DEFAULTS.templateProfile +
+        ")",
       "  --render-concurrency <n>       Sitemap render concurrency (default: " +
         BENCHMARK_DEFAULTS.renderConcurrency +
         ")",
@@ -239,6 +253,6 @@ function printHelp() {
       "  --path <path>                  Limit benchmark discovery to path",
       "  --help                         Show this help message",
       "",
-    ].join("\n")
+    ].join("\n"),
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a deterministic, worst-case template that exercises retrieval aliases, projected entry fields, nested sections, transparent helpers, partials, CDN targets, and repeated references so benchmarks measure real retrieval/render work. 
- Make the template selectable as a benchmark profile and record the chosen profile in results and CI for auditable comparisons and CI-driven worst-case runs.

### Description
- Add a deterministic `maximal` template fixture under `app/blog/benchmarks/fixtures/templates/maximal/` including `package.json`, views for `entries`, `entry`, `tagged`, `archives`, `search`, and `error`, shared partials, assets, and helpers. 
- Add `templateProfile` default and parsing/validation to benchmark defaults and config, propagate the option through `scripts/benchmarks/index.js`, and record `template_profile` in the JSON result. 
- Add `app/blog/benchmarks/util/templateProfile.js` to read profiles and install the selected profile on each generated benchmark blog before build by using the existing `template` helper in `app/blog/benchmarks/benchmarks.js`. 
- Add assertions in the benchmark spec that verify the maximal profile was installed and that representative markers from all-entries, archives, tags, and popular-tags appear in rendered responses, and document the profile and its worst-case intent in `scripts/benchmarks/README.md` and expose selection via the workflow. 

### Testing
- `npx prettier --check ...` was run against changed files and returned success. 
- Standalone Node assertions validating `parseBenchmarkConfig` behaviour and `readTemplateProfile('maximal')` fixture completeness passed. 
- `git diff --check` completed with no check failures. 
- Attempting to run the targeted Jasmine parseTemplate test in the bare shell failed due to missing Redis / test harness in this environment (environment limitation, not a change failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa2b2b884f483299dfd4475d446e4e8)