### PR TITLE
Route imported image/PDF downloads through the airlock (close known SSRF gap)

### DIFF
--- a/app/dashboard/site/import/helper/download_images.js
+++ b/app/dashboard/site/import/helper/download_images.js
@@ -8,6 +8,10 @@ var sharp = require("sharp");
 var mime = require("mime-types");
 var callOnce = require("helper/callOnce");
 var assetDirectory = require("./asset_directory");
+// Imported HTML can reference arbitrary, user-controlled image URLs, so route
+// the download through the airlock's forward proxy (SSRF egress boundary)
+// rather than the app container's direct network. Fails closed in production.
+var fetch = require("helper/airlock").fetch;
 
 // Consider using this algorithm to determine best part of alt tag or caption to use
 // as the file's name:
@@ -36,7 +40,7 @@ function download(url, _callback) {
     callback(new Error("Timeout: >10s downloading " + url));
   }, TIMEOUT);
 
-  fetch(url)
+  fetch(url, { airlockLabel: "import/download_images" })
     .then(function (res) {
       if (!res.ok) {
         throw new Error("Bad status code: " + res.status);

--- a/app/dashboard/site/import/helper/download_pdfs.js
+++ b/app/dashboard/site/import/helper/download_pdfs.js
@@ -5,6 +5,10 @@ var each_el = require("./each_el");
 var fs = require("fs-extra");
 var callOnce = require("helper/callOnce");
 var assetDirectory = require("./asset_directory");
+// Imported HTML can reference arbitrary, user-controlled PDF URLs, so route
+// the download through the airlock's forward proxy (SSRF egress boundary)
+// rather than the app container's direct network. Fails closed in production.
+var fetch = require("helper/airlock").fetch;
 
 var TIMEOUT = 5 * 1000; // 10s
 
@@ -30,7 +34,7 @@ function download(url, _callback) {
     callback(new Error("Timeout: >10s downloading " + url));
   }, TIMEOUT);
 
-  fetch(url)
+  fetch(url, { airlockLabel: "import/download_pdfs" })
     .then(function (res) {
       if (!res.ok) {
         return callback(new Error("Bad status code: " + res.status));


### PR DESCRIPTION
Hi, it's Claude (Opus 4.8; Effort: Low). This came out of a focused follow-up review of the new airlock plus your remediation commits — and first, the good news: that review came back **very clean**. Every fix I looked at verified as genuinely closed (no regressions), and the airlock boundary itself looks sound — the nftables egress filter covers the metadata address and all the private/reserved ranges (v4 and v6), and it fails closed at both the kernel and app layers. I couldn't find a way for a `linkScreenshot` or `transformer/download` user URL to reach loopback / metadata / the VPC.

The one live residue is the importer gap you already flag in `config/airlock/README.md` ("not yet routed or pinned — a known gap across all importers"), so this PR just closes that for the two easy sinks.

### What this does
`download_images.js` and `download_pdfs.js` fetch arbitrary image/PDF URLs out of imported HTML directly from the app container, bypassing the airlock — an authenticated SSRF (a user importing content with an `<img>`/PDF link at `169.254.169.254` or a private-range host gets it fetched from inside the network; the PDF path stores and serves the bytes). This routes both through `helper/airlock.fetch` — the same drop-in you already use in `create-site` and `transformer/download`: proxied through the airlock in production, fail-closed when the proxy is absent, direct in development. `node-fetch` (what the airlock uses) supports the `res.buffer()`/`res.arrayBuffer()` these callers rely on.

### Notes for you
- **Deploy dependency:** with this merged, imports that pull remote images/PDFs depend on `BLOT_AIRLOCK_PROXY_URL` being set for the app container in production — the same requirement `transformer/download` already has, and the same fail-closed behaviour. No change in development.
- **Out of scope:** `download_audio.js` uses the separate `download` package (not `fetch`), so it needs a proxy-agent wiring rather than this drop-in — left for a follow-up. It's the remaining importer sink.
- **Not run live:** verified control flow + the node-fetch `res.buffer()`/`arrayBuffer()` compatibility by reading; I don't have your airlock containers to exercise it, so a quick real-import smoke test before/after would be worth doing.

Separately — I wrote up the full follow-up review (the airlock boundary analysis + a point-by-point verification that each earlier fix is closed). Happy to share that document with you if it'd be useful; just say the word and I'll send it over.
