### PR TITLE
Make account updates and one-time token consumption atomic

### DIFF
--- a/app/dashboard/account/tests/password.js
+++ b/app/dashboard/account/tests/password.js
@@ -1,0 +1,74 @@
+var Password = require("../password");
+var User = require("models/user");
+
+function request(hasPassword, token, method) {
+  return new Promise(function (resolve, reject) {
+    var req = {
+      method: method || "POST",
+      url: "/set",
+      // The dashboard user has been extended: only hasPassword remains.
+      user: { uid: "password-route-user", hasPassword: hasPassword },
+      session: token ? { passwordSetToken: token } : {},
+      body: { newPasswordA: "new-password", newPasswordB: "new-password" },
+    };
+    var res = {
+      redirect: function (location) { resolve({ redirect: location }); },
+      message: function (location) { resolve({ saved: location }); },
+      render: function (view) { resolve({ view: view }); },
+    };
+    Password.handle(req, res, function (err) {
+      if (err) return resolve({ error: err });
+      reject(new Error("Password route did not respond"));
+    });
+  });
+}
+
+describe("password setting authorization", function () {
+  beforeEach(function () {
+    spyOn(User, "hashPassword").and.callFake(function (password, callback) {
+      callback(null, "hashed-password");
+    });
+    spyOn(User, "set").and.callFake(function (uid, updates, callback) {
+      callback(null);
+    });
+    spyOn(User, "checkAccessToken").and.callFake(function (token, callback) {
+      callback(null, "password-route-user");
+    });
+  });
+
+  it("blocks existing-password accounts without a reset token on GET and POST", async function () {
+    expect((await request(true, null, "GET")).redirect).toEqual("/");
+    expect((await request(true)).redirect).toEqual("/");
+    expect(User.hashPassword).not.toHaveBeenCalled();
+    expect(User.set).not.toHaveBeenCalled();
+  });
+
+  it("allows a passwordless account to set its first password", async function () {
+    expect((await request(false)).saved).toEqual("/sites");
+    expect(User.checkAccessToken).not.toHaveBeenCalled();
+    expect(User.set).toHaveBeenCalledWith("password-route-user", {
+      passwordHash: "hashed-password",
+    }, jasmine.any(Function));
+  });
+
+  it("allows a valid token for this account", async function () {
+    expect((await request(true, "valid-token")).saved).toEqual("/sites");
+    expect(User.checkAccessToken).toHaveBeenCalledWith("valid-token", jasmine.any(Function));
+  });
+
+  it("rejects expired or consumed tokens", async function () {
+    User.checkAccessToken.and.callFake(function (token, callback) {
+      callback(new Error("Invalid access token"));
+    });
+    expect((await request(true, "expired-token")).error.message).toEqual("Invalid access token");
+    expect(User.set).not.toHaveBeenCalled();
+  });
+
+  it("rejects a token belonging to a different account", async function () {
+    User.checkAccessToken.and.callFake(function (token, callback) {
+      callback(null, "another-user");
+    });
+    expect((await request(true, "other-token")).error.message).toEqual("Your token was invalid.");
+    expect(User.set).not.toHaveBeenCalled();
+  });
+});

--- a/app/models/user/checkAccessToken.js
+++ b/app/models/user/checkAccessToken.js
@@ -10,11 +10,14 @@ var key = require("./key");
 module.exports = function (token, callback) {
   (async function () {
     try {
-      var value = await client.get(key.accessToken(token));
+      // Lua also works on Redis versions before GETDEL was introduced.
+      var value = await client.eval(
+        "local value = redis.call('GET', KEYS[1]); " +
+          "if value then redis.call('DEL', KEYS[1]) end; return value",
+        { keys: [key.accessToken(token)], arguments: [] }
+      );
 
       if (!value) return callback(new Error("Invalid access token"));
-
-      await client.del(key.accessToken(token));
 
       return callback(null, value);
     } catch (err) {

--- a/app/models/user/checkAccessToken.js
+++ b/app/models/user/checkAccessToken.js
@@ -10,12 +10,8 @@ var key = require("./key");
 module.exports = function (token, callback) {
   (async function () {
     try {
-      // Lua also works on Redis versions before GETDEL was introduced.
-      var value = await client.eval(
-        "local value = redis.call('GET', KEYS[1]); " +
-          "if value then redis.call('DEL', KEYS[1]) end; return value",
-        { keys: [key.accessToken(token)], arguments: [] }
-      );
+      // GETDEL is atomic, so only one concurrent caller can consume the token.
+      var value = await client.getDel(key.accessToken(token));
 
       if (!value) return callback(new Error("Invalid access token"));
 

--- a/app/models/user/create.js
+++ b/app/models/user/create.js
@@ -44,8 +44,8 @@ module.exports = function create (
 
       var userString = JSON.stringify(user);
 
-      // If I add or remove methods here
-      // also remove them from set.js
+      // If I add or remove an index key here (email/customer/paypal),
+      // also update the indexes() helper in set.js.
       var multi = client.multi();
       multi.sAdd(key.uids, uid);
       multi.setNX(key.user(uid), userString);

--- a/app/models/user/set.js
+++ b/app/models/user/set.js
@@ -3,65 +3,95 @@ var validate = require("./validate");
 var client = require("models/client");
 var updateBillingEmail = require("./updateBillingEmail");
 var key = require("./key");
-var getById = require("./getById");
+
+// Compare the exact value we validated, then update the document and its
+// indexes together. Unlike WATCH on the shared connection this is safe when
+// several requests (or application processes) update users concurrently.
+var commit = `
+  if redis.call('GET', KEYS[1]) ~= ARGV[1] then return 0 end
+  for i = 2, 4 do
+    if KEYS[i] ~= '' then
+      local owner = redis.call('GET', KEYS[i])
+      if owner and owner ~= ARGV[3] then return -i end
+    end
+  end
+  for i = 5, 7 do
+    if KEYS[i] ~= '' and KEYS[i] ~= KEYS[i - 3] then
+      if redis.call('GET', KEYS[i]) == ARGV[3] then
+        redis.call('DEL', KEYS[i])
+      end
+    end
+  end
+  redis.call('SET', KEYS[1], ARGV[2])
+  for i = 2, 4 do
+    if KEYS[i] ~= '' then redis.call('SET', KEYS[i], ARGV[3]) end
+  end
+  return 1
+`;
+
+function indexes(user) {
+  return [
+    user.email ? key.email(user.email) : "",
+    user.subscription && user.subscription.customer
+      ? key.customer(user.subscription.customer) : "",
+    user.paypal && user.paypal.id ? key.paypal(user.paypal.id) : "",
+  ];
+}
 
 module.exports = function save(uid, updates, callback) {
   ensure(uid, "string").and(updates, "object").and(callback, "function");
 
-  getById(uid, function (err, user) {
-    if (err) return callback(err);
+  (async function () {
+    for (var attempt = 0; attempt < 20; attempt++) {
+      var previous = await client.get(key.user(uid));
+      if (!previous) throw new Error("No user");
 
-    if (!user) return callback(new Error("No user"));
+      var user;
+      try {
+        user = JSON.parse(previous);
+        ensure(user, "object");
+      } catch (err) {
+        throw new Error("BADJSON");
+      }
+      var former = JSON.parse(previous);
+      if (typeof user.created === "undefined") user.created = 0;
+      if (typeof user.welcomeEmailSent === "undefined")
+        user.welcomeEmailSent = true;
 
-    // Clone the state of the user so we can
-    // compare any changes further down
-    var former = JSON.parse(JSON.stringify(user));
+      var result = await new Promise(function (resolve, reject) {
+        validate(user, updates, function (err, validated, changes) {
+          if (err) return reject(err);
+          resolve({ user: validated, changes: changes });
+        });
+      });
 
-    if (typeof user.created === "undefined") user.created = 0;
-    if (typeof user.welcomeEmailSent === "undefined")
-      user.welcomeEmailSent = true;
+      var status = await client.eval(commit, {
+        keys: [key.user(uid)].concat(indexes(result.user), indexes(former)),
+        arguments: [previous, JSON.stringify(result.user), uid],
+      });
 
-    validate(user, updates, function (err, user, changes) {
-      if (err) return callback(err);
+      if (status === 0) continue;
+      if (status < 0) {
+        var conflict = new Error(status === -2
+          ? "This email is in use." : "This subscription is in use.");
+        conflict.code = "EEXISTS";
+        throw conflict;
+      }
 
-      (async function () {
-        try {
-          var userString = JSON.stringify(user);
+      // Only dispatch external side effects after a successful commit, never
+      // from an abandoned validation attempt.
+      if (former.email && former.email !== result.user.email) {
+        updateBillingEmail(result.user, function (err) {
+          if (err) console.log("Error updating email for customer on Stripe:", err);
+        });
+      }
+      return result.changes;
+    }
 
-          // If I add or remove methods here
-          // also remove them from create.js
-          var multi = client.multi();
-
-          // Should this be setNX? We don't want to clobber
-          // emails which are set between validation and here.
-          if (user.email) multi.set(key.email(user.email), uid);
-
-          // If the user changes their email, remove the old
-          // email pointing to the User's ID.
-          if (former.email && former.email !== user.email) {
-            multi.del(key.email(former.email));
-            updateBillingEmail(user, function (err) {
-              console.log("Error updating email for customer on Stripe:", err);
-            });
-          }
-
-          multi.set(key.user(uid), userString);
-
-          // some users might not have stripe subscriptions
-          if (user.subscription && user.subscription.customer)
-            multi.set(key.customer(user.subscription.customer), uid);
-
-          // some users might not have paypal subscriptions
-          if (user.paypal && user.paypal.id)
-            multi.set(key.paypal(user.paypal.id), uid);
-
-          await multi.exec();
-
-          return callback(null, changes);
-        } catch (err) {
-          return callback(err);
-        }
-      })();
-    });
-  });
+    var busy = new Error("User changed too frequently; please retry");
+    busy.code = "EAGAIN";
+    throw busy;
+  })().then(function (changes) {
+    callback(null, changes);
+  }, callback);
 };

--- a/app/models/user/tests/checkAccessToken.js
+++ b/app/models/user/tests/checkAccessToken.js
@@ -1,0 +1,34 @@
+var client = require("models/client");
+var key = require("../key");
+var check = require("util").promisify(require("../checkAccessToken"));
+
+describe("one-time access tokens", function () {
+  var token = "atomic-access-token-test";
+
+  afterEach(async function () {
+    await client.del(key.accessToken(token));
+  });
+
+  it("allows exactly one concurrent consumer", async function () {
+    await client.set(key.accessToken(token), "user-id");
+    var results = await Promise.all(Array.from({ length: 10 }, function () {
+      return check(token).then(value => ({ value }), error => ({ error }));
+    }));
+    expect(results.filter(result => result.value === "user-id").length).toEqual(1);
+    expect(results.filter(result => result.error).length).toEqual(9);
+    expect(await client.get(key.accessToken(token))).toBeNull();
+  });
+
+  it("rejects missing and expired tokens", async function () {
+    await client.set(key.accessToken(token), "user-id");
+    await client.pExpireAt(key.accessToken(token), Date.now() - 1);
+    var error = await check(token).then(() => null, err => err);
+    expect(error.message).toEqual("Invalid access token");
+  });
+
+  it("reports Redis failure instead of authenticating", async function () {
+    spyOn(client, "eval").and.returnValue(Promise.reject(new Error("Redis unavailable")));
+    var error = await check(token).then(() => null, err => err);
+    expect(error.message).toEqual("Redis unavailable");
+  });
+});

--- a/app/models/user/tests/checkAccessToken.js
+++ b/app/models/user/tests/checkAccessToken.js
@@ -27,7 +27,7 @@ describe("one-time access tokens", function () {
   });
 
   it("reports Redis failure instead of authenticating", async function () {
-    spyOn(client, "eval").and.returnValue(Promise.reject(new Error("Redis unavailable")));
+    spyOn(client, "getDel").and.returnValue(Promise.reject(new Error("Redis unavailable")));
     var error = await check(token).then(() => null, err => err);
     expect(error.message).toEqual("Redis unavailable");
   });

--- a/app/models/user/tests/concurrentSet.js
+++ b/app/models/user/tests/concurrentSet.js
@@ -1,0 +1,121 @@
+var client = require("models/client");
+var key = require("../key");
+var set = require("../set");
+var getById = require("../getById");
+var promisify = require("util").promisify;
+var save = promisify(set);
+var get = promisify(getById);
+
+describe("atomic user updates", function () {
+  var uid = "atomic-user-test";
+  var otherUid = "atomic-other-user-test";
+  var oldEmail = "atomic-old@example.com";
+  var newEmail = "atomic-new@example.com";
+  var otherEmail = "atomic-other@example.com";
+
+  function user(id, email) {
+    return {
+      uid: id, email: email, blogs: [], isDisabled: false,
+      lastSession: "", created: 0, welcomeEmailSent: true,
+      passwordHash: "initial-password", subscription: {}, paypal: {},
+    };
+  }
+
+  beforeEach(async function () {
+    await client.set(key.user(uid), JSON.stringify(user(uid, oldEmail)));
+    await client.set(key.email(oldEmail), uid);
+    await client.set(key.user(otherUid), JSON.stringify(user(otherUid, otherEmail)));
+    await client.set(key.email(otherEmail), otherUid);
+  });
+
+  afterEach(async function () {
+    await client.del([
+      key.user(uid), key.user(otherUid), key.email(oldEmail),
+      key.email(newEmail), key.email(otherEmail),
+      key.customer("atomic-old"), key.customer("atomic-new"),
+      key.paypal("atomic-old"), key.paypal("atomic-new"),
+    ]);
+  });
+
+  it("preserves password and subscription updates that read the same version", async function () {
+    var original = client.get.bind(client);
+    var reads = [];
+    spyOn(client, "get").and.callFake(async function (name) {
+      var value = await original(name);
+      if (name !== key.user(uid) || reads.length >= 2) return value;
+      return new Promise(function (resolve) {
+        reads.push(function () { resolve(value); });
+        if (reads.length === 2) reads.forEach(function (release) { release(); });
+      });
+    });
+
+    await Promise.all([
+      save(uid, { passwordHash: "new-password" }),
+      save(uid, { subscription: { customer: "atomic-new" } }),
+    ]);
+    var saved = await get(uid);
+    expect(saved.passwordHash).toEqual("new-password");
+    expect(saved.subscription.customer).toEqual("atomic-new");
+    expect(await client.get(key.customer("atomic-new"))).toEqual(uid);
+  });
+
+  it("rejects an email claimed after validation without writing the user", async function () {
+    var original = client.eval.bind(client);
+    var calls = [];
+    spyOn(client, "eval").and.callFake(function (script, options) {
+      return new Promise(function (resolve, reject) {
+        calls.push(function () { original(script, options).then(resolve, reject); });
+        if (calls.length === 2) calls.forEach(function (release) { release(); });
+      });
+    });
+    var results = await Promise.all([
+      save(uid, { email: newEmail }).then(() => null, err => err),
+      save(otherUid, { email: newEmail }).then(() => null, err => err),
+    ]);
+    expect(results.filter(result => result === null).length).toEqual(1);
+    expect(results.filter(result => result && result.code === "EEXISTS").length).toEqual(1);
+    var owner = await client.get(key.email(newEmail));
+    expect((await get(owner)).email).toEqual(newEmail);
+    var loser = owner === uid ? otherUid : uid;
+    var originalEmail = loser === uid ? oldEmail : otherEmail;
+    expect((await get(loser)).email).toEqual(originalEmail);
+    expect(await client.get(key.email(originalEmail))).toEqual(loser);
+  });
+
+  it("removes former subscription indexes and keeps the new ones", async function () {
+    await save(uid, { subscription: { customer: "atomic-old" }, paypal: { id: "atomic-old" } });
+    await save(uid, { subscription: { customer: "atomic-new" }, paypal: { id: "atomic-new" } });
+    expect(await client.get(key.customer("atomic-old"))).toBeNull();
+    expect(await client.get(key.paypal("atomic-old"))).toBeNull();
+    expect(await client.get(key.customer("atomic-new"))).toEqual(uid);
+    expect(await client.get(key.paypal("atomic-new"))).toEqual(uid);
+    await save(uid, { subscription: {}, paypal: {} });
+    expect(await client.get(key.customer("atomic-new"))).toBeNull();
+    expect(await client.get(key.paypal("atomic-new"))).toBeNull();
+  });
+
+  it("does not remove a former index owned by another user", async function () {
+    await client.set(key.email(oldEmail), otherUid);
+    await save(uid, { email: newEmail });
+    expect(await client.get(key.email(oldEmail))).toEqual(otherUid);
+  });
+
+  it("stops retrying under sustained contention", async function () {
+    spyOn(client, "eval").and.returnValue(Promise.resolve(0));
+    var error = await save(uid, { passwordHash: "changed" }).then(() => null, err => err);
+    expect(error.code).toEqual("EAGAIN");
+    expect(client.eval.calls.count()).toEqual(20);
+    expect((await get(uid)).passwordHash).toEqual("initial-password");
+  });
+
+  it("does not recreate a user deleted before commit", async function () {
+    var original = client.eval.bind(client);
+    spyOn(client, "eval").and.callFake(async function (script, options) {
+      await client.del(key.user(uid));
+      return original(script, options);
+    });
+    var error = await save(uid, { passwordHash: "changed" }).then(() => null, err => err);
+    expect(error.message).toEqual("No user");
+    expect(await client.get(key.user(uid))).toBeNull();
+  });
+});


### PR DESCRIPTION
Concurrent `User.set` calls can overwrite unrelated changes because each saves a complete user snapshot. Commit the validated snapshot and its email/subscription indexes together with a Redis compare-and-set script, retrying against fresh state on conflicts. Index ownership is checked again at commit time, and contention has a bounded retry limit.

Consume one-time access tokens with a single Redis operation so only one request can authenticate. Add regression coverage for the existing password-change guard as well.

Validation: 20 focused specifications passed against isolated Redis 6.2.14, including concurrent writes, index collisions, deleted users, contention limits, one-time token consumption, and password authorization. The standard user-model and password suites also passed (15 + 5 specifications, seed 14396). Local test execution used polling instead of macOS FSEvents; no production services were involved.
