### PR TITLE
Manage import cancellation, bounded downloads, and upload ownership

### DIFF
--- a/app/dashboard/index.js
+++ b/app/dashboard/index.js
@@ -11,49 +11,7 @@ dashboard.use(trace("loading session information"));
 dashboard.use(require("dashboard/util/session"));
 dashboard.use(trace("loaded session information"));
 
-const multiparty = require("multiparty");
-
-var tempDir = require("helper/tempDir")();
-
-const maxFilesSize = 30 * 1024 * 1024; // 30mb
-
-var FORM_OPTIONS = {
-  uploadDir: tempDir,
-  maxFilesSize
-};
-
-// Middleware to parse multipart forms and regular forms
-const parse = (req, res, next) => {
-  if (!req.is('multipart/form-data')) {
-    return next();
-  }
-
-  const form = new multiparty.Form(FORM_OPTIONS);
-  
-  form.parse(req, (err, fields, files) => {
-    if (err) {
-      if (err.code === "ETOOBIG") {
-        err.status = 413;
-      }
-      return next(err);
-    }
-
-    // Convert arrays to single values when only one value exists
-    req.body = Object.keys(fields).reduce((acc, key) => {
-      acc[key] = fields[key].length === 1 ? fields[key][0] : fields[key];
-      return acc;
-    }, {});
-
-    req.files = files;
-
-    if (req.files.avatar) {
-      req.files = { avatar: files.avatar[0] };
-    }
-
-    next();
-  });
-};
-dashboard.use(parse);
+dashboard.use(require("dashboard/util/multipart")());
 
 dashboard.use(require("dashboard/util/parse"));
 dashboard.use(cookieParser());

--- a/app/dashboard/site/import/helper/asset_directory.js
+++ b/app/dashboard/site/import/helper/asset_directory.js
@@ -18,19 +18,25 @@ module.exports = function assetDirectory(entry, callback) {
 
   entry.asset_directory_callbacks = [callback];
 
-  fs.mkdtemp(path.join(os.tmpdir(), "blot-import-"), function (err, directory) {
+  const state = require("../lifecycle").current();
+  const parent = state ? state.stagingDirectory : os.tmpdir();
+  fs.ensureDir(parent, function (err) {
+    if (err) return finish(err);
+    fs.mkdtemp(path.join(parent, "blot-import-"), finish);
+  });
+
+  function finish(err, directory) {
     var callbacks = entry.asset_directory_callbacks;
 
     delete entry.asset_directory_callbacks;
 
     if (!err) {
       entry.asset_directory = directory;
-      const state = require("../lifecycle").current();
       if (state) state.assets.add(directory);
     }
 
     callbacks.forEach(function (callback) {
       callback(err, directory);
     });
-  });
+  }
 };

--- a/app/dashboard/site/import/helper/asset_directory.js
+++ b/app/dashboard/site/import/helper/asset_directory.js
@@ -23,7 +23,11 @@ module.exports = function assetDirectory(entry, callback) {
 
     delete entry.asset_directory_callbacks;
 
-    if (!err) entry.asset_directory = directory;
+    if (!err) {
+      entry.asset_directory = directory;
+      const state = require("../lifecycle").current();
+      if (state) state.assets.add(directory);
+    }
 
     callbacks.forEach(function (callback) {
       callback(err, directory);

--- a/app/dashboard/site/import/helper/download.js
+++ b/app/dashboard/site/import/helper/download.js
@@ -39,8 +39,13 @@ module.exports = async function download(url, options = {}) {
     const chunks = [];
     let bytes = 0;
     for await (const chunk of body) {
+      // lifecycle.check() does synchronous filesystem I/O (existsSync/
+      // readJsonSync); calling it once per stream chunk would block the
+      // event loop hundreds of times per download. lifecycle's own 250ms
+      // background timer (see lifecycle.js) already polls the same state and
+      // aborts this signal, and an explicit cancel aborts it immediately, so
+      // checking it here is enough to react promptly without the extra I/O.
       if (controller.signal.aborted) throw lifecycle.cancelled();
-      lifecycle.check();
       bytes += chunk.length;
       if (state) state.bytes += chunk.length;
       if (state && state.bytes > MAX_IMPORT_BYTES) {

--- a/app/dashboard/site/import/helper/download.js
+++ b/app/dashboard/site/import/helper/download.js
@@ -1,0 +1,63 @@
+const airlock = require("helper/airlock");
+const lifecycle = require("../lifecycle");
+
+// Each import processes assets sequentially. Keep per-asset memory and total
+// transferred data bounded independently of remote Content-Length headers.
+const MAX_BYTES = 50 * 1024 * 1024;
+const MAX_IMPORT_BYTES = 1024 * 1024 * 1024;
+
+// Count decompressed response bytes, including chunked bodies. The deadline
+// covers both headers and body consumption, and abort destroys the socket.
+module.exports = async function download(url, options = {}) {
+  const { timeout = 5000, maxBytes = MAX_BYTES, ...fetchOptions } = options;
+  lifecycle.check();
+  const state = lifecycle.current();
+  const signal = fetchOptions.signal || (state && state.signal);
+  const controller = new AbortController();
+  let body;
+  const abort = () => {
+    controller.abort();
+    if (body && !body.destroyed) body.destroy(lifecycle.cancelled());
+  };
+  if (signal) {
+    signal.addEventListener("abort", abort, { once: true });
+    if (signal.aborted) controller.abort();
+  }
+  const timer = setTimeout(abort, timeout);
+  try {
+    const response = await airlock.fetch(url, {
+      ...fetchOptions,
+      signal: controller.signal,
+      size: maxBytes,
+    });
+    body = response.body;
+    if (controller.signal.aborted) throw lifecycle.cancelled();
+    if (!response.ok) throw new Error("Bad status code: " + response.status);
+    if (Number(response.headers.get("content-length")) > maxBytes) {
+      throw new Error("Import download exceeds byte limit");
+    }
+    const chunks = [];
+    let bytes = 0;
+    for await (const chunk of body) {
+      if (controller.signal.aborted) throw lifecycle.cancelled();
+      lifecycle.check();
+      bytes += chunk.length;
+      if (state) state.bytes += chunk.length;
+      if (state && state.bytes > MAX_IMPORT_BYTES) {
+        const error = new Error("Import exceeds 1 GiB download limit");
+        error.code = "IMPORT_BYTE_LIMIT";
+        state.abort(error);
+        throw error;
+      }
+      if (bytes > maxBytes) throw new Error("Import download exceeds byte limit");
+      chunks.push(chunk);
+    }
+    if (controller.signal.aborted) throw lifecycle.cancelled();
+    return { data: Buffer.concat(chunks, bytes), headers: response.headers };
+  } finally {
+    clearTimeout(timer);
+    if (signal) signal.removeEventListener("abort", abort);
+    controller.abort();
+    if (body && !body.destroyed) body.destroy();
+  }
+};

--- a/app/dashboard/site/import/helper/download_audio.js
+++ b/app/dashboard/site/import/helper/download_audio.js
@@ -4,12 +4,8 @@ var parse = require("url").parse;
 var each_el = require("./each_el");
 var fs = require("fs-extra");
 var assetDirectory = require("./asset_directory");
-// Imported HTML can reference arbitrary, user-controlled audio URLs, so route
-// the download through the airlock's forward proxy (SSRF egress boundary)
-// rather than the app container's direct network. Fails closed in production.
-// This replaces the unproxied `download` package, which was also never
-// declared in package.json (it resolved only as a transitive dependency).
-var fetch = require("helper/airlock").fetch;
+var download = require("./download");
+var lifecycle = require("../lifecycle");
 
 module.exports = function download_audio(post, callback) {
   var $ = cheerio.load(post.html, { decodeEntities: false });
@@ -34,16 +30,8 @@ module.exports = function download_audio(post, callback) {
 
       if (name.charAt(0) !== "_") name = "_" + name;
 
-      fetch(href, { airlockLabel: "import/download_audio" })
-        .then(function (res) {
-          if (!res.ok) {
-            throw new Error("Bad status code: " + res.status);
-          }
-          return res.arrayBuffer();
-        })
-        .then(function (arrayBuffer) {
-          var data = Buffer.from(arrayBuffer);
-
+      download(href, { airlockLabel: "import/download_audio" })
+        .then(function ({ data }) {
           assetDirectory(post, function (err, directory) {
             if (err) return next();
 
@@ -58,10 +46,11 @@ module.exports = function download_audio(post, callback) {
         })
         .catch(function (err) {
           console.log("Audio error:", href, err && err.message);
-          next();
+          next(lifecycle.current() && lifecycle.current().signal.aborted ? err : null);
         });
     },
-    function () {
+    function (err) {
+      if (err) return callback(err);
       post.html = $.html();
       callback(null, post);
     }

--- a/app/dashboard/site/import/helper/download_images.js
+++ b/app/dashboard/site/import/helper/download_images.js
@@ -6,72 +6,22 @@ var each_el = require("./each_el");
 var fs = require("fs-extra");
 var sharp = require("sharp");
 var mime = require("mime-types");
-var callOnce = require("helper/callOnce");
 var assetDirectory = require("./asset_directory");
-// Imported HTML can reference arbitrary, user-controlled image URLs, so route
-// the download through the airlock's forward proxy (SSRF egress boundary)
-// rather than the app container's direct network. Fails closed in production.
-var fetch = require("helper/airlock").fetch;
+var boundedDownload = require("./download");
+var lifecycle = require("../lifecycle");
 
-// Consider using this algorithm to determine best part of alt tag or caption to use
-// as the file's name:
-// http://www.bearcave.com/misl/misl_tech/wavelets/compression/shannon.html
-var TIMEOUT = 5 * 1000; // 10s
-
-function download(url, _callback) {
-  console.log("Attempting to download", url);
-
-  var time;
-
-  var callback = callOnce(function (err, data, format, headers) {
-    console.log("Finishing attempt to download", url);
-    clearTimeout(time);
-    _callback(err, data, format, headers);
-  });
-
-  if (!require("url").parse(url).hostname)
-    return callback(new Error("Failed to parse hostname: " + url));
-
-  if (!url || url.indexOf("data:") === 0)
-    return callback(new Error("Invalid URL: " + url));
-
-  time = setTimeout(function () {
-    console.log("Timing out downloading", url);
-    callback(new Error("Timeout: >10s downloading " + url));
-  }, TIMEOUT);
-
-  fetch(url, { airlockLabel: "import/download_images" })
-    .then(function (res) {
-      if (!res.ok) {
-        throw new Error("Bad status code: " + res.status);
-      }
-
-      console.log("Successfully downloaded", url);
-
-      var headers = {
-        contentType: res.headers.get("content-type"),
-        contentDisposition: res.headers.get("content-disposition"),
-      };
-
-      return res.arrayBuffer().then(function (arrayBuffer) {
-        return { arrayBuffer: arrayBuffer, headers: headers };
-      });
+function download(url, callback) {
+  boundedDownload(url, { airlockLabel: "import/download_images" })
+    .then(async ({ data, headers }) => {
+      lifecycle.check();
+      const metadata = await sharp(data).metadata();
+      lifecycle.check();
+      return { data, format: metadata.format, headers: {
+        contentType: headers.get("content-type"),
+        contentDisposition: headers.get("content-disposition"),
+      }};
     })
-    .then(function (result) {
-      const buffer = Buffer.from(result.arrayBuffer);
-      sharp(buffer).metadata(function (err, metadata) {
-        var format;
-        if (metadata && metadata.format) {
-          format = metadata.format;
-        }
-
-        callback(null, buffer, format, result.headers);
-      });
-    })
-    .catch(function (err) {
-      console.log("Failed to download", url, err);
-      callback(err);
-    });
+    .then(result => callback(null, result.data, result.format, result.headers), callback);
 }
 
 function download_thumbnail(post, callback) {
@@ -82,7 +32,7 @@ function download_thumbnail(post, callback) {
   if (!thumbnail) return callback();
 
   download(thumbnail, function (err, data, format, headers) {
-    if (err || !data) return callback();
+    if (err || !data) return callback(lifecycle.current() && lifecycle.current().signal.aborted ? err : null);
 
     var name = nameFrom(thumbnail, headers, format);
 
@@ -120,7 +70,7 @@ module.exports = function download_images(post, callback) {
 
         download(src, function (err, data, format, headers) {
           if (err || !data) {
-            return next();
+            return next(lifecycle.current() && lifecycle.current().signal.aborted ? err : null);
           }
 
           var name = nameFrom(src, headers, format);
@@ -142,7 +92,8 @@ module.exports = function download_images(post, callback) {
           });
         });
       },
-      function () {
+      function (err) {
+        if (err) return callback(err);
         post.html = $.html();
 
         callback(null, post);

--- a/app/dashboard/site/import/helper/download_pdfs.js
+++ b/app/dashboard/site/import/helper/download_pdfs.js
@@ -3,53 +3,13 @@ var basename = require("path").basename;
 var parse = require("url").parse;
 var each_el = require("./each_el");
 var fs = require("fs-extra");
-var callOnce = require("helper/callOnce");
 var assetDirectory = require("./asset_directory");
-// Imported HTML can reference arbitrary, user-controlled PDF URLs, so route
-// the download through the airlock's forward proxy (SSRF egress boundary)
-// rather than the app container's direct network. Fails closed in production.
-var fetch = require("helper/airlock").fetch;
+var boundedDownload = require("./download");
+var lifecycle = require("../lifecycle");
 
-var TIMEOUT = 5 * 1000; // 10s
-
-function download(url, _callback) {
-  console.log("Attempting to download", url);
-
-  var time;
-
-  var callback = callOnce(function (err, data) {
-    console.log("Finishing attempt to download", url);
-    clearTimeout(time);
-    _callback(err, data);
-  });
-
-  if (!require("url").parse(url).hostname)
-    return callback(new Error("Failed to parse hostname: " + url));
-
-  if (!url || url.indexOf("data:") === 0)
-    return callback(new Error("Invalid URL: " + url));
-
-  time = setTimeout(function () {
-    console.log("Timing out downloading", url);
-    callback(new Error("Timeout: >10s downloading " + url));
-  }, TIMEOUT);
-
-  fetch(url, { airlockLabel: "import/download_pdfs" })
-    .then(function (res) {
-      if (!res.ok) {
-        return callback(new Error("Bad status code: " + res.status));
-      }
-      console.log("Successfully downloaded", url);
-
-      return res.buffer();
-    })
-    .then(function (data) {
-      callback(null, data);
-    })
-    .catch(function (err) {
-      console.log("Failed to download", url, err);
-      callback(err);
-    });
+function download(url, callback) {
+  boundedDownload(url, { airlockLabel: "import/download_pdfs" })
+    .then(({ data }) => callback(null, data), callback);
 }
 
 module.exports = function download_pdfs(post, callback) {
@@ -95,7 +55,7 @@ module.exports = function download_pdfs(post, callback) {
       download(href, function (err, data) {
         if (err) {
           console.log("PDF error:", href, err.name, err.statusCode);
-          return next();
+          return next(lifecycle.current() && lifecycle.current().signal.aborted ? err : null);
         }
 
         assetDirectory(post, function (err, directory) {
@@ -117,7 +77,8 @@ module.exports = function download_pdfs(post, callback) {
         });
       });
     },
-    function () {
+    function (err) {
+      if (err) return callback(err);
       post.html = $.html();
       callback(null, post);
     }

--- a/app/dashboard/site/import/helper/tests/download.js
+++ b/app/dashboard/site/import/helper/tests/download.js
@@ -1,0 +1,94 @@
+const { PassThrough, Readable } = require("stream");
+const fs = require("fs-extra");
+const os = require("os");
+const path = require("path");
+const airlock = require("helper/airlock");
+const download = require("../download");
+const lifecycle = require("../../lifecycle");
+
+function response(body, headers = {}) {
+  return { ok: true, body, headers: { get: name => headers[name] || null } };
+}
+
+describe("bounded import downloads", function () {
+  it("aborts a stalled body at its deadline", async function () {
+    const body = new PassThrough();
+    let signal;
+    spyOn(airlock, "fetch").and.callFake(async (url, options) => {
+      signal = options.signal;
+      return response(body);
+    });
+    let error;
+    try { await download("https://example.com/slow", { timeout: 10 }); } catch (e) { error = e; }
+    expect(error.name).toBe("AbortError");
+    expect(signal.aborted).toBe(true);
+    expect(body.destroyed).toBe(true);
+  });
+
+  it("aborts before headers arrive", async function () {
+    let signal;
+    spyOn(airlock, "fetch").and.callFake((url, options) => {
+      signal = options.signal;
+      return new Promise((resolve, reject) => {
+        signal.addEventListener("abort", () => reject(lifecycle.cancelled()));
+      });
+    });
+    let error;
+    try { await download("https://example.com/slow", { timeout: 10 }); } catch (e) { error = e; }
+    expect(error.name).toBe("AbortError");
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("enforces actual bytes without Content-Length", async function () {
+    const body = Readable.from([Buffer.from("123"), Buffer.from("456")]);
+    spyOn(airlock, "fetch").and.returnValue(Promise.resolve(response(body)));
+    let error;
+    try { await download("https://example.com/large", { maxBytes: 5 }); } catch (e) { error = e; }
+    expect(error.message).toContain("byte limit");
+    expect(body.destroyed).toBe(true);
+  });
+
+  it("preserves small bodies and headers", async function () {
+    spyOn(airlock, "fetch").and.returnValue(Promise.resolve(response(
+      Readable.from([Buffer.from("abc")]), { "content-type": "application/pdf" }
+    )));
+    const result = await download("https://example.com/small");
+    expect(result.data.toString()).toBe("abc");
+    expect(result.headers.get("content-type")).toBe("application/pdf");
+  });
+
+  it("stops at the cumulative job limit", async function () {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "import-limit-"));
+    const state = lifecycle.create(directory);
+    state.bytes = 1024 * 1024 * 1024 - 1;
+    spyOn(airlock, "fetch").and.callFake(async () => response(Readable.from([Buffer.from("ab")])));
+    try {
+      let error;
+      try { await state.run(() => download("https://example.com/asset")); } catch (e) { error = e; }
+      expect(error.code).toBe("IMPORT_BYTE_LIMIT");
+      expect(state.signal.aborted).toBe(true);
+    } finally {
+      state.dispose();
+      fs.removeSync(directory);
+    }
+  });
+
+  it("interrupts active I/O when another worker creates the cancellation marker", async function () {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "import-cancel-"));
+    const state = lifecycle.create(directory);
+    const body = new PassThrough();
+    spyOn(airlock, "fetch").and.callFake(async () => {
+      await fs.outputFile(path.join(directory, "cancelled.txt"), "true");
+      return response(body);
+    });
+    try {
+      let error;
+      try { await state.run(() => download("https://example.com/asset")); } catch (e) { error = e; }
+      expect(error.name).toBe("AbortError");
+      expect(body.destroyed).toBe(true);
+    } finally {
+      state.dispose();
+      fs.removeSync(directory);
+    }
+  });
+});

--- a/app/dashboard/site/import/index.js
+++ b/app/dashboard/site/import/index.js
@@ -76,12 +76,9 @@ Import.post("/cancel/:importID", async function (req, res) {
 
 Import.post("/delete/:importID", async function (req, res) {
   try {
-    // Cancel first so another worker cannot recreate a deleted running job.
-    await require("./lifecycle").cancel(req.importDirectory);
-    if (fs.existsSync(join(req.importDirectory, "running.txt"))) {
+    if (!(await require("./lifecycle").remove(req.importDirectory))) {
       return res.message(req.baseUrl, "Cancellation requested; remove the import after it stops");
     }
-    await fs.remove(req.importDirectory);
   } catch (e) {
     return res.message(req.baseUrl, new Error("Failed to remove import"));
   }

--- a/app/dashboard/site/import/index.js
+++ b/app/dashboard/site/import/index.js
@@ -48,6 +48,10 @@ Import.get("/download/:importID", async function (req, res, next) {
       );
     } catch (e) {}
 
+    if (fs.existsSync(join(req.importDirectory, "cancelled.txt"))) {
+      return next(new Error("Import was cancelled"));
+    }
+
     if (!fs.existsSync(resultZip)) {
       return next(new Error("Result zip does not exist"));
     }
@@ -62,7 +66,7 @@ Import.get("/download/:importID", async function (req, res, next) {
 
 Import.post("/cancel/:importID", async function (req, res) {
   try {
-    await fs.outputFile(join(req.importDirectory, "cancelled.txt"), "true");
+    await require("./lifecycle").cancel(req.importDirectory);
   } catch (e) {
     return res.message(req.baseUrl, new Error("Failed to cancel import"));
   }
@@ -72,6 +76,11 @@ Import.post("/cancel/:importID", async function (req, res) {
 
 Import.post("/delete/:importID", async function (req, res) {
   try {
+    // Cancel first so another worker cannot recreate a deleted running job.
+    await require("./lifecycle").cancel(req.importDirectory);
+    if (fs.existsSync(join(req.importDirectory, "running.txt"))) {
+      return res.message(req.baseUrl, "Cancellation requested; remove the import after it stops");
+    }
     await fs.remove(req.importDirectory);
   } catch (e) {
     return res.message(req.baseUrl, new Error("Failed to remove import"));

--- a/app/dashboard/site/import/init.js
+++ b/app/dashboard/site/import/init.js
@@ -17,7 +17,10 @@ module.exports = ({ blogID, label }) => {
   function status(message) {
     // Progress must not overwrite a terminal cancellation status.
     if (state.signal.aborted && message !== "Cancelled" && message !== "Failed") return;
-    statuses = statuses.then(() => fs.outputFile(join(importDirectory, "status.txt"), message));
+    // Recover from any prior write failure before chaining the next one, so a
+    // single rejected write (e.g. ENOSPC) can't permanently stop status.txt
+    // from ever being updated again for the rest of this job.
+    statuses = statuses.catch(() => {}).then(() => fs.outputFile(join(importDirectory, "status.txt"), message));
     statuses.catch(err => console.error("Failed to write import status", err));
     client.publish("import:status:" + blogID, JSON.stringify({ status: message, importID }))
       .catch(err => console.error("Failed to publish import status", err));

--- a/app/dashboard/site/import/init.js
+++ b/app/dashboard/site/import/init.js
@@ -6,11 +6,11 @@ const archiver = require("archiver");
 const lifecycle = require("./lifecycle");
 
 module.exports = ({ blogID, label }) => {
-  const importID = label + "-" + Date.now();
+  // Keep the existing label/timestamp parser compatible while avoiding same-tick collisions.
+  const importID = label + "-" + Date.now() + "." + require("crypto").randomBytes(12).toString("hex");
   const importDirectory = join(tempDir, "import", blogID, importID);
   const outputDirectory = join(importDirectory, "output");
   fs.ensureDirSync(outputDirectory);
-  fs.writeFileSync(join(importDirectory, "running.txt"), "true");
   const state = lifecycle.create(importDirectory);
   let statuses = Promise.resolve();
 
@@ -74,6 +74,8 @@ module.exports = ({ blogID, label }) => {
         await finish();
         state.check();
       } catch (error) {
+        // A replaced owner must not erase or publish over another worker.
+        if (!state.ownsLease()) return;
         const wasCancelled = fs.existsSync(join(importDirectory, "cancelled.txt"));
         await fs.remove(outputDirectory);
         await fs.remove(join(importDirectory, "result.zip.part"));
@@ -83,7 +85,10 @@ module.exports = ({ blogID, label }) => {
       } finally {
         state.dispose();
         await Promise.all(Array.from(state.assets, directory => fs.remove(directory)));
-        await fs.remove(join(importDirectory, "running.txt"));
+        if (state.ownsLease()) {
+          await fs.remove(state.stagingDirectory);
+          await fs.remove(join(importDirectory, "running.txt"));
+        }
       }
     });
   }

--- a/app/dashboard/site/import/init.js
+++ b/app/dashboard/site/import/init.js
@@ -3,58 +3,90 @@ const tempDir = require("helper/tempDir")();
 const client = require("models/client");
 const { join } = require("path");
 const archiver = require("archiver");
+const lifecycle = require("./lifecycle");
 
 module.exports = ({ blogID, label }) => {
   const importID = label + "-" + Date.now();
-
   const importDirectory = join(tempDir, "import", blogID, importID);
   const outputDirectory = join(importDirectory, "output");
+  fs.ensureDirSync(outputDirectory);
+  fs.writeFileSync(join(importDirectory, "running.txt"), "true");
+  const state = lifecycle.create(importDirectory);
+  let statuses = Promise.resolve();
 
-  fs.ensureDir(importDirectory);
-  fs.ensureDir(outputDirectory);
-
-  const lastStatus = join(importDirectory, "status.txt");
+  function status(message) {
+    // Progress must not overwrite a terminal cancellation status.
+    if (state.signal.aborted && message !== "Cancelled" && message !== "Failed") return;
+    statuses = statuses.then(() => fs.outputFile(join(importDirectory, "status.txt"), message));
+    statuses.catch(err => console.error("Failed to write import status", err));
+    client.publish("import:status:" + blogID, JSON.stringify({ status: message, importID }))
+      .catch(err => console.error("Failed to publish import status", err));
+    return statuses;
+  }
 
   async function finish() {
-    return new Promise(async (resolve, reject) => {
+    state.check();
+    let identifier;
+    try {
+      identifier = await fs.readFile(join(importDirectory, "identifier.txt"), "utf8");
+    } catch (_) {
+      identifier = importID;
+    }
+    state.check();
+    // Expose the archive only once its output stream has closed successfully.
+    const temporary = join(importDirectory, "result.zip.part");
+    await new Promise((resolve, reject) => {
       const archive = archiver("zip");
-      const resultWS = fs.createWriteStream(
-        join(importDirectory, "result.zip")
-      );
-
-      let identifier;
-
-      try {
-        identifier = await fs.readFile(
-          join(importDirectory, "identifier.txt"),
-          "utf-8"
-        );
-      } catch (e) {
-        identifier = importID;
-      }
-      archive.on("end", () => {
-        status("Finished");
-        resolve();
+      const output = fs.createWriteStream(temporary);
+      let error;
+      const fail = err => {
+        if (error) return;
+        error = err;
+        archive.abort();
+        output.destroy();
+      };
+      const abort = () => fail(lifecycle.cancelled());
+      state.signal.addEventListener("abort", abort, { once: true });
+      archive.on("error", fail);
+      output.on("error", fail);
+      output.on("close", () => {
+        state.signal.removeEventListener("abort", abort);
+        error ? reject(error) : resolve();
       });
-
-      archive.on("error", reject);
-      archive.pipe(resultWS);
+      archive.pipe(output);
       archive.directory(outputDirectory, identifier);
-      archive.finalize();
+      if (state.signal.aborted) return abort();
+      archive.finalize().catch(fail);
+    });
+    state.check();
+    await fs.move(temporary, join(importDirectory, "result.zip"), { overwrite: true });
+    state.check();
+    await status("Finished");
+  }
+
+  // Own the complete worker lifetime, including its archive and cleanup. Async
+  // context carries cancellation into legacy callback-based asset pipelines.
+  async function run(worker) {
+    return state.run(async () => {
+      try {
+        state.check();
+        await worker();
+        await finish();
+        state.check();
+      } catch (error) {
+        const wasCancelled = fs.existsSync(join(importDirectory, "cancelled.txt"));
+        await fs.remove(outputDirectory);
+        await fs.remove(join(importDirectory, "result.zip.part"));
+        await fs.remove(join(importDirectory, "result.zip"));
+        if (!wasCancelled) await fs.outputFile(join(importDirectory, "error.txt"), error.message);
+        await status(wasCancelled ? "Cancelled" : "Failed");
+      } finally {
+        state.dispose();
+        await Promise.all(Array.from(state.assets, directory => fs.remove(directory)));
+        await fs.remove(join(importDirectory, "running.txt"));
+      }
     });
   }
 
-  function status(message) {
-    console.log("reporting status", message);
-    // should write to disk somehow
-    client
-      .publish(
-        "import:status:" + blogID,
-        JSON.stringify({ status: message, importID })
-      )
-      .catch((err) => console.error("failed to publish import status", err));
-    fs.outputFile(lastStatus, message);
-  }
-
-  return { importID, finish, outputDirectory, importDirectory, status };
+  return { importID, run, finish, outputDirectory, importDirectory, status };
 };

--- a/app/dashboard/site/import/lifecycle.js
+++ b/app/dashboard/site/import/lifecycle.js
@@ -1,6 +1,8 @@
 const { AsyncLocalStorage } = require("async_hooks");
 const fs = require("fs-extra");
 const { join } = require("path");
+const { randomUUID } = require("crypto");
+const LEASE_MS = 30000;
 const context = new AsyncLocalStorage();
 const active = new Map();
 
@@ -13,26 +15,53 @@ function cancelled() {
 function create(directory) {
   const controller = new AbortController();
   const marker = join(directory, "cancelled.txt");
+  const leaseFile = join(directory, "running.txt");
+  const owner = randomUUID();
+  const lease = () => ({ owner, expiresAt: Date.now() + LEASE_MS });
+  fs.writeFileSync(leaseFile, JSON.stringify(lease()));
   const state = {
     signal: controller.signal,
+    stagingDirectory: join(directory, "staging"),
+    ownsLease() {
+      try { return fs.readJsonSync(leaseFile).owner === owner; } catch (_) { return false; }
+    },
     bytes: 0,
     assets: new Set(),
     check() {
-      if (fs.existsSync(marker)) controller.abort(cancelled());
+      if (fs.existsSync(marker) || fs.existsSync(join(directory, "deleted.txt"))) controller.abort(cancelled());
+      if (!controller.signal.aborted) {
+        try {
+          const current = fs.readJsonSync(leaseFile);
+          if (current.owner !== owner || current.expiresAt <= Date.now()) {
+            throw new Error("Import worker lease expired");
+          }
+        } catch (error) {
+          controller.abort(error);
+        }
+      }
       if (controller.signal.aborted) throw controller.signal.reason;
     },
     abort: (error = cancelled()) => controller.abort(error),
   };
-  // Imports and cancellation requests can be handled by different Node workers.
-  // The durable marker is authoritative; polling also interrupts active I/O.
+  // Workers share the job directory. Leases expire after a crash; a resumed
+  // worker must stop rather than renew an expired or revoked ownership claim.
   const timer = setInterval(() => {
-    if (fs.existsSync(marker)) controller.abort(cancelled());
+    try {
+      state.check();
+      // r+ never recreates a lease or directory removed by cleanup.
+      const current = fs.readJsonSync(leaseFile);
+      if (current.expiresAt - Date.now() < LEASE_MS / 2) {
+        fs.writeFileSync(leaseFile, JSON.stringify(lease()), { flag: "r+" });
+      }
+    } catch (error) {
+      controller.abort(error);
+    }
   }, 250);
   timer.unref();
   active.set(directory, state);
   state.dispose = () => {
     clearInterval(timer);
-    active.delete(directory);
+    if (active.get(directory) === state) active.delete(directory);
   };
   state.run = (fn) => context.run(state, fn);
   return state;
@@ -41,6 +70,37 @@ function create(directory) {
 async function cancel(directory) {
   await fs.outputFile(join(directory, "cancelled.txt"), "true");
   if (active.has(directory)) active.get(directory).abort();
+}
+
+function leaseExpiry(directory) {
+  const leaseFile = join(directory, "running.txt");
+  try {
+    const stat = fs.statSync(leaseFile);
+    let expiresAt;
+    try { expiresAt = fs.readJsonSync(leaseFile).expiresAt; } catch (_) {}
+    // Also recover markers left by the previous non-leased implementation.
+    return Number.isFinite(expiresAt) ? expiresAt : stat.mtimeMs + LEASE_MS;
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+}
+
+async function remove(directory) {
+  await cancel(directory);
+  const expiresAt = leaseExpiry(directory);
+  if (expiresAt > Date.now()) return false;
+  if (expiresAt !== undefined) {
+    // Retain a small permanent tombstone for an expired owner. In-flight I/O
+    // may still return in a paused process, so removing its cancellation marker
+    // would let that process mistake the deleted job for a live one.
+    await fs.writeFile(join(directory, "deleted.txt"), "true");
+    await Promise.all(["output", "staging", "result.zip", "result.zip.part"].map(
+      name => fs.remove(join(directory, name))
+    ));
+  } else {
+    await fs.remove(directory);
+  }
+  return true;
 }
 
 function check() {
@@ -60,4 +120,4 @@ function guard(step) {
   };
 }
 
-module.exports = { create, cancel, check, guard, current: () => context.getStore(), cancelled };
+module.exports = { create, cancel, remove, leaseExpiry, check, guard, current: () => context.getStore(), cancelled };

--- a/app/dashboard/site/import/lifecycle.js
+++ b/app/dashboard/site/import/lifecycle.js
@@ -1,0 +1,63 @@
+const { AsyncLocalStorage } = require("async_hooks");
+const fs = require("fs-extra");
+const { join } = require("path");
+const context = new AsyncLocalStorage();
+const active = new Map();
+
+function cancelled() {
+  const error = new Error("Import cancelled");
+  error.name = "AbortError";
+  return error;
+}
+
+function create(directory) {
+  const controller = new AbortController();
+  const marker = join(directory, "cancelled.txt");
+  const state = {
+    signal: controller.signal,
+    bytes: 0,
+    assets: new Set(),
+    check() {
+      if (fs.existsSync(marker)) controller.abort(cancelled());
+      if (controller.signal.aborted) throw controller.signal.reason;
+    },
+    abort: (error = cancelled()) => controller.abort(error),
+  };
+  // Imports and cancellation requests can be handled by different Node workers.
+  // The durable marker is authoritative; polling also interrupts active I/O.
+  const timer = setInterval(() => {
+    if (fs.existsSync(marker)) controller.abort(cancelled());
+  }, 250);
+  timer.unref();
+  active.set(directory, state);
+  state.dispose = () => {
+    clearInterval(timer);
+    active.delete(directory);
+  };
+  state.run = (fn) => context.run(state, fn);
+  return state;
+}
+
+async function cancel(directory) {
+  await fs.outputFile(join(directory, "cancelled.txt"), "true");
+  if (active.has(directory)) active.get(directory).abort();
+}
+
+function check() {
+  const state = context.getStore();
+  if (state) state.check();
+}
+
+function guard(step) {
+  return function (...args) {
+    const next = args[args.length - 1];
+    try {
+      check();
+      step(...args);
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+module.exports = { create, cancel, check, guard, current: () => context.getStore(), cancelled };

--- a/app/dashboard/site/import/list.js
+++ b/app/dashboard/site/import/list.js
@@ -10,6 +10,7 @@ module.exports = async function (req, res, next) {
     const imports = await fs.readdir(join(tempDir, "import", req.blog.id));
 
     res.locals.imports = imports
+      .filter(i => !fs.existsSync(join(tempDir, "import", req.blog.id, i, "deleted.txt")))
       .map((i) => {
         let size;
         let started;
@@ -65,6 +66,11 @@ module.exports = async function (req, res, next) {
             "utf-8"
           );
         } catch (e) {}
+
+        const leaseExpiry = require("./lifecycle").leaseExpiry(join(tempDir, "import", req.blog.id, i));
+        if (leaseExpiry !== undefined && leaseExpiry <= Date.now()) {
+          error = "Import worker stopped. Delete this import and try again.";
+        }
 
         return {
           id: i,

--- a/app/dashboard/site/import/list.js
+++ b/app/dashboard/site/import/list.js
@@ -81,14 +81,14 @@ module.exports = async function (req, res, next) {
           cancelled,
           size,
           error,
-          lastStatus: !!error ? error : lastStatus,
+          lastStatus: cancelled ? (lastStatus === "Cancelled" ? "Cancelled" : "Cancelling") : (!!error ? error : lastStatus),
           started,
           importedOn,
           timestamp,
-          complete: !!size || !!error,
+          complete: !!size || !!error || lastStatus === "Cancelled",
         };
       })
-      .filter((i) => !!i && !!i.name && i.cancelled === undefined);
+      .filter((i) => !!i && !!i.name);
 
       // sort by timestamp
       res.locals.imports.sort((a, b) => {

--- a/app/dashboard/site/import/sources/arena/index.js
+++ b/app/dashboard/site/import/sources/arena/index.js
@@ -5,21 +5,23 @@
 
 const Posts = require("./posts");
 const parse = require("./parse");
-const fetch = require("node-fetch");
+const download = require("../../helper/download");
+const lifecycle = require("../../lifecycle");
 const fs = require("fs-extra");
 const { join } = require("path");
 
 async function main({ slug, outputDirectory, status }) {
   status("Fetching posts from Are.na channel " + slug);
-  const response = await fetch(`https://api.are.na/v2/channels/${slug}`);
-  const json = await response.json();
+  const { data } = await download(`https://api.are.na/v2/channels/${slug}`);
+  const json = JSON.parse(data.toString("utf8"));
+  lifecycle.check();
   
   const {
     metadata: { description },
     owner,
   } = json;
 
-  fs.outputFile(
+  await fs.outputFile(
     join(outputDirectory, "_description.txt"),
     `${description}
 

--- a/app/dashboard/site/import/sources/arena/parse.js
+++ b/app/dashboard/site/import/sources/arena/parse.js
@@ -1,4 +1,5 @@
-const fetch = require("node-fetch");
+const lifecycle = require("dashboard/site/import/lifecycle");
+const download = require("../../helper/download");
 const { join, extname } = require("path");
 const moment = require("moment");
 const fs = require("fs-extra");
@@ -20,6 +21,7 @@ async function parse({ outputDirectory, posts, status }) {
   const write = helper.write.createWriter();
 
   for (const item of posts) {
+    lifecycle.check();
     const label =
       (item && (item.title || item.generated_title || item.id)) || "Untitled";
     status(`(${++done}/${posts.length}) Processing ${label}`);
@@ -34,6 +36,7 @@ async function parse({ outputDirectory, posts, status }) {
         status(`Cannot process Are.na block ${label}`);
       }
     } catch (error) {
+      lifecycle.check();
       status(`Failed to process Are.na block ${label}: ${error.message}`);
       console.error("Failed to process Are.na block", label, error);
     }
@@ -77,7 +80,7 @@ function text(item, outputDirectory, write) {
         helper.convert_to_markdown,
         helper.insert_metadata,
         write,
-      ],
+      ].map(lifecycle.guard),
       (error) => (error ? reject(error) : resolve())
     );
   });
@@ -102,12 +105,13 @@ async function link(item, outputDirectory) {
 `;
 
   const path = getPath({ outputDirectory, draft, name, created });
+  lifecycle.check();
   await fs.outputFile(path, content, "utf-8");
   await fs.utimes(path, createdDate, createdDate);
 }
 
 async function image(item, outputDirectory) {
-  const response = await fetch(item.image.original.url, {
+  const { data } = await download(item.image.original.url, {
     headers: {
       "User-Agent":
         "Mozilla/5.0 (compatible; Blot/1.0; +https://blot.im)",
@@ -115,13 +119,7 @@ async function image(item, outputDirectory) {
       Accept: "image/*,*/*;q=0.8",
     },
   });
-  const data = await response.buffer();
-
-  if (!response.ok || !data.length) {
-    throw new Error(
-      `Failed to download image (${response.status}, ${data.length} bytes)`
-    );
-  }
+  lifecycle.check();
 
   const title = item.title || item.generated_title || "Untitled";
 
@@ -138,6 +136,7 @@ async function image(item, outputDirectory) {
   const name = sanitize(title) + extension;
 
   const path = getPath({ outputDirectory, draft, name, created });
+  lifecycle.check();
   await fs.outputFile(path, data);
   await fs.utimes(path, createdDate, createdDate);
 }

--- a/app/dashboard/site/import/sources/arena/posts.js
+++ b/app/dashboard/site/import/sources/arena/posts.js
@@ -1,4 +1,5 @@
-const fetch = require("node-fetch");
+const download = require("../../helper/download");
+const lifecycle = require("../../lifecycle");
 const PAGE_SIZE = 100;
 
 module.exports = async function posts ({ slug, status }) {
@@ -9,12 +10,9 @@ module.exports = async function posts ({ slug, status }) {
   async function fetchPage (page) {
     const url = base(slug, page);
     status(`Fetching page ${page + 1} of channel`);
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    const data = await response.json();
-    return data.contents;
+    lifecycle.check();
+    const { data } = await download(url);
+    return JSON.parse(data.toString("utf8")).contents;
   }
 
   new_posts = await fetchPage(page);

--- a/app/dashboard/site/import/sources/arena/router.js
+++ b/app/dashboard/site/import/sources/arena/router.js
@@ -8,7 +8,7 @@ const normalizeIdentifier = require(
 const fs = require("fs-extra");
 const { join } = require("path");
 const URL = require("url");
-const fetch = require("node-fetch");
+const download = require("../../helper/download");
 
 Importer.get("/are.na", function (req, res) {
   res.redirect(req.baseUrl + "/arena");
@@ -42,29 +42,24 @@ Importer.route("/arena")
       );
     }
 
-    const { importDirectory, outputDirectory, finish, status } = init({
+    const job = init({
       blogID: req.blog.id,
       label: "Are.na",
     });
 
-    try {
-      const response = await fetch(`https://api.are.na/v2/channels/${slug}`);
-      const json = await response.json();
-      const { title } = json;
-
-      fs.outputFileSync(
+    const { importDirectory, outputDirectory, status } = job;
+    res.message(req.baseUrl, "Began import");
+    await job.run(async () => {
+      const { data } = await download(`https://api.are.na/v2/channels/${slug}`);
+      const { title } = JSON.parse(data.toString("utf8"));
+      await fs.outputFile(
         join(importDirectory, "identifier.txt"),
         normalizeIdentifier(title, { fallback: "Are.na channel" }),
-        "utf-8"
+        "utf8"
       );
-      res.message(req.baseUrl, "Began import");
-
       await arena({ slug, outputDirectory, status });
-      await finish();
-    } catch (err) {
-      console.error(err);
-      fs.outputFile(join(importDirectory, "error.txt"), err.message);
-    }
+    }).catch(error => console.error("Failed to clean up Are.na import", error));
+
   });
 
 module.exports = Importer;

--- a/app/dashboard/site/import/sources/blogger/index.js
+++ b/app/dashboard/site/import/sources/blogger/index.js
@@ -1,3 +1,4 @@
+const lifecycle = require("dashboard/site/import/lifecycle");
 const async = require("async");
 const fs = require("fs-extra");
 const helper = require("dashboard/site/import/helper");
@@ -14,7 +15,7 @@ function processEntry(entry, outputDirectory) {
         helper.convert_to_markdown,
         helper.insert_metadata,
         helper.write,
-      ],
+      ].map(lifecycle.guard),
       (err) => (err ? reject(err) : resolve())
     );
   });
@@ -30,6 +31,7 @@ async function importBlogger(sourceFile, outputDirectory, status, siteHost) {
     throw new Error("No published posts or pages found in this Blogger export.");
   }
   for (let index = 0; index < entries.length; index++) {
+    lifecycle.check();
     status(
       `(${index + 1}/${entries.length}) Processing ${entries[index].title}`
     );

--- a/app/dashboard/site/import/sources/blogger/router.js
+++ b/app/dashboard/site/import/sources/blogger/router.js
@@ -23,14 +23,6 @@ function isBloggerExport(upload) {
   return extension === ".atom" || contentType === "application/atom+xml";
 }
 
-function errorMessage(error) {
-  const message = error && error.message ? error.message : String(error);
-  return (
-    message.replace(/[\r\n]+/g, " ").replace(/\s+/g, " ").trim() ||
-    "Blogger import failed"
-  ).slice(0, 300);
-}
-
 Importer.route("/blogger")
   .get(function (req, res) {
     res.locals.breadcrumbs.add("Blogger", "blogger");
@@ -66,41 +58,25 @@ Importer.route("/blogger")
     }
 
     const job = init({ blogID: req.blog.id, label: "Blogger" });
+    const releaseUpload = req.retainUpload
+      ? req.retainUpload(upload)
+      : () => fs.remove(upload.path);
     res.message(req.baseUrl, "Began import");
 
-    // Start after the response has been handed back to Express. The converter's
-    // promise resolves only after its Markdown and asset-writing pipeline ends.
-    setImmediate(async () => {
-      try {
-        await fs.outputFile(
-          join(job.importDirectory, "identifier.txt"),
-          normalizeIdentifier(upload.originalFilename, {
-            extension: ".atom",
-            fallback: "Blogger export",
-          }),
-          "utf8"
-        );
-        await blogger(upload.path, job.outputDirectory, job.status, {
-          siteHost,
-        });
-        await job.finish();
-      } catch (error) {
-        const message = errorMessage(error);
+    job.run(async () => {
+      await fs.outputFile(
+        join(job.importDirectory, "identifier.txt"),
+        normalizeIdentifier(upload.originalFilename, {
+          extension: ".atom",
+          fallback: "Blogger export",
+        }),
+        "utf8"
+      );
+      await blogger(upload.path, job.outputDirectory, job.status, { siteHost });
+    }).catch(error => console.error("Failed to clean up import", error))
+      .finally(() => releaseUpload())
+      .catch(error => console.error("Failed to remove Blogger upload", error));
 
-        await fs
-          .outputFile(join(job.importDirectory, "error.txt"), message, "utf8")
-          .then(() => job.status("Failed"))
-          .catch((writeError) =>
-            console.error("Failed to record import error", writeError)
-          );
-      } finally {
-        await fs
-          .remove(upload.path)
-          .catch((removeError) =>
-            console.error("Failed to remove Blogger upload", removeError)
-          );
-      }
-    });
   });
 
 module.exports = Importer;

--- a/app/dashboard/site/import/sources/blogger/tests/index.js
+++ b/app/dashboard/site/import/sources/blogger/tests/index.js
@@ -7,31 +7,14 @@ describe("Blogger importer", function () {
   const legacyFixture = path.join(__dirname, "fixtures", "export.xml");
   const atomFixture = path.join(__dirname, "fixtures", "export.atom");
 
-  // The full import pipeline runs helper.download_images / download_pdfs, which
-  // fetch() the external asset URLs embedded in export.xml (e.g.
-  // https://blogger.googleusercontent.com/...). Those real network calls make
-  // the pipeline specs depend on CI egress and time out intermittently
-  // (helper/download_images.js has its own 5s timeout that collides with
-  // Jasmine's). Stub fetch so downloads fail fast and offline; none of these
-  // specs assert on downloaded asset content.
-  let realFetch;
-
-  beforeAll(function () {
-    realFetch = global.fetch;
-    global.fetch = function () {
-      return Promise.resolve({
-        ok: false,
-        status: 404,
-        headers: { get: () => null },
-        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-        text: () => Promise.resolve(""),
-        json: () => Promise.resolve({}),
-      });
-    };
-  });
-
-  afterAll(function () {
-    global.fetch = realFetch;
+  // Stub the actual airlock boundary used by the download helpers. These
+  // conversion specs deliberately leave assets remote and never need egress.
+  beforeEach(function () {
+    spyOn(require("helper/airlock"), "fetch").and.returnValue(Promise.resolve({
+      ok: false,
+      status: 404,
+      headers: { get: () => null },
+    }));
   });
 
   it("selects published posts and pages and maps Atom fields", async function () {

--- a/app/dashboard/site/import/sources/squarespace/router.js
+++ b/app/dashboard/site/import/sources/squarespace/router.js
@@ -10,21 +10,6 @@ const normalizeIdentifier = require(
 );
 const wordpress = require("../wordpress");
 
-async function recordFailure(importDirectory, status, err) {
-  try {
-    await fs.outputFile(join(importDirectory, "error.txt"), err.message);
-  } catch (writeError) {
-    console.error("Failed to record Squarespace import error", writeError);
-    return;
-  }
-
-  try {
-    await status("Failed");
-  } catch (statusError) {
-    console.error("Failed to update Squarespace import status", statusError);
-  }
-}
-
 Importer.route("/squarespace")
   .get(function (req, res) {
     res.locals.breadcrumbs.add("Squarespace", "squarespace");
@@ -43,11 +28,15 @@ Importer.route("/squarespace")
       );
     }
 
-    const { importDirectory, outputDirectory, finish, status } = init({
+    const job = init({
       blogID: req.blog.id,
       label: "Squarespace",
     });
 
+    const { importDirectory, outputDirectory, status } = job;
+    const releaseUpload = req.retainUpload
+      ? req.retainUpload(exportUpload)
+      : () => fs.remove(exportUpload.path);
     res.message(req.baseUrl, "Began import");
 
     const identifier = normalizeIdentifier(exportUpload.originalFilename, {
@@ -56,32 +45,15 @@ Importer.route("/squarespace")
     });
     const inputXML = exportUpload.path;
 
-    fs.outputFileSync(
-      join(importDirectory, "identifier.txt"),
-      identifier,
-      "utf-8"
-    );
+    job.run(async () => {
+      await fs.outputFile(join(importDirectory, "identifier.txt"), identifier, "utf8");
+      await new Promise((resolve, reject) => {
+        wordpress(inputXML, outputDirectory, status, {}, err => err ? reject(err) : resolve());
+      });
+    }).catch(error => console.error("Failed to clean up import", error))
+      .finally(() => releaseUpload())
+      .catch(error => console.error("Failed to remove import upload", error));
 
-    wordpress(inputXML, outputDirectory, status, {}, async function (err) {
-      try {
-        if (err) {
-          await recordFailure(importDirectory, status, err);
-          return;
-        }
-
-        try {
-          await finish();
-        } catch (err) {
-          await recordFailure(importDirectory, status, err);
-        }
-      } finally {
-        await fs
-          .remove(inputXML)
-          .catch((removeError) =>
-            console.error("Failed to remove Squarespace upload", removeError)
-          );
-      }
-    });
   });
 
 module.exports = Importer;

--- a/app/dashboard/site/import/sources/wordpress/index.js
+++ b/app/dashboard/site/import/sources/wordpress/index.js
@@ -66,6 +66,7 @@ function main(sourceFile, outputDirectory, status, options, callback) {
       async.eachOfSeries(
         items,
         function (item, index, done) {
+          try { require("../../lifecycle").check(); } catch (err) { return done(err); }
           var current = Number(index) + 1;
           var title = item.title[0].trim();
 

--- a/app/dashboard/site/import/sources/wordpress/item/index.js
+++ b/app/dashboard/site/import/sources/wordpress/item/index.js
@@ -1,3 +1,4 @@
+const lifecycle = require("dashboard/site/import/lifecycle");
 var async = require("async");
 var helper = require("dashboard/site/import/helper");
 var extract_entry = require("./extract_entry");
@@ -28,10 +29,12 @@ module.exports = function (item, output_directory, write, callback) {
       helper.convert_to_markdown,
       helper.insert_metadata,
       write,
-    ],
+    ].map(lifecycle.guard),
     function (err, result) {
-      if (err) console.error(err);
-      callback(null);
+      if (err) {
+        err.message = `Failed to import ${item.title && item.title[0] || "WordPress item"}: ${err.message}`;
+      }
+      callback(err);
     }
   );
 };

--- a/app/dashboard/site/import/sources/wordpress/router.js
+++ b/app/dashboard/site/import/sources/wordpress/router.js
@@ -29,11 +29,15 @@ Importer.route("/wordpress")
       );
     }
 
-    const { importDirectory, outputDirectory, finish, status } = init({
+    const job = init({
       blogID: req.blog.id,
       label: "WordPress",
     });
 
+    const { importDirectory, outputDirectory, status } = job;
+    const releaseUpload = req.retainUpload
+      ? req.retainUpload(exportUpload)
+      : () => fs.remove(exportUpload.path);
     res.message(req.baseUrl, "Began import");
 
     const identifier = normalizeIdentifier(exportUpload.originalFilename, {
@@ -42,25 +46,15 @@ Importer.route("/wordpress")
     });
     const inputXML = exportUpload.path;
 
-    fs.outputFileSync(
-      join(importDirectory, "identifier.txt"),
-      identifier,
-      "utf-8"
-    );
+    job.run(async () => {
+      await fs.outputFile(join(importDirectory, "identifier.txt"), identifier, "utf8");
+      await new Promise((resolve, reject) => {
+        wordpress(inputXML, outputDirectory, status, {}, err => err ? reject(err) : resolve());
+      });
+    }).catch(error => console.error("Failed to clean up import", error))
+      .finally(() => releaseUpload())
+      .catch(error => console.error("Failed to remove import upload", error));
 
-    wordpress(inputXML, outputDirectory, status, {}, async function (err) {
-      if (err) {
-        console.trace();
-        console.log("finally here with message", err);
-        return fs.outputFile(join(importDirectory, "error.txt"), err.message);
-      }
-
-      try {
-        await finish();
-      } catch (err) {
-        fs.outputFile(join(importDirectory, "error.txt"), err.message);
-      }
-    });
   });
 
 module.exports = Importer;

--- a/app/dashboard/site/import/tests/lifecycle.js
+++ b/app/dashboard/site/import/tests/lifecycle.js
@@ -21,6 +21,65 @@ describe("import job lifecycle", function () {
   });
   afterEach(async function () { await fs.remove(job.importDirectory); });
 
+  it("allocates distinct job identities in the same millisecond", async function () {
+    const now = Date.now();
+    spyOn(Date, "now").and.returnValue(now);
+    const first = init({ blogID: "test", label: "Collision" });
+    const second = init({ blogID: "test", label: "Collision" });
+    try {
+      expect(first.importID).not.toBe(second.importID);
+      expect(parseInt(first.importID.split("-").pop(), 10)).toBe(now);
+      await Promise.all([first.run(async () => {}), second.run(async () => {})]);
+    } finally {
+      await fs.remove(first.importDirectory);
+      await fs.remove(second.importDirectory);
+      await job.run(async () => {});
+    }
+  });
+
+  it("recovers an expired worker while retaining a revocation tombstone", async function () {
+    await fs.outputFile(path.join(job.outputDirectory, "partial.txt"), "partial");
+    await fs.outputFile(path.join(job.importDirectory, "staging", "asset"), "partial");
+    const leaseFile = path.join(job.importDirectory, "running.txt");
+    const lease = await fs.readJson(leaseFile);
+    lease.expiresAt = Date.now() - 1;
+    await fs.writeJson(leaseFile, lease);
+    const response = { locals: {} };
+    await require("../list")({ blog: { id: "test" } }, response, () => {});
+    expect(response.locals.imports.find(item => item.id === job.importID).complete).toBe(true);
+    expect(await lifecycle.remove(job.importDirectory)).toBe(true);
+    await require("../list")({ blog: { id: "test" } }, response, () => {});
+    expect(response.locals.imports.find(item => item.id === job.importID)).toBeUndefined();
+    expect(fs.existsSync(job.outputDirectory)).toBe(false);
+    expect(fs.existsSync(path.join(job.importDirectory, "staging"))).toBe(false);
+    expect(fs.existsSync(path.join(job.importDirectory, "deleted.txt"))).toBe(true);
+    const resumed = jasmine.createSpy("resumed worker");
+    await job.run(resumed);
+    expect(resumed).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(job.importDirectory, "deleted.txt"))).toBe(true);
+    expect(fs.existsSync(path.join(job.importDirectory, "result.zip"))).toBe(false);
+  });
+
+  it("cancels a fresh owner but waits for its cleanup before deleting", async function () {
+    expect(await lifecycle.remove(job.importDirectory)).toBe(false);
+    expect(fs.existsSync(path.join(job.importDirectory, "deleted.txt"))).toBe(false);
+    await job.run(async () => {});
+    expect(await lifecycle.remove(job.importDirectory)).toBe(true);
+    expect(fs.existsSync(job.importDirectory)).toBe(false);
+  });
+
+  it("rejects a replaced ownership token even if its lease is fresh", async function () {
+    const leaseFile = path.join(job.importDirectory, "running.txt");
+    const lease = await fs.readJson(leaseFile);
+    lease.owner = "another worker";
+    await fs.writeJson(leaseFile, lease);
+    const worker = jasmine.createSpy("worker");
+    await job.run(worker);
+    expect(worker).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(job.importDirectory, "error.txt"))).toBe(false);
+    expect((await fs.readJson(leaseFile)).owner).toBe("another worker");
+  });
+
   it("publishes Finished only after a readable archive exists", async function () {
     await job.run(() => fs.outputFile(path.join(job.outputDirectory, "post.txt"), "hello"));
     expect(fs.readFileSync(path.join(job.importDirectory, "result.zip")).slice(0, 2).toString()).toBe("PK");

--- a/app/dashboard/site/import/tests/lifecycle.js
+++ b/app/dashboard/site/import/tests/lifecycle.js
@@ -1,0 +1,91 @@
+const fs = require("fs-extra");
+const os = require("os");
+const path = require("path");
+const lifecycle = require("../lifecycle");
+const wordpress = require("../sources/wordpress");
+const helper = require("../helper");
+const assetDirectory = require("../helper/asset_directory");
+const client = require("models/client");
+const init = require("../init");
+
+const xml = `<?xml version="1.0"?><rss><channel><title>Test</title><link>https://example.com</link>
+<item><title>First post</title><link>https://example.com/post</link><pubDate>Tue, 04 Aug 2020 12:00:00 GMT</pubDate><wp:post_type>post</wp:post_type><wp:status>publish</wp:status><content:encoded><![CDATA[<p>Hello</p>]]></content:encoded></item>
+<item><title>Second post</title><link>https://example.com/post</link><pubDate>Tue, 04 Aug 2020 12:00:00 GMT</pubDate><wp:post_type>post</wp:post_type><wp:status>publish</wp:status><content:encoded><![CDATA[<p>Later</p>]]></content:encoded></item>
+</channel></rss>`;
+
+describe("import job lifecycle", function () {
+  let job;
+  beforeEach(function () {
+    spyOn(client, "publish").and.returnValue(Promise.resolve());
+    job = init({ blogID: "test", label: "Test" });
+  });
+  afterEach(async function () { await fs.remove(job.importDirectory); });
+
+  it("publishes Finished only after a readable archive exists", async function () {
+    await job.run(() => fs.outputFile(path.join(job.outputDirectory, "post.txt"), "hello"));
+    expect(fs.readFileSync(path.join(job.importDirectory, "result.zip")).slice(0, 2).toString()).toBe("PK");
+    expect(fs.readFileSync(path.join(job.importDirectory, "status.txt"), "utf8")).toBe("Finished");
+    expect(fs.existsSync(path.join(job.importDirectory, "result.zip.part"))).toBe(false);
+  });
+
+  it("removes partial output and asset staging directories on cancellation", async function () {
+    let staging;
+    await job.run(async () => {
+      await fs.outputFile(path.join(job.outputDirectory, "partial.txt"), "partial");
+      staging = await new Promise((resolve, reject) => assetDirectory({}, (err, dir) => err ? reject(err) : resolve(dir)));
+      await fs.outputFile(path.join(staging, "asset"), "partial");
+      await lifecycle.cancel(job.importDirectory);
+    });
+    expect(fs.existsSync(staging)).toBe(false);
+    expect(fs.existsSync(job.outputDirectory)).toBe(false);
+    expect(fs.existsSync(path.join(job.importDirectory, "result.zip"))).toBe(false);
+    expect(fs.readFileSync(path.join(job.importDirectory, "status.txt"), "utf8")).toBe("Cancelled");
+  });
+
+  it("cancels an archive in progress and removes its partial zip", async function () {
+    const create = fs.createWriteStream;
+    spyOn(fs, "createWriteStream").and.callFake(function (...args) {
+      const stream = create(...args);
+      const write = stream.write;
+      let cancelled = false;
+      stream.write = function (...writeArgs) {
+        if (!cancelled) {
+          cancelled = true;
+          fs.writeFileSync(path.join(job.importDirectory, "cancelled.txt"), "true");
+          lifecycle.current().abort();
+        }
+        return write.apply(this, writeArgs);
+      };
+      return stream;
+    });
+    await job.run(() => fs.outputFile(path.join(job.outputDirectory, "post.txt"), "hello"));
+    expect(fs.existsSync(path.join(job.importDirectory, "result.zip.part"))).toBe(false);
+    expect(fs.existsSync(path.join(job.importDirectory, "result.zip"))).toBe(false);
+    expect(fs.readFileSync(path.join(job.importDirectory, "status.txt"), "utf8")).toBe("Cancelled");
+  });
+
+  it("reports WordPress write errors with the post title and stops before the next post", async function () {
+    const input = path.join(job.importDirectory, "input.xml");
+    await fs.outputFile(input, xml);
+    const writer = jasmine.createSpy("writer").and.callFake((post, cb) => cb(new Error("ENOSPC")));
+    spyOn(helper.write, "createWriter").and.returnValue(writer);
+    await job.run(() => new Promise((resolve, reject) => wordpress(input, job.outputDirectory, job.status, {}, err => err ? reject(err) : resolve())));
+    expect(writer.calls.count()).toBe(1);
+    expect(fs.readFileSync(path.join(job.importDirectory, "error.txt"), "utf8")).toContain("First post: ENOSPC");
+    expect(fs.readFileSync(path.join(job.importDirectory, "status.txt"), "utf8")).toBe("Failed");
+    expect(fs.existsSync(path.join(job.importDirectory, "result.zip"))).toBe(false);
+  });
+
+  it("stops between WordPress entries without finalizing", async function () {
+    const input = path.join(job.importDirectory, "input.xml");
+    await fs.outputFile(input, xml);
+    const writer = jasmine.createSpy("writer").and.callFake((post, cb) => {
+      lifecycle.cancel(job.importDirectory).then(() => cb(), cb);
+    });
+    spyOn(helper.write, "createWriter").and.returnValue(writer);
+    await job.run(() => new Promise((resolve, reject) => wordpress(input, job.outputDirectory, job.status, {}, err => err ? reject(err) : resolve())));
+    expect(writer.calls.count()).toBe(1);
+    expect(fs.readFileSync(path.join(job.importDirectory, "status.txt"), "utf8")).toBe("Cancelled");
+    expect(fs.existsSync(path.join(job.importDirectory, "result.zip"))).toBe(false);
+  });
+});

--- a/app/dashboard/util/multipart.js
+++ b/app/dashboard/util/multipart.js
@@ -1,0 +1,70 @@
+const multiparty = require("multiparty");
+const fs = require("fs-extra");
+
+// Request-owned uploads are removed even when later middleware rejects the
+// request. Background jobs explicitly take ownership before sending a response.
+module.exports = function multipart(options = {}) {
+  const formOptions = {
+    maxFilesSize: 30 * 1024 * 1024,
+    ...options,
+    uploadDir: options.uploadDir || require("helper/tempDir")(),
+  };
+
+  return function parse(req, res, next) {
+    if (!req.is("multipart/form-data")) return next();
+
+    const files = new Set();
+    const retained = new Set();
+    let finished = false;
+    const remove = async (path) => {
+      try {
+        await fs.remove(path);
+        files.delete(path);
+      } catch (err) {
+        console.error("Failed to remove temporary upload", err);
+      }
+    };
+    const cleanup = () => {
+      finished = true;
+      return Promise.all([...files].filter(path => !retained.has(path)).map(remove));
+    };
+
+    req.retainUpload = (file) => {
+      if (finished || !file || !files.has(file.path)) {
+        throw new Error("Cannot retain an upload not owned by this request");
+      }
+      const path = file.path;
+      retained.add(path);
+      return async () => {
+        retained.delete(path);
+        await remove(path);
+      };
+    };
+
+    res.once("finish", cleanup);
+    res.once("close", cleanup);
+
+    const form = new multiparty.Form(formOptions);
+    form.on("file", (_name, file) => {
+      files.add(file.path);
+      if (finished) remove(file.path);
+    });
+    form.parse(req, (err, fields, uploads) => {
+      if (err) {
+        cleanup(); // multiparty also removes partially written files on error
+        if (err.code === "ETOOBIG") err.status = 413;
+        if (!res.destroyed && !res.writableEnded) next(err);
+        return;
+      }
+      if (finished) return;
+
+      req.body = Object.fromEntries(Object.keys(fields).map(key => [
+        key, fields[key].length === 1 ? fields[key][0] : fields[key],
+      ]));
+      req.files = uploads;
+      // Preserve other upload fields; cleanup retains the complete file list.
+      if (uploads.avatar) req.files.avatar = uploads.avatar[0];
+      next();
+    });
+  };
+};

--- a/app/dashboard/util/tests/multipart.js
+++ b/app/dashboard/util/tests/multipart.js
@@ -1,0 +1,80 @@
+const express = require("express");
+const fs = require("fs-extra");
+const os = require("os");
+const path = require("path");
+const fetch = require("node-fetch");
+const multipart = require("../multipart");
+
+describe("multipart upload ownership", function () {
+  let directory, server, base, handle, options;
+  beforeEach(async function () {
+    directory = await fs.mkdtemp(path.join(os.tmpdir(), "blot-upload-test-"));
+    options = { uploadDir: directory };
+    const app = express();
+    app.use((req, res, next) => multipart(options)(req, res, next));
+    app.use((req, res) => handle(req, res));
+    app.use((err, req, res, next) => res.status(err.status || 400).end());
+    server = await new Promise(resolve => {
+      const listening = app.listen(0, "127.0.0.1", () => resolve(listening));
+    });
+    base = `http://127.0.0.1:${server.address().port}`;
+  });
+  afterEach(async function () {
+    await new Promise(resolve => server.close(resolve));
+    await fs.remove(directory);
+  });
+  function send(fields = ["upload"]) {
+    const boundary = "blot-test-boundary";
+    const body = fields.map(name =>
+      `--${boundary}\r\nContent-Disposition: form-data; name="${name}"; filename="test.txt"\r\nContent-Type: text/plain\r\n\r\nretained test contents\r\n`
+    ).join("") + `--${boundary}--\r\n`;
+    return fetch(base, { method: "POST", redirect: "manual",
+      headers: { "content-type": `multipart/form-data; boundary=${boundary}` }, body });
+  }
+  async function expectEmpty() {
+    for (let attempt = 0; attempt < 100; attempt++) {
+      if (!(await fs.readdir(directory)).length) return;
+      await new Promise(resolve => setTimeout(resolve, 5));
+    }
+    expect(await fs.readdir(directory)).toEqual([]);
+  }
+  it("cleans files after a downstream rejection", async function () {
+    handle = (req, res) => res.status(403).end();
+    expect((await send()).status).toBe(403);
+    await expectEmpty();
+  });
+  it("cleans files after an authentication redirect", async function () {
+    handle = (req, res) => res.redirect("/log-in");
+    expect((await send()).status).toBe(302);
+    await expectEmpty();
+  });
+  it("preserves other fields when normalizing an avatar and cleans all files", async function () {
+    let fields;
+    handle = (req, res) => {
+      fields = { avatar: !!req.files.avatar.path, other: req.files.other.length };
+      res.end();
+    };
+    await send(["avatar", "other"]);
+    expect(fields).toEqual({ avatar: true, other: 1 });
+    await expectEmpty();
+  });
+  it("keeps a background job upload until its explicit release", async function () {
+    let upload, release;
+    handle = (req, res) => {
+      upload = req.files.upload[0];
+      release = req.retainUpload(upload);
+      res.end();
+    };
+    await send();
+    expect(await fs.readFile(upload.path, "utf8")).toBe("retained test contents");
+    await release();
+    await release(); // finalizers may safely run more than once
+    await expectEmpty();
+  });
+  it("cleans up on parser size errors", async function () {
+    options.maxFilesSize = 5;
+    handle = () => fail("A rejected upload must not reach the route");
+    expect((await send()).status).toBe(413);
+    await expectEmpty();
+  });
+});

--- a/app/views/dashboard/import/index.html
+++ b/app/views/dashboard/import/index.html
@@ -109,6 +109,7 @@
     <div class="import-row__meta">
       {{#icon}}<img width="14" height="14" src="{{icon}}" alt="">{{/icon}}
       <span>{{name}}</span>
+      {{#cancelled}}<span>Cancelled</span>{{/cancelled}}
       {{^error}}
       {{#started}}<span>&bull; {{started}}</span>{{/started}}
       {{#size}}<span>&bull; {{size}}</span>{{/size}}
@@ -139,9 +140,11 @@
 
   <div class="import-row__actions">
   {{#complete}}
-    {{^error}}
+    {{#size}}
+    {{^cancelled}}
     <a href="{{{importBase}}}/download/{{id}}" target="_blank" class="s no-underline">Download</a>
-    {{/error}}
+    {{/cancelled}}
+    {{/size}}
     <form method="post" action="{{{importBase}}}/delete/{{id}}">
       <input type="hidden" name="_csrf" value="{{csrftoken}}">
       <button type="submit">Delete</button>


### PR DESCRIPTION
Give background imports an explicit lifetime from upload ownership through archive completion. Request-scoped uploads are removed on completion, disconnect, or parse failure; importer routes retain their source upload before responding and release it when the worker exits.

Downloads share the existing airlock boundary and enforce a 5-second deadline, 50 MiB per response, and 1 GiB per job using actual streamed bytes. Cancellation reaches downloads and pipeline boundaries, WordPress write failures propagate, and archives become available only after the output stream closes successfully. Import IDs include random suffixes. Expiring worker leases make crashed jobs removable; stale deletion retains small cancellation tombstones so resumed workers cannot make deleted jobs visible again.

Validation: 58 combined specifications passed (seed 06789), covering actual HTTP multipart handling, streamed response failures, byte limits, filesystem/archive cleanup, cancellation, stale-job recovery, ownership replacement, and same-tick IDs. The Blogger suite separately passed all 10 specifications after restoring its tracked Atom fixture omitted by the local sparse checkout and updating its test stub to the airlock boundary.

Integration limits: no live provider imports, multi-container worker deployment, or deployed airlock test. Cancellation is cooperative around synchronous/native work. Stale-job tombstones are deliberately retained; hard process crashes can still bypass retained-upload release. The new download limits may leave oversized or slow individual assets as remote references.
