### PR TITLE
Add deterministic large-content benchmark workloads

### DIFF
--- a/app/blog/benchmarks/benchmarks.js
+++ b/app/blog/benchmarks/benchmarks.js
@@ -45,20 +45,33 @@ describe("blog benchmarks", function () {
     }));
 
     const buildSiteDurations = [];
+    const writeDurations = { ordinary: [], largeContent: [] };
 
     buildPhaseMonitor.start();
 
-    await runWithConcurrency(writeTasks, benchmarkConfig.writeConcurrency, async (task) => {
-      if (task.sourcePath != null) {
-        let blogDir = localPath(task.blog.id, "/");
-        if (blogDir.endsWith("/")) blogDir = blogDir.slice(0, -1);
-        const destPath = blogDir + task.path;
-        await fs.ensureDir(path.dirname(destPath));
-        await fs.copy(task.sourcePath, destPath);
-      } else {
-        await task.blog.write({ path: task.path, content: task.content });
+    await runWithConcurrency(
+      writeTasks,
+      benchmarkConfig.writeConcurrency,
+      async (task) => {
+        const startedAt = performance.now();
+        if (task.sourcePath != null) {
+          let blogDir = localPath(task.blog.id, "/");
+          if (blogDir.endsWith("/")) blogDir = blogDir.slice(0, -1);
+          const destPath = blogDir + task.path;
+          await fs.ensureDir(path.dirname(destPath));
+          await fs.copy(task.sourcePath, destPath);
+        } else {
+          await task.blog.write({ path: task.path, content: task.content });
+        }
+        const elapsedMs = performance.now() - startedAt;
+        if (task.workload === "ordinary") {
+          writeDurations.ordinary.push(elapsedMs);
+        }
+        if (task.workload === "large-content") {
+          writeDurations.largeContent.push(elapsedMs);
+        }
       }
-    });
+    );
 
     await Promise.all(
       blogs.map(async (blog, index) => {
@@ -76,6 +89,8 @@ describe("blog benchmarks", function () {
     });
 
     const renderDurations = [];
+    const renderDurationsByWorkload = { ordinary: [], largeContent: [] };
+    const renderBytesByWorkload = { ordinary: 0, largeContent: 0 };
     const renderFailures = [];
     const siteSummaries = [];
     const renderTasks = [];
@@ -134,6 +149,10 @@ describe("blog benchmarks", function () {
 
     renderPhaseMonitor.start();
 
+    const largePaths = new Set(
+      workload.largeEntries.map((entry) => entry.linkPath)
+    );
+
     await runWithConcurrency(
       renderTasks,
       benchmarkConfig.renderConcurrency,
@@ -145,6 +164,13 @@ describe("blog benchmarks", function () {
         const elapsedMs = performance.now() - startedAt;
         renderDurations.push(elapsedMs);
         bytesPerSite[blogIndex] += body.byteLength;
+        const normalizedPath =
+          path.length > 1 ? path.replace(/\/$/, "") : path;
+        const category = largePaths.has(normalizedPath)
+          ? "largeContent"
+          : "ordinary";
+        renderDurationsByWorkload[category].push(elapsedMs);
+        renderBytesByWorkload[category] += body.byteLength;
 
         if (res.status >= 400) {
           renderFailures.push({ blogIndex, path, status: res.status });
@@ -179,13 +205,25 @@ describe("blog benchmarks", function () {
       siteSummaries,
       renderTasks,
       renderFailures,
+      writeTimingByWorkload: {
+        ordinary: summarizeDurations(writeDurations.ordinary),
+        largeContent: summarizeDurations(writeDurations.largeContent),
+      },
+      renderTimingByWorkload: {
+        ordinary: summarizeDurations(renderDurationsByWorkload.ordinary),
+        largeContent: summarizeDurations(renderDurationsByWorkload.largeContent),
+      },
+      renderBytesByWorkload,
     });
 
     global.__BLOT_BENCHMARK_RESULT = result;
 
     expect(workload.files.length).toEqual(
-      benchmarkConfig.files + workload.fixtureCount * blogs.length
+      benchmarkConfig.files +
+        benchmarkConfig.largeEntryCount +
+        workload.fixtureCount * blogs.length
     );
+    expect(workload.largeEntries.length).toEqual(benchmarkConfig.largeEntryCount);
     expect(renderTasks.length).toBeGreaterThan(0);
     expect(renderFailures.length).toEqual(0);
 

--- a/app/blog/benchmarks/util/config.js
+++ b/app/blog/benchmarks/util/config.js
@@ -8,10 +8,35 @@ function num(value, fallback) {
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+function boundedInt(value, fallback, min, max) {
+  const parsed = num(value, fallback);
+  return Number.isInteger(parsed) && parsed >= min && parsed <= max
+    ? parsed
+    : fallback;
+}
+
 function parseBenchmarkConfig(raw = {}) {
   return {
     sites: num(raw.sites, BENCHMARK_DEFAULTS.sites),
     files: num(raw.files, BENCHMARK_DEFAULTS.files),
+    largeEntryCount: boundedInt(
+      raw.largeEntryCount,
+      BENCHMARK_DEFAULTS.largeEntryCount,
+      0,
+      25
+    ),
+    largeEntryKilobytes: boundedInt(
+      raw.largeEntryKilobytes,
+      BENCHMARK_DEFAULTS.largeEntryKilobytes,
+      64,
+      2048
+    ),
+    imagesPerMediaEntry: boundedInt(
+      raw.imagesPerMediaEntry,
+      BENCHMARK_DEFAULTS.imagesPerMediaEntry,
+      1,
+      250
+    ),
     seed: String(raw.seed || BENCHMARK_DEFAULTS.seed),
     renderConcurrency: num(
       raw.renderConcurrency,

--- a/app/blog/benchmarks/util/defaults.js
+++ b/app/blog/benchmarks/util/defaults.js
@@ -12,6 +12,12 @@ const BENCHMARK_DEFAULTS = Object.freeze({
   sites: 5,
   // Total number of generated text entries, spread evenly across sites.
   files: 1000,
+  // Large markdown entries generated per run (about 256 KiB each by default).
+  largeEntryCount: 3,
+  // UTF-8 size target for each generated large markdown entry.
+  largeEntryKilobytes: 256,
+  // Repeated image references in each generated gallery entry.
+  imagesPerMediaEntry: 48,
   // Deterministic seed for workload generation.
   seed: "blot-benchmark-seed",
   // Concurrency used when replaying sitemap URLs during the render phase.

--- a/app/blog/benchmarks/util/result.js
+++ b/app/blog/benchmarks/util/result.js
@@ -11,9 +11,13 @@ function buildBenchmarkResult(options) {
     siteSummaries,
     renderTasks,
     renderFailures,
+    writeTimingByWorkload = { ordinary: {}, largeContent: {} },
+    renderTimingByWorkload = { ordinary: {}, largeContent: {} },
+    renderBytesByWorkload = { ordinary: 0, largeContent: 0 },
   } = options;
 
   const renderedPages = renderTasks.length;
+  const largeEntries = workload.largeEntries || [];
 
   return {
     schema_version: 1,
@@ -23,6 +27,9 @@ function buildBenchmarkResult(options) {
       sites: benchmarkConfig.sites,
       files: benchmarkConfig.files,
       fixture_files_per_site: workload.fixtureCount,
+      large_entry_count: benchmarkConfig.largeEntryCount,
+      large_entry_kilobytes: benchmarkConfig.largeEntryKilobytes,
+      images_per_media_entry: benchmarkConfig.imagesPerMediaEntry,
       seed: benchmarkConfig.seed,
       render_concurrency: benchmarkConfig.renderConcurrency,
       requests_per_page: benchmarkConfig.requestsPerPage,
@@ -44,6 +51,10 @@ function buildBenchmarkResult(options) {
       },
       cpu: buildPhaseMetrics.cpu,
       memory_mb: buildPhaseMetrics.memory_mb,
+      workload_timing_ms: {
+        ordinary_entries: writeTimingByWorkload.ordinary,
+        large_content_entries: writeTimingByWorkload.largeContent,
+      },
     },
     render: {
       sitemap_pages_total: renderTasks.length,
@@ -64,6 +75,22 @@ function buildBenchmarkResult(options) {
         mean_per_page:
           renderedPages > 0 ? (renderBytesTotal || 0) / renderedPages : 0,
       },
+      workload_timing_ms: {
+        ordinary_entries: renderTimingByWorkload.ordinary,
+        large_content_entries: renderTimingByWorkload.largeContent,
+      },
+      workload_bytes: {
+        ordinary_entries: renderBytesByWorkload.ordinary,
+        large_content_entries: renderBytesByWorkload.largeContent,
+      },
+    },
+    workload: {
+      large_content: largeEntries.map((entry) => ({
+        path: entry.path,
+        link_path: entry.linkPath,
+        bytes: entry.byteSize,
+        feature_counts: entry.featureCounts,
+      })),
     },
     sites: siteSummaries,
     status: "pass",

--- a/app/blog/benchmarks/util/workload.js
+++ b/app/blog/benchmarks/util/workload.js
@@ -1,4 +1,15 @@
 const { getFixtures } = require("./fixtures");
+const assert = require("assert");
+const { BENCHMARK_DEFAULTS } = require("./defaults");
+
+const LARGE_FEATURE_MINIMUMS = Object.freeze({
+  headings: 48,
+  listDepth: 10,
+  tableRows: 64,
+  footnoteReferences: 48,
+  codeFences: 8,
+  internalLinks: 64,
+});
 
 function buildWorkload(config, blogs, rng) {
   const files = [];
@@ -22,13 +33,59 @@ function buildWorkload(config, blogs, rng) {
       blogIndex,
       path: filePath,
       content: makeEntryContent({ rng, slug, blogIndex, index }),
+      workload: "ordinary",
     });
+  }
+
+  const largeEntries = [];
+  const largeEntryCount =
+    config.largeEntryCount == null
+      ? BENCHMARK_DEFAULTS.largeEntryCount
+      : config.largeEntryCount;
+  const largeEntryKilobytes =
+    config.largeEntryKilobytes || BENCHMARK_DEFAULTS.largeEntryKilobytes;
+  const imagesPerMediaEntry =
+    config.imagesPerMediaEntry || BENCHMARK_DEFAULTS.imagesPerMediaEntry;
+  for (let index = 0; index < largeEntryCount; index++) {
+    const blogIndex = index % blogs.length;
+    const slug = `benchmark-large-${index}`;
+    const generated = makeLargeEntryContent({
+      index,
+      slug,
+      seed: config.seed,
+      targetBytes: largeEntryKilobytes * 1024,
+      imagesPerMediaEntry,
+    });
+    const repeated = makeLargeEntryContent({
+      index,
+      slug,
+      seed: config.seed,
+      targetBytes: largeEntryKilobytes * 1024,
+      imagesPerMediaEntry,
+    });
+    assert.strictEqual(
+      generated.content,
+      repeated.content,
+      "seeded large entry output is not byte-for-byte reproducible"
+    );
+    const entry = {
+      blogIndex,
+      path: `/benchmark-large/${slug}.txt`,
+      linkPath: `/${slug}`,
+      content: generated.content,
+      workload: "large-content",
+      byteSize: generated.byteSize,
+      featureCounts: generated.featureCounts,
+    };
+    files.push(entry);
+    largeEntries.push(entry);
+    filesPerSite[blogIndex] += 1;
   }
 
   const fixtures = getFixtures();
   for (let blogIndex = 0; blogIndex < blogs.length; blogIndex++) {
     for (const { sourcePath, targetPath } of fixtures) {
-      files.push({ blogIndex, path: targetPath, sourcePath });
+      files.push({ blogIndex, path: targetPath, sourcePath, workload: "fixture" });
       filesPerSite[blogIndex] += 1;
     }
   }
@@ -37,6 +94,132 @@ function buildWorkload(config, blogs, rng) {
     files,
     filesPerSite,
     fixtureCount: fixtures.length,
+    largeEntries,
+  };
+}
+
+/**
+ * Produce an exactly-sized UTF-8 markdown document. At the defaults each entry
+ * is approximately 256 KiB and contains all parser-heavy feature families. The
+ * final ASCII padding makes byte size stable even though the document uses
+ * multibyte Unicode text.
+ */
+function makeLargeEntryContent(options) {
+  const { index, slug, seed, targetBytes, imagesPerMediaEntry } = options;
+  const lines = [
+    `Title: Large benchmark ${index}`,
+    `Link: /${slug}`,
+    "Benchmark-Workload: large-content",
+    "",
+    `Seed marker: ${seed} — Καλημέρα κόσμε — こんにちは世界 — مرحبًا بالعالم — 🌍`,
+    "",
+  ];
+
+  for (let i = 1; i <= LARGE_FEATURE_MINIMUMS.headings; i++) {
+    lines.push(`${"#".repeat(1 + ((i - 1) % 6))} Deterministic section ${i}`);
+    lines.push(`Unicode paragraph ${i}: naïve café, Ελληνικά, 中文, हिन्दी, العربية, 🚀.`);
+  }
+
+  lines.push("# Deeply nested list");
+  for (let depth = 0; depth < LARGE_FEATURE_MINIMUMS.listDepth; depth++) {
+    lines.push(`${"  ".repeat(depth)}- nested level ${depth + 1}`);
+  }
+
+  lines.push(
+    "",
+    "# Large table",
+    "| Row | Key | Unicode | Link |",
+    "| ---: | --- | --- | --- |"
+  );
+  for (let i = 1; i <= LARGE_FEATURE_MINIMUMS.tableRows; i++) {
+    lines.push(
+      `| ${i} | cell-${index}-${i} | 東京 café ✓ | [section ${i}](#deterministic-section-${i}) |`
+    );
+  }
+
+  lines.push("", "# Footnotes and internal links");
+  for (let i = 1; i <= LARGE_FEATURE_MINIMUMS.footnoteReferences; i++) {
+    lines.push(
+      `Repeated note reference ${i}[^shared] and [entry link ${i}](/benchmark-large-${i % 7}).`
+    );
+  }
+  lines.push(
+    "",
+    "[^shared]: One deliberately repeated footnote definition target.",
+    ""
+  );
+
+  const languages = [
+    "javascript",
+    "python",
+    "ruby",
+    "go",
+    "rust",
+    "css",
+    "html",
+    "sql",
+  ];
+  languages.forEach((language, i) => {
+    lines.push(
+      "```" + language,
+      `// deterministic ${language} example ${i}\nvalue_${i} = "${seed}"`,
+      "```",
+      ""
+    );
+  });
+
+  lines.push("# Image-heavy gallery");
+  const images = ["bunny.png", "sky.webp", "land.avif"];
+  for (let i = 0; i < imagesPerMediaEntry; i++) {
+    lines.push(
+      `![Gallery image ${i + 1}](/benchmark-fixtures/${
+        images[i % images.length]
+      } "Fixture ${i + 1}")`
+    );
+  }
+
+  // Repeat deterministic prose to exercise long block parsing, then pad to an
+  // exact byte boundary. No random state or platform-specific newline is used.
+  const paragraph = `\nCorpus ${index}: The quick benchmark paragraph links [home](/) and preserves Unicode Ω雪🙂. `;
+  let content = lines.join("\n") + "\n";
+  while (Buffer.byteLength(content + paragraph, "utf8") <= targetBytes) {
+    content += paragraph;
+  }
+  const remaining = targetBytes - Buffer.byteLength(content, "utf8");
+  assert(
+    remaining >= 0,
+    "largeEntryKilobytes is too small for required features"
+  );
+  content += " ".repeat(remaining);
+
+  const featureCounts = countLargeEntryFeatures(content);
+  assert.strictEqual(Buffer.byteLength(content, "utf8"), targetBytes);
+  for (const [feature, minimum] of Object.entries(LARGE_FEATURE_MINIMUMS)) {
+    assert(
+      featureCounts[feature] >= minimum,
+      `${feature} generator count fell below ${minimum}`
+    );
+  }
+  assert(
+    featureCounts.images === imagesPerMediaEntry,
+    "gallery image count changed"
+  );
+  return { content, byteSize: targetBytes, featureCounts };
+}
+
+function countLargeEntryFeatures(content) {
+  const lines = content.split("\n");
+  const indents = lines
+    .filter((line) => /^\s*- nested level/.test(line))
+    .map((line) => line.match(/^\s*/)[0].length / 2 + 1);
+  return {
+    headings: lines.filter((line) => /^#{1,6} /.test(line)).length,
+    listDepth: Math.max(0, ...indents),
+    tableRows: lines.filter((line) => /^\| \d+ \|/.test(line)).length,
+    footnoteReferences: (content.match(/\[\^shared\]/g) || []).length - 1,
+    codeFences: (content.match(/^```[^\n]+$/gm) || []).length,
+    internalLinks: (content.match(/\]\(\/(?!\/)/g) || []).length,
+    images: (content.match(/^!\[Gallery image /gm) || []).length,
   };
 }
 
@@ -88,4 +271,7 @@ module.exports = {
   makeEntryContent,
   randomSentence,
   randomWord,
+  makeLargeEntryContent,
+  countLargeEntryFeatures,
+  LARGE_FEATURE_MINIMUMS,
 };

--- a/scripts/benchmarks/index.js
+++ b/scripts/benchmarks/index.js
@@ -47,6 +47,9 @@ if (args.path) {
 var benchmarkConfig = {
   sites: args.sites,
   files: args.files,
+  largeEntryCount: args.largeEntryCount,
+  largeEntryKilobytes: args.largeEntryKilobytes,
+  imagesPerMediaEntry: args.imagesPerMediaEntry,
   seed: args.seed,
   renderConcurrency: args.renderConcurrency,
   writeConcurrency: args.writeConcurrency,
@@ -117,6 +120,9 @@ function parseArgs(argv) {
   var parsed = {
     sites: BENCHMARK_DEFAULTS.sites,
     files: BENCHMARK_DEFAULTS.files,
+    largeEntryCount: BENCHMARK_DEFAULTS.largeEntryCount,
+    largeEntryKilobytes: BENCHMARK_DEFAULTS.largeEntryKilobytes,
+    imagesPerMediaEntry: BENCHMARK_DEFAULTS.imagesPerMediaEntry,
     seed: BENCHMARK_DEFAULTS.seed,
     renderConcurrency: BENCHMARK_DEFAULTS.renderConcurrency,
     writeConcurrency: BENCHMARK_DEFAULTS.writeConcurrency,
@@ -132,6 +138,9 @@ function parseArgs(argv) {
   var numericFlags = {
     "--sites": "sites",
     "--files": "files",
+    "--large-entry-count": "largeEntryCount",
+    "--large-entry-kilobytes": "largeEntryKilobytes",
+    "--images-per-media-entry": "imagesPerMediaEntry",
     "--render-concurrency": "renderConcurrency",
     "--write-concurrency": "writeConcurrency",
     "--cpu-sample-interval-ms": "cpuSampleIntervalMs",
@@ -193,12 +202,39 @@ function parseArgs(argv) {
 
   ensurePositiveInt(parsed.sites, "--sites");
   ensurePositiveInt(parsed.files, "--files");
+  ensureNonNegativeInt(parsed.largeEntryCount, "--large-entry-count");
+  ensureBoundedInt(
+    parsed.largeEntryKilobytes,
+    "--large-entry-kilobytes",
+    64,
+    2048
+  );
+  ensureBoundedInt(
+    parsed.imagesPerMediaEntry,
+    "--images-per-media-entry",
+    1,
+    250
+  );
   ensurePositiveInt(parsed.renderConcurrency, "--render-concurrency");
   ensurePositiveInt(parsed.writeConcurrency, "--write-concurrency");
   ensurePositiveInt(parsed.cpuSampleIntervalMs, "--cpu-sample-interval-ms");
   ensurePositiveInt(parsed.requestsPerPage, "--requests-per-page");
 
   return parsed;
+}
+
+function ensureNonNegativeInt(value, name) {
+  if (!Number.isInteger(value) || value < 0 || value > 25) {
+    throw new Error(name + " must be an integer between 0 and 25");
+  }
+}
+
+function ensureBoundedInt(value, name, min, max) {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(
+      name + " must be an integer between " + min + " and " + max
+    );
+  }
 }
 
 function ensurePositiveInt(value, name) {
@@ -218,6 +254,15 @@ function printHelp() {
         ")",
       "  --files <n>                    Total generated files (default: " +
         BENCHMARK_DEFAULTS.files +
+        ")",
+      "  --large-entry-count <n>        Large entries, 0-25 (default: " +
+        BENCHMARK_DEFAULTS.largeEntryCount +
+        ")",
+      "  --large-entry-kilobytes <n>    Size per large entry, 64-2048 KiB (default: " +
+        BENCHMARK_DEFAULTS.largeEntryKilobytes +
+        ")",
+      "  --images-per-media-entry <n>   Gallery images, 1-250 (default: " +
+        BENCHMARK_DEFAULTS.imagesPerMediaEntry +
         ")",
       "  --seed <value>                 Deterministic seed (default: " +
         BENCHMARK_DEFAULTS.seed +


### PR DESCRIPTION
### Motivation

- Provide deterministic, seed-stable generators that produce large markdown documents exercising headings, deep nested lists, large tables, repeated footnotes, fenced code blocks in multiple languages, Unicode text, many internal links, and image-heavy galleries to stress the build and render paths.
- Make large-workload behavior controllable and safe with bounded knobs so CI and local runs cannot accidentally create arbitrarily huge artifacts.
- Reuse existing converter/image fixtures to avoid committing or duplicating large binaries while still exercising converter/image handling in benchmarks.
- Surface large-workload metadata and measure build/write/render timings and bytes separately so regressions in heavy-content handling are visible independently from ordinary entries.

### Description

- Added new benchmark defaults `largeEntryCount`, `largeEntryKilobytes`, and `imagesPerMediaEntry` in `app/blog/benchmarks/util/defaults.js` and wired bounded parsing into `app/blog/benchmarks/util/config.js` via `boundedInt`.
- Added CLI flags and validation for the new knobs in `scripts/benchmarks/index.js` (`--large-entry-count`, `--large-entry-kilobytes`, `--images-per-media-entry`) and propagated them into the injected benchmark config used by the spec.
- Implemented a deterministic large-content generator `makeLargeEntryContent` in `app/blog/benchmarks/util/workload.js` that produces byte-for-byte reproducible UTF-8 markdown sized to a target byte count, includes headings, nested lists, tables, repeated footnotes, multiple fenced-code languages, Unicode text, many internal links, and image gallery references that reuse existing converter fixtures; the generator asserts size, feature minima, gallery counts, and reproducibility.
- Labeled files with `workload` categories (`ordinary`, `large-content`, `fixture`), collected write and render timings/bytes per workload, and extended `app/blog/benchmarks/util/result.js` to include the new configuration, per-workload timing/byte summaries, and per-large-entry metadata (path, link, bytes, feature counts).

### Testing

- Static checks: `node --check app/blog/benchmarks/util/workload.js`, `node --check app/blog/benchmarks/util/result.js`, `node --check app/blog/benchmarks/benchmarks.js`, and `node --check scripts/benchmarks/index.js` all succeeded.
- CLI help: `NODE_PATH=app node scripts/benchmarks/index.js --help` executed and shows the new flags and defaults.
- Determinism and feature assertions: ran a small deterministic generator script (invoking `makeLargeEntryContent`) that validated byte-for-byte reproducibility, exact target byte size, and feature counts (headings, list depth, table rows, footnote references, code fences, internal links, and images), and it passed.
- Repository checks: `git diff --check` reported no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa2b3036ef8832988206ff5e9563df5)