### PR TITLE
Install Redis mount dependency and restart policy before startup

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -62,6 +62,7 @@ jobs:
         - app/sync:1
         - app/templates:1
         - config/openresty:1
+        - config/redis:1
         - proxy:1
     steps:
       - name: Sparse checkout for hash calculation

--- a/config/redis/scripts/install-service-overrides.sh
+++ b/config/redis/scripts/install-service-overrides.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+# The optional directory lets provisioning tests inspect generated units without
+# touching the host's systemd configuration.
+unit_dir="${1:-/etc/systemd/system}"
+mkdir -p "$unit_dir/redis6.service.d"
+
+# Mount preparation needs root privileges; Redis itself keeps its packaged
+# service user. A separate dependency avoids putting service commands in [Unit]
+# or ordering redis6.service against itself.
+cat > "$unit_dir/blot-redis-backups-mount.service" <<'EOF'
+[Unit]
+Description=Prepare Blot Redis backup storage
+Before=redis6.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash /home/ec2-user/scripts/mount-instance-store.sh
+RemainAfterExit=yes
+EOF
+
+cat > "$unit_dir/redis6.service.d/override.conf" <<'EOF'
+[Unit]
+Requires=blot-redis-backups-mount.service
+After=blot-redis-backups-mount.service
+
+[Service]
+Restart=always
+EOF

--- a/config/redis/scripts/setup.sh
+++ b/config/redis/scripts/setup.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 # This should only be run once, when the instance is launched
 # It will only work when run as root
@@ -24,9 +23,9 @@ dnf install -y redis6
 
 # Keep mount preparation in a root-owned dependency and Redis service settings
 # in the service drop-in, without overwriting one section with another.
-/bin/bash "$(dirname "$0")/install-service-overrides.sh"
+/bin/bash "$(dirname "$0")/install-service-overrides.sh" || exit $?
 
-systemctl daemon-reload
+systemctl daemon-reload || exit $?
 
 # Start only after the mount dependency and restart policy are installed.
 systemctl start redis6

--- a/config/redis/scripts/setup.sh
+++ b/config/redis/scripts/setup.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -e
 
 # This should only be run once, when the instance is launched
 # It will only work when run as root
@@ -21,26 +22,16 @@ dd if=/dev/zero of=/swapfile1 bs=1024 count=4194304
 # install redis
 dnf install -y redis6
 
-# install redis systemd service
-# start redis server
+# Keep mount preparation in a root-owned dependency and Redis service settings
+# in the service drop-in, without overwriting one section with another.
+/bin/bash "$(dirname "$0")/install-service-overrides.sh"
+
+systemctl daemon-reload
+
+# Start only after the mount dependency and restart policy are installed.
 systemctl start redis6
 systemctl enable redis6
 chkconfig redis6 on
-
-# edit the redis6 service and all the following:
-# under [Service]:   'Restart=always'
-mkdir -p /etc/systemd/system/redis6.service.d
-echo "[Service]" > /etc/systemd/system/redis6.service.d/override.conf
-echo "Restart=" >> /etc/systemd/system/redis6.service.d/override.conf
-echo "Restart=always" >> /etc/systemd/system/redis6.service.d/override.conf
-
-# before the redis server launches, run the bash script 
-# located at /home/ec2-user/scripts/mount-instance-store.sh
-echo "[Unit]" > /etc/systemd/system/redis6.service.d/override.conf
-echo "Before=redis6.service" >> /etc/systemd/system/redis6.service.d/override.conf
-echo "ExecStartPre=/home/ec2-user/scripts/mount-instance-store.sh" >> /etc/systemd/system/redis6.service.d/override.conf
-
-systemctl daemon-reload
 
 # update redis configuration so it listens on all interfaces
 # we lock down the instance using AWS security groups
@@ -85,4 +76,3 @@ chmod 0644 /etc/cron.d/blot-redis-backups
 # limit the SystemMaxUse of the journal to 100M
 # overwriting /etc/systemd/journald.conf
 # and then restart the systemd-journald service
-

--- a/config/redis/tests/service-overrides.js
+++ b/config/redis/tests/service-overrides.js
@@ -1,0 +1,32 @@
+const fs = require("fs").promises;
+const path = require("path");
+const os = require("os");
+const execFile = require("util").promisify(require("child_process").execFile);
+
+describe("Redis systemd configuration", function () {
+  it("generates idempotent mount ordering and Redis restart settings", async function () {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "blot-redis-units-"));
+    const script = path.resolve(__dirname, "../scripts/install-service-overrides.sh");
+    try {
+      await execFile("bash", [script, dir]);
+      const overridePath = path.join(dir,"redis6.service.d/override.conf");
+      const mountPath = path.join(dir,"blot-redis-backups-mount.service");
+      const override = await fs.readFile(overridePath,"utf8");
+      const mount = await fs.readFile(mountPath,"utf8");
+      const sections = text => Object.fromEntries(text.trim().split(/\n\n/).map(section => {
+        const [name,...lines] = section.split("\n"); return [name,lines];
+      }));
+      expect(sections(override)["[Unit]"]).toEqual([
+        "Requires=blot-redis-backups-mount.service", "After=blot-redis-backups-mount.service",
+      ]);
+      expect(sections(override)["[Service]"]).toEqual(["Restart=always"]);
+      expect(sections(mount)["[Unit]"]).toContain("Before=redis6.service");
+      expect(sections(mount)["[Service]"]).toContain("Type=oneshot");
+      expect(sections(mount)["[Service]"]).toContain("ExecStart=/bin/bash /home/ec2-user/scripts/mount-instance-store.sh");
+      expect(mount).not.toContain("User=");
+      await execFile("bash", [script, dir]);
+      expect(await fs.readFile(overridePath,"utf8")).toBe(override);
+      expect(await fs.readFile(mountPath,"utf8")).toBe(mount);
+    } finally { await fs.rm(dir,{recursive:true,force:true}); }
+  });
+});


### PR DESCRIPTION
Redis provisioning currently overwrites its restart-policy drop-in and puts the mount command in the wrong systemd section. Generate a complete drop-in and a separate root-owned oneshot mount dependency, then install and reload both before starting Redis. This preserves the packaged Redis service user while ordering backup storage preparation ahead of startup.

The existing transfer script copies the new helper along with the scripts directory. Installer and daemon-reload failures stop this provisioning step without changing error handling for unrelated setup commands.

Validation: a temporary-directory test executes the installer twice and checks the generated unit sections, dependency ordering, and idempotence. Bash syntax checks pass. No host provisioning or disk/mount operation was executed; validate startup, restart, and reboot behavior on a disposable deployment before applying to a running host.
