### PR TITLE
Add tag-burst benchmark phase to catch render-queueing regressions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,6 +37,12 @@ on:
       iterations:
         description: "Iterations to run and aggregate"
         default: "3"
+      tags:
+        description: "Distinct tags generated per site"
+        default: ""
+      tag_burst_concurrency:
+        description: "Distinct /tagged/<slug> pages hit at once"
+        default: ""
 
 permissions:
   contents: read
@@ -165,6 +171,8 @@ jobs:
               -e GITHUB_SHA=${{ github.sha }} \
               -e SITES_ARG="${{ github.event.inputs.sites }}" \
               -e FILES_ARG="${{ github.event.inputs.files }}" \
+              -e TAGS_ARG="${{ github.event.inputs.tags }}" \
+              -e TAG_BURST_CONCURRENCY_ARG="${{ github.event.inputs.tag_burst_concurrency }}" \
               -v ${{ github.workspace }}/app:/usr/src/app/app \
               -v ${{ github.workspace }}/scripts:/usr/src/app/scripts \
               -v ${{ github.workspace }}/config:/usr/src/app/config \
@@ -175,6 +183,8 @@ jobs:
                 ARGS="--output /benchmarks/runs/run-'"$i"'.json"
                 [ -n "$SITES_ARG" ] && ARGS="$ARGS --sites $SITES_ARG"
                 [ -n "$FILES_ARG" ] && ARGS="$ARGS --files $FILES_ARG"
+                [ -n "$TAGS_ARG" ] && ARGS="$ARGS --tags $TAGS_ARG"
+                [ -n "$TAG_BURST_CONCURRENCY_ARG" ] && ARGS="$ARGS --tag-burst-concurrency $TAG_BURST_CONCURRENCY_ARG"
                 npm run benchmark:ci -- $ARGS
               '
             echo "::endgroup::"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -46,6 +46,18 @@ on:
       archives_burst_concurrency:
         description: "Concurrent /archives requests"
         default: ""
+      search_keywords:
+        description: "Distinct search keywords generated per site"
+        default: ""
+      search_burst_concurrency:
+        description: "Distinct /search?q= queries hit at once"
+        default: ""
+      backlinks_burst_concurrency:
+        description: "Concurrent hits to each site's hub entry"
+        default: ""
+      sitemap_burst_concurrency:
+        description: "Concurrent /sitemap.xml requests"
+        default: ""
 
 permissions:
   contents: read
@@ -177,6 +189,10 @@ jobs:
               -e TAGS_ARG="${{ github.event.inputs.tags }}" \
               -e TAG_BURST_CONCURRENCY_ARG="${{ github.event.inputs.tag_burst_concurrency }}" \
               -e ARCHIVES_BURST_CONCURRENCY_ARG="${{ github.event.inputs.archives_burst_concurrency }}" \
+              -e SEARCH_KEYWORDS_ARG="${{ github.event.inputs.search_keywords }}" \
+              -e SEARCH_BURST_CONCURRENCY_ARG="${{ github.event.inputs.search_burst_concurrency }}" \
+              -e BACKLINKS_BURST_CONCURRENCY_ARG="${{ github.event.inputs.backlinks_burst_concurrency }}" \
+              -e SITEMAP_BURST_CONCURRENCY_ARG="${{ github.event.inputs.sitemap_burst_concurrency }}" \
               -v ${{ github.workspace }}/app:/usr/src/app/app \
               -v ${{ github.workspace }}/scripts:/usr/src/app/scripts \
               -v ${{ github.workspace }}/config:/usr/src/app/config \
@@ -190,6 +206,10 @@ jobs:
                 [ -n "$TAGS_ARG" ] && ARGS="$ARGS --tags $TAGS_ARG"
                 [ -n "$TAG_BURST_CONCURRENCY_ARG" ] && ARGS="$ARGS --tag-burst-concurrency $TAG_BURST_CONCURRENCY_ARG"
                 [ -n "$ARCHIVES_BURST_CONCURRENCY_ARG" ] && ARGS="$ARGS --archives-burst-concurrency $ARCHIVES_BURST_CONCURRENCY_ARG"
+                [ -n "$SEARCH_KEYWORDS_ARG" ] && ARGS="$ARGS --search-keywords $SEARCH_KEYWORDS_ARG"
+                [ -n "$SEARCH_BURST_CONCURRENCY_ARG" ] && ARGS="$ARGS --search-burst-concurrency $SEARCH_BURST_CONCURRENCY_ARG"
+                [ -n "$BACKLINKS_BURST_CONCURRENCY_ARG" ] && ARGS="$ARGS --backlinks-burst-concurrency $BACKLINKS_BURST_CONCURRENCY_ARG"
+                [ -n "$SITEMAP_BURST_CONCURRENCY_ARG" ] && ARGS="$ARGS --sitemap-burst-concurrency $SITEMAP_BURST_CONCURRENCY_ARG"
                 npm run benchmark:ci -- $ARGS
               '
             echo "::endgroup::"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -43,6 +43,9 @@ on:
       tag_burst_concurrency:
         description: "Distinct /tagged/<slug> pages hit at once"
         default: ""
+      archives_burst_concurrency:
+        description: "Concurrent /archives requests"
+        default: ""
 
 permissions:
   contents: read
@@ -173,6 +176,7 @@ jobs:
               -e FILES_ARG="${{ github.event.inputs.files }}" \
               -e TAGS_ARG="${{ github.event.inputs.tags }}" \
               -e TAG_BURST_CONCURRENCY_ARG="${{ github.event.inputs.tag_burst_concurrency }}" \
+              -e ARCHIVES_BURST_CONCURRENCY_ARG="${{ github.event.inputs.archives_burst_concurrency }}" \
               -v ${{ github.workspace }}/app:/usr/src/app/app \
               -v ${{ github.workspace }}/scripts:/usr/src/app/scripts \
               -v ${{ github.workspace }}/config:/usr/src/app/config \
@@ -185,6 +189,7 @@ jobs:
                 [ -n "$FILES_ARG" ] && ARGS="$ARGS --files $FILES_ARG"
                 [ -n "$TAGS_ARG" ] && ARGS="$ARGS --tags $TAGS_ARG"
                 [ -n "$TAG_BURST_CONCURRENCY_ARG" ] && ARGS="$ARGS --tag-burst-concurrency $TAG_BURST_CONCURRENCY_ARG"
+                [ -n "$ARCHIVES_BURST_CONCURRENCY_ARG" ] && ARGS="$ARGS --archives-burst-concurrency $ARCHIVES_BURST_CONCURRENCY_ARG"
                 npm run benchmark:ci -- $ARGS
               '
             echo "::endgroup::"

--- a/app/blog/benchmarks/benchmarks.js
+++ b/app/blog/benchmarks/benchmarks.js
@@ -11,6 +11,9 @@ const { parseBenchmarkConfig } = require("./util/config");
 const { buildBenchmarkResult } = require("./util/result");
 const { runTagBurst } = require("./util/tagBurst");
 const { runArchivesBurst } = require("./util/archivesBurst");
+const { runSearchBurst } = require("./util/searchBurst");
+const { runSitemapBurst } = require("./util/sitemapBurst");
+const { runBacklinksBurst } = require("./util/backlinksBurst");
 
 describe("blog benchmarks", function () {
   require("./util/setup")();
@@ -184,6 +187,46 @@ describe("blog benchmarks", function () {
       getForBlog: this.getForBlog.bind(this),
     });
 
+    console.log(
+      "[benchmark] search burst:",
+      benchmarkConfig.searchBurstConcurrency,
+      "distinct search queries requested concurrently per site"
+    );
+
+    const searchBurst = await runSearchBurst({
+      blogs,
+      keywordsBySite: workload.searchKeywordsBySite,
+      concurrency: benchmarkConfig.searchBurstConcurrency,
+      getForBlog: this.getForBlog.bind(this),
+    });
+
+    console.log(
+      "[benchmark] sitemap burst:",
+      benchmarkConfig.sitemapBurstConcurrency,
+      "concurrent /sitemap.xml requests across",
+      blogs.length,
+      "site(s)"
+    );
+
+    const sitemapBurst = await runSitemapBurst({
+      blogs,
+      concurrency: benchmarkConfig.sitemapBurstConcurrency,
+      getForBlog: this.getForBlog.bind(this),
+    });
+
+    console.log(
+      "[benchmark] backlinks burst:",
+      benchmarkConfig.backlinksBurstConcurrency,
+      "concurrent requests to each site's hub entry"
+    );
+
+    const backlinksBurst = await runBacklinksBurst({
+      blogs,
+      hubPathBySite: workload.hubPathBySite,
+      concurrency: benchmarkConfig.backlinksBurstConcurrency,
+      getForBlog: this.getForBlog.bind(this),
+    });
+
     siteSummaries.forEach((summary, index) => {
       summary.rendered_pages = renderTasks.filter(
         (task) => task.blog.id === summary.blog_id
@@ -210,6 +253,9 @@ describe("blog benchmarks", function () {
       renderFailures,
       tagBurst,
       archivesBurst,
+      searchBurst,
+      sitemapBurst,
+      backlinksBurst,
     });
 
     global.__BLOT_BENCHMARK_RESULT = result;
@@ -260,34 +306,32 @@ describe("blog benchmarks", function () {
         " kb per page"
     );
     console.log("");
-    console.log(
-      label("Tag burst inflation") +
-        num(
-          result.render.tag_burst.inflation_ratio === null
-            ? "n/a"
-            : result.render.tag_burst.inflation_ratio.toFixed(2),
-          8
-        ) + "x"
-    );
-    console.log(
-      label("Tag burst p95") +
-        num(result.render.tag_burst.burst_timing_ms.p95.toFixed(0), 8) +
-        " ms"
-    );
-    console.log(
-      label("Archives burst inflation") +
-        num(
-          result.render.archives_burst.inflation_ratio === null
-            ? "n/a"
-            : result.render.archives_burst.inflation_ratio.toFixed(2),
-          8
-        ) + "x"
-    );
-    console.log(
-      label("Archives burst p95") +
-        num(result.render.archives_burst.burst_timing_ms.p95.toFixed(0), 8) +
-        " ms"
-    );
+
+    const bursts = [
+      ["Tag burst", result.render.tag_burst],
+      ["Archives burst", result.render.archives_burst],
+      ["Search burst", result.render.search_burst],
+      ["Sitemap burst", result.render.sitemap_burst],
+      ["Backlinks burst", result.render.backlinks_burst],
+    ];
+
+    for (const [burstLabel, burst] of bursts) {
+      console.log(
+        label(`${burstLabel} inflation`) +
+          num(
+            burst.inflation_ratio === null
+              ? "n/a"
+              : burst.inflation_ratio.toFixed(2),
+            8
+          ) + "x"
+      );
+      console.log(
+        label(`${burstLabel} p95`) +
+          num(burst.burst_timing_ms.p95.toFixed(0), 8) +
+          " ms"
+      );
+    }
+
     console.log("");
   });
 });

--- a/app/blog/benchmarks/benchmarks.js
+++ b/app/blog/benchmarks/benchmarks.js
@@ -9,6 +9,7 @@ const { expandSitemapUrls } = require("./util/sitemap");
 const { runWithConcurrency } = require("./util/concurrency");
 const { parseBenchmarkConfig } = require("./util/config");
 const { buildBenchmarkResult } = require("./util/result");
+const { runTagBurst } = require("./util/tagBurst");
 
 describe("blog benchmarks", function () {
   require("./util/setup")();
@@ -155,6 +156,19 @@ describe("blog benchmarks", function () {
     const renderPhaseMetrics = renderPhaseMonitor.stop();
     const renderTiming = summarizeDurations(renderDurations);
 
+    console.log(
+      "[benchmark] tag burst:",
+      benchmarkConfig.tagBurstConcurrency,
+      "distinct tag pages requested concurrently per site"
+    );
+
+    const tagBurst = await runTagBurst({
+      blogs,
+      tagsBySite: workload.tagsBySite,
+      concurrency: benchmarkConfig.tagBurstConcurrency,
+      getForBlog: this.getForBlog.bind(this),
+    });
+
     siteSummaries.forEach((summary, index) => {
       summary.rendered_pages = renderTasks.filter(
         (task) => task.blog.id === summary.blog_id
@@ -179,6 +193,7 @@ describe("blog benchmarks", function () {
       siteSummaries,
       renderTasks,
       renderFailures,
+      tagBurst,
     });
 
     global.__BLOT_BENCHMARK_RESULT = result;
@@ -227,6 +242,21 @@ describe("blog benchmarks", function () {
       label("Mean output size") +
         num((result.render.bytes.mean_per_page / 1024).toFixed(1), 8) +
         " kb per page"
+    );
+    console.log("");
+    console.log(
+      label("Tag burst inflation") +
+        num(
+          result.render.tag_burst.inflation_ratio === null
+            ? "n/a"
+            : result.render.tag_burst.inflation_ratio.toFixed(2),
+          8
+        ) + "x"
+    );
+    console.log(
+      label("Tag burst p95") +
+        num(result.render.tag_burst.burst_timing_ms.p95.toFixed(0), 8) +
+        " ms"
     );
     console.log("");
   });

--- a/app/blog/benchmarks/benchmarks.js
+++ b/app/blog/benchmarks/benchmarks.js
@@ -10,6 +10,7 @@ const { runWithConcurrency } = require("./util/concurrency");
 const { parseBenchmarkConfig } = require("./util/config");
 const { buildBenchmarkResult } = require("./util/result");
 const { runTagBurst } = require("./util/tagBurst");
+const { runArchivesBurst } = require("./util/archivesBurst");
 
 describe("blog benchmarks", function () {
   require("./util/setup")();
@@ -169,6 +170,20 @@ describe("blog benchmarks", function () {
       getForBlog: this.getForBlog.bind(this),
     });
 
+    console.log(
+      "[benchmark] archives burst:",
+      benchmarkConfig.archivesBurstConcurrency,
+      "concurrent /archives requests across",
+      blogs.length,
+      "site(s)"
+    );
+
+    const archivesBurst = await runArchivesBurst({
+      blogs,
+      concurrency: benchmarkConfig.archivesBurstConcurrency,
+      getForBlog: this.getForBlog.bind(this),
+    });
+
     siteSummaries.forEach((summary, index) => {
       summary.rendered_pages = renderTasks.filter(
         (task) => task.blog.id === summary.blog_id
@@ -194,6 +209,7 @@ describe("blog benchmarks", function () {
       renderTasks,
       renderFailures,
       tagBurst,
+      archivesBurst,
     });
 
     global.__BLOT_BENCHMARK_RESULT = result;
@@ -256,6 +272,20 @@ describe("blog benchmarks", function () {
     console.log(
       label("Tag burst p95") +
         num(result.render.tag_burst.burst_timing_ms.p95.toFixed(0), 8) +
+        " ms"
+    );
+    console.log(
+      label("Archives burst inflation") +
+        num(
+          result.render.archives_burst.inflation_ratio === null
+            ? "n/a"
+            : result.render.archives_burst.inflation_ratio.toFixed(2),
+          8
+        ) + "x"
+    );
+    console.log(
+      label("Archives burst p95") +
+        num(result.render.archives_burst.burst_timing_ms.p95.toFixed(0), 8) +
         " ms"
     );
     console.log("");

--- a/app/blog/benchmarks/util/archivesBurst.js
+++ b/app/blog/benchmarks/util/archivesBurst.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const { performance } = require("perf_hooks");
+const { summarizeDurations } = require("./metrics");
+
+/**
+ * Each blog has exactly one /archives URL, so "bursting" it can't mean many
+ * distinct URLs the way the tag burst does. Instead this reproduces the same
+ * request-queueing failure mode from the other direction: many customer
+ * blogs sharing one Node process land on their (each equally expensive,
+ * uncached) /archives page at the same moment. When there are fewer blogs
+ * than the requested concurrency, blogs repeat round-robin, so this also
+ * covers the "many tabs hit one big blog's /archives at once" case with
+ * `--sites 1`.
+ *
+ * Like archives.js itself, this pulls the full entry set via
+ * Entries.getAll and does a synchronous year/month grouping pass with
+ * per-entry moment.tz formatting on every request (see
+ * app/blog/render/retrieve/archives.js) - no caching, so concurrent hits
+ * should queue behind each other's synchronous work exactly like the tag
+ * burst does.
+ */
+async function runArchivesBurst({ blogs, concurrency, getForBlog }) {
+  if (!blogs.length) {
+    const empty = summarizeDurations([]);
+    return {
+      requests_tested_total: 0,
+      solo_timing_ms: empty,
+      burst_timing_ms: empty,
+      inflation_ratio: null,
+    };
+  }
+
+  const targets = [];
+  for (let i = 0; i < concurrency; i++) {
+    targets.push(blogs[i % blogs.length]);
+  }
+
+  // Uncontended baseline: one at a time, sequentially.
+  const soloDurations = [];
+  for (const blog of targets) {
+    const startedAt = performance.now();
+    await getForBlog(blog, "/archives", { redirect: "manual" });
+    soloDurations.push(performance.now() - startedAt);
+  }
+
+  // Genuine concurrent burst: every target blog's /archives at once.
+  const burstDurations = await Promise.all(
+    targets.map(async (blog) => {
+      const startedAt = performance.now();
+      await getForBlog(blog, "/archives", { redirect: "manual" });
+      return performance.now() - startedAt;
+    })
+  );
+
+  const soloTiming = summarizeDurations(soloDurations);
+  const burstTiming = summarizeDurations(burstDurations);
+
+  return {
+    requests_tested_total: targets.length,
+    solo_timing_ms: soloTiming,
+    burst_timing_ms: burstTiming,
+    inflation_ratio:
+      soloTiming.mean > 0 ? burstTiming.mean / soloTiming.mean : null,
+  };
+}
+
+module.exports = { runArchivesBurst };

--- a/app/blog/benchmarks/util/archivesBurst.js
+++ b/app/blog/benchmarks/util/archivesBurst.js
@@ -2,6 +2,7 @@
 
 const { performance } = require("perf_hooks");
 const { summarizeDurations } = require("./metrics");
+const { timedRequest } = require("./burstRequest");
 
 /**
  * Each blog has exactly one /archives URL, so "bursting" it can't mean many
@@ -40,7 +41,7 @@ async function runArchivesBurst({ blogs, concurrency, getForBlog }) {
   const soloDurations = [];
   for (const blog of targets) {
     const startedAt = performance.now();
-    await getForBlog(blog, "/archives", { redirect: "manual" });
+    await timedRequest(getForBlog, blog, "/archives");
     soloDurations.push(performance.now() - startedAt);
   }
 
@@ -48,7 +49,7 @@ async function runArchivesBurst({ blogs, concurrency, getForBlog }) {
   const burstDurations = await Promise.all(
     targets.map(async (blog) => {
       const startedAt = performance.now();
-      await getForBlog(blog, "/archives", { redirect: "manual" });
+      await timedRequest(getForBlog, blog, "/archives");
       return performance.now() - startedAt;
     })
   );

--- a/app/blog/benchmarks/util/backlinksBurst.js
+++ b/app/blog/benchmarks/util/backlinksBurst.js
@@ -2,6 +2,7 @@
 
 const { performance } = require("perf_hooks");
 const { summarizeDurations } = require("./metrics");
+const { timedRequest } = require("./burstRequest");
 
 /**
  * Each blog's workload includes one "hub" entry that a fraction of its other
@@ -35,14 +36,14 @@ async function runBacklinksBurst({ blogs, hubPathBySite, concurrency, getForBlog
   const soloDurations = [];
   for (const { blog, hubPath } of targets) {
     const startedAt = performance.now();
-    await getForBlog(blog, hubPath, { redirect: "manual" });
+    await timedRequest(getForBlog, blog, hubPath);
     soloDurations.push(performance.now() - startedAt);
   }
 
   const burstDurations = await Promise.all(
     targets.map(async ({ blog, hubPath }) => {
       const startedAt = performance.now();
-      await getForBlog(blog, hubPath, { redirect: "manual" });
+      await timedRequest(getForBlog, blog, hubPath);
       return performance.now() - startedAt;
     })
   );

--- a/app/blog/benchmarks/util/backlinksBurst.js
+++ b/app/blog/benchmarks/util/backlinksBurst.js
@@ -1,0 +1,62 @@
+"use strict";
+
+const { performance } = require("perf_hooks");
+const { summarizeDurations } = require("./metrics");
+
+/**
+ * Each blog's workload includes one "hub" entry that a fraction of its other
+ * entries link to (see hubPathBySite in workload.js), so it accumulates a
+ * realistic backlinks list. Rendering an entry runs augment.js, which does
+ * an async.map over entry.backlinks, issuing one Entry.getByUrl Redis
+ * round trip per backlink - so rendering a heavily-backlinked entry fans out
+ * into N lookups every time, uncached. This fires concurrent requests at
+ * each blog's hub entry (repeating blogs round-robin when there are fewer
+ * sites than the requested concurrency, like the archives/sitemap bursts)
+ * to see whether that per-render fan-out serializes under concurrent load.
+ */
+async function runBacklinksBurst({ blogs, hubPathBySite, concurrency, getForBlog }) {
+  const targets = [];
+  for (let i = 0; i < concurrency && blogs.length; i++) {
+    const blogIndex = i % blogs.length;
+    const hubPath = hubPathBySite[blogIndex];
+    if (hubPath) targets.push({ blog: blogs[blogIndex], hubPath });
+  }
+
+  if (!targets.length) {
+    const empty = summarizeDurations([]);
+    return {
+      requests_tested_total: 0,
+      solo_timing_ms: empty,
+      burst_timing_ms: empty,
+      inflation_ratio: null,
+    };
+  }
+
+  const soloDurations = [];
+  for (const { blog, hubPath } of targets) {
+    const startedAt = performance.now();
+    await getForBlog(blog, hubPath, { redirect: "manual" });
+    soloDurations.push(performance.now() - startedAt);
+  }
+
+  const burstDurations = await Promise.all(
+    targets.map(async ({ blog, hubPath }) => {
+      const startedAt = performance.now();
+      await getForBlog(blog, hubPath, { redirect: "manual" });
+      return performance.now() - startedAt;
+    })
+  );
+
+  const soloTiming = summarizeDurations(soloDurations);
+  const burstTiming = summarizeDurations(burstDurations);
+
+  return {
+    requests_tested_total: targets.length,
+    solo_timing_ms: soloTiming,
+    burst_timing_ms: burstTiming,
+    inflation_ratio:
+      soloTiming.mean > 0 ? burstTiming.mean / soloTiming.mean : null,
+  };
+}
+
+module.exports = { runBacklinksBurst };

--- a/app/blog/benchmarks/util/burstRequest.js
+++ b/app/blog/benchmarks/util/burstRequest.js
@@ -1,0 +1,24 @@
+"use strict";
+
+/**
+ * Fetch does not reject on a 4xx/5xx response, so every burst phase must
+ * check the status itself - otherwise a routing or rendering failure specific
+ * to that phase's URLs can make it look *faster* (an error page renders
+ * quicker than the real one) while still producing a passing benchmark.
+ * Also consumes the response body so an unread stream doesn't tie up a
+ * connection across the dozens of requests each burst phase fires.
+ */
+async function timedRequest(getForBlog, blog, url) {
+  const res = await getForBlog(blog, url, { redirect: "manual" });
+  await res.arrayBuffer();
+
+  if (res.status >= 400) {
+    throw new Error(
+      `Burst request to ${url} on ${blog.handle} failed: status=${res.status}`
+    );
+  }
+
+  return res;
+}
+
+module.exports = { timedRequest };

--- a/app/blog/benchmarks/util/config.js
+++ b/app/blog/benchmarks/util/config.js
@@ -38,6 +38,10 @@ function parseBenchmarkConfig(raw = {}) {
       raw.tagBurstConcurrency,
       BENCHMARK_DEFAULTS.tagBurstConcurrency
     ),
+    archivesBurstConcurrency: num(
+      raw.archivesBurstConcurrency,
+      BENCHMARK_DEFAULTS.archivesBurstConcurrency
+    ),
   };
 }
 

--- a/app/blog/benchmarks/util/config.js
+++ b/app/blog/benchmarks/util/config.js
@@ -33,6 +33,11 @@ function parseBenchmarkConfig(raw = {}) {
       raw.requestsPerPage,
       BENCHMARK_DEFAULTS.requestsPerPage
     ),
+    tags: num(raw.tags, BENCHMARK_DEFAULTS.tags),
+    tagBurstConcurrency: num(
+      raw.tagBurstConcurrency,
+      BENCHMARK_DEFAULTS.tagBurstConcurrency
+    ),
   };
 }
 

--- a/app/blog/benchmarks/util/config.js
+++ b/app/blog/benchmarks/util/config.js
@@ -42,6 +42,19 @@ function parseBenchmarkConfig(raw = {}) {
       raw.archivesBurstConcurrency,
       BENCHMARK_DEFAULTS.archivesBurstConcurrency
     ),
+    searchKeywords: num(raw.searchKeywords, BENCHMARK_DEFAULTS.searchKeywords),
+    searchBurstConcurrency: num(
+      raw.searchBurstConcurrency,
+      BENCHMARK_DEFAULTS.searchBurstConcurrency
+    ),
+    backlinksBurstConcurrency: num(
+      raw.backlinksBurstConcurrency,
+      BENCHMARK_DEFAULTS.backlinksBurstConcurrency
+    ),
+    sitemapBurstConcurrency: num(
+      raw.sitemapBurstConcurrency,
+      BENCHMARK_DEFAULTS.sitemapBurstConcurrency
+    ),
   };
 }
 

--- a/app/blog/benchmarks/util/defaults.js
+++ b/app/blog/benchmarks/util/defaults.js
@@ -22,6 +22,15 @@ const BENCHMARK_DEFAULTS = Object.freeze({
   cpuSampleIntervalMs: 250,
   // Requests issued per sitemap URL per blog during the render phase.
   requestsPerPage: 1,
+  // Number of distinct tags generated across each blog's entries. Modelled on
+  // a real customer blog (~800 entries / ~40 tags) that suffered severe
+  // event-loop-blocking slowdowns when several distinct /tagged/<slug> pages
+  // were requested at the same time.
+  tags: 40,
+  // How many distinct /tagged/<slug> pages are requested in one genuinely
+  // concurrent burst (Promise.all, not the pooled render-phase queue) during
+  // the tag-burst phase, to catch request-queueing regressions.
+  tagBurstConcurrency: 8,
   // CI gate / trend-alert threshold, in percent, applied to timing metrics.
   regressionThresholdPercent: 15,
   // Tight threshold for near-deterministic metrics (output byte size).
@@ -32,6 +41,13 @@ const BENCHMARK_DEFAULTS = Object.freeze({
   baselineWindow: 20,
   // Consecutive master commits that must all regress before an issue opens.
   regressionConsecutive: 3,
+  // Bump this whenever a change meaningfully redefines what a tracked metric
+  // means (new/removed metric, changed workload shape that shifts totals,
+  // etc). Records written under an older version are kept in history for
+  // reference but excluded from the rolling baseline, so the next master run
+  // starts a fresh baseline automatically instead of requiring someone to
+  // manually clear the benchmarks-history-* Actions cache.
+  historySchemaVersion: 2,
 });
 
 module.exports = { BENCHMARK_DEFAULTS };

--- a/app/blog/benchmarks/util/defaults.js
+++ b/app/blog/benchmarks/util/defaults.js
@@ -37,6 +37,27 @@ const BENCHMARK_DEFAULTS = Object.freeze({
   // (many customers' blogs sharing one Node process) as well as many tabs
   // hitting one big blog's /archives at once.
   archivesBurstConcurrency: 8,
+  // Number of distinct search keywords spliced into ~35% of each blog's
+  // entries, so full-text search (Entry.search, which scans candidates and
+  // synchronously matches against each entry's full HTML per chunk) has
+  // realistic, guaranteed-to-match terms to search for.
+  searchKeywords: 15,
+  // How many distinct /search?q=<keyword> pages are requested in one
+  // genuinely concurrent burst, to catch regressions in Entry.search's
+  // per-request, uncached full-text scan.
+  searchBurstConcurrency: 8,
+  // How many requests to a blog's single "hub" entry (linked to by ~25% of
+  // its other entries, so it accumulates a realistic backlinks list) are
+  // fired in one genuinely concurrent burst. Exercises augment.js's
+  // per-backlink Entry.getByUrl fan-out (N Redis round trips per render)
+  // under concurrent contention; blogs repeat round-robin when there are
+  // fewer sites than this.
+  backlinksBurstConcurrency: 8,
+  // How many concurrent /sitemap.xml requests are fired across blogs (same
+  // round-robin repeat rule as the archives burst). sitemap.xml iterates
+  // {{#all_entries}} just like archives.js, but crawlers can and do fetch
+  // several blogs' sitemaps around the same time.
+  sitemapBurstConcurrency: 8,
   // CI gate / trend-alert threshold, in percent, applied to timing metrics.
   regressionThresholdPercent: 15,
   // Tight threshold for near-deterministic metrics (output byte size).
@@ -53,7 +74,7 @@ const BENCHMARK_DEFAULTS = Object.freeze({
   // reference but excluded from the rolling baseline, so the next master run
   // starts a fresh baseline automatically instead of requiring someone to
   // manually clear the benchmarks-history-* Actions cache.
-  historySchemaVersion: 3,
+  historySchemaVersion: 4,
 });
 
 module.exports = { BENCHMARK_DEFAULTS };

--- a/app/blog/benchmarks/util/defaults.js
+++ b/app/blog/benchmarks/util/defaults.js
@@ -31,6 +31,12 @@ const BENCHMARK_DEFAULTS = Object.freeze({
   // concurrent burst (Promise.all, not the pooled render-phase queue) during
   // the tag-burst phase, to catch request-queueing regressions.
   tagBurstConcurrency: 8,
+  // How many /archives requests are fired in one genuinely concurrent burst.
+  // Each blog has only one archives URL, so blogs repeat round-robin when
+  // there are fewer sites than this — this reproduces cross-blog contention
+  // (many customers' blogs sharing one Node process) as well as many tabs
+  // hitting one big blog's /archives at once.
+  archivesBurstConcurrency: 8,
   // CI gate / trend-alert threshold, in percent, applied to timing metrics.
   regressionThresholdPercent: 15,
   // Tight threshold for near-deterministic metrics (output byte size).
@@ -47,7 +53,7 @@ const BENCHMARK_DEFAULTS = Object.freeze({
   // reference but excluded from the rolling baseline, so the next master run
   // starts a fresh baseline automatically instead of requiring someone to
   // manually clear the benchmarks-history-* Actions cache.
-  historySchemaVersion: 2,
+  historySchemaVersion: 3,
 });
 
 module.exports = { BENCHMARK_DEFAULTS };

--- a/app/blog/benchmarks/util/result.js
+++ b/app/blog/benchmarks/util/result.js
@@ -13,6 +13,9 @@ function buildBenchmarkResult(options) {
     renderFailures,
     tagBurst,
     archivesBurst,
+    searchBurst,
+    sitemapBurst,
+    backlinksBurst,
   } = options;
 
   const renderedPages = renderTasks.length;
@@ -31,6 +34,10 @@ function buildBenchmarkResult(options) {
       tags: benchmarkConfig.tags,
       tag_burst_concurrency: benchmarkConfig.tagBurstConcurrency,
       archives_burst_concurrency: benchmarkConfig.archivesBurstConcurrency,
+      search_keywords: benchmarkConfig.searchKeywords,
+      search_burst_concurrency: benchmarkConfig.searchBurstConcurrency,
+      sitemap_burst_concurrency: benchmarkConfig.sitemapBurstConcurrency,
+      backlinks_burst_concurrency: benchmarkConfig.backlinksBurstConcurrency,
       regression_threshold_percent: benchmarkConfig.regressionThresholdPercent,
       cpu_sample_interval_ms: benchmarkConfig.cpuSampleIntervalMs,
     },
@@ -85,6 +92,25 @@ function buildBenchmarkResult(options) {
         solo_timing_ms: archivesBurst.solo_timing_ms,
         burst_timing_ms: archivesBurst.burst_timing_ms,
         inflation_ratio: archivesBurst.inflation_ratio,
+      },
+      search_burst: {
+        keywords_tested_total: searchBurst.keywords_tested_total,
+        solo_timing_ms: searchBurst.solo_timing_ms,
+        burst_timing_ms: searchBurst.burst_timing_ms,
+        inflation_ratio: searchBurst.inflation_ratio,
+        sites: searchBurst.sites,
+      },
+      sitemap_burst: {
+        requests_tested_total: sitemapBurst.requests_tested_total,
+        solo_timing_ms: sitemapBurst.solo_timing_ms,
+        burst_timing_ms: sitemapBurst.burst_timing_ms,
+        inflation_ratio: sitemapBurst.inflation_ratio,
+      },
+      backlinks_burst: {
+        requests_tested_total: backlinksBurst.requests_tested_total,
+        solo_timing_ms: backlinksBurst.solo_timing_ms,
+        burst_timing_ms: backlinksBurst.burst_timing_ms,
+        inflation_ratio: backlinksBurst.inflation_ratio,
       },
     },
     sites: siteSummaries,

--- a/app/blog/benchmarks/util/result.js
+++ b/app/blog/benchmarks/util/result.js
@@ -11,6 +11,7 @@ function buildBenchmarkResult(options) {
     siteSummaries,
     renderTasks,
     renderFailures,
+    tagBurst,
   } = options;
 
   const renderedPages = renderTasks.length;
@@ -26,6 +27,8 @@ function buildBenchmarkResult(options) {
       seed: benchmarkConfig.seed,
       render_concurrency: benchmarkConfig.renderConcurrency,
       requests_per_page: benchmarkConfig.requestsPerPage,
+      tags: benchmarkConfig.tags,
+      tag_burst_concurrency: benchmarkConfig.tagBurstConcurrency,
       regression_threshold_percent: benchmarkConfig.regressionThresholdPercent,
       cpu_sample_interval_ms: benchmarkConfig.cpuSampleIntervalMs,
     },
@@ -63,6 +66,17 @@ function buildBenchmarkResult(options) {
         total: renderBytesTotal || 0,
         mean_per_page:
           renderedPages > 0 ? (renderBytesTotal || 0) / renderedPages : 0,
+      },
+      tag_burst: {
+        tags_tested_total: tagBurst.tags_tested_total,
+        // Uncontended, one-at-a-time baseline for the same tag pages.
+        solo_timing_ms: tagBurst.solo_timing_ms,
+        // Same pages requested all at once (Promise.all). A healthy render
+        // path keeps this close to the solo timing; queueing behind
+        // synchronous, uncached per-request work blows it up.
+        burst_timing_ms: tagBurst.burst_timing_ms,
+        inflation_ratio: tagBurst.inflation_ratio,
+        sites: tagBurst.sites,
       },
     },
     sites: siteSummaries,

--- a/app/blog/benchmarks/util/result.js
+++ b/app/blog/benchmarks/util/result.js
@@ -12,6 +12,7 @@ function buildBenchmarkResult(options) {
     renderTasks,
     renderFailures,
     tagBurst,
+    archivesBurst,
   } = options;
 
   const renderedPages = renderTasks.length;
@@ -29,6 +30,7 @@ function buildBenchmarkResult(options) {
       requests_per_page: benchmarkConfig.requestsPerPage,
       tags: benchmarkConfig.tags,
       tag_burst_concurrency: benchmarkConfig.tagBurstConcurrency,
+      archives_burst_concurrency: benchmarkConfig.archivesBurstConcurrency,
       regression_threshold_percent: benchmarkConfig.regressionThresholdPercent,
       cpu_sample_interval_ms: benchmarkConfig.cpuSampleIntervalMs,
     },
@@ -77,6 +79,12 @@ function buildBenchmarkResult(options) {
         burst_timing_ms: tagBurst.burst_timing_ms,
         inflation_ratio: tagBurst.inflation_ratio,
         sites: tagBurst.sites,
+      },
+      archives_burst: {
+        requests_tested_total: archivesBurst.requests_tested_total,
+        solo_timing_ms: archivesBurst.solo_timing_ms,
+        burst_timing_ms: archivesBurst.burst_timing_ms,
+        inflation_ratio: archivesBurst.inflation_ratio,
       },
     },
     sites: siteSummaries,

--- a/app/blog/benchmarks/util/searchBurst.js
+++ b/app/blog/benchmarks/util/searchBurst.js
@@ -2,6 +2,7 @@
 
 const { performance } = require("perf_hooks");
 const { summarizeDurations } = require("./metrics");
+const { timedRequest } = require("./burstRequest");
 
 /**
  * Same solo-vs-burst pattern as tagBurst.js, aimed at Entry.search
@@ -41,7 +42,7 @@ async function runSearchBurst({ blogs, keywordsBySite, concurrency, getForBlog }
     const soloForSite = [];
     for (const url of urls) {
       const startedAt = performance.now();
-      await getForBlog(blog, url, { redirect: "manual" });
+      await timedRequest(getForBlog, blog, url);
       const elapsedMs = performance.now() - startedAt;
       soloForSite.push(elapsedMs);
       soloDurations.push(elapsedMs);
@@ -51,7 +52,7 @@ async function runSearchBurst({ blogs, keywordsBySite, concurrency, getForBlog }
     const burstForSite = await Promise.all(
       urls.map(async (url) => {
         const startedAt = performance.now();
-        await getForBlog(blog, url, { redirect: "manual" });
+        await timedRequest(getForBlog, blog, url);
         return performance.now() - startedAt;
       })
     );

--- a/app/blog/benchmarks/util/searchBurst.js
+++ b/app/blog/benchmarks/util/searchBurst.js
@@ -1,0 +1,89 @@
+"use strict";
+
+const { performance } = require("perf_hooks");
+const { summarizeDurations } = require("./metrics");
+
+/**
+ * Same solo-vs-burst pattern as tagBurst.js, aimed at Entry.search
+ * (app/models/entry/search.js): for each blog, pick up to `concurrency`
+ * distinct search keywords (guaranteed to be present in some entries - see
+ * buildSearchKeywordPool in workload.js), time each query solo, then fire
+ * them all again with Promise.all. Entry.search scans the blog's entries in
+ * chunks of 200 and, for each chunk, synchronously concatenates and
+ * substring-matches against every candidate's *full HTML*, uncached and
+ * redone from scratch on every request - a plausible real pattern (several
+ * visitors searching a blog at once) as well as a structurally similar
+ * risk to the tag/archives queueing bug.
+ */
+async function runSearchBurst({ blogs, keywordsBySite, concurrency, getForBlog }) {
+  const soloDurations = [];
+  const burstDurations = [];
+  const perSite = [];
+
+  for (let blogIndex = 0; blogIndex < blogs.length; blogIndex++) {
+    const blog = blogs[blogIndex];
+    const keywords = (keywordsBySite[blogIndex] || []).slice(0, concurrency);
+
+    if (!keywords.length) {
+      perSite.push({
+        blog_id: blog.id,
+        handle: blog.handle,
+        keywords_tested: 0,
+      });
+      continue;
+    }
+
+    const urls = keywords.map(
+      (keyword) => `/search?q=${encodeURIComponent(keyword)}`
+    );
+
+    // Uncontended baseline: one at a time, sequentially.
+    const soloForSite = [];
+    for (const url of urls) {
+      const startedAt = performance.now();
+      await getForBlog(blog, url, { redirect: "manual" });
+      const elapsedMs = performance.now() - startedAt;
+      soloForSite.push(elapsedMs);
+      soloDurations.push(elapsedMs);
+    }
+
+    // Genuine concurrent burst: every distinct search query at once.
+    const burstForSite = await Promise.all(
+      urls.map(async (url) => {
+        const startedAt = performance.now();
+        await getForBlog(blog, url, { redirect: "manual" });
+        return performance.now() - startedAt;
+      })
+    );
+
+    burstForSite.forEach((elapsedMs) => burstDurations.push(elapsedMs));
+
+    const soloMean =
+      soloForSite.reduce((sum, ms) => sum + ms, 0) / soloForSite.length;
+    const burstMean =
+      burstForSite.reduce((sum, ms) => sum + ms, 0) / burstForSite.length;
+
+    perSite.push({
+      blog_id: blog.id,
+      handle: blog.handle,
+      keywords_tested: keywords.length,
+      solo_mean_ms: soloMean,
+      burst_mean_ms: burstMean,
+      inflation_ratio: soloMean > 0 ? burstMean / soloMean : null,
+    });
+  }
+
+  const soloTiming = summarizeDurations(soloDurations);
+  const burstTiming = summarizeDurations(burstDurations);
+
+  return {
+    keywords_tested_total: perSite.reduce((sum, s) => sum + s.keywords_tested, 0),
+    solo_timing_ms: soloTiming,
+    burst_timing_ms: burstTiming,
+    inflation_ratio:
+      soloTiming.mean > 0 ? burstTiming.mean / soloTiming.mean : null,
+    sites: perSite,
+  };
+}
+
+module.exports = { runSearchBurst };

--- a/app/blog/benchmarks/util/sitemapBurst.js
+++ b/app/blog/benchmarks/util/sitemapBurst.js
@@ -2,6 +2,7 @@
 
 const { performance } = require("perf_hooks");
 const { summarizeDurations } = require("./metrics");
+const { timedRequest } = require("./burstRequest");
 
 /**
  * Same shape as archivesBurst.js, aimed at /sitemap.xml. Like /archives it
@@ -33,14 +34,14 @@ async function runSitemapBurst({ blogs, concurrency, getForBlog }) {
   const soloDurations = [];
   for (const blog of targets) {
     const startedAt = performance.now();
-    await getForBlog(blog, "/sitemap.xml", { redirect: "manual" });
+    await timedRequest(getForBlog, blog, "/sitemap.xml");
     soloDurations.push(performance.now() - startedAt);
   }
 
   const burstDurations = await Promise.all(
     targets.map(async (blog) => {
       const startedAt = performance.now();
-      await getForBlog(blog, "/sitemap.xml", { redirect: "manual" });
+      await timedRequest(getForBlog, blog, "/sitemap.xml");
       return performance.now() - startedAt;
     })
   );

--- a/app/blog/benchmarks/util/sitemapBurst.js
+++ b/app/blog/benchmarks/util/sitemapBurst.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const { performance } = require("perf_hooks");
+const { summarizeDurations } = require("./metrics");
+
+/**
+ * Same shape as archivesBurst.js, aimed at /sitemap.xml. Like /archives it
+ * iterates {{#all_entries}} over the full entry set on every request (see
+ * app/templates/source/blog/sitemap.xml), and like /archives there's only
+ * one sitemap URL per blog, so bursting it means firing concurrently across
+ * blogs (repeating round-robin when there are fewer sites than the
+ * requested concurrency) rather than across distinct pages. Search engines
+ * and other crawlers routinely fetch several blogs' sitemaps around the
+ * same time, so this is a realistic concurrent-access pattern in its own
+ * right, not just a duplicate of the archives burst's root cause.
+ */
+async function runSitemapBurst({ blogs, concurrency, getForBlog }) {
+  if (!blogs.length) {
+    const empty = summarizeDurations([]);
+    return {
+      requests_tested_total: 0,
+      solo_timing_ms: empty,
+      burst_timing_ms: empty,
+      inflation_ratio: null,
+    };
+  }
+
+  const targets = [];
+  for (let i = 0; i < concurrency; i++) {
+    targets.push(blogs[i % blogs.length]);
+  }
+
+  const soloDurations = [];
+  for (const blog of targets) {
+    const startedAt = performance.now();
+    await getForBlog(blog, "/sitemap.xml", { redirect: "manual" });
+    soloDurations.push(performance.now() - startedAt);
+  }
+
+  const burstDurations = await Promise.all(
+    targets.map(async (blog) => {
+      const startedAt = performance.now();
+      await getForBlog(blog, "/sitemap.xml", { redirect: "manual" });
+      return performance.now() - startedAt;
+    })
+  );
+
+  const soloTiming = summarizeDurations(soloDurations);
+  const burstTiming = summarizeDurations(burstDurations);
+
+  return {
+    requests_tested_total: targets.length,
+    solo_timing_ms: soloTiming,
+    burst_timing_ms: burstTiming,
+    inflation_ratio:
+      soloTiming.mean > 0 ? burstTiming.mean / soloTiming.mean : null,
+  };
+}
+
+module.exports = { runSitemapBurst };

--- a/app/blog/benchmarks/util/tagBurst.js
+++ b/app/blog/benchmarks/util/tagBurst.js
@@ -1,0 +1,90 @@
+"use strict";
+
+const { performance } = require("perf_hooks");
+const { summarizeDurations } = require("./metrics");
+
+/**
+ * Reproduces the queueing bug found on a real customer blog: individual
+ * requests to different /tagged/<slug> pages were each fast in isolation,
+ * but requesting several distinct tag pages at the same time made every one
+ * of them queue behind the others' synchronous, uncached, per-request work
+ * over the full entry set (see app/blog/render/load/augment.js and
+ * app/blog/render/locals.js).
+ *
+ * For each blog: pick up to `concurrency` distinct tags, time each one
+ * in isolation (uncontended baseline), then fire all of them at once with
+ * Promise.all (a genuine concurrent burst, unlike the render phase's pooled
+ * queue) and time that too. The ratio between the two is a direct signal for
+ * this class of regression — it should stay close to 1 on a healthy render
+ * path and blow up when requests are serializing behind blocking work.
+ */
+async function runTagBurst({ blogs, tagsBySite, concurrency, getForBlog }) {
+  const soloDurations = [];
+  const burstDurations = [];
+  const perSite = [];
+
+  for (let blogIndex = 0; blogIndex < blogs.length; blogIndex++) {
+    const blog = blogs[blogIndex];
+    const tags = (tagsBySite[blogIndex] || []).slice(0, concurrency);
+
+    if (!tags.length) {
+      perSite.push({
+        blog_id: blog.id,
+        handle: blog.handle,
+        tags_tested: 0,
+      });
+      continue;
+    }
+
+    const urls = tags.map((tag) => `/tagged/${encodeURIComponent(tag)}`);
+
+    // Uncontended baseline: one at a time, sequentially.
+    const soloForSite = [];
+    for (const url of urls) {
+      const startedAt = performance.now();
+      await getForBlog(blog, url, { redirect: "manual" });
+      const elapsedMs = performance.now() - startedAt;
+      soloForSite.push(elapsedMs);
+      soloDurations.push(elapsedMs);
+    }
+
+    // Genuine concurrent burst: every distinct tag page requested at once.
+    const burstForSite = await Promise.all(
+      urls.map(async (url) => {
+        const startedAt = performance.now();
+        await getForBlog(blog, url, { redirect: "manual" });
+        return performance.now() - startedAt;
+      })
+    );
+
+    burstForSite.forEach((elapsedMs) => burstDurations.push(elapsedMs));
+
+    const soloMean =
+      soloForSite.reduce((sum, ms) => sum + ms, 0) / soloForSite.length;
+    const burstMean =
+      burstForSite.reduce((sum, ms) => sum + ms, 0) / burstForSite.length;
+
+    perSite.push({
+      blog_id: blog.id,
+      handle: blog.handle,
+      tags_tested: tags.length,
+      solo_mean_ms: soloMean,
+      burst_mean_ms: burstMean,
+      inflation_ratio: soloMean > 0 ? burstMean / soloMean : null,
+    });
+  }
+
+  const soloTiming = summarizeDurations(soloDurations);
+  const burstTiming = summarizeDurations(burstDurations);
+
+  return {
+    tags_tested_total: perSite.reduce((sum, s) => sum + s.tags_tested, 0),
+    solo_timing_ms: soloTiming,
+    burst_timing_ms: burstTiming,
+    inflation_ratio:
+      soloTiming.mean > 0 ? burstTiming.mean / soloTiming.mean : null,
+    sites: perSite,
+  };
+}
+
+module.exports = { runTagBurst };

--- a/app/blog/benchmarks/util/tagBurst.js
+++ b/app/blog/benchmarks/util/tagBurst.js
@@ -2,6 +2,7 @@
 
 const { performance } = require("perf_hooks");
 const { summarizeDurations } = require("./metrics");
+const { timedRequest } = require("./burstRequest");
 
 /**
  * Reproduces the queueing bug found on a real customer blog: individual
@@ -42,7 +43,7 @@ async function runTagBurst({ blogs, tagsBySite, concurrency, getForBlog }) {
     const soloForSite = [];
     for (const url of urls) {
       const startedAt = performance.now();
-      await getForBlog(blog, url, { redirect: "manual" });
+      await timedRequest(getForBlog, blog, url);
       const elapsedMs = performance.now() - startedAt;
       soloForSite.push(elapsedMs);
       soloDurations.push(elapsedMs);
@@ -52,7 +53,7 @@ async function runTagBurst({ blogs, tagsBySite, concurrency, getForBlog }) {
     const burstForSite = await Promise.all(
       urls.map(async (url) => {
         const startedAt = performance.now();
-        await getForBlog(blog, url, { redirect: "manual" });
+        await timedRequest(getForBlog, blog, url);
         return performance.now() - startedAt;
       })
     );

--- a/app/blog/benchmarks/util/workload.js
+++ b/app/blog/benchmarks/util/workload.js
@@ -1,8 +1,38 @@
 const { getFixtures } = require("./fixtures");
 
+// Modelled on a real customer blog that suffered severe request-queueing
+// slowdowns: several hundred entries, each carrying a handful of tags out of
+// a few dozen distinct ones, so most tag pages have a healthy number of
+// matching entries rather than one or two.
+function buildTagPool(config, rng) {
+  const tagCount = Math.max(0, Math.floor(config.tags));
+  const pool = [];
+
+  for (let i = 0; i < tagCount; i++) {
+    pool.push(`benchmark-tag-${i}-${randomWord(rng, 6)}`);
+  }
+
+  return pool;
+}
+
+function pickTags(rng, tagPool) {
+  if (!tagPool.length) return [];
+
+  const tagsPerEntry = 1 + Math.floor(rng() * 4); // 1-4 tags, like real posts
+  const picked = new Set();
+
+  for (let i = 0; i < tagsPerEntry && picked.size < tagPool.length; i++) {
+    picked.add(tagPool[Math.floor(rng() * tagPool.length)]);
+  }
+
+  return Array.from(picked);
+}
+
 function buildWorkload(config, blogs, rng) {
   const files = [];
   const filesPerSite = new Array(blogs.length).fill(0);
+  const tagPoolBySite = blogs.map(() => buildTagPool(config, rng));
+  const tagsUsedBySite = blogs.map(() => new Set());
 
   for (let index = 0; index < config.files; index++) {
     const blogIndex = index % blogs.length;
@@ -17,11 +47,13 @@ function buildWorkload(config, blogs, rng) {
 
     const slug = `benchmark-${blogIndex}-${index}-${randomWord(rng, 8)}`;
     const filePath = `/${segments.join("/")}/${slug}.txt`;
+    const tags = pickTags(rng, tagPoolBySite[blogIndex]);
+    tags.forEach((tag) => tagsUsedBySite[blogIndex].add(tag));
 
     files.push({
       blogIndex,
       path: filePath,
-      content: makeEntryContent({ rng, slug, blogIndex, index }),
+      content: makeEntryContent({ rng, slug, blogIndex, index, tags }),
     });
   }
 
@@ -37,10 +69,11 @@ function buildWorkload(config, blogs, rng) {
     files,
     filesPerSite,
     fixtureCount: fixtures.length,
+    tagsBySite: tagsUsedBySite.map((set) => Array.from(set)),
   };
 }
 
-function makeEntryContent({ rng, slug, blogIndex, index }) {
+function makeEntryContent({ rng, slug, blogIndex, index, tags }) {
   const sentenceCount = 3 + Math.floor(rng() * 5);
   const sentences = [];
 
@@ -48,13 +81,13 @@ function makeEntryContent({ rng, slug, blogIndex, index }) {
     sentences.push(randomSentence(rng));
   }
 
-  return [
-    `Title: Benchmark ${blogIndex}-${index}`,
-    `Link: /${slug}`,
-    "",
-    sentences.join(" "),
-    "",
-  ].join("\n");
+  const header = [`Title: Benchmark ${blogIndex}-${index}`, `Link: /${slug}`];
+
+  if (tags && tags.length) {
+    header.push(`Tags: ${tags.join(", ")}`);
+  }
+
+  return [...header, "", sentences.join(" "), ""].join("\n");
 }
 
 function randomSentence(rng) {

--- a/app/blog/benchmarks/util/workload.js
+++ b/app/blog/benchmarks/util/workload.js
@@ -28,11 +28,41 @@ function pickTags(rng, tagPool) {
   return Array.from(picked);
 }
 
+// A distinct word pool spliced verbatim into a fraction of entry bodies, so
+// full-text search (Entry.search matches against title/tags/path/html) has
+// realistic, guaranteed-to-match terms instead of relying on random word
+// collisions.
+function buildSearchKeywordPool(config, rng) {
+  const keywordCount = Math.max(0, Math.floor(config.searchKeywords));
+  const pool = [];
+
+  for (let i = 0; i < keywordCount; i++) {
+    pool.push(`benchmarkkeyword${i}${randomWord(rng, 5)}`);
+  }
+
+  return pool;
+}
+
+// Roughly a third of entries carry one search keyword, so most keywords have
+// a healthy pool of matching entries for Entry.search to scan and sort.
+const SEARCH_KEYWORD_PROBABILITY = 0.35;
+// Roughly a quarter of non-hub entries link to their site's hub entry, so
+// the hub accumulates a realistic backlinks list.
+const HUB_LINK_PROBABILITY = 0.25;
+
 function buildWorkload(config, blogs, rng) {
   const files = [];
   const filesPerSite = new Array(blogs.length).fill(0);
   const tagPoolBySite = blogs.map(() => buildTagPool(config, rng));
   const tagsUsedBySite = blogs.map(() => new Set());
+  const searchKeywordPoolBySite = blogs.map(() =>
+    buildSearchKeywordPool(config, rng)
+  );
+  const searchKeywordsUsedBySite = blogs.map(() => new Set());
+  const hubSlugBySite = blogs.map(
+    (_, blogIndex) => `benchmark-hub-${blogIndex}`
+  );
+  const hubCreatedBySite = blogs.map(() => false);
 
   for (let index = 0; index < config.files; index++) {
     const blogIndex = index % blogs.length;
@@ -45,15 +75,44 @@ function buildWorkload(config, blogs, rng) {
       segments.push(randomWord(rng, 6 + Math.floor(rng() * 8)));
     }
 
-    const slug = `benchmark-${blogIndex}-${index}-${randomWord(rng, 8)}`;
-    const filePath = `/${segments.join("/")}/${slug}.txt`;
+    // The first entry generated for each site becomes that site's "hub" -
+    // a fixed, known URL that a fraction of later entries link to, so it
+    // accumulates a realistic backlinks list (see augment.js's per-backlink
+    // Entry.getByUrl fan-out).
+    const isHub = !hubCreatedBySite[blogIndex];
+    hubCreatedBySite[blogIndex] = true;
+
+    const slug = isHub
+      ? hubSlugBySite[blogIndex]
+      : `benchmark-${blogIndex}-${index}-${randomWord(rng, 8)}`;
+    const filePath = isHub
+      ? `/${slug}.txt`
+      : `/${segments.join("/")}/${slug}.txt`;
+
     const tags = pickTags(rng, tagPoolBySite[blogIndex]);
     tags.forEach((tag) => tagsUsedBySite[blogIndex].add(tag));
+
+    let keyword = null;
+    const keywordPool = searchKeywordPoolBySite[blogIndex];
+    if (keywordPool.length && rng() < SEARCH_KEYWORD_PROBABILITY) {
+      keyword = keywordPool[Math.floor(rng() * keywordPool.length)];
+      searchKeywordsUsedBySite[blogIndex].add(keyword);
+    }
+
+    const linksToHub = !isHub && rng() < HUB_LINK_PROBABILITY;
 
     files.push({
       blogIndex,
       path: filePath,
-      content: makeEntryContent({ rng, slug, blogIndex, index, tags }),
+      content: makeEntryContent({
+        rng,
+        slug,
+        blogIndex,
+        index,
+        tags,
+        keyword,
+        hubPath: linksToHub ? `/${hubSlugBySite[blogIndex]}` : null,
+      }),
     });
   }
 
@@ -70,10 +129,26 @@ function buildWorkload(config, blogs, rng) {
     filesPerSite,
     fixtureCount: fixtures.length,
     tagsBySite: tagsUsedBySite.map((set) => Array.from(set)),
+    searchKeywordsBySite: searchKeywordsUsedBySite.map((set) =>
+      Array.from(set)
+    ),
+    // null for a site that ended up with zero entries (fewer --files than
+    // --sites); consumers should treat that as "no hub for this site".
+    hubPathBySite: hubCreatedBySite.map((created, blogIndex) =>
+      created ? `/${hubSlugBySite[blogIndex]}` : null
+    ),
   };
 }
 
-function makeEntryContent({ rng, slug, blogIndex, index, tags }) {
+function makeEntryContent({
+  rng,
+  slug,
+  blogIndex,
+  index,
+  tags,
+  keyword,
+  hubPath,
+}) {
   const sentenceCount = 3 + Math.floor(rng() * 5);
   const sentences = [];
 
@@ -87,7 +162,17 @@ function makeEntryContent({ rng, slug, blogIndex, index, tags }) {
     header.push(`Tags: ${tags.join(", ")}`);
   }
 
-  return [...header, "", sentences.join(" "), ""].join("\n");
+  let body = sentences.join(" ");
+
+  if (keyword) {
+    body += ` This entry also mentions ${keyword} in passing.`;
+  }
+
+  if (hubPath) {
+    body += ` See also [this related entry](${hubPath}) for more.`;
+  }
+
+  return [...header, "", body, ""].join("\n");
 }
 
 function randomSentence(rng) {

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -14,6 +14,7 @@ reused from `app/build/converters/*/tests`), then:
 | **build**  | write the workload to disk, then `blog.rebuild()` every site   | per-site wall time p50 / p95, peak RSS, CPU % |
 | **render** | fetch every URL in each blog's sitemap and read the full body  | per-page wall time p50 / p95, peak RSS, CPU %, output bytes/page |
 | **tag burst** | for each site, request several distinct `/tagged/<slug>` pages once solo (uncontended) and once as a genuine concurrent burst | burst p50/p95, burst ÷ solo inflation ratio |
+| **archives burst** | request `/archives` (repeating blogs round-robin if there are fewer sites than the concurrency) once solo per target and once as a genuine concurrent burst | burst p50/p95, burst ÷ solo inflation ratio |
 
 Each generated entry also gets 1-4 tags drawn from a `--tags` (default 40)
 pool, so `/tagged/<slug>` pages exist with a realistic number of matching
@@ -27,6 +28,20 @@ ratio stays close to 1×; requests queueing behind synchronous, uncached
 per-request work blows it up, same as the render-phase pooled queue does but
 isolated to a controlled, always-the-same-N-pages burst so the signal is
 comparable run to run.
+
+The **archives burst** phase reproduces the same failure mode from the other
+direction. `/archives` (like `/tagged/<slug>`) pulls the full entry set via
+`Entries.getAll` and does a synchronous year/month grouping pass with
+per-entry `moment.tz` formatting on every request — see
+[`archives.js`](../../app/blog/render/retrieve/archives.js) — but there is
+only one `/archives` URL per blog, so there's no "distinct pages" axis to
+burst along. Instead it fires `--archives-burst-concurrency` (default 8)
+concurrent `/archives` requests, cycling through the benchmark's `--sites`
+round-robin when there are fewer blogs than the requested concurrency. With
+the default multi-site config this reproduces cross-customer contention
+(many blogs sharing one Node process each landing on their own `/archives` at
+once); with `--sites 1` it instead reproduces many tabs/crawlers hitting one
+big blog's `/archives` at the same time.
 
 Everything is seeded (`--seed`, default `blot-benchmark-seed`) so the generated
 workload is identical from run to run. The full result is written as JSON; the
@@ -118,8 +133,9 @@ constant — older records stay in the NDJSON file for reference but are
 invisible to the baseline. Bump `historySchemaVersion` whenever a change
 meaningfully redefines a tracked metric (new/removed metric, a workload shape
 that shifts totals — e.g. this file's own `tags` / `tagBurstConcurrency`
-addition bumped it from 1 to 2) and the next master run starts a fresh
-baseline on its own, no manual cache-clearing required.
+addition bumped it 1 → 2, and the `archivesBurstConcurrency` addition bumped
+it 2 → 3) and the next master run starts a fresh baseline on its own, no
+manual cache-clearing required.
 
 **Manual — clear the history.** For anything the schema-version bump doesn't
 cover (e.g. you want to discard recent noisy runs without changing what's
@@ -151,6 +167,7 @@ information-only, and `detect-regression.js` will not open an issue.
 | `index.js` | container | run the spec once, write result JSON |
 | `app/blog/benchmarks/benchmarks.js` | container | the Jasmine spec itself |
 | `app/blog/benchmarks/util/tagBurst.js` | container | tag-burst phase: solo vs. concurrent `/tagged/<slug>` timing |
+| `app/blog/benchmarks/util/archivesBurst.js` | container | archives-burst phase: solo vs. concurrent `/archives` timing |
 | `invoke.sh` | host | run `index.js` in Docker + throwaway Redis |
 | `compare.js` / `format-diff.js` | host | local branch-vs-branch comparison |
 | `aggregate.js` | host | merge N iteration JSONs into one (median per metric) |

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -13,6 +13,20 @@ reused from `app/build/converters/*/tests`), then:
 |------------|----------------------------------------------------------------|------------------|
 | **build**  | write the workload to disk, then `blog.rebuild()` every site   | per-site wall time p50 / p95, peak RSS, CPU % |
 | **render** | fetch every URL in each blog's sitemap and read the full body  | per-page wall time p50 / p95, peak RSS, CPU %, output bytes/page |
+| **tag burst** | for each site, request several distinct `/tagged/<slug>` pages once solo (uncontended) and once as a genuine concurrent burst | burst p50/p95, burst ÷ solo inflation ratio |
+
+Each generated entry also gets 1-4 tags drawn from a `--tags` (default 40)
+pool, so `/tagged/<slug>` pages exist with a realistic number of matching
+entries — modelled on a real customer blog (~800 entries, ~40 tags) that hit
+severe request-queueing slowdowns when several distinct tag pages were
+requested at once. The **tag burst** phase reproduces that directly: it times
+`--tag-burst-concurrency` (default 8) distinct tag pages one at a time, then
+fires the same pages all at once with `Promise.all` (not the render phase's
+pooled queue) and compares the two. On a healthy render path the inflation
+ratio stays close to 1×; requests queueing behind synchronous, uncached
+per-request work blows it up, same as the render-phase pooled queue does but
+isolated to a controlled, always-the-same-N-pages burst so the signal is
+comparable run to run.
 
 Everything is seeded (`--seed`, default `blot-benchmark-seed`) so the generated
 workload is identical from run to run. The full result is written as JSON; the
@@ -94,15 +108,30 @@ manual step required.
 
 ### Resetting / editing the baseline
 
-The baseline is derived, not stored, so to reset it you clear the history:
+The baseline is derived, not stored, so there are two ways to reset it:
+
+**Automatic — bump `historySchemaVersion`.** Every history record carries the
+`historySchemaVersion` from [`defaults.js`](../../app/blog/benchmarks/util/defaults.js)
+at the time it was written. `computeBaseline` and `detect-regression.js` only
+look at records whose `schema_version` matches the *current* value of that
+constant — older records stay in the NDJSON file for reference but are
+invisible to the baseline. Bump `historySchemaVersion` whenever a change
+meaningfully redefines a tracked metric (new/removed metric, a workload shape
+that shifts totals — e.g. this file's own `tags` / `tagBurstConcurrency`
+addition bumped it from 1 to 2) and the next master run starts a fresh
+baseline on its own, no manual cache-clearing required.
+
+**Manual — clear the history.** For anything the schema-version bump doesn't
+cover (e.g. you want to discard recent noisy runs without changing what's
+measured):
 
 1. delete the `benchmarks-history-amd64-*` / `-arm64-*` entries under the repo's
    Actions caches, and
 2. delete the `benchmark-history-<arch>` artifacts (or let them age out).
 
-Until `minBaselineSamples` (see defaults) master commits have accumulated, the
-PR comment still shows deltas but marks them information-only, and
-`detect-regression.js` will not open an issue.
+Until `minBaselineSamples` (see defaults) master commits have accumulated *at
+the current schema version*, the PR comment still shows deltas but marks them
+information-only, and `detect-regression.js` will not open an issue.
 
 ## Interpreting the numbers
 
@@ -121,6 +150,7 @@ PR comment still shows deltas but marks them information-only, and
 |------|-----------|---------|
 | `index.js` | container | run the spec once, write result JSON |
 | `app/blog/benchmarks/benchmarks.js` | container | the Jasmine spec itself |
+| `app/blog/benchmarks/util/tagBurst.js` | container | tag-burst phase: solo vs. concurrent `/tagged/<slug>` timing |
 | `invoke.sh` | host | run `index.js` in Docker + throwaway Redis |
 | `compare.js` / `format-diff.js` | host | local branch-vs-branch comparison |
 | `aggregate.js` | host | merge N iteration JSONs into one (median per metric) |

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -15,6 +15,9 @@ reused from `app/build/converters/*/tests`), then:
 | **render** | fetch every URL in each blog's sitemap and read the full body  | per-page wall time p50 / p95, peak RSS, CPU %, output bytes/page |
 | **tag burst** | for each site, request several distinct `/tagged/<slug>` pages once solo (uncontended) and once as a genuine concurrent burst | burst p50/p95, burst ÷ solo inflation ratio |
 | **archives burst** | request `/archives` (repeating blogs round-robin if there are fewer sites than the concurrency) once solo per target and once as a genuine concurrent burst | burst p50/p95, burst ÷ solo inflation ratio |
+| **search burst** | for each site, request several distinct `/search?q=<keyword>` queries once solo and once as a genuine concurrent burst | burst p50/p95, burst ÷ solo inflation ratio |
+| **sitemap burst** | request `/sitemap.xml` (same round-robin rule as archives) once solo per target and once as a genuine concurrent burst | burst p50/p95, burst ÷ solo inflation ratio |
+| **backlinks burst** | request each site's "hub" entry — linked to by ~25% of its other entries — (same round-robin rule) once solo and once as a genuine concurrent burst | burst p50/p95, burst ÷ solo inflation ratio |
 
 Each generated entry also gets 1-4 tags drawn from a `--tags` (default 40)
 pool, so `/tagged/<slug>` pages exist with a realistic number of matching
@@ -42,6 +45,37 @@ the default multi-site config this reproduces cross-customer contention
 (many blogs sharing one Node process each landing on their own `/archives` at
 once); with `--sites 1` it instead reproduces many tabs/crawlers hitting one
 big blog's `/archives` at the same time.
+
+Each entry also has a ~35% chance of mentioning one of `--search-keywords`
+(default 15) distinct keywords, guaranteeing realistic, non-trivial result
+sets for the **search burst** phase. It targets
+[`Entry.search`](../../app/models/entry/search.js), which scans a blog's
+entries in chunks of 200 and, per chunk, synchronously concatenates and
+substring-matches against every candidate's *full HTML* — uncached, redone
+from scratch every request. `--search-burst-concurrency` (default 8) distinct
+`/search?q=...` queries are timed solo, then fired again as one burst, same
+pattern as the tag burst. Concurrent site search by several visitors is a
+realistic traffic pattern in its own right, not just another way to trigger
+the queueing bug.
+
+The **sitemap burst** phase is the archives burst's sibling: `/sitemap.xml`
+(see [`sitemap.xml`](../../app/templates/source/blog/sitemap.xml)) iterates
+`{{#all_entries}}` over the full entry set on every request just like
+`archives.js`, and like archives there's only one sitemap URL per blog, so
+`--sitemap-burst-concurrency` (default 8) requests cycle round-robin across
+`--sites`. Kept as a separate phase (rather than folded into the archives
+burst) because it's a genuinely distinct customer-facing URL and traffic
+pattern — search engines and other crawlers routinely fetch several blogs'
+sitemaps around the same time.
+
+Each site's workload also includes one "hub" entry that ~25% of its other
+entries link to, so it accumulates a realistic backlinks list. Rendering an
+entry runs [`augment.js`](../../app/blog/render/load/augment.js), which does
+an `async.map` over `entry.backlinks`, issuing one uncached `Entry.getByUrl`
+Redis round trip per backlink. The **backlinks burst** phase fires
+`--backlinks-burst-concurrency` (default 8) concurrent requests at each
+site's hub entry (same round-robin rule as archives/sitemap) to see whether
+that per-render N+1 fan-out serializes under concurrent load.
 
 Everything is seeded (`--seed`, default `blot-benchmark-seed`) so the generated
 workload is identical from run to run. The full result is written as JSON; the
@@ -133,9 +167,9 @@ constant — older records stay in the NDJSON file for reference but are
 invisible to the baseline. Bump `historySchemaVersion` whenever a change
 meaningfully redefines a tracked metric (new/removed metric, a workload shape
 that shifts totals — e.g. this file's own `tags` / `tagBurstConcurrency`
-addition bumped it 1 → 2, and the `archivesBurstConcurrency` addition bumped
-it 2 → 3) and the next master run starts a fresh baseline on its own, no
-manual cache-clearing required.
+addition bumped it 1 → 2, `archivesBurstConcurrency` bumped it 2 → 3, and the
+search/sitemap/backlinks burst additions bumped it 3 → 4) and the next master
+run starts a fresh baseline on its own, no manual cache-clearing required.
 
 **Manual — clear the history.** For anything the schema-version bump doesn't
 cover (e.g. you want to discard recent noisy runs without changing what's
@@ -168,6 +202,9 @@ information-only, and `detect-regression.js` will not open an issue.
 | `app/blog/benchmarks/benchmarks.js` | container | the Jasmine spec itself |
 | `app/blog/benchmarks/util/tagBurst.js` | container | tag-burst phase: solo vs. concurrent `/tagged/<slug>` timing |
 | `app/blog/benchmarks/util/archivesBurst.js` | container | archives-burst phase: solo vs. concurrent `/archives` timing |
+| `app/blog/benchmarks/util/searchBurst.js` | container | search-burst phase: solo vs. concurrent `/search?q=` timing |
+| `app/blog/benchmarks/util/sitemapBurst.js` | container | sitemap-burst phase: solo vs. concurrent `/sitemap.xml` timing |
+| `app/blog/benchmarks/util/backlinksBurst.js` | container | backlinks-burst phase: solo vs. concurrent hub-entry timing |
 | `invoke.sh` | host | run `index.js` in Docker + throwaway Redis |
 | `compare.js` / `format-diff.js` | host | local branch-vs-branch comparison |
 | `aggregate.js` | host | merge N iteration JSONs into one (median per metric) |
@@ -190,3 +227,9 @@ information-only, and `detect-regression.js` will not open an issue.
 - **Larger dedicated runner** — a fixed-size runner would cut variance enough to
   consider a soft gate; add it as another matrix row.
 - **GC / event-loop-lag metrics** during the render phase.
+- **Multi-tag / `sort=id` burst** — `fetchTaggedEntries.js` pulls a tag's
+  whole entry-ID list and sorts it locally for `id`-sort and multi-tag
+  intersection queries (`/tagged/a+b`), instead of paginating in Redis like
+  the single-tag date-sort path does. Lower priority than the bursts already
+  built here since it's bounded by a tag's size rather than the whole blog's
+  entry count, but worth a burst if a customer's tags grow very large.

--- a/scripts/benchmarks/detect-regression.js
+++ b/scripts/benchmarks/detect-regression.js
@@ -62,7 +62,12 @@ function main() {
   const dryRun = flag("--dry-run");
   const repo = process.env.GITHUB_REPOSITORY;
 
-  const history = loadHistory(historyDir, arch);
+  // Records from an older history schema (a prior tracked-metric set, or a
+  // workload shape that shifted totals) are excluded so a schema bump resets
+  // the "how many samples do we have" count too, not just the baseline math.
+  const history = loadHistory(historyDir, arch).filter(
+    (r) => r.schema_version === BENCHMARK_DEFAULTS.historySchemaVersion
+  );
 
   if (history.length < BENCHMARK_DEFAULTS.minBaselineSamples + consecutive) {
     console.log(

--- a/scripts/benchmarks/format-diff.js
+++ b/scripts/benchmarks/format-diff.js
@@ -20,12 +20,17 @@ function metricsFromResult(result) {
     (render.memory_mb && render.memory_mb.peak_rss) || 0
   );
   const totalSeconds = totalWallMs / 1000;
+  const tagBurst = render.tag_burst || {};
+  const tagBurstTiming = tagBurst.burst_timing_ms || {};
   return {
     totalCpuPercent,
     totalMemoryMb,
     totalSeconds,
     meanBuildMs: buildTiming.mean != null ? buildTiming.mean : 0,
     meanRenderMs: renderTiming.mean != null ? renderTiming.mean : 0,
+    tagBurstP95Ms: tagBurstTiming.p95 != null ? tagBurstTiming.p95 : 0,
+    tagBurstInflationRatio:
+      tagBurst.inflation_ratio != null ? tagBurst.inflation_ratio : null,
   };
 }
 
@@ -77,6 +82,31 @@ function printCompareTable(currentResult, branchResult) {
       " ms per page  ->  " +
       fmtNum(br.meanRenderMs.toFixed(0), 8) +
       " ms per page"
+  );
+  console.log("");
+  console.log(
+    label("Tag burst p95") +
+      fmtNum(cur.tagBurstP95Ms.toFixed(0), 8) +
+      " ms  ->  " +
+      fmtNum(br.tagBurstP95Ms.toFixed(0), 8) +
+      " ms"
+  );
+  console.log(
+    label("Tag burst inflation") +
+      fmtNum(
+        cur.tagBurstInflationRatio == null
+          ? "n/a"
+          : cur.tagBurstInflationRatio.toFixed(2),
+        8
+      ) +
+      "x  ->  " +
+      fmtNum(
+        br.tagBurstInflationRatio == null
+          ? "n/a"
+          : br.tagBurstInflationRatio.toFixed(2),
+        8
+      ) +
+      "x"
   );
   console.log("");
 }

--- a/scripts/benchmarks/format-diff.js
+++ b/scripts/benchmarks/format-diff.js
@@ -22,6 +22,8 @@ function metricsFromResult(result) {
   const totalSeconds = totalWallMs / 1000;
   const tagBurst = render.tag_burst || {};
   const tagBurstTiming = tagBurst.burst_timing_ms || {};
+  const archivesBurst = render.archives_burst || {};
+  const archivesBurstTiming = archivesBurst.burst_timing_ms || {};
   return {
     totalCpuPercent,
     totalMemoryMb,
@@ -31,6 +33,12 @@ function metricsFromResult(result) {
     tagBurstP95Ms: tagBurstTiming.p95 != null ? tagBurstTiming.p95 : 0,
     tagBurstInflationRatio:
       tagBurst.inflation_ratio != null ? tagBurst.inflation_ratio : null,
+    archivesBurstP95Ms:
+      archivesBurstTiming.p95 != null ? archivesBurstTiming.p95 : 0,
+    archivesBurstInflationRatio:
+      archivesBurst.inflation_ratio != null
+        ? archivesBurst.inflation_ratio
+        : null,
   };
 }
 
@@ -104,6 +112,30 @@ function printCompareTable(currentResult, branchResult) {
         br.tagBurstInflationRatio == null
           ? "n/a"
           : br.tagBurstInflationRatio.toFixed(2),
+        8
+      ) +
+      "x"
+  );
+  console.log(
+    label("Archives burst p95") +
+      fmtNum(cur.archivesBurstP95Ms.toFixed(0), 8) +
+      " ms  ->  " +
+      fmtNum(br.archivesBurstP95Ms.toFixed(0), 8) +
+      " ms"
+  );
+  console.log(
+    label("Archives burst inflation") +
+      fmtNum(
+        cur.archivesBurstInflationRatio == null
+          ? "n/a"
+          : cur.archivesBurstInflationRatio.toFixed(2),
+        8
+      ) +
+      "x  ->  " +
+      fmtNum(
+        br.archivesBurstInflationRatio == null
+          ? "n/a"
+          : br.archivesBurstInflationRatio.toFixed(2),
         8
       ) +
       "x"

--- a/scripts/benchmarks/format-diff.js
+++ b/scripts/benchmarks/format-diff.js
@@ -1,5 +1,13 @@
 "use strict";
 
+const BURSTS = [
+  { key: "tag_burst", label: "Tag burst" },
+  { key: "archives_burst", label: "Archives burst" },
+  { key: "search_burst", label: "Search burst" },
+  { key: "sitemap_burst", label: "Sitemap burst" },
+  { key: "backlinks_burst", label: "Backlinks burst" },
+];
+
 /**
  * Extract summary metrics from a benchmark result JSON (same shape as the
  * table printed at the end of a run).
@@ -20,30 +28,34 @@ function metricsFromResult(result) {
     (render.memory_mb && render.memory_mb.peak_rss) || 0
   );
   const totalSeconds = totalWallMs / 1000;
-  const tagBurst = render.tag_burst || {};
-  const tagBurstTiming = tagBurst.burst_timing_ms || {};
-  const archivesBurst = render.archives_burst || {};
-  const archivesBurstTiming = archivesBurst.burst_timing_ms || {};
+
+  const bursts = {};
+  for (const { key } of BURSTS) {
+    const burst = render[key] || {};
+    const timing = burst.burst_timing_ms || {};
+    bursts[key] = {
+      p95Ms: timing.p95 != null ? timing.p95 : 0,
+      inflationRatio:
+        burst.inflation_ratio != null ? burst.inflation_ratio : null,
+    };
+  }
+
   return {
     totalCpuPercent,
     totalMemoryMb,
     totalSeconds,
     meanBuildMs: buildTiming.mean != null ? buildTiming.mean : 0,
     meanRenderMs: renderTiming.mean != null ? renderTiming.mean : 0,
-    tagBurstP95Ms: tagBurstTiming.p95 != null ? tagBurstTiming.p95 : 0,
-    tagBurstInflationRatio:
-      tagBurst.inflation_ratio != null ? tagBurst.inflation_ratio : null,
-    archivesBurstP95Ms:
-      archivesBurstTiming.p95 != null ? archivesBurstTiming.p95 : 0,
-    archivesBurstInflationRatio:
-      archivesBurst.inflation_ratio != null
-        ? archivesBurst.inflation_ratio
-        : null,
+    bursts,
   };
 }
 
 function fmtNum(n, width) {
   return String(n).padStart(width || 8);
+}
+
+function fmtRatio(ratio) {
+  return ratio == null ? "n/a" : ratio.toFixed(2);
 }
 
 /**
@@ -92,54 +104,26 @@ function printCompareTable(currentResult, branchResult) {
       " ms per page"
   );
   console.log("");
-  console.log(
-    label("Tag burst p95") +
-      fmtNum(cur.tagBurstP95Ms.toFixed(0), 8) +
-      " ms  ->  " +
-      fmtNum(br.tagBurstP95Ms.toFixed(0), 8) +
-      " ms"
-  );
-  console.log(
-    label("Tag burst inflation") +
-      fmtNum(
-        cur.tagBurstInflationRatio == null
-          ? "n/a"
-          : cur.tagBurstInflationRatio.toFixed(2),
-        8
-      ) +
-      "x  ->  " +
-      fmtNum(
-        br.tagBurstInflationRatio == null
-          ? "n/a"
-          : br.tagBurstInflationRatio.toFixed(2),
-        8
-      ) +
-      "x"
-  );
-  console.log(
-    label("Archives burst p95") +
-      fmtNum(cur.archivesBurstP95Ms.toFixed(0), 8) +
-      " ms  ->  " +
-      fmtNum(br.archivesBurstP95Ms.toFixed(0), 8) +
-      " ms"
-  );
-  console.log(
-    label("Archives burst inflation") +
-      fmtNum(
-        cur.archivesBurstInflationRatio == null
-          ? "n/a"
-          : cur.archivesBurstInflationRatio.toFixed(2),
-        8
-      ) +
-      "x  ->  " +
-      fmtNum(
-        br.archivesBurstInflationRatio == null
-          ? "n/a"
-          : br.archivesBurstInflationRatio.toFixed(2),
-        8
-      ) +
-      "x"
-  );
+
+  for (const { key, label: burstLabel } of BURSTS) {
+    const curBurst = cur.bursts[key];
+    const brBurst = br.bursts[key];
+
+    console.log(
+      label(`${burstLabel} p95`) +
+        fmtNum(curBurst.p95Ms.toFixed(0), 8) +
+        " ms  ->  " +
+        fmtNum(brBurst.p95Ms.toFixed(0), 8) +
+        " ms"
+    );
+    console.log(
+      label(`${burstLabel} inflation`) +
+        fmtNum(fmtRatio(curBurst.inflationRatio), 8) +
+        "x  ->  " +
+        fmtNum(fmtRatio(brBurst.inflationRatio), 8) +
+        "x"
+    );
+  }
   console.log("");
 }
 

--- a/scripts/benchmarks/index.js
+++ b/scripts/benchmarks/index.js
@@ -52,6 +52,8 @@ var benchmarkConfig = {
   writeConcurrency: args.writeConcurrency,
   cpuSampleIntervalMs: args.cpuSampleIntervalMs,
   requestsPerPage: args.requestsPerPage,
+  tags: args.tags,
+  tagBurstConcurrency: args.tagBurstConcurrency,
 };
 
 global.__BLOT_BENCHMARK_CONFIG = benchmarkConfig;
@@ -122,6 +124,8 @@ function parseArgs(argv) {
     writeConcurrency: BENCHMARK_DEFAULTS.writeConcurrency,
     cpuSampleIntervalMs: BENCHMARK_DEFAULTS.cpuSampleIntervalMs,
     requestsPerPage: BENCHMARK_DEFAULTS.requestsPerPage,
+    tags: BENCHMARK_DEFAULTS.tags,
+    tagBurstConcurrency: BENCHMARK_DEFAULTS.tagBurstConcurrency,
     output: null,
     path: null,
     ci: false,
@@ -136,6 +140,8 @@ function parseArgs(argv) {
     "--write-concurrency": "writeConcurrency",
     "--cpu-sample-interval-ms": "cpuSampleIntervalMs",
     "--requests-per-page": "requestsPerPage",
+    "--tags": "tags",
+    "--tag-burst-concurrency": "tagBurstConcurrency",
   };
 
   for (var i = 0; i < argv.length; i++) {
@@ -197,6 +203,8 @@ function parseArgs(argv) {
   ensurePositiveInt(parsed.writeConcurrency, "--write-concurrency");
   ensurePositiveInt(parsed.cpuSampleIntervalMs, "--cpu-sample-interval-ms");
   ensurePositiveInt(parsed.requestsPerPage, "--requests-per-page");
+  ensurePositiveInt(parsed.tags, "--tags");
+  ensurePositiveInt(parsed.tagBurstConcurrency, "--tag-burst-concurrency");
 
   return parsed;
 }
@@ -230,6 +238,12 @@ function printHelp() {
         ")",
       "  --requests-per-page <n>        Requests per sitemap URL (default: " +
         BENCHMARK_DEFAULTS.requestsPerPage +
+        ")",
+      "  --tags <n>                     Distinct tags generated per site (default: " +
+        BENCHMARK_DEFAULTS.tags +
+        ")",
+      "  --tag-burst-concurrency <n>    Distinct /tagged/<slug> pages hit at once (default: " +
+        BENCHMARK_DEFAULTS.tagBurstConcurrency +
         ")",
       "  --cpu-sample-interval-ms <ms>  CPU/memory sampling interval (default: " +
         BENCHMARK_DEFAULTS.cpuSampleIntervalMs +

--- a/scripts/benchmarks/index.js
+++ b/scripts/benchmarks/index.js
@@ -55,6 +55,10 @@ var benchmarkConfig = {
   tags: args.tags,
   tagBurstConcurrency: args.tagBurstConcurrency,
   archivesBurstConcurrency: args.archivesBurstConcurrency,
+  searchKeywords: args.searchKeywords,
+  searchBurstConcurrency: args.searchBurstConcurrency,
+  backlinksBurstConcurrency: args.backlinksBurstConcurrency,
+  sitemapBurstConcurrency: args.sitemapBurstConcurrency,
 };
 
 global.__BLOT_BENCHMARK_CONFIG = benchmarkConfig;
@@ -128,6 +132,10 @@ function parseArgs(argv) {
     tags: BENCHMARK_DEFAULTS.tags,
     tagBurstConcurrency: BENCHMARK_DEFAULTS.tagBurstConcurrency,
     archivesBurstConcurrency: BENCHMARK_DEFAULTS.archivesBurstConcurrency,
+    searchKeywords: BENCHMARK_DEFAULTS.searchKeywords,
+    searchBurstConcurrency: BENCHMARK_DEFAULTS.searchBurstConcurrency,
+    backlinksBurstConcurrency: BENCHMARK_DEFAULTS.backlinksBurstConcurrency,
+    sitemapBurstConcurrency: BENCHMARK_DEFAULTS.sitemapBurstConcurrency,
     output: null,
     path: null,
     ci: false,
@@ -145,6 +153,10 @@ function parseArgs(argv) {
     "--tags": "tags",
     "--tag-burst-concurrency": "tagBurstConcurrency",
     "--archives-burst-concurrency": "archivesBurstConcurrency",
+    "--search-keywords": "searchKeywords",
+    "--search-burst-concurrency": "searchBurstConcurrency",
+    "--backlinks-burst-concurrency": "backlinksBurstConcurrency",
+    "--sitemap-burst-concurrency": "sitemapBurstConcurrency",
   };
 
   for (var i = 0; i < argv.length; i++) {
@@ -212,6 +224,19 @@ function parseArgs(argv) {
     parsed.archivesBurstConcurrency,
     "--archives-burst-concurrency"
   );
+  ensurePositiveInt(parsed.searchKeywords, "--search-keywords");
+  ensurePositiveInt(
+    parsed.searchBurstConcurrency,
+    "--search-burst-concurrency"
+  );
+  ensurePositiveInt(
+    parsed.backlinksBurstConcurrency,
+    "--backlinks-burst-concurrency"
+  );
+  ensurePositiveInt(
+    parsed.sitemapBurstConcurrency,
+    "--sitemap-burst-concurrency"
+  );
 
   return parsed;
 }
@@ -254,6 +279,18 @@ function printHelp() {
         ")",
       "  --archives-burst-concurrency <n>  Concurrent /archives requests (default: " +
         BENCHMARK_DEFAULTS.archivesBurstConcurrency +
+        ")",
+      "  --search-keywords <n>          Distinct search keywords generated per site (default: " +
+        BENCHMARK_DEFAULTS.searchKeywords +
+        ")",
+      "  --search-burst-concurrency <n>  Distinct /search?q= queries hit at once (default: " +
+        BENCHMARK_DEFAULTS.searchBurstConcurrency +
+        ")",
+      "  --backlinks-burst-concurrency <n>  Concurrent hits to each site's hub entry (default: " +
+        BENCHMARK_DEFAULTS.backlinksBurstConcurrency +
+        ")",
+      "  --sitemap-burst-concurrency <n>  Concurrent /sitemap.xml requests (default: " +
+        BENCHMARK_DEFAULTS.sitemapBurstConcurrency +
         ")",
       "  --cpu-sample-interval-ms <ms>  CPU/memory sampling interval (default: " +
         BENCHMARK_DEFAULTS.cpuSampleIntervalMs +

--- a/scripts/benchmarks/index.js
+++ b/scripts/benchmarks/index.js
@@ -54,6 +54,7 @@ var benchmarkConfig = {
   requestsPerPage: args.requestsPerPage,
   tags: args.tags,
   tagBurstConcurrency: args.tagBurstConcurrency,
+  archivesBurstConcurrency: args.archivesBurstConcurrency,
 };
 
 global.__BLOT_BENCHMARK_CONFIG = benchmarkConfig;
@@ -126,6 +127,7 @@ function parseArgs(argv) {
     requestsPerPage: BENCHMARK_DEFAULTS.requestsPerPage,
     tags: BENCHMARK_DEFAULTS.tags,
     tagBurstConcurrency: BENCHMARK_DEFAULTS.tagBurstConcurrency,
+    archivesBurstConcurrency: BENCHMARK_DEFAULTS.archivesBurstConcurrency,
     output: null,
     path: null,
     ci: false,
@@ -142,6 +144,7 @@ function parseArgs(argv) {
     "--requests-per-page": "requestsPerPage",
     "--tags": "tags",
     "--tag-burst-concurrency": "tagBurstConcurrency",
+    "--archives-burst-concurrency": "archivesBurstConcurrency",
   };
 
   for (var i = 0; i < argv.length; i++) {
@@ -205,6 +208,10 @@ function parseArgs(argv) {
   ensurePositiveInt(parsed.requestsPerPage, "--requests-per-page");
   ensurePositiveInt(parsed.tags, "--tags");
   ensurePositiveInt(parsed.tagBurstConcurrency, "--tag-burst-concurrency");
+  ensurePositiveInt(
+    parsed.archivesBurstConcurrency,
+    "--archives-burst-concurrency"
+  );
 
   return parsed;
 }
@@ -244,6 +251,9 @@ function printHelp() {
         ")",
       "  --tag-burst-concurrency <n>    Distinct /tagged/<slug> pages hit at once (default: " +
         BENCHMARK_DEFAULTS.tagBurstConcurrency +
+        ")",
+      "  --archives-burst-concurrency <n>  Concurrent /archives requests (default: " +
+        BENCHMARK_DEFAULTS.archivesBurstConcurrency +
         ")",
       "  --cpu-sample-interval-ms <ms>  CPU/memory sampling interval (default: " +
         BENCHMARK_DEFAULTS.cpuSampleIntervalMs +

--- a/scripts/benchmarks/lib/aggregate.js
+++ b/scripts/benchmarks/lib/aggregate.js
@@ -28,6 +28,16 @@ const METRIC_PATHS = {
   build_peak_rss_mb: "build.memory_mb.peak_rss",
   render_peak_rss_mb: "render.memory_mb.peak_rss",
   render_bytes_mean: "render.bytes.mean_per_page",
+  tag_burst_p95_ms: "render.tag_burst.burst_timing_ms.p95",
+  tag_burst_inflation_ratio: "render.tag_burst.inflation_ratio",
+  archives_burst_p95_ms: "render.archives_burst.burst_timing_ms.p95",
+  archives_burst_inflation_ratio: "render.archives_burst.inflation_ratio",
+  search_burst_p95_ms: "render.search_burst.burst_timing_ms.p95",
+  search_burst_inflation_ratio: "render.search_burst.inflation_ratio",
+  sitemap_burst_p95_ms: "render.sitemap_burst.burst_timing_ms.p95",
+  sitemap_burst_inflation_ratio: "render.sitemap_burst.inflation_ratio",
+  backlinks_burst_p95_ms: "render.backlinks_burst.burst_timing_ms.p95",
+  backlinks_burst_inflation_ratio: "render.backlinks_burst.inflation_ratio",
 };
 
 /**

--- a/scripts/benchmarks/lib/history.js
+++ b/scripts/benchmarks/lib/history.js
@@ -37,7 +37,7 @@ function loadHistory(dir, arch) {
 
 function recordFromResult(result, extra = {}) {
   return {
-    schema_version: 1,
+    schema_version: BENCHMARK_DEFAULTS.historySchemaVersion,
     git_sha: result.git_sha || process.env.GITHUB_SHA || null,
     timestamp: result.timestamp || new Date().toISOString(),
     arch: extra.arch || null,
@@ -62,10 +62,23 @@ function computeBaseline(records, options = {}) {
   const {
     window = BENCHMARK_DEFAULTS.baselineWindow,
     excludeSha = null,
+    schemaVersion = BENCHMARK_DEFAULTS.historySchemaVersion,
   } = options;
 
+  // Records written under an older schema version measured a different set
+  // of metrics (or a workload shape that shifts totals), so mixing them into
+  // this baseline would make every comparison noise. Excluding them means a
+  // schema bump resets the baseline automatically on the next master run,
+  // instead of requiring someone to clear the benchmarks-history-* Actions
+  // cache by hand.
   const usable = records
-    .filter((r) => r && r.metrics && (!excludeSha || r.git_sha !== excludeSha))
+    .filter(
+      (r) =>
+        r &&
+        r.metrics &&
+        r.schema_version === schemaVersion &&
+        (!excludeSha || r.git_sha !== excludeSha)
+    )
     .slice(-window);
 
   const metrics = {};
@@ -80,7 +93,7 @@ function computeBaseline(records, options = {}) {
   }
 
   return {
-    schema_version: 1,
+    schema_version: schemaVersion,
     generated_at: new Date().toISOString(),
     window,
     sample_count: usable.length,

--- a/scripts/benchmarks/lib/metrics.js
+++ b/scripts/benchmarks/lib/metrics.js
@@ -75,6 +75,42 @@ const METRICS = [
     unit: "ratio",
     get: (r) => num(r?.render?.archives_burst?.inflation_ratio),
   },
+  {
+    key: "search_burst_p95_ms",
+    label: "Search burst p95 (concurrent /search)",
+    unit: "ms",
+    get: (r) => num(r?.render?.search_burst?.burst_timing_ms?.p95),
+  },
+  {
+    key: "search_burst_inflation_ratio",
+    label: "Search burst inflation (burst ÷ solo)",
+    unit: "ratio",
+    get: (r) => num(r?.render?.search_burst?.inflation_ratio),
+  },
+  {
+    key: "sitemap_burst_p95_ms",
+    label: "Sitemap burst p95 (concurrent /sitemap.xml)",
+    unit: "ms",
+    get: (r) => num(r?.render?.sitemap_burst?.burst_timing_ms?.p95),
+  },
+  {
+    key: "sitemap_burst_inflation_ratio",
+    label: "Sitemap burst inflation (burst ÷ solo)",
+    unit: "ratio",
+    get: (r) => num(r?.render?.sitemap_burst?.inflation_ratio),
+  },
+  {
+    key: "backlinks_burst_p95_ms",
+    label: "Backlinks burst p95 (concurrent hub-entry hits)",
+    unit: "ms",
+    get: (r) => num(r?.render?.backlinks_burst?.burst_timing_ms?.p95),
+  },
+  {
+    key: "backlinks_burst_inflation_ratio",
+    label: "Backlinks burst inflation (burst ÷ solo)",
+    unit: "ratio",
+    get: (r) => num(r?.render?.backlinks_burst?.inflation_ratio),
+  },
 ];
 
 const METRIC_BY_KEY = Object.fromEntries(METRICS.map((m) => [m.key, m]));

--- a/scripts/benchmarks/lib/metrics.js
+++ b/scripts/benchmarks/lib/metrics.js
@@ -63,6 +63,18 @@ const METRICS = [
     unit: "ratio",
     get: (r) => num(r?.render?.tag_burst?.inflation_ratio),
   },
+  {
+    key: "archives_burst_p95_ms",
+    label: "Archives burst p95 (concurrent /archives)",
+    unit: "ms",
+    get: (r) => num(r?.render?.archives_burst?.burst_timing_ms?.p95),
+  },
+  {
+    key: "archives_burst_inflation_ratio",
+    label: "Archives burst inflation (burst ÷ solo)",
+    unit: "ratio",
+    get: (r) => num(r?.render?.archives_burst?.inflation_ratio),
+  },
 ];
 
 const METRIC_BY_KEY = Object.fromEntries(METRICS.map((m) => [m.key, m]));

--- a/scripts/benchmarks/lib/metrics.js
+++ b/scripts/benchmarks/lib/metrics.js
@@ -51,6 +51,18 @@ const METRICS = [
     deterministic: true,
     get: (r) => num(r?.render?.bytes?.mean_per_page),
   },
+  {
+    key: "tag_burst_p95_ms",
+    label: "Tag burst p95 (concurrent /tagged/*)",
+    unit: "ms",
+    get: (r) => num(r?.render?.tag_burst?.burst_timing_ms?.p95),
+  },
+  {
+    key: "tag_burst_inflation_ratio",
+    label: "Tag burst inflation (burst ÷ solo)",
+    unit: "ratio",
+    get: (r) => num(r?.render?.tag_burst?.inflation_ratio),
+  },
 ];
 
 const METRIC_BY_KEY = Object.fromEntries(METRICS.map((m) => [m.key, m]));
@@ -78,6 +90,7 @@ function formatValue(value, unit) {
 
   if (unit === "MB") return Math.round(value) + " MB";
   if (unit === "ms") return Math.round(value) + " ms";
+  if (unit === "ratio") return value.toFixed(2) + "x";
   return String(value);
 }
 


### PR DESCRIPTION
## Summary

While investigating slow/crashing renders on a real customer blog (~800 entries, 39 tags), we found that individual `/tagged/<slug>` requests were each fast in isolation (0.2-0.4s), but requesting several *distinct* tag pages at the same time made every one of them queue behind the others' synchronous, uncached, per-request work over the full entry set (`JSON.parse` of all entries, eager `moment.tz` formatting, a full locals-tree Mustache scan) — mean response time under concurrent load ballooned to 10-16s. The benchmark's sitemap.xml template never included tag pages, so this class of regression was entirely invisible to CI.

This PR adds five benchmark phases that reproduce this class of bug directly and track it as regular, CI-comparable metrics, after auditing `app/blog/render` for other code paths with the same shape (unbounded, uncached, synchronous per-request work):

- **tag burst** — several distinct `/tagged/<slug>` pages, requested once solo (uncontended) and once as a genuine `Promise.all` burst. Generated entries now get 1-4 tags drawn from a `--tags` pool (default 40).
- **archives burst** — `/archives` pulls the full entry set via `Entries.getAll` and does the same kind of synchronous per-request work as tagged pages. Only one archives URL per blog, so the burst fires concurrently *across* blogs (repeating round-robin with `--sites 1`), reproducing cross-customer contention on a shared Node process.
- **search burst** — `Entry.search` scans candidates in chunks and, per chunk, synchronously concatenates and substring-matches against each candidate's *full HTML*, uncached. Each blog's workload now splices ~15 distinct search keywords into ~35% of its entries so `/search?q=<keyword>` has realistic, guaranteed matches to burst against.
- **sitemap burst** — `/sitemap.xml` iterates `{{#all_entries}}` exactly like `archives.js` and shares its one-URL-per-blog shape, but is tracked as its own phase since crawlers hitting several blogs' sitemaps at once is a distinct, realistic traffic pattern.
- **backlinks burst** — `augment.js` does an `async.map` of `Entry.getByUrl` over `entry.backlinks` on every render (one Redis round trip per backlink, uncached). Each site's workload now includes one "hub" entry linked to by ~25% of its other entries, so it accumulates a realistic backlinks list to burst-request, exercising that per-render N+1 fan-out under concurrency.

Checked and found already well-bounded (no benchmark needed, but confirms the pattern the vulnerable code should follow): `posts.js` (proper Redis-side pagination + LRU cache), `recent_entries.js` (bounded to 30), `popular_tags.js` (cached). Documented one lower-priority remaining candidate — multi-tag/`sort=id` queries in `fetchTaggedEntries.js`, bounded by tag size rather than total entries — in the README's "Ideas not yet built".

Each burst phase tracks p95 timing and a burst ÷ solo **inflation ratio** — close to 1× on a healthy render path, and it blows up when requests queue behind synchronous work, same signature as the manual `ab` investigation that found this class of bug.

Since adding phases changes what "total time" means and introduces new metrics with no history, `historySchemaVersion` (in `defaults.js`) is bumped with each addition (now at 4). `computeBaseline` and `detect-regression.js` only consider history records whose `schema_version` matches the current value, so the rolling baseline resets itself automatically on the next master run — no manual Actions-cache clearing needed. Documented both the automatic and manual reset paths in the README.

## Test plan

- [x] `node -c` / `require()` syntax-checked every touched file
- [x] Ran `npm run benchmark -- --sites 3 --files 90 --tags 10 --tag-burst-concurrency 5 --archives-burst-concurrency 6 --search-keywords 10 --search-burst-concurrency 5 --backlinks-burst-concurrency 6 --sitemap-burst-concurrency 6` end to end (Docker + throwaway Redis) — 1 spec, 0 failures; all five bursts reported meaningful inflation (2.7x-5.5x) even at this tiny test scale
- [x] Verified `update-history.js` writes correctly schema-versioned records and `computeBaseline` excludes older-schema records
- [x] Verified `detect-regression.js` gates correctly on schema-filtered sample count (dry run)
- [x] Verified `pr-comment.js`'s `compareToBaseline`/`markdownTable` and the local `format-diff.js` compare table render all 13 tracked metrics correctly

No production render code was changed — this is benchmark/CI tooling only. The actual render-path fix (caching entry data, lazy date formatting, etc.) is separate follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)