### PR TITLE
Add regression tests for posts cache and renderLocals

### DIFF
--- a/app/blog/render/retrieve/folder.js
+++ b/app/blog/render/retrieve/folder.js
@@ -23,7 +23,9 @@ module.exports = function (req, res, callback) {
 
     // Remove dotfiles and folders
     contents = contents.filter((item) => item[0] !== ".");
-    contents = alphanum(contents, { property: "name" });
+    // `contents` is an array of raw filenames at this point, not objects,
+    // so there's no `name` property to sort by - sort the strings directly.
+    contents = alphanum(contents);
 
     async.mapLimit(
       contents,

--- a/app/blog/render/retrieve/tests/asset.js
+++ b/app/blog/render/retrieve/tests/asset.js
@@ -1,0 +1,37 @@
+const asset = require("../asset");
+
+describe("asset", function () {
+  function getLambda() {
+    return new Promise((resolve, reject) => {
+      asset({}, {}, (err, factory) => {
+        if (err) return reject(err);
+        resolve(factory());
+      });
+    });
+  }
+
+  it("adds a leading slash and a cache-busting query string for files with an extension", async function () {
+    const lambda = await getLambda();
+    const render = (text) => text.replace("{{cacheID}}", "123");
+
+    expect(lambda("logo.png", render)).toEqual(
+      "/logo.png?cache=123&amp;extension=.png"
+    );
+  });
+
+  it("leaves an existing leading slash alone", async function () {
+    const lambda = await getLambda();
+    const render = (text) => text.replace("{{cacheID}}", "123");
+
+    expect(lambda("/logo.png", render)).toEqual(
+      "/logo.png?cache=123&amp;extension=.png"
+    );
+  });
+
+  it("does not append a cache-busting query string for text without an extension", async function () {
+    const lambda = await getLambda();
+    const render = (text) => text;
+
+    expect(lambda("logo", render)).toEqual("/logo");
+  });
+});

--- a/app/blog/render/retrieve/tests/folder.js
+++ b/app/blog/render/retrieve/tests/folder.js
@@ -1,0 +1,74 @@
+const folder = require("../folder");
+
+describe("folder", function () {
+  require("blog/tests/util/setup")();
+
+  function run(context, query) {
+    return new Promise((resolve, reject) => {
+      folder({ blog: context.blog, query: query || {} }, {}, (err, result) => {
+        if (err) return reject(err);
+        resolve(result);
+      });
+    });
+  }
+
+  it("lists files and directories at the root of the blog folder", async function () {
+    await this.write({ path: "/a.txt", content: "Hello" });
+    await this.write({ path: "/sub/b.txt", content: "World" });
+
+    const result = await run(this, {});
+
+    const names = result.contents.map((item) => item.name).sort();
+    expect(names).toEqual(["a.txt", "sub"]);
+
+    const file = result.contents.find((item) => item.name === "a.txt");
+    expect(file.isFile).toBe(true);
+    expect(file.isDirectory).toBe(false);
+    expect(file.path).toEqual("/a.txt");
+    expect(file.pathURI).toEqual(encodeURIComponent("/a.txt"));
+
+    const dir = result.contents.find((item) => item.name === "sub");
+    expect(dir.isDirectory).toBe(true);
+    expect(dir.isFile).toBe(false);
+  });
+
+  it("lists the contents of a subdirectory and exposes its parent", async function () {
+    await this.write({ path: "/sub/b.txt", content: "World" });
+
+    const result = await run(this, { path: "/sub" });
+
+    expect(result.contents.map((item) => item.name)).toEqual(["b.txt"]);
+    expect(result.parent).toEqual("/");
+  });
+
+  it("filters out dotfiles", async function () {
+    await this.write({ path: "/.hidden", content: "secret" });
+    await this.write({ path: "/visible.txt", content: "Hello" });
+
+    const result = await run(this, {});
+
+    expect(result.contents.map((item) => item.name)).toEqual(["visible.txt"]);
+  });
+
+  it("sorts contents in natural alphanumeric order, not filesystem order", async function () {
+    await this.write({ path: "/b.txt", content: "B" });
+    await this.write({ path: "/a.txt", content: "A" });
+    await this.write({ path: "/10.txt", content: "10" });
+    await this.write({ path: "/2.txt", content: "2" });
+
+    const result = await run(this, {});
+
+    expect(result.contents.map((item) => item.name)).toEqual([
+      "2.txt",
+      "10.txt",
+      "a.txt",
+      "b.txt",
+    ]);
+  });
+
+  it("returns an empty list when the requested path does not exist", async function () {
+    const result = await run(this, { path: "/does-not-exist" });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/app/blog/render/retrieve/tests/is_active.js
+++ b/app/blog/render/retrieve/tests/is_active.js
@@ -1,0 +1,32 @@
+const isActive = require("../is_active");
+
+describe("is_active", function () {
+  function getLambda(url) {
+    return new Promise((resolve, reject) => {
+      isActive({ url: url }, {}, (err, factory) => {
+        if (err) return reject(err);
+        resolve(factory());
+      });
+    });
+  }
+
+  it("marks the current page as active", async function () {
+    const lambda = await getLambda("/about");
+    expect(lambda("/about")).toEqual("active");
+  });
+
+  it("leaves other pages unmarked", async function () {
+    const lambda = await getLambda("/about");
+    expect(lambda("/contact")).toEqual("");
+  });
+
+  it("normalizes trailing slashes and case before comparing", async function () {
+    const lambda = await getLambda("/About/");
+    expect(lambda("/about")).toEqual("active");
+  });
+
+  it("treats an empty request url as the homepage", async function () {
+    const lambda = await getLambda("");
+    expect(lambda("/")).toEqual("active");
+  });
+});

--- a/app/blog/render/retrieve/tests/plugin.js
+++ b/app/blog/render/retrieve/tests/plugin.js
@@ -1,0 +1,77 @@
+const plugin = require("../plugin");
+const Plugins = require("build/plugins");
+
+describe("plugin", function () {
+  var originalList;
+
+  beforeEach(function () {
+    originalList = Plugins.list;
+    Plugins.list = {
+      syntax: { publicCSS: "syntax.css", publicJS: "syntax.js" },
+    };
+  });
+
+  afterEach(function () {
+    Plugins.list = originalList;
+  });
+
+  function run(req) {
+    return new Promise((resolve, reject) => {
+      plugin(req, {}, (err, result) => (err ? reject(err) : resolve(result)));
+    });
+  }
+
+  it("returns css and js for an enabled, requested plugin", async function () {
+    const result = await run({
+      retrieve: { plugin: { syntax: { css: true, js: true } } },
+      blog: { plugins: { syntax: { enabled: true } } },
+    });
+
+    expect(result).toEqual({ syntax: { css: "syntax.css", js: "syntax.js" } });
+  });
+
+  it("only includes the fields actually requested", async function () {
+    const result = await run({
+      retrieve: { plugin: { syntax: { css: true } } },
+      blog: { plugins: { syntax: { enabled: true } } },
+    });
+
+    expect(result).toEqual({ syntax: { css: "syntax.css" } });
+  });
+
+  it("omits plugins the blog has not enabled", async function () {
+    const result = await run({
+      retrieve: { plugin: { syntax: { css: true } } },
+      blog: { plugins: { syntax: { enabled: false } } },
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("omits plugins the blog has not configured at all", async function () {
+    const result = await run({
+      retrieve: { plugin: { syntax: { css: true } } },
+      blog: { plugins: {} },
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("omits plugins that don't exist in the plugin registry", async function () {
+    const result = await run({
+      retrieve: { plugin: { missing: { css: true } } },
+      blog: { plugins: { missing: { enabled: true } } },
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("treats a boolean retrieve.plugin request as requesting nothing", async function () {
+    const result = await run({
+      retrieve: { plugin: true },
+      blog: { plugins: { syntax: { enabled: true } } },
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/app/blog/render/retrieve/tests/recent_entries.js
+++ b/app/blog/render/retrieve/tests/recent_entries.js
@@ -1,0 +1,67 @@
+const recentEntries = require("../recent_entries");
+const Entries = require("models/entries");
+
+describe("recent_entries", function () {
+  function run(req) {
+    return new Promise((resolve, reject) => {
+      recentEntries(req, {}, (err, result) =>
+        err ? reject(err) : resolve(result)
+      );
+    });
+  }
+
+  it("fetches the full entry list when no field projection metadata is present", async function () {
+    spyOn(Entries, "getRecent").and.callFake(function (blogID, callback) {
+      callback([{ id: "/a.txt", title: "A", html: "<p>A</p>" }]);
+    });
+
+    const result = await run({ blog: { id: "blog-1" }, retrieve: {} });
+
+    expect(Entries.getRecent).toHaveBeenCalledWith(
+      "blog-1",
+      jasmine.any(Function)
+    );
+    expect(result).toEqual([{ id: "/a.txt", title: "A", html: "<p>A</p>" }]);
+  });
+
+  it("requests a narrowed field list when the template only references non-heavy fields", async function () {
+    spyOn(Entries, "getRecent").and.callFake(function (
+      blogID,
+      options,
+      callback
+    ) {
+      callback([{ id: "/a.txt", title: "A", html: "<p>A</p>" }]);
+    });
+
+    const result = await run({
+      blog: { id: "blog-1" },
+      retrieve: { recentEntries: { fields: { title: true } } },
+    });
+
+    expect(Entries.getRecent).toHaveBeenCalledWith(
+      "blog-1",
+      jasmine.objectContaining({ fields: jasmine.any(Array) }),
+      jasmine.any(Function)
+    );
+    // The template only referenced `title`, so the unreferenced heavy `html`
+    // field should be stripped even though the fetch above returned it.
+    expect(result).toEqual([{ id: "/a.txt", title: "A" }]);
+  });
+
+  it("recognizes the recent_entries alias", async function () {
+    spyOn(Entries, "getRecent").and.callFake(function (
+      blogID,
+      options,
+      callback
+    ) {
+      callback([{ id: "/a.txt", title: "A", html: "<p>A</p>" }]);
+    });
+
+    const result = await run({
+      blog: { id: "blog-1" },
+      retrieve: { recent_entries: { fields: { title: true } } },
+    });
+
+    expect(result).toEqual([{ id: "/a.txt", title: "A" }]);
+  });
+});

--- a/app/blog/render/retrieve/tests/simpleLocals.js
+++ b/app/blog/render/retrieve/tests/simpleLocals.js
@@ -1,0 +1,102 @@
+const avatarUrl = require("../avatar_url");
+const cssUrl = require("../css_url");
+const feedUrl = require("../feed_url");
+const scriptUrl = require("../script_url");
+const searchQuery = require("../search_query");
+const totalPosts = require("../total_posts");
+const encodeJSON = require("../encode_json");
+const encodeURIComponentLocal = require("../encode_uri_component");
+const Entries = require("models/entries");
+
+function run(fn, req) {
+  return new Promise((resolve, reject) => {
+    fn(req, {}, (err, result) => (err ? reject(err) : resolve(result)));
+  });
+}
+
+function getLambda(fn, req) {
+  return new Promise((resolve, reject) => {
+    fn(req || {}, {}, (err, factory) =>
+      err ? reject(err) : resolve(factory())
+    );
+  });
+}
+
+describe("simple pass-through retrieve locals", function () {
+  it("avatar_url returns the blog's avatar", async function () {
+    const result = await run(avatarUrl, {
+      blog: { avatar: "https://cdn/avatar.png" },
+    });
+    expect(result).toEqual("https://cdn/avatar.png");
+  });
+
+  it("css_url returns the blog's stylesheet URL", async function () {
+    const result = await run(cssUrl, { blog: { cssURL: "/style.css?cache=1" } });
+    expect(result).toEqual("/style.css?cache=1");
+  });
+
+  it("feed_url returns the blog's feed URL", async function () {
+    const result = await run(feedUrl, { blog: { feedURL: "/feed" } });
+    expect(result).toEqual("/feed");
+  });
+
+  it("script_url returns the blog's script URL", async function () {
+    const result = await run(scriptUrl, {
+      blog: { scriptURL: "/script.js?cache=1" },
+    });
+    expect(result).toEqual("/script.js?cache=1");
+  });
+
+  it("search_query returns the q query parameter", async function () {
+    const result = await run(searchQuery, { query: { q: "hello" } });
+    expect(result).toEqual("hello");
+  });
+
+  it("total_posts returns the blog's total entry count", async function () {
+    spyOn(Entries, "getTotal").and.callFake((blogID, cb) => cb(null, 42));
+
+    const result = await run(totalPosts, { blog: { id: "blog-1" } });
+
+    expect(result).toEqual(42);
+    expect(Entries.getTotal).toHaveBeenCalledWith(
+      "blog-1",
+      jasmine.any(Function)
+    );
+  });
+});
+
+describe("encode_json", function () {
+  it("escapes characters mustache's default escaping leaves alone, e.g. newlines", async function () {
+    const lambda = await getLambda(encodeJSON);
+    const render = (text) => text;
+
+    expect(lambda("Hello\nWorld", render)).toEqual("Hello\\nWorld");
+  });
+
+  it("returns the rendered text unchanged if it cannot be JSON encoded", async function () {
+    const lambda = await getLambda(encodeJSON);
+    // JSON.stringify throws on a BigInt - exercises the catch branch.
+    const unserializable = 10n;
+    const render = () => unserializable;
+
+    expect(lambda("ignored", render)).toBe(unserializable);
+  });
+});
+
+describe("encode_uri_component", function () {
+  it("percent-encodes the rendered text", async function () {
+    const lambda = await getLambda(encodeURIComponentLocal);
+    const render = (text) => text;
+
+    expect(lambda("A/B?c=d", render)).toEqual(encodeURIComponent("A/B?c=d"));
+  });
+
+  it("returns the rendered text unchanged if it cannot be encoded", async function () {
+    const lambda = await getLambda(encodeURIComponentLocal);
+    // A lone surrogate makes encodeURIComponent throw a URIError.
+    const malformed = "\uD800";
+    const render = () => malformed;
+
+    expect(lambda("ignored", render)).toEqual(malformed);
+  });
+});

--- a/app/blog/render/tests/error.js
+++ b/app/blog/render/tests/error.js
@@ -1,0 +1,17 @@
+const ERROR = require("../error");
+
+describe("render error factory", function () {
+  it("builds a named error with its predefined message", function () {
+    const err = ERROR.UNCLOSED();
+
+    expect(err.message).toEqual("Your template has an unclosed tag");
+    expect(err.code).toEqual("BADTEMPLATE");
+  });
+
+  it("falls back to a default message when called directly", function () {
+    const err = ERROR();
+
+    expect(err.message).toEqual("Your template was badly formed");
+    expect(err.code).toEqual("BADTEMPLATE");
+  });
+});

--- a/app/blog/render/tests/locals.js
+++ b/app/blog/render/tests/locals.js
@@ -1,79 +1,117 @@
-// Import the renderLocals function
 var renderLocals = require("../locals");
 
-// Mock dependencies
-var render = require("../main");
-
-var type = require("helper/type");
-var ensure = require("helper/ensure");
-
-xdescribe("renderLocals", function() {
+describe("renderLocals", function () {
   var req, res, callback;
 
-  beforeEach(function() {
-    // Setup the request and response objects
+  beforeEach(function () {
     req = {};
+    callback = jasmine.createSpy("callback");
+  });
+
+  it("renders template tags in string locals against the full locals object", function () {
     res = {
       locals: {
+        name: "World",
         title: "Hello {{name}}",
-        description: "Test",
-        partials: {}
-      }
+        partials: {},
+      },
     };
 
-    // Setup the callback function
-    callback = jasmine.createSpy("callback");
-
-    // Spy on external functions
-    spyOn(type, 'call').and.callThrough();
-    spyOn(ensure, 'call').and.callThrough();
-    spyOn(render, 'call').and.callFake(function(str, locals, partials) {
-      return str.replace("{{name}}", "World");
-    });
-  });
-
-  it("should ensure proper types and structures", function() {
-    renderLocals(req, res, callback);
-    expect(ensure).toHaveBeenCalled();
-  });
-
-  it("should handle recursive replacement of locals", function() {
     renderLocals(req, res, callback);
 
     expect(res.locals.title).toEqual("Hello World");
     expect(callback).toHaveBeenCalledWith(null, req, res);
   });
 
-  it("should continue processing when encountering non-string values", function() {
-    res.locals.number = 123;
+  it("leaves strings without template tags unchanged", function () {
+    res = { locals: { description: "Plain text", partials: {} } };
+
     renderLocals(req, res, callback);
 
-    expect(res.locals.number).toEqual(123);
-    expect(callback).toHaveBeenCalledWith(null, req, res);
+    expect(res.locals.description).toEqual("Plain text");
   });
 
-  it("should skip 'partials' during replacement", function() {
-    res.locals.partials = {
-      sub: "Should not change {{value}}"
+  it("leaves non-string locals untouched", function () {
+    res = { locals: { count: 123, enabled: true, partials: {} } };
+
+    renderLocals(req, res, callback);
+
+    expect(res.locals.count).toEqual(123);
+    expect(res.locals.enabled).toEqual(true);
+  });
+
+  it("recurses into nested objects", function () {
+    res = {
+      locals: {
+        entry: { title: "{{greeting}}, entry!" },
+        greeting: "Hi",
+        partials: {},
+      },
     };
+
     renderLocals(req, res, callback);
 
-    expect(res.locals.partials.sub).toEqual("Should not change {{value}}");
+    expect(res.locals.entry.title).toEqual("Hi, entry!");
   });
 
-  it("should handle exceptions by returning original values", function() {
-    spyOn(render, 'call').and.throwError("Rendering failed");
+  it("recurses into arrays", function () {
+    res = {
+      locals: {
+        name: "World",
+        items: ["Hello {{name}}", "plain"],
+        partials: {},
+      },
+    };
+
     renderLocals(req, res, callback);
 
-    expect(res.locals.title).toEqual("Hello {{name}}");
+    expect(res.locals.items[0]).toEqual("Hello World");
+    expect(res.locals.items[1]).toEqual("plain");
+  });
+
+  it("does not render tags inside the partials object", function () {
+    res = {
+      locals: {
+        name: "World",
+        partials: { sub: "Hello {{name}}" },
+      },
+    };
+
+    renderLocals(req, res, callback);
+
+    expect(res.locals.partials.sub).toEqual("Hello {{name}}");
+  });
+
+  it("leaves a local unchanged when rendering it throws", function () {
+    res = {
+      // An unclosed tag makes the underlying mustache renderer throw.
+      locals: { title: "Hello {{> missing}", partials: {} },
+    };
+
+    renderLocals(req, res, callback);
+
+    expect(res.locals.title).toEqual("Hello {{> missing}");
     expect(callback).toHaveBeenCalledWith(null, req, res);
   });
 
-  it("should callback with error if any during the process", function() {
-    let error = new Error("Test error");
-    spyOn(renderLocals, 'handle').and.throwError(error);
-    renderLocals(req, res, callback);
+  it("still calls back when a circular local causes traversal to fail", function () {
+    var circular = {};
+    circular.self = circular;
+
+    res = { locals: { circular: circular, partials: {} } };
+
+    expect(function () {
+      renderLocals(req, res, callback);
+    }).not.toThrow();
 
     expect(callback).toHaveBeenCalledWith(null, req, res);
+  });
+
+  it("throws when res.locals.partials is missing", function () {
+    res = { locals: { title: "Hello" } };
+
+    expect(function () {
+      renderLocals(req, res, callback);
+    }).toThrowError();
   });
 });

--- a/app/blog/render/tests/middleware.js
+++ b/app/blog/render/tests/middleware.js
@@ -2,6 +2,7 @@
 describe("render middleware", function() {
 
   require('blog/tests/util/setup')();
+  const config = require("config");
 
   // it("should handle errors in retrieving the full view", function() {
 
@@ -10,6 +11,30 @@ describe("render middleware", function() {
   // it("should handle non-existing views", function() {
 
   // });
+
+  it("rewrites CDN links to http for requests served over http", async function () {
+    // forceSSL defaults to true, and vhosts.js redirects any plain-http
+    // request to https before it reaches this middleware - disable it so
+    // the request actually reaches the CDN-link rewrite branch below.
+    await this.blog.update({ forceSSL: false });
+    await this.template({ "entries.html": "{{{cdn}}}" });
+
+    const res = await this.get("/", {
+      headers: { "x-forwarded-proto": "http" },
+    });
+    const body = await res.text();
+
+    expect(res.status).toEqual(200);
+    expect(body).toEqual(config.cdn.origin.split("https://").join("http://"));
+  });
+
+  it("leaves CDN links as https for requests served over https", async function () {
+    await this.template({ "entries.html": "{{{cdn}}}" });
+
+    const body = await this.text("/");
+
+    expect(body).toEqual(config.cdn.origin);
+  });
 
   it("sends json when the query string debug or json is present", async function() {
 

--- a/app/blog/tests/dates.js
+++ b/app/blog/tests/dates.js
@@ -129,7 +129,6 @@ describe("dates", function () {
   });
 
   it("updates the entry's updated property when the post is modified", async function () {
-    const before = new Date();
     await this.write({ path: "/a.txt", content: "Foo" });
 
     await this.template({
@@ -139,13 +138,15 @@ describe("dates", function () {
     const firstUpdated = new Date(parseInt(await this.text("/")));
     await this.write({ path: "/a.txt", content: "Bar" });
     const secondUpdated = new Date(parseInt(await this.text("/")));
-    const after = new Date();
 
-    console.log({ before, firstUpdated, secondUpdated, after });
-
-    expect(firstUpdated >= before).toBe(true);
-    expect(secondUpdated >= firstUpdated).toBe(true);
-    expect(secondUpdated <= after).toBe(true);
+    // `updated` is derived from the file's mtime (see app/build/index.js),
+    // which is stamped by the filesystem rather than this process's clock.
+    // The two can drift by a few milliseconds (e.g. Docker on macOS), so
+    // comparing `updated` against a `new Date()` captured in this process
+    // is racy. What the test actually needs to protect is that editing a
+    // post moves its `updated` timestamp forward, which is stable because
+    // both timestamps come from the same clock source.
+    expect(secondUpdated.getTime()).toBeGreaterThan(firstUpdated.getTime());
   });
 
   it("does not change entry created date on modification", async function () {

--- a/app/blog/tests/posts.js
+++ b/app/blog/tests/posts.js
@@ -1,0 +1,316 @@
+const entriesModel = require("models/entries");
+const postsRetrieve = require("../render/retrieve/posts");
+
+describe("posts", function () {
+  describe("rendering", function () {
+    require("./util/setup")();
+
+    it("lists entries via the posts local", async function () {
+      await this.publish({ path: "/a.txt", content: "Hello, A!" });
+      await this.publish({ path: "/b.txt", content: "Hello, B!" });
+      await this.publish({ path: "/c.txt", content: "Hello, C!" });
+
+      await this.template({
+        "entries.html": "{{#posts}}{{{html}}}{{/posts}}",
+      });
+
+      const body = await this.text("/");
+      expect(body).toContain("Hello, A!");
+      expect(body).toContain("Hello, B!");
+      expect(body).toContain("Hello, C!");
+    });
+
+    it("paginates according to page_size", async function () {
+      await this.publish({ path: "/c.txt", content: "Hello, C!" });
+      await this.publish({ path: "/b.txt", content: "Hello, B!" });
+      await this.publish({ path: "/a.txt", content: "Hello, A!" });
+
+      await this.template(
+        { "entries.html": "{{#posts}}{{{html}}}{{/posts}}" },
+        { locals: { page_size: 2 } }
+      );
+
+      const page1 = await this.text("/");
+      expect(page1).toContain("Hello, A!");
+      expect(page1).toContain("Hello, B!");
+      expect(page1).not.toContain("Hello, C!");
+
+      const page2 = await this.text("/page/2");
+      expect(page2).not.toContain("Hello, A!");
+      expect(page2).not.toContain("Hello, B!");
+      expect(page2).toContain("Hello, C!");
+    });
+
+    it("exposes pagination alongside the posts local", async function () {
+      const totalEntries = 5;
+      const page_size = 2;
+
+      for (let i = totalEntries; i > 0; i--) {
+        await this.publish({ path: `/${i}.txt`, content: `Hello, ${i}!` });
+      }
+
+      await this.template(
+        {
+          "entries.html":
+            "{{#posts}}{{/posts}}{{pagination.current}}/{{pagination.total}}/{{pagination.total_entries}}",
+        },
+        { locals: { page_size } }
+      );
+
+      const body = await this.text("/page/1");
+      expect(body).toContain("1/3/5");
+    });
+
+    it("filters to a single tag via the query string", async function () {
+      await this.publish({ path: "/first.txt", content: "Tags: A\n\nFoo" });
+      await this.publish({
+        path: "/second.txt",
+        content: "Tags: A,B\n\nBar",
+      });
+      await this.publish({ path: "/third.txt", content: "Tags: B\n\nBaz" });
+
+      await this.template({
+        "entries.html": "{{#posts}}{{title}} {{/posts}}",
+      });
+
+      const body = await this.text("/?tag=a");
+      const titles = body.trim().toLowerCase();
+
+      expect(titles).toContain("second");
+      expect(titles).toContain("first");
+      expect(titles).not.toContain("third");
+    });
+
+    it("does not serve a stale post list after new content is synced", async function () {
+      // Use the real incremental sync path (as a live customer publish would),
+      // not rebuild - see app/sync/index.js, which bumps blog.cacheID at the
+      // end of a sync and is what actually busts the posts cache below.
+      await this.write({ path: "/a.txt", content: "Hello, A!" });
+
+      await this.template({
+        "entries.html": "{{#posts}}{{{html}}}{{/posts}}",
+      });
+
+      const before = await this.text("/");
+      expect(before).toContain("Hello, A!");
+      expect(before).not.toContain("Hello, B!");
+
+      await this.write({ path: "/b.txt", content: "Hello, B!" });
+
+      const after = await this.text("/");
+      expect(after).toContain("Hello, A!");
+      expect(after).toContain("Hello, B!");
+    });
+  });
+
+  describe("caching", function () {
+    beforeEach(function () {
+      postsRetrieve._clear();
+    });
+
+    function fakeReqRes(overrides = {}) {
+      return {
+        req: Object.assign(
+          {
+            blog: { id: "blog-1", cacheID: 111 },
+            template: { locals: {} },
+            params: {},
+            query: {},
+            log: () => {},
+          },
+          overrides.req
+        ),
+        res: Object.assign({ locals: {} }, overrides.res),
+      };
+    }
+
+    it("reuses cached results for identical requests", function (done) {
+      const entries = [{ id: "/a.txt", title: "A", html: "<p>A</p>" }];
+
+      spyOn(entriesModel, "getPage").and.callFake(function (
+        blogID,
+        options,
+        callback
+      ) {
+        callback(null, entries, { current: 1, total: 1 });
+      });
+
+      const { req, res } = fakeReqRes();
+
+      postsRetrieve(req, res, function (err, firstResult) {
+        expect(err).toBeNull();
+        expect(firstResult).toEqual(entries);
+
+        const { req: req2, res: res2 } = fakeReqRes();
+
+        postsRetrieve(req2, res2, function (secondErr, secondResult) {
+          expect(secondErr).toBeNull();
+          expect(secondResult).toEqual(entries);
+          expect(entriesModel.getPage).toHaveBeenCalledTimes(1);
+          done();
+        });
+      });
+    });
+
+    it("returns isolated copies so caller mutations do not taint the cache", function (done) {
+      spyOn(entriesModel, "getPage").and.callFake(function (
+        blogID,
+        options,
+        callback
+      ) {
+        callback(null, [{ id: "/a.txt", title: "Original" }], { current: 1 });
+      });
+
+      const { req, res } = fakeReqRes();
+
+      postsRetrieve(req, res, function (err, firstResult) {
+        firstResult[0].title = "Mutated";
+
+        const { req: req2, res: res2 } = fakeReqRes();
+
+        postsRetrieve(req2, res2, function (secondErr, secondResult) {
+          expect(secondResult[0].title).toBe("Original");
+          expect(entriesModel.getPage).toHaveBeenCalledTimes(1);
+          done();
+        });
+      });
+    });
+
+    it("misses the cache when blog.cacheID changes", function (done) {
+      spyOn(entriesModel, "getPage").and.callFake(function (
+        blogID,
+        options,
+        callback
+      ) {
+        callback(null, [], { current: 1 });
+      });
+
+      const { req, res } = fakeReqRes();
+
+      postsRetrieve(req, res, function () {
+        const { req: req2, res: res2 } = fakeReqRes({
+          req: { blog: { id: "blog-1", cacheID: 222 } },
+        });
+
+        postsRetrieve(req2, res2, function () {
+          expect(entriesModel.getPage).toHaveBeenCalledTimes(2);
+          done();
+        });
+      });
+    });
+
+    it("misses the cache when the two blogs are different", function (done) {
+      spyOn(entriesModel, "getPage").and.callFake(function (
+        blogID,
+        options,
+        callback
+      ) {
+        callback(null, [], { current: 1 });
+      });
+
+      const { req, res } = fakeReqRes();
+
+      postsRetrieve(req, res, function () {
+        const { req: req2, res: res2 } = fakeReqRes({
+          req: { blog: { id: "blog-2", cacheID: 111 } },
+        });
+
+        postsRetrieve(req2, res2, function () {
+          expect(entriesModel.getPage).toHaveBeenCalledTimes(2);
+          done();
+        });
+      });
+    });
+
+    it("misses the cache when the requested page differs", function (done) {
+      spyOn(entriesModel, "getPage").and.callFake(function (
+        blogID,
+        options,
+        callback
+      ) {
+        callback(null, [], { current: options.pageNumber });
+      });
+
+      const { req, res } = fakeReqRes({ req: { params: { page: "1" } } });
+
+      postsRetrieve(req, res, function () {
+        const { req: req2, res: res2 } = fakeReqRes({
+          req: { params: { page: "2" } },
+        });
+
+        postsRetrieve(req2, res2, function () {
+          expect(entriesModel.getPage).toHaveBeenCalledTimes(2);
+          done();
+        });
+      });
+    });
+
+    it("does not fetch a page of entries when a tag is present", function (done) {
+      spyOn(entriesModel, "getPage");
+
+      const { req, res } = fakeReqRes({ req: { query: { tag: "design" } } });
+
+      postsRetrieve(req, res, function (err) {
+        // No entries with this tag exist, so we expect an empty result
+        // rather than an error, and the untagged code path must not run.
+        expect(err).toBeNull();
+        expect(entriesModel.getPage).not.toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it("builds equal cache keys regardless of tag array order", function () {
+      const base = {
+        branch: "tagged",
+        sortBy: undefined,
+        order: undefined,
+        pathPrefix: undefined,
+        pageNumber: 1,
+        pageSize: 100,
+        limit: 100,
+        offset: 0,
+      };
+
+      const keyA = postsRetrieve._createCacheKey(
+        { blog: { id: "blog-1", cacheID: 111 } },
+        {},
+        Object.assign({}, base, { tags: ["a", "b"] })
+      );
+
+      const keyB = postsRetrieve._createCacheKey(
+        { blog: { id: "blog-1", cacheID: 111 } },
+        {},
+        Object.assign({}, base, { tags: ["b", "a"] })
+      );
+
+      expect(keyA).toBe(keyB);
+    });
+
+    it("builds different cache keys for different tags", function () {
+      const base = {
+        branch: "tagged",
+        sortBy: undefined,
+        order: undefined,
+        pathPrefix: undefined,
+        pageNumber: 1,
+        pageSize: 100,
+        limit: 100,
+        offset: 0,
+      };
+
+      const keyA = postsRetrieve._createCacheKey(
+        { blog: { id: "blog-1", cacheID: 111 } },
+        {},
+        Object.assign({}, base, { tags: ["a"] })
+      );
+
+      const keyB = postsRetrieve._createCacheKey(
+        { blog: { id: "blog-1", cacheID: 111 } },
+        {},
+        Object.assign({}, base, { tags: ["b"] })
+      );
+
+      expect(keyA).not.toBe(keyB);
+    });
+  });
+});

--- a/app/blog/tests/posts.js
+++ b/app/blog/tests/posts.js
@@ -1,85 +1,14 @@
 const entriesModel = require("models/entries");
 const postsRetrieve = require("../render/retrieve/posts");
 
+// app/blog/render/retrieve/tests/posts.js already covers the {{#posts}}
+// local's pagination, tag filtering, and cache-key/mutation-isolation
+// behavior in depth. This file only adds the scenarios that suite doesn't:
+// cache invalidation via the real incremental sync path, tag-array-order
+// independence, and the tagged/untagged branch split.
 describe("posts", function () {
   describe("rendering", function () {
     require("./util/setup")();
-
-    it("lists entries via the posts local", async function () {
-      await this.publish({ path: "/a.txt", content: "Hello, A!" });
-      await this.publish({ path: "/b.txt", content: "Hello, B!" });
-      await this.publish({ path: "/c.txt", content: "Hello, C!" });
-
-      await this.template({
-        "entries.html": "{{#posts}}{{{html}}}{{/posts}}",
-      });
-
-      const body = await this.text("/");
-      expect(body).toContain("Hello, A!");
-      expect(body).toContain("Hello, B!");
-      expect(body).toContain("Hello, C!");
-    });
-
-    it("paginates according to page_size", async function () {
-      await this.publish({ path: "/c.txt", content: "Hello, C!" });
-      await this.publish({ path: "/b.txt", content: "Hello, B!" });
-      await this.publish({ path: "/a.txt", content: "Hello, A!" });
-
-      await this.template(
-        { "entries.html": "{{#posts}}{{{html}}}{{/posts}}" },
-        { locals: { page_size: 2 } }
-      );
-
-      const page1 = await this.text("/");
-      expect(page1).toContain("Hello, A!");
-      expect(page1).toContain("Hello, B!");
-      expect(page1).not.toContain("Hello, C!");
-
-      const page2 = await this.text("/page/2");
-      expect(page2).not.toContain("Hello, A!");
-      expect(page2).not.toContain("Hello, B!");
-      expect(page2).toContain("Hello, C!");
-    });
-
-    it("exposes pagination alongside the posts local", async function () {
-      const totalEntries = 5;
-      const page_size = 2;
-
-      for (let i = totalEntries; i > 0; i--) {
-        await this.publish({ path: `/${i}.txt`, content: `Hello, ${i}!` });
-      }
-
-      await this.template(
-        {
-          "entries.html":
-            "{{#posts}}{{/posts}}{{pagination.current}}/{{pagination.total}}/{{pagination.total_entries}}",
-        },
-        { locals: { page_size } }
-      );
-
-      const body = await this.text("/page/1");
-      expect(body).toContain("1/3/5");
-    });
-
-    it("filters to a single tag via the query string", async function () {
-      await this.publish({ path: "/first.txt", content: "Tags: A\n\nFoo" });
-      await this.publish({
-        path: "/second.txt",
-        content: "Tags: A,B\n\nBar",
-      });
-      await this.publish({ path: "/third.txt", content: "Tags: B\n\nBaz" });
-
-      await this.template({
-        "entries.html": "{{#posts}}{{title}} {{/posts}}",
-      });
-
-      const body = await this.text("/?tag=a");
-      const titles = body.trim().toLowerCase();
-
-      expect(titles).toContain("second");
-      expect(titles).toContain("first");
-      expect(titles).not.toContain("third");
-    });
 
     it("does not serve a stale post list after new content is synced", async function () {
       // Use the real incremental sync path (as a live customer publish would),
@@ -124,127 +53,6 @@ describe("posts", function () {
       };
     }
 
-    it("reuses cached results for identical requests", function (done) {
-      const entries = [{ id: "/a.txt", title: "A", html: "<p>A</p>" }];
-
-      spyOn(entriesModel, "getPage").and.callFake(function (
-        blogID,
-        options,
-        callback
-      ) {
-        callback(null, entries, { current: 1, total: 1 });
-      });
-
-      const { req, res } = fakeReqRes();
-
-      postsRetrieve(req, res, function (err, firstResult) {
-        expect(err).toBeNull();
-        expect(firstResult).toEqual(entries);
-
-        const { req: req2, res: res2 } = fakeReqRes();
-
-        postsRetrieve(req2, res2, function (secondErr, secondResult) {
-          expect(secondErr).toBeNull();
-          expect(secondResult).toEqual(entries);
-          expect(entriesModel.getPage).toHaveBeenCalledTimes(1);
-          done();
-        });
-      });
-    });
-
-    it("returns isolated copies so caller mutations do not taint the cache", function (done) {
-      spyOn(entriesModel, "getPage").and.callFake(function (
-        blogID,
-        options,
-        callback
-      ) {
-        callback(null, [{ id: "/a.txt", title: "Original" }], { current: 1 });
-      });
-
-      const { req, res } = fakeReqRes();
-
-      postsRetrieve(req, res, function (err, firstResult) {
-        firstResult[0].title = "Mutated";
-
-        const { req: req2, res: res2 } = fakeReqRes();
-
-        postsRetrieve(req2, res2, function (secondErr, secondResult) {
-          expect(secondResult[0].title).toBe("Original");
-          expect(entriesModel.getPage).toHaveBeenCalledTimes(1);
-          done();
-        });
-      });
-    });
-
-    it("misses the cache when blog.cacheID changes", function (done) {
-      spyOn(entriesModel, "getPage").and.callFake(function (
-        blogID,
-        options,
-        callback
-      ) {
-        callback(null, [], { current: 1 });
-      });
-
-      const { req, res } = fakeReqRes();
-
-      postsRetrieve(req, res, function () {
-        const { req: req2, res: res2 } = fakeReqRes({
-          req: { blog: { id: "blog-1", cacheID: 222 } },
-        });
-
-        postsRetrieve(req2, res2, function () {
-          expect(entriesModel.getPage).toHaveBeenCalledTimes(2);
-          done();
-        });
-      });
-    });
-
-    it("misses the cache when the two blogs are different", function (done) {
-      spyOn(entriesModel, "getPage").and.callFake(function (
-        blogID,
-        options,
-        callback
-      ) {
-        callback(null, [], { current: 1 });
-      });
-
-      const { req, res } = fakeReqRes();
-
-      postsRetrieve(req, res, function () {
-        const { req: req2, res: res2 } = fakeReqRes({
-          req: { blog: { id: "blog-2", cacheID: 111 } },
-        });
-
-        postsRetrieve(req2, res2, function () {
-          expect(entriesModel.getPage).toHaveBeenCalledTimes(2);
-          done();
-        });
-      });
-    });
-
-    it("misses the cache when the requested page differs", function (done) {
-      spyOn(entriesModel, "getPage").and.callFake(function (
-        blogID,
-        options,
-        callback
-      ) {
-        callback(null, [], { current: options.pageNumber });
-      });
-
-      const { req, res } = fakeReqRes({ req: { params: { page: "1" } } });
-
-      postsRetrieve(req, res, function () {
-        const { req: req2, res: res2 } = fakeReqRes({
-          req: { params: { page: "2" } },
-        });
-
-        postsRetrieve(req2, res2, function () {
-          expect(entriesModel.getPage).toHaveBeenCalledTimes(2);
-          done();
-        });
-      });
-    });
-
     it("does not fetch a page of entries when a tag is present", function (done) {
       spyOn(entriesModel, "getPage");
 
@@ -284,33 +92,6 @@ describe("posts", function () {
       );
 
       expect(keyA).toBe(keyB);
-    });
-
-    it("builds different cache keys for different tags", function () {
-      const base = {
-        branch: "tagged",
-        sortBy: undefined,
-        order: undefined,
-        pathPrefix: undefined,
-        pageNumber: 1,
-        pageSize: 100,
-        limit: 100,
-        offset: 0,
-      };
-
-      const keyA = postsRetrieve._createCacheKey(
-        { blog: { id: "blog-1", cacheID: 111 } },
-        {},
-        Object.assign({}, base, { tags: ["a"] })
-      );
-
-      const keyB = postsRetrieve._createCacheKey(
-        { blog: { id: "blog-1", cacheID: 111 } },
-        {},
-        Object.assign({}, base, { tags: ["b"] })
-      );
-
-      expect(keyA).not.toBe(keyB);
     });
   });
 });

--- a/app/blog/tests/verifySubscriptionDuration.js
+++ b/app/blog/tests/verifySubscriptionDuration.js
@@ -1,0 +1,39 @@
+const { promisify } = require("util");
+const User = require("models/user");
+
+const setUser = promisify(User.set);
+
+describe("verify-subscription-duration", function () {
+  require("./util/setup")();
+
+  it("returns the subscription duration in ms for a paying user", async function () {
+    const startedAt = Date.now() - 1000 * 60 * 60 * 24 * 30; // 30 days ago
+
+    await setUser(this.user.uid, {
+      subscription: { customer: "cus_123", created: startedAt / 1000 },
+    });
+
+    const res = await this.get("/verify/subscription-duration");
+    const body = await res.json();
+
+    expect(res.status).toEqual(200);
+    expect(body.duration).toBeGreaterThan(0);
+    // Roughly 30 days, allowing generous slack for test runtime.
+    expect(body.duration).toBeGreaterThan(1000 * 60 * 60 * 24 * 29);
+  });
+
+  it("returns 404 when the blog's owner has no subscription", async function () {
+    const res = await this.get("/verify/subscription-duration");
+
+    expect(res.status).toEqual(404);
+  });
+
+  it("returns 404 when the blog has no owner", async function () {
+    // Simulate an orphaned blog by pointing owner at a uid that doesn't exist.
+    await this.blog.update({ owner: "does-not-exist" });
+
+    const res = await this.get("/verify/subscription-duration");
+
+    expect(res.status).toEqual(404);
+  });
+});

--- a/app/blog/tests/vhosts.js
+++ b/app/blog/tests/vhosts.js
@@ -108,6 +108,110 @@ describe("blog server vhosts", function () {
     }).not.toThrow();
   });
 
+  it("returns an error when the request has no host header", function (done) {
+    this.req.get = function () {
+      return undefined;
+    };
+
+    vhosts(this.req, this.res, function (err) {
+      expect(err).toBeDefined();
+      expect(err.code).toEqual("ENOENT");
+      done();
+    });
+  });
+
+  it("returns an error when no blog matches the host", function (done) {
+    this.url("http://this-handle-does-not-exist." + config.host);
+
+    vhosts(this.req, this.res, function (err) {
+      expect(err).toBeDefined();
+      expect(err.code).toEqual("ENOENT");
+      done();
+    });
+  });
+
+  it("returns an error when the blog is disabled", async function () {
+    await this.blog.update({ isDisabled: true });
+    this.url("http://" + this.blog.handle + "." + config.host);
+
+    await new Promise((resolve) => {
+      vhosts(this.req, this.res, function (err) {
+        expect(err).toBeDefined();
+        expect(err.code).toEqual("ENOENT");
+        resolve();
+      });
+    });
+  });
+
+  // Note: blog.isUnpaid is checked alongside isDisabled below, but nothing
+  // in the codebase ever sets that field on a Blog object (only on User -
+  // see app/models/user/extend.js) - flagged separately as a likely dead
+  // branch rather than tested here as if it worked.
+
+  it("redirects the www variant of a custom domain to the apex", async function () {
+    // A real, non-blot domain - the blog id itself contains characters
+    // (e.g. underscores) that aren't valid in a domain name.
+    var domain =
+      "example-" + Math.random().toString(36).slice(2, 10) + ".com";
+
+    await this.blog.update({ domain: domain });
+    this.url("http://www." + domain);
+    // Use https here so blog.forceSSL's http->https redirect (defaults to
+    // true - see models/blog/defaults.js) doesn't take precedence over the
+    // www->apex redirect this test is targeting; a real browser already on
+    // https://www.<domain> hits exactly this path.
+    this.req.protocol = "https";
+
+    // vhosts() responds directly via res.redirect() for this branch and
+    // never calls the `next` callback, so resolve on whichever fires.
+    await new Promise((resolve) => {
+      this.res.redirect.and.callFake(resolve);
+      vhosts(this.req, this.res, resolve);
+    });
+
+    // Express's res.redirect(url) hard-codes 302 regardless of any prior
+    // res.status() call, so the permanent-redirect status must be passed
+    // to redirect() itself - assert the call shape that actually works.
+    expect(this.res.redirect).toHaveBeenCalledWith(
+      301,
+      "https://" + domain + "/"
+    );
+  });
+
+  it("redirects http to https when the blog has forceSSL enabled", async function () {
+    await this.blog.update({ forceSSL: true });
+    this.url("http://" + this.blog.handle + "." + config.host);
+    this.req.protocol = "http";
+
+    // vhosts() responds directly via res.redirect() for this branch and
+    // never calls the `next` callback, so resolve on whichever fires.
+    await new Promise((resolve) => {
+      this.res.redirect.and.callFake(resolve);
+      vhosts(this.req, this.res, resolve);
+    });
+
+    expect(this.res.redirect).toHaveBeenCalledWith(
+      301,
+      "https://" + this.blog.handle + "." + config.host + "/"
+    );
+  });
+
+  it("does not force an https redirect when the request comes via Cloudflare", async function () {
+    await this.blog.update({ forceSSL: true });
+    this.url("http://" + this.blog.handle + "." + config.host);
+    this.req.protocol = "http";
+    this.req.headers = { "cf-connecting-ip": "1.2.3.4" };
+
+    await new Promise((resolve, reject) => {
+      vhosts(this.req, this.res, function (err) {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+
+    expect(this.res.redirect).not.toHaveBeenCalled();
+  });
+
   global.test.blog();
 
   beforeEach(function () {
@@ -123,12 +227,17 @@ describe("blog server vhosts", function () {
       },
       log: function () {},
       url: ctx.url.pathname,
+      originalUrl: "/",
       protocol: ctx.url.protocol,
     };
 
     ctx.res = {
       set: function () {},
       removeHeader: function () {},
+      status: jasmine.createSpy("status").and.callFake(function () {
+        return ctx.res;
+      }),
+      redirect: jasmine.createSpy("redirect"),
     };
   });
 });

--- a/app/blog/vhosts.js
+++ b/app/blog/vhosts.js
@@ -75,9 +75,10 @@ module.exports = function (req, res, next) {
       blog.redirectSubdomain &&
       !previewTemplate
     )
-      return res
-        .status(302)
-        .redirect(req.protocol + "://" + blog.domain + req.originalUrl);
+      return res.redirect(
+        302,
+        req.protocol + "://" + blog.domain + req.originalUrl
+      );
 
     // Redirect HTTP to HTTPS. Preview subdomains are not currently
     // available over HTTPS but when they are, remove this.
@@ -89,8 +90,10 @@ module.exports = function (req, res, next) {
     )
       redirect = "https://" + host + req.originalUrl;
 
-    // Should we be using 302 temporary for this?
-    if (redirect) return res.status(301).redirect(redirect);
+    // Note: Express's res.redirect(url) hard-codes 302 regardless of any
+    // prior res.status() call - the status must be passed to redirect()
+    // itself to actually send a permanent redirect.
+    if (redirect) return res.redirect(301, redirect);
 
     // Retrieve the name of the template from the host
     // If the request came from a preview domain


### PR DESCRIPTION
## Summary

Coverage analysis and hardening of `app/blog` (the code that renders every customer site), done across three passes. Found and fixed three real bugs along the way, and fixed a pre-existing flaky test.

## Bugs found and fixed

1. **`retrieve/folder.js` silently didn't sort directory listings.** `alphanum(contents, {property: "name"})` was looking up a `.name` field on raw filename strings (not objects), so the sort was a no-op - `{{#folder}}` navigation on customer sites returned arbitrary filesystem order instead of alphanumeric order. Fixed to `alphanum(contents)`.

2. **`vhosts.js`'s "permanent" redirects were never actually 301.** `res.status(301).redirect(url)` doesn't work as it looks - Express's `res.redirect(url)` (single-arg form) hard-codes status 302 regardless of any prior `res.status()` call; the status has to be passed to `redirect()` itself (confirmed directly in the installed Express source). This means every domain-mismatch, handle-mismatch, and forceSSL-upgrade redirect was silently sent as a temporary 302 instead of a permanent 301 - affecting SEO/caching for any customer who sets up a custom domain, changes handle, or uses forceSSL. Fixed both call sites to `res.redirect(301, url)` / `res.redirect(302, url)`.

3. **Flaky test, not a bug**: `dates.js`'s "updates the entry's updated property" test compared a file-mtime-derived timestamp against `new Date()` captured in the test process - racy across the container/filesystem clock boundary (reproduced a 1ms reversal in isolation). Rewrote it to assert the actual invariant (`updated` moves forward on edit) instead of wall-clock bounds.

## Flagged, not fixed here

- **`vhosts.js`: `blog.isUnpaid` is dead code.** It's checked alongside `isDisabled` to block a blog from rendering, but `isUnpaid` is never set on a `Blog` object anywhere in the codebase (only on `User`, computed from subscription status). This touches billing/access-control logic, so I flagged it as a follow-up task for someone who knows the intended behavior rather than guessing at a fix.

## Test coverage added

- `render/retrieve/posts.js`: LRU cache correctness, tagged/untagged branching (real-sync cache-invalidation regression test; tag-array-order cache-key independence) - trimmed down after finding an existing 500+ line suite (`render/retrieve/tests/posts.js`) already covered most of what I'd first written.
- `render/retrieve/{folder,is_active,asset,plugin,recent_entries}.js` and the trivial pass-through locals (`avatar_url`, `css_url`, `feed_url`, `script_url`, `search_query`, `total_posts`, `encode_json`, `encode_uri_component`) - none of these had ever actually been invoked by a test.
- `render/locals.js`: its dedicated spec was disabled with `xdescribe` and used broken mocks, so it never ran - rewrote it with working tests (nested/array recursion, circular-reference safety, etc.).
- `vhosts.js`: missing host header, unknown blog, disabled blog, www→apex redirect, forceSSL upgrade, Cloudflare SSL bypass - previously only the happy path (blot subdomain, preview domains) was tested.
- `robots.js`'s `/verify/subscription-duration` route, `render/error.js`, and `render/middleware.js`'s CDN-link protocol rewrite branch (only reachable with `forceSSL` off, which is why it needed its own test).

## Coverage: before → after (`app/blog`, via `nyc`)

| Scope | Statements | Branches | Functions | Lines |
|---|---|---|---|---|
| All files | 94.07% → 96.35% | 77.13% → 80.57% | 92.97% → 97.32% | 95.18% → 97.36% |
| `retrieve/posts.js` | 95.12% → 97.56% | 85.96% → 87.71% | 85.71% → 92.85% | 96.15% → 97.43% |
| `render/locals.js` | 91.3% → 100% | 100% → 100% | 100% → 100% | 90.9% → 100% |
| `retrieve/folder.js` | 21.21% → 90.9% | 0% → 75% | 0% → 100% | 25% → 100% |
| `retrieve/is_active.js` | 22.22% → 100% | 0% → 100% | 0% → 100% | 25% → 100% |
| `retrieve/asset.js` | 10% → 100% | 0% → 100% | 0% → 100% | 11.11% → 100% |
| `vhosts.js` | 82.92% → 92.68% | 73.43% → 87.5% | 100% → 100% | 84.21% → 93.42% |
| `robots.js` | 48.14% → 88.88% | 42.1% → 84.21% | 60% → 100% | 59.09% → 100% |
| `render/middleware.js` | 90.09% → 91.08% | 76.27% → 81.35% | 100% → 100% | 92.63% → 93.68% |

Full suite: 489 specs, 0 failures.

## Test plan
- [x] `./scripts/tests/invoke.sh app/blog` — 489 specs, 0 failures, coverage captured at each pass