### PR TITLE
Fix "Page 1 of 0" pagination display with no entries

### DIFF
--- a/app/blog/render/retrieve/helpers/fetchTaggedEntries.js
+++ b/app/blog/render/retrieve/helpers/fetchTaggedEntries.js
@@ -6,7 +6,7 @@ const {
 const { sortEntryIDs, isNewestFirst } = require("blog/sortOptions");
 
 function buildPagination(current, pageSize, totalEntries) {
-  const total = pageSize > 0 ? Math.ceil(totalEntries / pageSize) : 0;
+  const total = pageSize > 0 ? Math.max(1, Math.ceil(totalEntries / pageSize)) : 0;
   const previous = current > 1 ? current - 1 : null;
   const next = total > 0 && current < total ? current + 1 : null;
   return {

--- a/app/blog/render/retrieve/helpers/tests/fetchTaggedEntries.js
+++ b/app/blog/render/retrieve/helpers/tests/fetchTaggedEntries.js
@@ -73,4 +73,12 @@ describe("fetchTaggedEntries sort ordering", function () {
     const result = await run({ limit: 1, offset: 1, sortBy: "id", order: "asc" });
     expect(result.entryIDs).toEqual(["b.txt"]);
   });
+
+  it("reports pagination.total as 1 (not 0) when the tag has no entries", async function () {
+    stubTag([]);
+    const result = await run({ limit: 10, offset: 0 });
+    expect(result.entryIDs).toEqual([]);
+    expect(result.pagination.current).toBe(1);
+    expect(result.pagination.total).toBe(1);
+  });
 });

--- a/app/models/entries/index.js
+++ b/app/models/entries/index.js
@@ -742,7 +742,7 @@ module.exports = (function () {
 
       totalEntries = parseInt(totalEntries);
 
-      pagination.total = Math.ceil(totalEntries / pageSize);
+      pagination.total = Math.max(1, Math.ceil(totalEntries / pageSize));
       pagination.current = pageNo;
       pagination.pageSize = pageSize;
       pagination.page_size = pageSize;

--- a/app/models/entries/tests.js
+++ b/app/models/entries/tests.js
@@ -530,6 +530,20 @@ describe("entries", function () {
     );
   });
 
+  it("getPage should report total as 1 (not 0) when the blog has no entries", function (done) {
+    Entries.getPage(
+      this.blog.id,
+      { pageNumber: 1, pageSize: 10, sortBy: "date" },
+      function (error, entries, pagination) {
+        expect(error).toBeNull();
+        expect(entries).toEqual([]);
+        expect(pagination.current).toBe(1);
+        expect(pagination.total).toBe(1);
+        done();
+      }
+    );
+  });
+
   it("getRecent should return the most recent entries with their indices", async function (done) {
     const key = `blog:${this.blog.id}:entries`;
 


### PR DESCRIPTION
## Summary
- Fixes the pagination block showing "Page 1 of 0" and "Page 1 of 0" style text when a blog/tag archive has zero posts, since `pagination.total` was computed as `Math.ceil(totalEntries / pageSize)`, which is `0` for an empty set while `pagination.current` stays `1`.
- Clamp `pagination.total` to a minimum of `1` in both places that compute it: [app/models/entries/index.js](app/models/entries/index.js) (used by `entries.html`/default pagination) and [app/blog/render/retrieve/helpers/fetchTaggedEntries.js](app/blog/render/retrieve/helpers/fetchTaggedEntries.js) (used by `tagged.html` pagination).
- This affects every template using `{{current}}`/`{{total}}` pagination vars (blog, magazine, portfolio, gallery, wireframe, keynote, organization, studio, fieldnotes, notebook, album, text, index, links), since they all share this backend logic — not a template-specific bug.

## Test plan
- [ ] CI test suite (per project convention, relying on GitHub Actions runners rather than local Docker tests)