### PR TITLE
Bound statistics reads to the requested history window

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -59,6 +59,7 @@ jobs:
         - app/models|app/models/entry:2
         - app/models/entry:1
         - app/site:1
+        - app/stats:1
         - app/sync:1
         - app/templates:1
         - config/openresty:1

--- a/app/stats/index.js
+++ b/app/stats/index.js
@@ -27,15 +27,11 @@ Stats.get("/stats.json", async (req, res) => {
     // Get the most recent files
     const files = await fs.readdir(stats_directory);
 
-    let most_recent_files = files
-      .filter(file => file.indexOf(".json") > -1)
-      .sort();
-
-    if (files.length < number_of_files) {
-      most_recent_files = most_recent_files
-        // we fetch an extra file to ensure we have enough data if the hour just rolled over
-        .slice(-1 * (number_of_files + 1));
-    }
+    const most_recent_files = files
+      .filter(file => file.endsWith(".json"))
+      .sort()
+      // Include the preceding file when the current hour is incomplete.
+      .slice(-(number_of_files + 1));
 
     // Read the files
     const data = await Promise.all(

--- a/app/stats/tests/history-bounds.js
+++ b/app/stats/tests/history-bounds.js
@@ -1,0 +1,35 @@
+const fs = require("fs");
+const vm = require("vm");
+
+describe("stats history bounds", function () {
+  for (const [range,hours] of [["hour",1],["day",24],["week",168]]) {
+    it("reads only the necessary recent JSON files for " + range, async function () {
+      let handler;
+      const read = [];
+      const files = Array.from({length:200}, (_,i)=>String(i).padStart(3,"0")+".json");
+      const module = {exports:{}};
+      const stubs = {
+        express:{Router:function(){return {use(){},get(route,fn){if(route==="/stats.json") handler=fn;}};}},
+        config:{admin:{uid:"test"}}, "./statsDirectory":"/stats",
+        "fs-extra":{
+          readdir:async()=>[...files,"zzz.json.backup","README"].reverse(),
+          readJson:async filename=>{
+            read.push(filename);
+            const hour = Number(filename.split("/").pop().slice(0,3));
+            return Array.from({length:60},(_,minute)=>({date:hour*60+minute}));
+          },
+        },
+      };
+      vm.runInNewContext(fs.readFileSync(require.resolve("../index"),"utf8"), {
+        module,exports:module.exports,console:{log(){}},require:name=>stubs[name],
+      });
+      const res = {json:body=>{res.body=body;},status:code=>{throw new Error("Unexpected status "+code);}};
+      await handler({query:{range,server:"node"}},res);
+      expect(read.length).toBe(hours+1);
+      expect(read).toEqual(files.slice(-(hours+1)).map(name=>"/stats/node/"+name));
+      expect(res.body.length).toBe(hours*60);
+      expect(res.body[0].date).toBe(11998);
+      expect(res.body[res.body.length-1].date).toBe(11999-hours*60);
+    });
+  }
+});


### PR DESCRIPTION
The stats endpoint's history slice runs only when fewer files exist than requested, so a mature archive is read in full for every query. Always select the newest requested hours plus one rollover file, and ignore files whose names do not end in `.json`.

Validation: 3 focused specifications pass, exercising bounded hour/day/week history reads, non-JSON exclusion, and returned result ordering through the actual route handler. Tests use controlled filesystem data and do not access production statistics.
