### PR TITLE
Add progress bars to client reset tools

### DIFF
--- a/app/clients/dropbox/sync/reset-to-blot.js
+++ b/app/clients/dropbox/sync/reset-to-blot.js
@@ -88,18 +88,8 @@ async function resetToBlot(blogID, publish) {
 
   const localRoot = localPath(blogID, "/");
   const progress = createProgress(await countLocalFiles(localRoot), publish);
-  const processed = new Set();
 
-  await walk(
-    blogID,
-    client,
-    publish,
-    dropboxRoot,
-    "/",
-    summary,
-    progress,
-    processed
-  );
+  await walk(blogID, client, publish, dropboxRoot, "/", summary, progress);
 
   await set(blogID, {
     error_code: 0,
@@ -117,8 +107,7 @@ const walk = async (
   dropboxRoot,
   dir,
   summary,
-  progress,
-  processed
+  progress
 ) => {
   const localRoot = localPath(blogID, "/");
   publish("Checking", dir);
@@ -127,13 +116,19 @@ const walk = async (
     localReaddir(blogID, localRoot, dir),
   ]);
 
-  for (const { name, path_display } of localContents) {
+  for (const { name, path_display, is_directory } of localContents) {
     const pathOnBlot = join(dir, name);
+    const pathOnDisk = join(localRoot, dir, name);
+    // A directory removed in one fs.remove call still accounts for every
+    // file total counted inside it, so current must advance by that many.
+    const removedCount = is_directory
+      ? await countLocalFiles(pathOnDisk)
+      : 1;
 
     if (shouldIgnoreFile(pathOnBlot)) {
-      publishProgress(progress, processed, "Removing ignored", pathOnBlot);
+      progress.publish("Removing ignored", pathOnBlot, false, removedCount);
       try {
-        await fs.remove(join(localRoot, dir, name));
+        await fs.remove(pathOnDisk);
         summary.removed += 1;
       } catch (e) {
         publish("Failed to remove ignored", path_display, e.message);
@@ -146,9 +141,9 @@ const walk = async (
     );
 
     if (!remoteCounterpart) {
-      publishProgress(progress, processed, "Removing", pathOnBlot);
+      progress.publish("Removing", pathOnBlot, false, removedCount);
       try {
-        await fs.remove(join(localRoot, dir, name));
+        await fs.remove(pathOnDisk);
         summary.removed += 1;
       } catch (e) {
         publish("Failed to remove", path_display, e.message);
@@ -170,7 +165,7 @@ const walk = async (
 
     if (remoteItem.is_directory) {
       if (localCounterpart && !localCounterpart.is_directory) {
-        publishProgress(progress, processed, "Removing", pathOnBlot);
+        progress.publish("Removing", pathOnBlot);
         await fs.remove(pathOnDisk);
         summary.removed += 1;
         publish("Creating directory", pathOnDisk);
@@ -189,14 +184,11 @@ const walk = async (
         dropboxRoot,
         join(dir, name),
         summary,
-        progress,
-        processed
+        progress
       );
     } else {
       if (hasUnsupportedExtension(pathOnDropbox)) {
-        publishProgress(
-          progress,
-          processed,
+        progress.publish(
           "Skipping unsupported file",
           pathOnBlot,
           !localCounterpart || localCounterpart.is_directory
@@ -214,9 +206,7 @@ const walk = async (
         typeof remoteItem.size === "number" &&
         remoteItem.size > MAX_FILE_SIZE
       ) {
-        publishProgress(
-          progress,
-          processed,
+        progress.publish(
           "Skipping oversized file",
           `${pathOnBlot} (${remoteItem.size} bytes > ${MAX_FILE_SIZE} byte limit)`,
           !localCounterpart || localCounterpart.is_directory
@@ -235,9 +225,7 @@ const walk = async (
         localCounterpart.content_hash === remoteItem.content_hash;
 
       if (localCounterpart && !identicalLocally) {
-        publishProgress(
-          progress,
-          processed,
+        progress.publish(
           "Downloading",
           pathOnBlot,
           localCounterpart.is_directory
@@ -249,7 +237,7 @@ const walk = async (
           continue;
         }
       } else if (!localCounterpart) {
-        publishProgress(progress, processed, "Downloading", pathOnBlot, true);
+        progress.publish("Downloading", pathOnBlot, true);
         try {
           await download(client, pathOnDropbox, pathOnDisk);
           summary.downloaded += 1;
@@ -257,17 +245,11 @@ const walk = async (
           continue;
         }
       } else {
-        publishProgress(progress, processed, "Checking", pathOnBlot);
+        progress.publish("Checking", pathOnBlot);
       }
     }
   }
 };
-
-function publishProgress(progress, processed, message, path, additional) {
-  if (processed.has(path)) return;
-  processed.add(path);
-  progress.publish(message, path, additional);
-}
 
 const localReaddir = async (blogID, localRoot, dir) => {
   const contents = await fs.readdir(join(localRoot, dir));

--- a/app/clients/dropbox/sync/reset-to-blot.js
+++ b/app/clients/dropbox/sync/reset-to-blot.js
@@ -151,6 +151,19 @@ const walk = async (
     }
   }
 
+  // Add every new remote file in this directory to the total before
+  // processing any of them, so progress reflects the real amount of work
+  // discovered instead of total growing in lockstep with current.
+  const newFileCount = remoteContents.filter((remoteItem) => {
+    const pathOnBlot = join(dir, remoteItem.name);
+    return (
+      !remoteItem.is_directory &&
+      !isDotfileOrDotfolder(pathOnBlot) &&
+      !localContents.find((localItem) => localItem.name === remoteItem.name)
+    );
+  }).length;
+  progress.discover(newFileCount);
+
   for (const remoteItem of remoteContents) {
     const localCounterpart = localContents.find(
       (localItem) => localItem.name === remoteItem.name
@@ -188,10 +201,13 @@ const walk = async (
       );
     } else {
       if (hasUnsupportedExtension(pathOnDropbox)) {
+        // A missing localCounterpart was already added to total by the
+        // discover() pass above; only a type mismatch (local dir where a
+        // file is expected) is new work discovered here.
         progress.publish(
           "Skipping unsupported file",
           pathOnBlot,
-          !localCounterpart || localCounterpart.is_directory
+          Boolean(localCounterpart && localCounterpart.is_directory)
         );
         summary.skipped += 1;
         try {
@@ -209,7 +225,7 @@ const walk = async (
         progress.publish(
           "Skipping oversized file",
           `${pathOnBlot} (${remoteItem.size} bytes > ${MAX_FILE_SIZE} byte limit)`,
-          !localCounterpart || localCounterpart.is_directory
+          Boolean(localCounterpart && localCounterpart.is_directory)
         );
         summary.skipped += 1;
         try {
@@ -237,7 +253,8 @@ const walk = async (
           continue;
         }
       } else if (!localCounterpart) {
-        progress.publish("Downloading", pathOnBlot, true);
+        // Already added to total by the discover() pass above.
+        progress.publish("Downloading", pathOnBlot, false);
         try {
           await download(client, pathOnDropbox, pathOnDisk);
           summary.downloaded += 1;
@@ -245,7 +262,7 @@ const walk = async (
           continue;
         }
       } else {
-        progress.publish("Checking", pathOnBlot);
+        progress.publishThrottled("Checking", pathOnBlot);
       }
     }
   }

--- a/app/clients/dropbox/sync/reset-to-blot.js
+++ b/app/clients/dropbox/sync/reset-to-blot.js
@@ -15,6 +15,10 @@ const {
   isDotfileOrDotfolder,
 } = require("../util/constants");
 const shouldIgnoreFile = require("clients/util/shouldIgnoreFile");
+const {
+  countLocalFiles,
+  createProgress,
+} = require("clients/util/resyncProgress");
 
 const set = promisify(require("../database").set);
 const createClient = promisify((blogID, cb) =>
@@ -82,18 +86,40 @@ async function resetToBlot(blogID, publish) {
     skipped: 0,
   };
 
-  await walk(blogID, client, publish, dropboxRoot, "/", summary);
+  const localRoot = localPath(blogID, "/");
+  const progress = createProgress(await countLocalFiles(localRoot), publish);
+  const processed = new Set();
+
+  await walk(
+    blogID,
+    client,
+    publish,
+    dropboxRoot,
+    "/",
+    summary,
+    progress,
+    processed
+  );
 
   await set(blogID, {
     error_code: 0,
   });
 
-  publish("Finished processing folder");
+  progress.finish("Finished processing folder");
 
   return summary;
 }
 
-const walk = async (blogID, client, publish, dropboxRoot, dir, summary) => {
+const walk = async (
+  blogID,
+  client,
+  publish,
+  dropboxRoot,
+  dir,
+  summary,
+  progress,
+  processed
+) => {
   const localRoot = localPath(blogID, "/");
   publish("Checking", dir);
   const [remoteContents, localContents] = await Promise.all([
@@ -105,7 +131,7 @@ const walk = async (blogID, client, publish, dropboxRoot, dir, summary) => {
     const pathOnBlot = join(dir, name);
 
     if (shouldIgnoreFile(pathOnBlot)) {
-      publish("Removing ignored", path_display);
+      publishProgress(progress, processed, "Removing ignored", pathOnBlot);
       try {
         await fs.remove(join(localRoot, dir, name));
         summary.removed += 1;
@@ -120,7 +146,7 @@ const walk = async (blogID, client, publish, dropboxRoot, dir, summary) => {
     );
 
     if (!remoteCounterpart) {
-      publish("Removing", path_display);
+      publishProgress(progress, processed, "Removing", pathOnBlot);
       try {
         await fs.remove(join(localRoot, dir, name));
         summary.removed += 1;
@@ -144,7 +170,7 @@ const walk = async (blogID, client, publish, dropboxRoot, dir, summary) => {
 
     if (remoteItem.is_directory) {
       if (localCounterpart && !localCounterpart.is_directory) {
-        publish("Removing", pathOnDisk);
+        publishProgress(progress, processed, "Removing", pathOnBlot);
         await fs.remove(pathOnDisk);
         summary.removed += 1;
         publish("Creating directory", pathOnDisk);
@@ -162,11 +188,19 @@ const walk = async (blogID, client, publish, dropboxRoot, dir, summary) => {
         publish,
         dropboxRoot,
         join(dir, name),
-        summary
+        summary,
+        progress,
+        processed
       );
     } else {
       if (hasUnsupportedExtension(pathOnDropbox)) {
-        publish("Skipping unsupported file", pathOnBlot);
+        publishProgress(
+          progress,
+          processed,
+          "Skipping unsupported file",
+          pathOnBlot,
+          !localCounterpart || localCounterpart.is_directory
+        );
         summary.skipped += 1;
         try {
           await fs.outputFile(pathOnDisk, "");
@@ -180,9 +214,12 @@ const walk = async (blogID, client, publish, dropboxRoot, dir, summary) => {
         typeof remoteItem.size === "number" &&
         remoteItem.size > MAX_FILE_SIZE
       ) {
-        publish(
+        publishProgress(
+          progress,
+          processed,
           "Skipping oversized file",
-          `${pathOnBlot} (${remoteItem.size} bytes > ${MAX_FILE_SIZE} byte limit)`
+          `${pathOnBlot} (${remoteItem.size} bytes > ${MAX_FILE_SIZE} byte limit)`,
+          !localCounterpart || localCounterpart.is_directory
         );
         summary.skipped += 1;
         try {
@@ -198,7 +235,13 @@ const walk = async (blogID, client, publish, dropboxRoot, dir, summary) => {
         localCounterpart.content_hash === remoteItem.content_hash;
 
       if (localCounterpart && !identicalLocally) {
-        publish("Downloading", pathOnBlot);
+        publishProgress(
+          progress,
+          processed,
+          "Downloading",
+          pathOnBlot,
+          localCounterpart.is_directory
+        );
         try {
           await download(client, pathOnDropbox, pathOnDisk);
           summary.downloaded += 1;
@@ -206,17 +249,25 @@ const walk = async (blogID, client, publish, dropboxRoot, dir, summary) => {
           continue;
         }
       } else if (!localCounterpart) {
-        publish("Downloading", pathOnBlot);
+        publishProgress(progress, processed, "Downloading", pathOnBlot, true);
         try {
           await download(client, pathOnDropbox, pathOnDisk);
           summary.downloaded += 1;
         } catch (e) {
           continue;
         }
+      } else {
+        publishProgress(progress, processed, "Checking", pathOnBlot);
       }
     }
   }
 };
+
+function publishProgress(progress, processed, message, path, additional) {
+  if (processed.has(path)) return;
+  processed.add(path);
+  progress.publish(message, path, additional);
+}
 
 const localReaddir = async (blogID, localRoot, dir) => {
   const contents = await fs.readdir(join(localRoot, dir));

--- a/app/clients/google-drive/sync/sync.js
+++ b/app/clients/google-drive/sync/sync.js
@@ -127,6 +127,16 @@ module.exports = async function sync(blogID, publish, update) {
       }
     }
 
+    // Add every new remote file in this directory to the total before
+    // processing any of them, so progress reflects the real amount of work
+    // discovered instead of total growing in lockstep with current.
+    const newFileCount = remoteContents.filter(
+      (item) =>
+        !item.isDirectory &&
+        !localContents.find((localItem) => localItem.name === item.name)
+    ).length;
+    progress.discover(newFileCount);
+
     for (const {
       id,
       name,
@@ -157,10 +167,13 @@ module.exports = async function sync(blogID, publish, update) {
 
         if (!existsLocally || !identical) {
           await checkWeCanContinue();
+          // A missing existsLocally was already added to total by the
+          // discover() pass above; only a type mismatch (local dir where a
+          // file is expected) is new work discovered here.
           progress.publish(
             "Downloading",
             path,
-            !existsLocally || existsLocally.isDirectory
+            Boolean(existsLocally && existsLocally.isDirectory)
           );
 
           if (existsLocally) {
@@ -200,7 +213,7 @@ module.exports = async function sync(blogID, publish, update) {
             console.error("Download failed for", path, err);
           }
         } else {
-          progress.publish("Checking", path);
+          progress.publishThrottled("Checking", path);
         }
       } else {
         if (existsLocally && !existsLocally.isDirectory) {

--- a/app/clients/google-drive/sync/sync.js
+++ b/app/clients/google-drive/sync/sync.js
@@ -43,12 +43,6 @@ module.exports = async function sync(blogID, publish, update) {
     await countLocalFiles(localPath(blogID, "/")),
     publish
   );
-  const processed = new Set();
-  const publishProgress = (message, path, additional) => {
-    if (processed.has(path)) return;
-    processed.add(path);
-    progress.publish(message, path, additional);
-  };
 
   // fetch the latest folderName, in case it has changed
   // and also whether or not the folder is in the trash
@@ -101,12 +95,17 @@ module.exports = async function sync(blogID, publish, update) {
     // google docs to .gdoc files here.
     const remoteContents = transformDriveItems(driveItems);
 
-    for (const { name } of localContents) {
+    for (const { name, isDirectory: isLocalDirectory } of localContents) {
       const path = join(dir, name);
+      // A directory removed in one fs.remove call still accounts for every
+      // file total counted inside it, so current must advance by that many.
+      const removedCount = isLocalDirectory
+        ? await countLocalFiles(localPath(blogID, path))
+        : 1;
 
       if (shouldIgnoreFile(path)) {
         await checkWeCanContinue();
-        publishProgress("Removing ignored", path);
+        progress.publish("Removing ignored", path, false, removedCount);
         await fs.remove(localPath(blogID, path));
         await update(path);
         const id = await getByPath(path);
@@ -116,7 +115,7 @@ module.exports = async function sync(blogID, publish, update) {
 
       if (!remoteContents.find((item) => item.name === name)) {
         await checkWeCanContinue();
-        publishProgress("Removing", path);
+        progress.publish("Removing", path, false, removedCount);
         console.log(
           "Removing",
           join(dir, name),
@@ -158,7 +157,7 @@ module.exports = async function sync(blogID, publish, update) {
 
         if (!existsLocally || !identical) {
           await checkWeCanContinue();
-          publishProgress(
+          progress.publish(
             "Downloading",
             path,
             !existsLocally || existsLocally.isDirectory
@@ -201,12 +200,12 @@ module.exports = async function sync(blogID, publish, update) {
             console.error("Download failed for", path, err);
           }
         } else {
-          publishProgress("Checking", path);
+          progress.publish("Checking", path);
         }
       } else {
         if (existsLocally && !existsLocally.isDirectory) {
           await checkWeCanContinue();
-          publishProgress("Removing file", path);
+          progress.publish("Removing file", path);
           console.log("Removing file", path, "which is a directory remotely");
           await fs.remove(localPath(blogID, path));
           publish("Creating directory", path);

--- a/app/clients/google-drive/sync/sync.js
+++ b/app/clients/google-drive/sync/sync.js
@@ -6,6 +6,10 @@ const download = require("../util/download");
 const createDriveClient = require("../serviceAccount/createDriveClient");
 const CheckWeCanContinue = require("../util/checkWeCanContinue");
 const shouldIgnoreFile = require("clients/util/shouldIgnoreFile");
+const {
+  countLocalFiles,
+  createProgress,
+} = require("clients/util/resyncProgress");
 
 const driveReaddir = require("./util/driveReaddir");
 const localReaddir = require("./util/localReaddir");
@@ -35,6 +39,16 @@ module.exports = async function sync(blogID, publish, update) {
   const drive = await createDriveClient(serviceAccountId);
   const { getByPath, set, remove } = database.folder(folderId);
   const checkWeCanContinue = CheckWeCanContinue(blogID, account);
+  const progress = createProgress(
+    await countLocalFiles(localPath(blogID, "/")),
+    publish
+  );
+  const processed = new Set();
+  const publishProgress = (message, path, additional) => {
+    if (processed.has(path)) return;
+    processed.add(path);
+    progress.publish(message, path, additional);
+  };
 
   // fetch the latest folderName, in case it has changed
   // and also whether or not the folder is in the trash
@@ -92,7 +106,7 @@ module.exports = async function sync(blogID, publish, update) {
 
       if (shouldIgnoreFile(path)) {
         await checkWeCanContinue();
-        publish("Removing ignored", path);
+        publishProgress("Removing ignored", path);
         await fs.remove(localPath(blogID, path));
         await update(path);
         const id = await getByPath(path);
@@ -102,7 +116,7 @@ module.exports = async function sync(blogID, publish, update) {
 
       if (!remoteContents.find((item) => item.name === name)) {
         await checkWeCanContinue();
-        publish("Removing", join(dir, name));
+        publishProgress("Removing", path);
         console.log(
           "Removing",
           join(dir, name),
@@ -144,7 +158,11 @@ module.exports = async function sync(blogID, publish, update) {
 
         if (!existsLocally || !identical) {
           await checkWeCanContinue();
-          publish("Downloading", path);
+          publishProgress(
+            "Downloading",
+            path,
+            !existsLocally || existsLocally.isDirectory
+          );
 
           if (existsLocally) {
             console.log("Updating out-of-sync:", path);
@@ -157,15 +175,21 @@ module.exports = async function sync(blogID, publish, update) {
           }
 
           try {
-            const result = await download(blogID, drive, path, {
-              id,
-              md5Checksum,
-              mimeType,
-              modifiedTime,
-            }, {
-              serviceAccountId,
-              folderId,
-            });
+            const result = await download(
+              blogID,
+              drive,
+              path,
+              {
+                id,
+                md5Checksum,
+                mimeType,
+                modifiedTime,
+              },
+              {
+                serviceAccountId,
+                folderId,
+              }
+            );
 
             if (result?.skippedReason === "exportSizeLimitExceeded") {
               publish("Skipped oversized Google Doc", path);
@@ -176,11 +200,13 @@ module.exports = async function sync(blogID, publish, update) {
             publish("Download failed", path);
             console.error("Download failed for", path, err);
           }
+        } else {
+          publishProgress("Checking", path);
         }
       } else {
         if (existsLocally && !existsLocally.isDirectory) {
           await checkWeCanContinue();
-          publish("Removing file", path);
+          publishProgress("Removing file", path);
           console.log("Removing file", path, "which is a directory remotely");
           await fs.remove(localPath(blogID, path));
           publish("Creating directory", path);
@@ -201,6 +227,7 @@ module.exports = async function sync(blogID, publish, update) {
 
   try {
     await walk("/", folderId);
+    progress.finish("Finished processing folder");
   } catch (err) {
     publish("Sync failed", err.message);
   }

--- a/app/clients/icloud/sync/fromiCloud.js
+++ b/app/clients/icloud/sync/fromiCloud.js
@@ -8,6 +8,10 @@ const localReaddir = require("./util/localReaddir");
 const remoteReaddir = require("./util/remoteReaddir");
 const remoteRecursiveList = require("./util/remoteRecursiveList");
 const shouldIgnoreFile = require("clients/util/shouldIgnoreFile");
+const {
+  countLocalFiles,
+  createProgress,
+} = require("clients/util/resyncProgress");
 
 const database = require("../database");
 const config = require("config");
@@ -22,6 +26,16 @@ module.exports = async (blogID, publish, update) => {
   if (!update) update = () => {};
 
   const checkWeCanContinue = CheckWeCanContinue(blogID);
+  const progress = createProgress(
+    await countLocalFiles(localPath(blogID, "/")),
+    publish
+  );
+  const processed = new Set();
+  const publishProgress = (message, path, additional) => {
+    if (processed.has(path)) return;
+    processed.add(path);
+    progress.publish(message, path, additional);
+  };
   const summary = {
     downloaded: 0,
     removed: 0,
@@ -35,12 +49,9 @@ module.exports = async (blogID, publish, update) => {
     await remoteRecursiveList(blogID, "/");
     publish("Synced folder tree");
   } catch (error) {
-    console.error(
-      "Failed to sync folder tree",
-      {
-        error,
-      }
-    );
+    console.error("Failed to sync folder tree", {
+      error,
+    });
     publish("Failed to sync folder tree");
   }
 
@@ -56,7 +67,7 @@ module.exports = async (blogID, publish, update) => {
 
       if (shouldIgnoreFile(path)) {
         await checkWeCanContinue();
-        publish("Removing local ignored item", path);
+        publishProgress("Removing local ignored item", path);
         await fs.remove(localPath(blogID, path));
         summary.removed += 1;
         await update(path);
@@ -69,7 +80,7 @@ module.exports = async (blogID, publish, update) => {
         )
       ) {
         await checkWeCanContinue();
-        publish("Removing local item", join(dir, name));
+        publishProgress("Removing local item", path);
         await fs.remove(localPath(blogID, path));
         summary.removed += 1;
         await update(path);
@@ -85,7 +96,7 @@ module.exports = async (blogID, publish, update) => {
       if (isDirectory) {
         if (existsLocally && !existsLocally.isDirectory) {
           await checkWeCanContinue();
-          publish("Removing", path);
+          publishProgress("Removing", path);
           await fs.remove(localPath(blogID, path));
           summary.removed += 1;
           publish("Creating directory", path);
@@ -108,9 +119,10 @@ module.exports = async (blogID, publish, update) => {
         if (!existsLocally || (existsLocally && !identicalOnRemote)) {
           try {
             if (size > maxFileSize) {
-              publish(
+              publishProgress(
                 "File too large",
-                `${path} (${size} bytes > ${maxFileSize} byte limit)`
+                `${path} (${size} bytes > ${maxFileSize} byte limit)`,
+                !existsLocally || existsLocally.isDirectory
               );
               summary.skipped += 1;
 
@@ -126,7 +138,11 @@ module.exports = async (blogID, publish, update) => {
             }
 
             await checkWeCanContinue();
-            publish("Updating", path);
+            publishProgress(
+              "Downloading",
+              path,
+              !existsLocally || existsLocally.isDirectory
+            );
 
             await download(blogID, path);
             summary.downloaded += 1;
@@ -134,6 +150,8 @@ module.exports = async (blogID, publish, update) => {
           } catch (e) {
             publish("Failed to download", path, e);
           }
+        } else {
+          publishProgress("Checking", path);
         }
       }
     }
@@ -141,6 +159,7 @@ module.exports = async (blogID, publish, update) => {
 
   try {
     await walk("/");
+    progress.finish("Finished processing folder");
     // update the database to remove the error flag if it exists
     await database.store(blogID, { error: null });
   } catch (err) {

--- a/app/clients/icloud/sync/fromiCloud.js
+++ b/app/clients/icloud/sync/fromiCloud.js
@@ -30,12 +30,6 @@ module.exports = async (blogID, publish, update) => {
     await countLocalFiles(localPath(blogID, "/")),
     publish
   );
-  const processed = new Set();
-  const publishProgress = (message, path, additional) => {
-    if (processed.has(path)) return;
-    processed.add(path);
-    progress.publish(message, path, additional);
-  };
   const summary = {
     downloaded: 0,
     removed: 0,
@@ -62,12 +56,22 @@ module.exports = async (blogID, publish, update) => {
       localReaddir(localPath(blogID, dir)),
     ]);
 
-    for (const { name } of localContents) {
+    for (const { name, isDirectory: isLocalDirectory } of localContents) {
       const path = join(dir, name);
+      // A directory removed in one fs.remove call still accounts for every
+      // file total counted inside it, so current must advance by that many.
+      const removedCount = isLocalDirectory
+        ? await countLocalFiles(localPath(blogID, path))
+        : 1;
 
       if (shouldIgnoreFile(path)) {
         await checkWeCanContinue();
-        publishProgress("Removing local ignored item", path);
+        progress.publish(
+          "Removing local ignored item",
+          path,
+          false,
+          removedCount
+        );
         await fs.remove(localPath(blogID, path));
         summary.removed += 1;
         await update(path);
@@ -80,7 +84,7 @@ module.exports = async (blogID, publish, update) => {
         )
       ) {
         await checkWeCanContinue();
-        publishProgress("Removing local item", path);
+        progress.publish("Removing local item", path, false, removedCount);
         await fs.remove(localPath(blogID, path));
         summary.removed += 1;
         await update(path);
@@ -96,7 +100,7 @@ module.exports = async (blogID, publish, update) => {
       if (isDirectory) {
         if (existsLocally && !existsLocally.isDirectory) {
           await checkWeCanContinue();
-          publishProgress("Removing", path);
+          progress.publish("Removing", path);
           await fs.remove(localPath(blogID, path));
           summary.removed += 1;
           publish("Creating directory", path);
@@ -119,7 +123,7 @@ module.exports = async (blogID, publish, update) => {
         if (!existsLocally || (existsLocally && !identicalOnRemote)) {
           try {
             if (size > maxFileSize) {
-              publishProgress(
+              progress.publish(
                 "File too large",
                 `${path} (${size} bytes > ${maxFileSize} byte limit)`,
                 !existsLocally || existsLocally.isDirectory
@@ -138,7 +142,7 @@ module.exports = async (blogID, publish, update) => {
             }
 
             await checkWeCanContinue();
-            publishProgress(
+            progress.publish(
               "Downloading",
               path,
               !existsLocally || existsLocally.isDirectory
@@ -151,7 +155,7 @@ module.exports = async (blogID, publish, update) => {
             publish("Failed to download", path, e);
           }
         } else {
-          publishProgress("Checking", path);
+          progress.publish("Checking", path);
         }
       }
     }

--- a/app/clients/icloud/sync/fromiCloud.js
+++ b/app/clients/icloud/sync/fromiCloud.js
@@ -91,6 +91,19 @@ module.exports = async (blogID, publish, update) => {
       }
     }
 
+    // Add every new remote file in this directory to the total before
+    // processing any of them, so progress reflects the real amount of work
+    // discovered instead of total growing in lockstep with current.
+    const newFileCount = remoteContents.filter(
+      (item) =>
+        !item.isDirectory &&
+        !localContents.find(
+          (localItem) =>
+            localItem.name.normalize("NFC") === item.name.normalize("NFC")
+        )
+    ).length;
+    progress.discover(newFileCount);
+
     for (const { name, size, isDirectory } of remoteContents) {
       const path = join(dir, name);
       const existsLocally = localContents.find(
@@ -123,10 +136,13 @@ module.exports = async (blogID, publish, update) => {
         if (!existsLocally || (existsLocally && !identicalOnRemote)) {
           try {
             if (size > maxFileSize) {
+              // A missing existsLocally was already added to total by the
+              // discover() pass above; only a type mismatch (local dir
+              // where a file is expected) is new work discovered here.
               progress.publish(
                 "File too large",
                 `${path} (${size} bytes > ${maxFileSize} byte limit)`,
-                !existsLocally || existsLocally.isDirectory
+                Boolean(existsLocally && existsLocally.isDirectory)
               );
               summary.skipped += 1;
 
@@ -145,7 +161,7 @@ module.exports = async (blogID, publish, update) => {
             progress.publish(
               "Downloading",
               path,
-              !existsLocally || existsLocally.isDirectory
+              Boolean(existsLocally && existsLocally.isDirectory)
             );
 
             await download(blogID, path);
@@ -155,7 +171,7 @@ module.exports = async (blogID, publish, update) => {
             publish("Failed to download", path, e);
           }
         } else {
-          progress.publish("Checking", path);
+          progress.publishThrottled("Checking", path);
         }
       }
     }

--- a/app/clients/icloud/sync/tests/fromiCloud.js
+++ b/app/clients/icloud/sync/tests/fromiCloud.js
@@ -61,7 +61,11 @@ describe("icloud fromiCloud sync", function () {
   });
 
   it("creates a 0-byte placeholder when an oversized remote file is missing locally", async () => {
-    const remoteFile = { name: "huge.mov", size: 1000 * 1000 * 1000, isDirectory: false };
+    const remoteFile = {
+      name: "huge.mov",
+      size: 1000 * 1000 * 1000,
+      isDirectory: false,
+    };
 
     mockModule(remoteRecursiveListPath, async () => {});
     mockModule(remoteReaddirPath, async () => [remoteFile]);
@@ -85,11 +89,23 @@ describe("icloud fromiCloud sync", function () {
     expect(stat.size).toBe(0);
     expect(summary.skipped).toBe(1);
     expect(summary.placeholdersCreated).toBe(1);
-    expect(published.some((line) => line.includes("Created placeholder for oversized file"))).toBe(true);
+    expect(
+      published.some((line) =>
+        line.includes("Created placeholder for oversized file")
+      )
+    ).toBe(true);
+    expect(published).toContain(
+      "(1/1) File too large /huge.mov (1000000000 bytes > 100000000 byte limit)"
+    );
+    expect(published).toContain("(1/1) Finished processing folder");
   });
 
   it("replaces mismatched local content with a 0-byte placeholder for oversized remote files", async () => {
-    const remoteFile = { name: "archive.zip", size: 1000 * 1000 * 1000, isDirectory: false };
+    const remoteFile = {
+      name: "archive.zip",
+      size: 1000 * 1000 * 1000,
+      isDirectory: false,
+    };
     const localFile = localPath(blogID, join("/", remoteFile.name));
 
     await fs.outputFile(localFile, "existing local content");
@@ -103,7 +119,11 @@ describe("icloud fromiCloud sync", function () {
     mockModule(databasePath, { store: async () => {} });
 
     const fromiCloud = require(fromiCloudPath);
-    const summary = await fromiCloud(blogID, () => {}, async () => {});
+    const summary = await fromiCloud(
+      blogID,
+      () => {},
+      async () => {}
+    );
 
     const stat = await fs.stat(localFile);
 

--- a/app/clients/util/resyncProgress.js
+++ b/app/clients/util/resyncProgress.js
@@ -1,0 +1,34 @@
+const fs = require("fs-extra");
+const { join } = require("path");
+
+async function countLocalFiles(directory) {
+  let total = 0;
+  const contents = await fs.readdir(directory, { withFileTypes: true });
+
+  for (const item of contents) {
+    const path = join(directory, item.name);
+    if (item.isDirectory()) total += await countLocalFiles(path);
+    else total += 1;
+  }
+
+  return total;
+}
+
+function createProgress(total, publish) {
+  const progress = { current: 0, total };
+
+  progress.publish = function (message, path, additional) {
+    if (additional) progress.total += 1;
+    progress.current = Math.min(progress.current + 1, progress.total);
+    publish(`(${progress.current}/${progress.total}) ${message} ${path}`);
+  };
+
+  progress.finish = function (message) {
+    progress.current = progress.total;
+    publish(`(${progress.current}/${progress.total}) ${message}`);
+  };
+
+  return progress;
+}
+
+module.exports = { countLocalFiles, createProgress };

--- a/app/clients/util/resyncProgress.js
+++ b/app/clients/util/resyncProgress.js
@@ -16,10 +16,19 @@ async function countLocalFiles(directory) {
 
 function createProgress(total, publish) {
   const progress = { current: 0, total };
+  const processed = new Set();
 
-  progress.publish = function (message, path, additional) {
-    if (additional) progress.total += 1;
-    progress.current = Math.min(progress.current + 1, progress.total);
+  // `count` lets a caller that disposes of a whole directory in one action
+  // (e.g. removing an orphaned local folder with a single fs.remove call)
+  // advance current by the number of files that action accounted for,
+  // rather than by 1 - otherwise current permanently lags total, which was
+  // seeded by counting every file individually.
+  progress.publish = function (message, path, additional, count = 1) {
+    if (processed.has(path)) return;
+    processed.add(path);
+
+    if (additional) progress.total += count;
+    progress.current = Math.min(progress.current + count, progress.total);
     publish(`(${progress.current}/${progress.total}) ${message} ${path}`);
   };
 

--- a/app/clients/util/resyncProgress.js
+++ b/app/clients/util/resyncProgress.js
@@ -18,17 +18,53 @@ function createProgress(total, publish) {
   const progress = { current: 0, total };
   const processed = new Set();
 
+  // Add newly discovered remote-only work to total up front, before any of
+  // it is processed - e.g. once per remote directory listing, for every
+  // item in it with no local counterpart. Without this, total and current
+  // grow together one item at a time (additional=true on publish below),
+  // so the displayed percentage sits near 100% throughout a large batch of
+  // new downloads instead of reflecting how much is actually left.
+  progress.discover = function (count) {
+    if (count) progress.total += count;
+  };
+
   // `count` lets a caller that disposes of a whole directory in one action
   // (e.g. removing an orphaned local folder with a single fs.remove call)
   // advance current by the number of files that action accounted for,
   // rather than by 1 - otherwise current permanently lags total, which was
   // seeded by counting every file individually.
-  progress.publish = function (message, path, additional, count = 1) {
-    if (processed.has(path)) return;
+  function advance(path, additional, count) {
+    if (processed.has(path)) return false;
     processed.add(path);
 
     if (additional) progress.total += count;
     progress.current = Math.min(progress.current + count, progress.total);
+    return true;
+  }
+
+  progress.publish = function (message, path, additional, count = 1) {
+    if (!advance(path, additional, count)) return;
+    publish(`(${progress.current}/${progress.total}) ${message} ${path}`);
+  };
+
+  // Advances current/total exactly like publish(), but only actually emits
+  // a status at most once per intervalMs. Use this for high-volume, low-
+  // value updates (e.g. one "Checking" per unchanged file during a routine
+  // sync) - publishing every one of them would push older, more useful
+  // activity out of Blog.setStatus's capped history for no benefit, since
+  // the skipped ones carry no information a viewer would act on.
+  let lastThrottledPublish = 0;
+  progress.publishThrottled = function (
+    message,
+    path,
+    additional,
+    count = 1,
+    intervalMs = 2000
+  ) {
+    if (!advance(path, additional, count)) return;
+    const now = Date.now();
+    if (now - lastThrottledPublish < intervalMs) return;
+    lastThrottledPublish = now;
     publish(`(${progress.current}/${progress.total}) ${message} ${path}`);
   };
 

--- a/app/clients/util/tests/resyncProgress.js
+++ b/app/clients/util/tests/resyncProgress.js
@@ -35,4 +35,31 @@ describe("resync progress", function () {
       "(2/2) Finished processing folder",
     ]);
   });
+
+  it("does not publish the same path twice", function () {
+    const messages = [];
+    const progress = createProgress(2, (message) => messages.push(message));
+
+    progress.publish("Checking", "/one.txt");
+    progress.publish("Checking", "/one.txt");
+
+    expect(messages).toEqual(["(1/2) Checking /one.txt"]);
+  });
+
+  it("advances current by count when a whole directory is removed at once", function () {
+    const messages = [];
+    // total was seeded by counting 3 individual files, one of which lives
+    // inside a folder that gets removed with a single fs.remove call.
+    const progress = createProgress(3, (message) => messages.push(message));
+
+    progress.publish("Checking", "/one.txt");
+    progress.publish("Removing", "/orphaned-folder", false, 2);
+    progress.finish("Finished processing folder");
+
+    expect(messages).toEqual([
+      "(1/3) Checking /one.txt",
+      "(3/3) Removing /orphaned-folder",
+      "(3/3) Finished processing folder",
+    ]);
+  });
 });

--- a/app/clients/util/tests/resyncProgress.js
+++ b/app/clients/util/tests/resyncProgress.js
@@ -62,4 +62,37 @@ describe("resync progress", function () {
       "(3/3) Finished processing folder",
     ]);
   });
+
+  it("discovers work up front instead of growing total one item at a time", function () {
+    const messages = [];
+    // An empty local folder (total=0) about to download 3 remote-only files.
+    const progress = createProgress(0, (message) => messages.push(message));
+
+    progress.discover(3);
+    progress.publish("Downloading", "/one.txt");
+    progress.publish("Downloading", "/two.txt");
+    progress.publish("Downloading", "/three.txt");
+    progress.finish("Finished processing folder");
+
+    expect(messages).toEqual([
+      "(1/3) Downloading /one.txt",
+      "(2/3) Downloading /two.txt",
+      "(3/3) Downloading /three.txt",
+      "(3/3) Finished processing folder",
+    ]);
+  });
+
+  it("throttles high-volume updates without losing progress accounting", function () {
+    const messages = [];
+    const progress = createProgress(3, (message) => messages.push(message));
+
+    // All three calls land within the same throttle window, so only the
+    // first is actually emitted - but current still advances for each one.
+    progress.publishThrottled("Checking", "/one.txt", false, 1, 100000);
+    progress.publishThrottled("Checking", "/two.txt", false, 1, 100000);
+    progress.publishThrottled("Checking", "/three.txt", false, 1, 100000);
+
+    expect(messages).toEqual(["(1/3) Checking /one.txt"]);
+    expect(progress.current).toBe(3);
+  });
 });

--- a/app/clients/util/tests/resyncProgress.js
+++ b/app/clients/util/tests/resyncProgress.js
@@ -1,0 +1,38 @@
+const fs = require("fs-extra");
+const os = require("os");
+const { join } = require("path");
+const { countLocalFiles, createProgress } = require("../resyncProgress");
+
+describe("resync progress", function () {
+  let directory;
+
+  beforeEach(async function () {
+    directory = await fs.mkdtemp(join(os.tmpdir(), "blot-resync-progress-"));
+  });
+
+  afterEach(async function () {
+    await fs.remove(directory);
+  });
+
+  it("counts files recursively without counting directories", async function () {
+    await fs.outputFile(join(directory, "one.txt"), "one");
+    await fs.outputFile(join(directory, "nested", "two.txt"), "two");
+
+    expect(await countLocalFiles(directory)).toBe(2);
+  });
+
+  it("increases the total before publishing newly discovered work", function () {
+    const messages = [];
+    const progress = createProgress(1, (message) => messages.push(message));
+
+    progress.publish("Checking", "/one.txt");
+    progress.publish("Downloading", "/two.txt", true);
+    progress.finish("Finished processing folder");
+
+    expect(messages).toEqual([
+      "(1/1) Checking /one.txt",
+      "(2/2) Downloading /two.txt",
+      "(2/2) Finished processing folder",
+    ]);
+  });
+});

--- a/app/dashboard/site/client.js
+++ b/app/dashboard/site/client.js
@@ -146,17 +146,21 @@ client_routes.post("/reset/rebuild", function (req, res) {
     const thumbnails = !!req.query.thumbnails;
     const imageCache = !!req.query.imageCache;
 
-    Rebuild(req.blog.id, { thumbnails, imageCache }, function (err) {
-      if (err) console.log(err);
-      folder.status("Checking your site for issues");
-      Fix(req.blog, function (err) {
+    Rebuild(
+      req.blog.id,
+      { thumbnails, imageCache, status: folder.status, log: folder.log },
+      function (err) {
         if (err) console.log(err);
-        folder.status("Finished site rebuild");
-        done(null, function (err) {
-          if (err) console.log("Error releasing sync: ", err);
+        folder.status("Checking your site for issues");
+        Fix(req.blog, { status: folder.status, log: folder.log }, function (err) {
+          if (err) console.log(err);
+          folder.status("Finished site rebuild");
+          done(null, function (err) {
+            if (err) console.log("Error releasing sync: ", err);
+          });
         });
-      });
-    });
+      }
+    );
   });
 });
 
@@ -185,7 +189,7 @@ client_routes.post("/reset/resync", load.client, function (req, res, next) {
     }
 
     folder.status("Checking your site for issues");
-    Fix(req.blog, function (err) {
+    Fix(req.blog, { status: folder.status, log: folder.log }, function (err) {
       if (err) console.log(err);
       folder.status("Finished site rebuild");
       done(null, function (err) {

--- a/app/dashboard/site/client.js
+++ b/app/dashboard/site/client.js
@@ -73,6 +73,11 @@ const verbs = {
   Removing: "removed",
 };
 
+// Reset progress messages are prefixed with "(current/total) ", e.g.
+// "(1/10) Downloading /post.md" - strip it before matching a verb so
+// these still parse into a path, verb and folder URL below.
+const PROGRESS_PREFIX = /^\(\d+\/\d+\)\s+/;
+
 client_routes.route("/activity").get(load.clients, async function (req, res) {
   res.locals.breadcrumbs.add("Activity", "activity");
 
@@ -84,12 +89,13 @@ client_routes.route("/activity").get(load.clients, async function (req, res) {
       syncID: key,
       messages: value
         .map((item) => {
+          const message = item.message.replace(PROGRESS_PREFIX, "");
           const matchedVerb = Object.keys(verbs).find((i) =>
-            item.message.startsWith(i + " /")
+            message.startsWith(i + " /")
           );
 
           if (matchedVerb) {
-            const path = item.message.slice((matchedVerb + " ").length);
+            const path = message.slice((matchedVerb + " ").length);
             item.path = Path.parse(path);
             item.verb = verbs[matchedVerb];
             item.url = Path.join(

--- a/app/sync/fix/index.js
+++ b/app/sync/fix/index.js
@@ -26,24 +26,24 @@ module.exports = function (blog, options, callback) {
   const fallbackMessenger = options.status ? null : messenger(blog);
   const status = options.status || fallbackMessenger.status;
   const checks = [
-    entryGhosts,
-    tagGhosts,
-    listGhosts,
-    menuGhosts,
-    entriesPathIndex,
+    { name: "entry-ghosts", fn: entryGhosts },
+    { name: "tag-ghosts", fn: tagGhosts },
+    { name: "list-ghosts", fn: listGhosts },
+    { name: "menu-ghosts", fn: menuGhosts },
+    { name: "entries-path-index", fn: entriesPathIndex },
   ];
   let current = 0;
 
   async.eachSeries(
     checks,
-    function (fn, next) {
+    function (check, next) {
       current += 1;
-      status(`(${current}/${checks.length}) Checking ${fn.name}`);
-      fn(
+      status(`(${current}/${checks.length}) Checking ${check.name}`);
+      check.fn(
         blog,
         callOnce(function (err, report) {
           if (err) return next(err);
-          if (report && report.length) finalReport[fn.name] = report;
+          if (report && report.length) finalReport[check.name] = report;
           next();
         })
       );

--- a/app/sync/fix/index.js
+++ b/app/sync/fix/index.js
@@ -6,10 +6,16 @@ const tagGhosts = require("./tag-ghosts");
 const entriesPathIndex = require("./entries-path-index");
 const async = require("async");
 const callOnce = require("helper/callOnce");
+const messenger = require("../messenger");
 
-module.exports = function (blog, callback) {
+module.exports = function (blog, options, callback) {
   if (!blog) {
     throw new TypeError("Fix: Expected blog as first argument");
+  }
+
+  if (typeof options === "function") {
+    callback = options;
+    options = {};
   }
 
   if (typeof callback !== "function") {
@@ -17,10 +23,22 @@ module.exports = function (blog, callback) {
   }
 
   const finalReport = {};
+  const fallbackMessenger = options.status ? null : messenger(blog);
+  const status = options.status || fallbackMessenger.status;
+  const checks = [
+    entryGhosts,
+    tagGhosts,
+    listGhosts,
+    menuGhosts,
+    entriesPathIndex,
+  ];
+  let current = 0;
 
   async.eachSeries(
-    [entryGhosts, tagGhosts, listGhosts, menuGhosts, entriesPathIndex],
+    checks,
     function (fn, next) {
+      current += 1;
+      status(`(${current}/${checks.length}) Checking ${fn.name}`);
       fn(
         blog,
         callOnce(function (err, report) {

--- a/app/sync/fix/index.js
+++ b/app/sync/fix/index.js
@@ -6,7 +6,6 @@ const tagGhosts = require("./tag-ghosts");
 const entriesPathIndex = require("./entries-path-index");
 const async = require("async");
 const callOnce = require("helper/callOnce");
-const messenger = require("../messenger");
 
 module.exports = function (blog, options, callback) {
   if (!blog) {
@@ -23,8 +22,13 @@ module.exports = function (blog, options, callback) {
   }
 
   const finalReport = {};
-  const fallbackMessenger = options.status ? null : messenger(blog);
-  const status = options.status || fallbackMessenger.status;
+  // Callers that don't pass a status (the legacy two-argument API used by
+  // startup/hourly validators) never published one before this progress
+  // work was added. Keep that silent instead of writing a real messenger's
+  // status to Blog.setStatus - a "(n/5) Checking ..." message with no
+  // terminal follow-up would otherwise leave the dashboard showing that
+  // blog as syncing forever.
+  const status = options.status || function () {};
   const checks = [
     { name: "entry-ghosts", fn: entryGhosts },
     { name: "tag-ghosts", fn: tagGhosts },

--- a/app/sync/rebuild.js
+++ b/app/sync/rebuild.js
@@ -50,8 +50,14 @@ module.exports = function main(blogID, options, callback) {
   Blog.get({ id: blogID }, function (err, blog) {
     if (err || !blog) return callback(err || new Error("No blog"));
 
-    const { log, status } = messenger(blog);
-    const update = new Update(blog, log, status);
+    const fallbackMessenger =
+      options.log && options.status ? null : messenger(blog);
+    const log = options.log || fallbackMessenger.log;
+    const status = options.status || fallbackMessenger.status;
+    // Update's ordinary "Syncing" statuses would split the progress stream.
+    // Rebuild publishes the more specific, counted status below instead.
+    const updateStatus = function () {};
+    const update = new Update(blog, log, updateStatus);
 
     let blogDirectory = localPath(blog.id, "/");
 
@@ -81,26 +87,37 @@ module.exports = function main(blogID, options, callback) {
       // Files inside a + folder all rebuild the same aggregated entry.
       // Process each multi-folder once so a 50-file album is not built
       // 50 separate times during a full rebuild.
-      const seenMultiFolders = new Set();
       const updatePaths = [];
+      const updatePathCounts = new Map();
 
       paths.forEach(function (absPath) {
         var path = absPath.slice(blogDirectory.length);
         var multiInfo = build.findMultiFolder(path);
 
         if (multiInfo) {
-          if (seenMultiFolders.has(multiInfo.folderPath)) return;
-          seenMultiFolders.add(multiInfo.folderPath);
-          updatePaths.push(multiInfo.folderPath);
+          if (!updatePathCounts.has(multiInfo.folderPath)) {
+            updatePaths.push(multiInfo.folderPath);
+            updatePathCounts.set(multiInfo.folderPath, 0);
+          }
+          updatePathCounts.set(
+            multiInfo.folderPath,
+            updatePathCounts.get(multiInfo.folderPath) + 1
+          );
           return;
         }
 
         updatePaths.push(path);
+        updatePathCounts.set(path, 1);
       });
+
+      const total = paths.length;
+      let current = 0;
 
       async.eachSeries(
         updatePaths,
         function (path, next) {
+          current += updatePathCounts.get(path);
+          status(`(${current}/${total}) Rebuilding ${path}`);
           update(path, function () {
             // todo: don't swallow error here
             next();


### PR DESCRIPTION
### Motivation

- Surface live `(current/total)` progress on the dashboard reset UI by ensuring reset tools emit progress-prefixed status messages.
- Reuse the active Sync lock messenger for dashboard-triggered resets to keep a single coherent status stream across Rebuild → Resync → Fix. 
- Use raw local-walk counts as the progress `total` for rebuild/resync operations and allow increasing `total` when remote-only work is discovered. 
- Emit progress for Fix phases so the post-reset checks also show incremental progress.

### Description

- Added `app/clients/util/resyncProgress.js` exposing `countLocalFiles(directory)` and `createProgress(total, publish)` which increment totals when newly discovered work is published. 
- Wired the dashboard routes in `app/dashboard/site/client.js` to pass the active Sync messenger (`folder.status` / `folder.log`) into `Rebuild` and `Fix` so dashboard resets share one status stream. 
- Rebuild: updated `app/sync/rebuild.js` to accept optional `status`/`log` messengers, suppress `Update`’s default `Syncing` statuses during a dashboard run, and publish counted `Rebuilding /path` messages using the raw walk length and weighted multi-folder counts so progress completes at `total/total`. 
- Fix: updated `app/sync/fix/index.js` to accept an `options` messenger and publish `(current/total)` style `Checking …` messages for each fix phase while preserving the original fallback API. 
- Resyncs: instrumented Dropbox (`app/clients/dropbox/sync/reset-to-blot.js`), Google Drive (`app/clients/google-drive/sync/sync.js`) and iCloud (`app/clients/icloud/sync/fromiCloud.js`) flows to use the new progress helper, count local files for the initial `total`, increase `total` when remote-only items are discovered, and publish progress for downloads/removals/skips/checks. 
- Added an idempotent `processed` set and `publishProgress` helpers so duplicate status messages aren’t published. 
- Tests: added `app/clients/util/tests/resyncProgress.js` to validate recursive counting and dynamic total increments, and adjusted iCloud tests to assert progress-formatted messages when oversized files are handled. 

### Testing

- Syntax/type checks: ran `node --check` on modified modules (`app/dashboard/site/client.js`, `app/sync/rebuild.js`, `app/sync/fix/index.js`, `app/clients/dropbox/sync/reset-to-blot.js`, `app/clients/google-drive/sync/sync.js`, `app/clients/icloud/sync/fromiCloud.js`, `app/clients/util/resyncProgress.js`) and they passed. 
- Lint/sanity: ran `git diff --check` and addressed issues reported. 
- Unit tests: ran `NODE_PATH=app npx jasmine app/clients/util/tests/resyncProgress.js` and `NODE_PATH=app npx jasmine --helper=/tmp/blot-jasmine-helper.js app/clients/icloud/sync/tests/fromiCloud.js`; both suites ran and the specs in these files passed. 
- Full CI limitation: attempted containerized test invocation with `./scripts/tests/invoke.sh` but the repository Docker runner could not run in this environment (`docker: command not found`), so the complete integration suite was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa3d0ab4df083298ab6a92c4cdcfa28)