### PR TITLE
Wait for webhook persistence and preserve retryable account transitions

### DIFF
--- a/app/dashboard/tests/stripe_webhook.js
+++ b/app/dashboard/tests/stripe_webhook.js
@@ -58,6 +58,24 @@ describe("Stripe subscription webhooks", function () {
     webhook._resetStripeClient();
   });
 
+  it("preserves an independently disabled blog on an active subscription update", async function () {
+    await setBlog(this.blog.id, { isDisabled: true });
+    const event = {
+      type: "customer.subscription.updated",
+      data: { object: { id: this.subscriptionId, customer: this.customerId } },
+    };
+
+    const response = await this.fetch("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(event),
+    });
+
+    expect(response.status).toBe(200);
+    expect((await getUser(this.user.uid)).isDisabled).toBe(false);
+    expect((await getBlog({ id: this.blog.id })).isDisabled).toBe(true);
+  });
+
   it("updates subscription details on update event", async function () {
     const event = {
       type: "customer.subscription.updated",

--- a/app/dashboard/tests/stripe_webhook.js
+++ b/app/dashboard/tests/stripe_webhook.js
@@ -250,7 +250,7 @@ describe("Stripe subscription webhooks", function () {
     expect(blog.isDisabled).toBe(false);
   });
 
-  it("returns 400 when verification fails", async function () {
+  it("returns 503 when subscription retrieval fails", async function () {
     this.stripeClient.customers.retrieveSubscription.and.callFake((_, __, callback) =>
       callback(new Error("nope"))
     );
@@ -275,7 +275,7 @@ describe("Stripe subscription webhooks", function () {
       body: JSON.stringify(event),
     });
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(503);
     expect(this.stripeClient.customers.retrieveSubscription).toHaveBeenCalled();
 
     await delay(100);

--- a/app/dashboard/tests/webhook_reliability.js
+++ b/app/dashboard/tests/webhook_reliability.js
@@ -1,0 +1,153 @@
+const User = require("models/user");
+const config = require("config");
+const stripe = require("dashboard/webhooks/stripe_webhook");
+const paypal = require("dashboard/webhooks/paypal_webhook");
+
+function route(router) {
+  const layers = router.stack.find(layer => layer.route).route.stack;
+  return layers[layers.length - 1].handle;
+}
+function response() {
+  let code, complete;
+  const done = new Promise(resolve => { complete = resolve; });
+  return { done, get code() { return code; },
+    sendStatus(value) { code = value; complete(value); },
+    status(value) { code = value; return this; },
+    send() { complete(code); } };
+}
+
+describe("payment webhook delivery reliability", function () {
+  let stripeSecret, paypalID, stripeClient;
+  const user = { uid: "test-user", blogs: [], isDisabled: false,
+    subscription: { status: "active" } };
+  const event = { type: "customer.subscription.updated", data: {
+    object: { id: "sub_test", customer: "cus_test" } } };
+  const paypalEvent = { event_type: "BILLING.SUBSCRIPTION.UPDATED",
+    resource: { id: "I-TEST" } };
+  beforeEach(function () {
+    stripeSecret = config.stripe.webhook_secret;
+    paypalID = config.paypal.webhook_id;
+    config.stripe.webhook_secret = "";
+    config.paypal.webhook_id = "";
+    spyOn(console, "warn");
+    spyOn(console, "error");
+    spyOn(console, "log");
+    spyOn(User, "getByCustomerId").and.callFake((id, cb) => cb(null, user));
+    spyOn(User, "getByPayPalSubscriptionId").and.callFake((id, cb) => cb(null, user));
+    spyOn(User, "set").and.callFake((id, updates, cb) => cb(null));
+    spyOn(User, "enable").and.callFake((user, updates, cb) => User.set(user.uid, updates, cb));
+    spyOn(User, "disable").and.callFake((user, updates, cb) => User.set(user.uid, updates, cb));
+    spyOn(global, "fetch").and.callFake(async () => ({ ok: true,
+      json: async () => ({ id: "I-TEST", status: "ACTIVE" }) }));
+    stripeClient = { customers: { retrieveSubscription: (customer, id, cb) =>
+      cb(null, { id, customer, status: "active" }) } };
+    stripe._setStripeClient(stripeClient);
+  });
+  afterEach(function () {
+    config.stripe.webhook_secret = stripeSecret;
+    config.paypal.webhook_id = paypalID;
+    stripe._resetStripeClient();
+  });
+  const stripeRequest = () => ({ body: Buffer.from(JSON.stringify(event)) });
+  it("acknowledges Stripe only after the update completes", function () {
+    let save;
+    User.set.and.callFake((id, updates, cb) => { save = cb; });
+    const res = response();
+    route(stripe)(stripeRequest(), res);
+    expect(typeof save).toBe("function");
+    expect(res.code).toBeUndefined();
+    save(null);
+    expect(res.code).toBe(200);
+  });
+  it("returns a retryable Stripe response on a storage failure", function () {
+    User.set.and.callFake((id, updates, cb) => cb(new Error("temporary storage failure")));
+    const res = response();
+    route(stripe)(stripeRequest(), res);
+    expect(res.code).toBe(503);
+  });
+  it("returns a retryable Stripe response on a provider failure", function () {
+    stripeClient.customers.retrieveSubscription = (customer, id, cb) => cb(new Error("offline"));
+    const res = response();
+    route(stripe)(stripeRequest(), res);
+    expect(res.code).toBe(503);
+    expect(User.set).not.toHaveBeenCalled();
+  });
+  it("reconciles blogs even when the Stripe account flag already matches", function () {
+    const res = response();
+    route(stripe)(stripeRequest(), res);
+    expect(User.enable).toHaveBeenCalled();
+    expect(res.code).toBe(200);
+  });
+  it("settles PayPal network failures without updating the user", async function () {
+    global.fetch.and.callFake(async () => { throw new Error("offline"); });
+    const res = response();
+    await route(paypal)({ body: paypalEvent }, res);
+    expect(res.code).toBe(503);
+    expect(User.set).not.toHaveBeenCalled();
+  });
+  it("settles PayPal JSON failures without updating the user", async function () {
+    global.fetch.and.callFake(async () => ({ ok: true, json: async () => { throw new Error("bad JSON"); } }));
+    const res = response();
+    await route(paypal)({ body: paypalEvent }, res);
+    expect(res.code).toBe(503);
+    expect(User.set).not.toHaveBeenCalled();
+  });
+  it("does not persist a PayPal HTTP error body", async function () {
+    global.fetch.and.callFake(async () => ({ ok: false, status: 500 }));
+    const res = response();
+    await route(paypal)({ body: paypalEvent }, res);
+    expect(res.code).toBe(503);
+    expect(User.set).not.toHaveBeenCalled();
+  });
+  it("rejects a PayPal response for a different subscription", async function () {
+    global.fetch.and.callFake(async () => ({ ok: true, json: async () => ({ id: "OTHER", status: "ACTIVE" }) }));
+    const res = response();
+    await route(paypal)({ body: paypalEvent }, res);
+    expect(res.code).toBe(503);
+    expect(User.set).not.toHaveBeenCalled();
+  });
+  it("waits for PayPal persistence and reports its failure", async function () {
+    let save, started;
+    const saving = new Promise(resolve => { started = resolve; });
+    User.set.and.callFake((id, updates, cb) => { save = cb; started(); });
+    const res = response();
+    const handling = route(paypal)({ body: paypalEvent }, res);
+    await saving;
+    expect(res.code).toBeUndefined();
+    save(new Error("temporary storage failure"));
+    await handling;
+    expect(res.code).toBe(503);
+  });
+  it("acknowledges a persisted PayPal subscription", async function () {
+    const res = response();
+    await route(paypal)({ body: paypalEvent }, res);
+    expect(res.code).toBe(200);
+    expect(User.set).toHaveBeenCalled();
+  });
+  it("keeps malformed PayPal events as client errors", async function () {
+    const res = response();
+    await route(paypal)({ body: { event_type: paypalEvent.event_type } }, res);
+    expect(res.code).toBe(400);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+  it("aborts a stalled PayPal request and returns a retryable response", async function () {
+    jasmine.clock().install();
+    try {
+      let started;
+      const fetching = new Promise(resolve => { started = resolve; });
+      global.fetch.and.callFake((url, options) => new Promise((resolve, reject) => {
+        options.signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+        started();
+      }));
+      const res = response();
+      const handling = route(paypal)({ body: paypalEvent }, res);
+      await fetching;
+      jasmine.clock().tick(15001);
+      await handling;
+      expect(res.code).toBe(503);
+      expect(User.set).not.toHaveBeenCalled();
+    } finally {
+      jasmine.clock().uninstall();
+    }
+  });
+});

--- a/app/dashboard/tests/webhook_reliability.js
+++ b/app/dashboard/tests/webhook_reliability.js
@@ -72,10 +72,12 @@ describe("payment webhook delivery reliability", function () {
     expect(res.code).toBe(503);
     expect(User.set).not.toHaveBeenCalled();
   });
-  it("reconciles blogs even when the Stripe account flag already matches", function () {
+  it("preserves blog availability when the Stripe account is already enabled", function () {
     const res = response();
     route(stripe)(stripeRequest(), res);
-    expect(User.enable).toHaveBeenCalled();
+    expect(User.enable).not.toHaveBeenCalled();
+    expect(User.disable).not.toHaveBeenCalled();
+    expect(User.set).toHaveBeenCalled();
     expect(res.code).toBe(200);
   });
   it("settles PayPal network failures without updating the user", async function () {
@@ -123,6 +125,8 @@ describe("payment webhook delivery reliability", function () {
     await route(paypal)({ body: paypalEvent }, res);
     expect(res.code).toBe(200);
     expect(User.set).toHaveBeenCalled();
+    expect(User.enable).not.toHaveBeenCalled();
+    expect(User.disable).not.toHaveBeenCalled();
   });
   it("keeps malformed PayPal events as client errors", async function () {
     const res = response();

--- a/app/dashboard/webhooks/paypal_webhook.js
+++ b/app/dashboard/webhooks/paypal_webhook.js
@@ -18,6 +18,18 @@ const SUBSCRIPTION_EVENTS = [
 
 const prefix = () => `${clfdate()} PayPal Webhook:`;
 
+async function fetchJSON(url, options) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15000);
+  try {
+    const response = await fetch(url, { ...options, signal: controller.signal });
+    if (!response.ok) throw new Error(`PayPal returned HTTP ${response.status}`);
+    return await response.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // Verify an incoming PayPal webhook via PayPal's verify-webhook-signature API.
 // Returns true when verification succeeds - or when no webhook id is configured,
 // in which case verification is skipped and the previous behaviour preserved,
@@ -33,7 +45,7 @@ const verifyPayPalWebhook = async req => {
     return true;
   }
 
-  const response = await fetch(
+  const json = await fetchJSON(
     `${config.paypal.api_base}/v1/notifications/verify-webhook-signature`,
     {
       method: "POST",
@@ -55,8 +67,6 @@ const verifyPayPalWebhook = async req => {
     }
   );
 
-  const json = await response.json();
-
   return json.verification_status === "SUCCESS";
 };
 
@@ -70,7 +80,7 @@ paypal.post("/", parser.json(), async (req, res) => {
     }
   } catch (err) {
     console.log(prefix(), "signature verification error", err);
-    return res.sendStatus(400);
+    return res.sendStatus(503);
   }
 
   const eventType = req.body && req.body.event_type;
@@ -81,7 +91,7 @@ paypal.post("/", parser.json(), async (req, res) => {
 
   // if the webhook is for a subscription-related event, update the subscription
   if (SUBSCRIPTION_EVENTS.includes(eventType)) {
-    if (!subscriptionID) {
+    if (typeof subscriptionID !== "string" || !subscriptionID) {
       console.log(prefix(), "missing resource.id for", eventType);
       return res.sendStatus(400);
     }
@@ -93,6 +103,7 @@ paypal.post("/", parser.json(), async (req, res) => {
       console.log(prefix(), "Updated subscription successfully");
     } catch (err) {
       console.log(prefix(), err);
+      return res.sendStatus(503);
     }
   } else {
     console.log(prefix(), "Unhandled event", req.body);
@@ -102,54 +113,42 @@ paypal.post("/", parser.json(), async (req, res) => {
 });
 
 const updateSubscription = async subscriptionID => {
-  return new Promise((resolve, reject) => {
-    User.getByPayPalSubscriptionId(subscriptionID, async (err, user) => {
+  const user = await new Promise((resolve, reject) => {
+    User.getByPayPalSubscriptionId(subscriptionID, (err, user) => {
       if (err) return reject(err);
-
-      if (!user)
-        return reject(
-          new Error("No user associated with subscription ID " + subscriptionID)
-        );
-
-      const response = await fetch(
-        `${config.paypal.api_base}/v1/billing/subscriptions/${subscriptionID}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "Accept-Language": "en_US",
-            "Authorization": `Basic ${Buffer.from(
-              `${config.paypal.client_id}:${config.paypal.secret}`
-            ).toString("base64")}`
-          }
-        }
-      );
-
-      const paypal = await response.json();
-
-      const updates = { paypal };
-
-      const shouldDisable = subscriptionLifecycle.shouldDisableFromPaypalSubscription(paypal);
-      const shouldEnable = paypal.status === "ACTIVE" && user.isDisabled;
-
-      if (shouldDisable) {
-        return User.disable(user, updates, err => {
-          if (err) return reject(err);
-          resolve();
-        });
-      }
-
-      if (shouldEnable) {
-        return User.enable(user, updates, err => {
-          if (err) return reject(err);
-          resolve();
-        });
-      }
-
-      User.set(user.uid, updates, err => {
-        if (err) return reject(err);
-        resolve();
-      });
+      resolve(user);
     });
+  });
+  if (!user) {
+    throw new Error("No user associated with subscription ID " + subscriptionID);
+  }
+
+  const paypal = await fetchJSON(
+    `${config.paypal.api_base}/v1/billing/subscriptions/${encodeURIComponent(subscriptionID)}`,
+    {
+      headers: {
+        "Content-Type": "application/json",
+        "Accept-Language": "en_US",
+        "Authorization": `Basic ${Buffer.from(
+          `${config.paypal.client_id}:${config.paypal.secret}`
+        ).toString("base64")}`
+      }
+    }
+  );
+
+  if (!paypal || paypal.id !== subscriptionID || typeof paypal.status !== "string") {
+    throw new Error("Invalid PayPal subscription response");
+  }
+  return new Promise((resolve, reject) => {
+    const updates = { paypal };
+    const done = err => err ? reject(err) : resolve();
+    const shouldDisable = subscriptionLifecycle.shouldDisableFromPaypalSubscription(paypal);
+    // Reconcile all blogs on redelivery after a partial enable operation.
+    const shouldEnable = paypal.status === "ACTIVE";
+
+    if (shouldDisable) return User.disable(user, updates, done);
+    if (shouldEnable) return User.enable(user, updates, done);
+    User.set(user.uid, updates, done);
   });
 };
 

--- a/app/dashboard/webhooks/paypal_webhook.js
+++ b/app/dashboard/webhooks/paypal_webhook.js
@@ -143,10 +143,11 @@ const updateSubscription = async subscriptionID => {
     const updates = { paypal };
     const done = err => err ? reject(err) : resolve();
     const shouldDisable = subscriptionLifecycle.shouldDisableFromPaypalSubscription(paypal);
-    // Reconcile all blogs on redelivery after a partial enable operation.
-    const shouldEnable = paypal.status === "ACTIVE";
+    // Preserve deliberate per-blog availability when the account is unchanged.
+    // Recovering a partial blog transition requires separate durable state.
+    const shouldEnable = paypal.status === "ACTIVE" && user.isDisabled;
 
-    if (shouldDisable) return User.disable(user, updates, done);
+    if (shouldDisable && !user.isDisabled) return User.disable(user, updates, done);
     if (shouldEnable) return User.enable(user, updates, done);
     User.set(user.uid, updates, done);
   });

--- a/app/dashboard/webhooks/paypal_webhook.js
+++ b/app/dashboard/webhooks/paypal_webhook.js
@@ -144,7 +144,7 @@ const updateSubscription = async subscriptionID => {
     const done = err => err ? reject(err) : resolve();
     const shouldDisable = subscriptionLifecycle.shouldDisableFromPaypalSubscription(paypal);
     // Preserve deliberate per-blog availability when the account is unchanged.
-    // Recovering a partial blog transition requires separate durable state.
+    // The model saves the account flag last to keep failures retryable.
     const shouldEnable = paypal.status === "ACTIVE" && user.isDisabled;
 
     if (shouldDisable && !user.isDisabled) return User.disable(user, updates, done);

--- a/app/dashboard/webhooks/stripe_webhook.js
+++ b/app/dashboard/webhooks/stripe_webhook.js
@@ -228,14 +228,15 @@ function update_subscription(customer_id, subscription, callback) {
       User.set(user.uid, updates, next);
     };
 
-    // A prior attempt may have saved the user but failed while updating one
-    // of its blogs. Reconcile blogs again on redelivery even if the user flag
-    // already matches, so a 503 really can be repaired by retrying the event.
-    if (shouldDisable) {
+    // Change blog availability only on an account transition: individual
+    // blogs can also be disabled deliberately by an administrator. If a
+    // transition partially updates blogs, durable reconciliation needs its
+    // own state; redelivery alone must not overwrite deliberate blog state.
+    if (shouldDisable && !user.isDisabled) {
       handler = function (next) {
         User.disable(user, updates, next);
       };
-    } else if (subscription.status === "active") {
+    } else if (!shouldDisable && subscription.status === "active" && user.isDisabled) {
       handler = function (next) {
         User.enable(user, updates, next);
       };

--- a/app/dashboard/webhooks/stripe_webhook.js
+++ b/app/dashboard/webhooks/stripe_webhook.js
@@ -229,9 +229,8 @@ function update_subscription(customer_id, subscription, callback) {
     };
 
     // Change blog availability only on an account transition: individual
-    // blogs can also be disabled deliberately by an administrator. If a
-    // transition partially updates blogs, durable reconciliation needs its
-    // own state; redelivery alone must not overwrite deliberate blog state.
+    // blogs can also be disabled deliberately by an administrator. The model
+    // saves the account flag last so failed transitions remain retryable.
     if (shouldDisable && !user.isDisabled) {
       handler = function (next) {
         User.disable(user, updates, next);

--- a/app/dashboard/webhooks/stripe_webhook.js
+++ b/app/dashboard/webhooks/stripe_webhook.js
@@ -168,18 +168,20 @@ webhooks.post("/", parser.raw({ type: "application/json" }), function (req, res)
       function (err, subscription) {
         if (err || !subscription) {
           console.error("Failed to retrieve Stripe subscription", err);
-          return res.sendStatus(400);
+          return res.sendStatus(503);
         }
 
         update_subscription(
           event_data.customer,
           subscription,
           function (updateErr) {
-            if (updateErr) console.error("Failed to update subscription", updateErr);
+            if (updateErr) {
+              console.error("Failed to update subscription", updateErr);
+              return res.sendStatus(503);
+            }
+            return res.sendStatus(200);
           }
         );
-
-        return res.sendStatus(200);
       }
     );
   }
@@ -226,11 +228,14 @@ function update_subscription(customer_id, subscription, callback) {
       User.set(user.uid, updates, next);
     };
 
-    if (shouldDisable && !user.isDisabled) {
+    // A prior attempt may have saved the user but failed while updating one
+    // of its blogs. Reconcile blogs again on redelivery even if the user flag
+    // already matches, so a 503 really can be repaired by retrying the event.
+    if (shouldDisable) {
       handler = function (next) {
         User.disable(user, updates, next);
       };
-    } else if (!shouldDisable && subscription.status === "active" && user.isDisabled) {
+    } else if (subscription.status === "active") {
       handler = function (next) {
         User.enable(user, updates, next);
       };

--- a/app/models/user/disable.js
+++ b/app/models/user/disable.js
@@ -20,15 +20,16 @@ module.exports = function disable(user, updates, callback) {
 
   updates.isDisabled = true;
 
-  set(user.uid, updates, function (err) {
-    if (err) return callback(err);
-
-    async.each(
-      blogs,
-      function (blogID, next) {
-        setBlog(blogID, { isDisabled: true }, next);
-      },
-      callback
-    );
-  });
+  // Keep the persisted account flag unchanged until every blog is updated.
+  // If a blog write fails, webhook redelivery can still retry this transition.
+  async.each(
+    blogs,
+    function (blogID, next) {
+      setBlog(blogID, { isDisabled: true }, next);
+    },
+    function (err) {
+      if (err) return callback(err);
+      set(user.uid, updates, callback);
+    }
+  );
 };

--- a/app/models/user/enable.js
+++ b/app/models/user/enable.js
@@ -20,15 +20,16 @@ module.exports = function enable(user, updates, callback) {
 
   updates.isDisabled = false;
 
-  set(user.uid, updates, function (err) {
-    if (err) return callback(err);
-
-    async.each(
-      blogs,
-      function (blogID, next) {
-        setBlog(blogID, { isDisabled: false }, next);
-      },
-      callback
-    );
-  });
+  // Keep the persisted account flag unchanged until every blog is updated.
+  // If a blog write fails, webhook redelivery can still retry this transition.
+  async.each(
+    blogs,
+    function (blogID, next) {
+      setBlog(blogID, { isDisabled: false }, next);
+    },
+    function (err) {
+      if (err) return callback(err);
+      set(user.uid, updates, callback);
+    }
+  );
 };

--- a/app/models/user/tests/availability.js
+++ b/app/models/user/tests/availability.js
@@ -1,0 +1,102 @@
+const { promisify } = require("util");
+const User = require("models/user");
+const Blog = require("models/blog");
+const client = require("models/client");
+const userKey = require("../key");
+const blogKey = require("models/blog/key");
+const getUser = promisify(User.getById);
+const getBlog = promisify(Blog.get);
+const setUser = promisify(User.set);
+const setBlog = promisify(Blog.set);
+
+// Fail at the storage boundary once, allowing subsequent retries to use Redis.
+// Cover both transactional and Lua commits used by the user model.
+function failCommitOnce(target) {
+  let failed = false;
+  const multi = client.multi.bind(client);
+  spyOn(client, "multi").and.callFake(function () {
+    const transaction = multi();
+    let touchesTarget = false;
+    ["set", "hSet"].forEach(function (method) {
+      const command = transaction[method].bind(transaction);
+      transaction[method] = function (name, ...args) {
+        if (name === target) touchesTarget = true;
+        return command(name, ...args);
+      };
+    });
+    const exec = transaction.exec.bind(transaction);
+    transaction.exec = async function () {
+      if (touchesTarget && !failed) {
+        failed = true;
+        throw new Error("Temporary write failure");
+      }
+      return exec();
+    };
+    return transaction;
+  });
+  const evaluate = client.eval.bind(client);
+  spyOn(client, "eval").and.callFake(async function (script, options) {
+    if (options.keys[0] === target && !failed) {
+      failed = true;
+      throw new Error("Temporary write failure");
+    }
+    return evaluate(script, options);
+  });
+}
+
+describe("retryable account availability transitions", function () {
+  global.test.blogs(2);
+
+  ["enable", "disable"].forEach(function (operation) {
+    const targetDisabled = operation === "disable";
+    const transition = promisify(User[operation]);
+
+    async function prepare(context) {
+      await setUser(context.user.uid, {
+        isDisabled: !targetDisabled,
+        blogs: context.blogs.map(blog => blog.id),
+      });
+      for (const blog of context.blogs) {
+        await setBlog(blog.id, { isDisabled: !targetDisabled });
+      }
+      return getUser(context.user.uid);
+    }
+
+    async function expectCompleted(context) {
+      const saved = await getUser(context.user.uid);
+      expect(saved.isDisabled).toBe(targetDisabled);
+      expect(saved.lastSession).toBe("transition-complete");
+      for (const blog of context.blogs) {
+        expect((await getBlog({ id: blog.id })).isDisabled).toBe(targetDisabled);
+      }
+    }
+
+    it(operation + " keeps the account eligible for retry after a blog write fails", async function () {
+      const user = await prepare(this);
+      failCommitOnce(blogKey.info(this.blogs[1].id));
+      const error = await transition(user, { lastSession: "transition-complete" })
+        .then(() => null, err => err);
+      expect(error.message).toBe("Temporary write failure");
+      const pending = await getUser(user.uid);
+      expect(pending.isDisabled).toBe(!targetDisabled);
+      expect(pending.lastSession).not.toBe("transition-complete");
+      await transition(pending, { lastSession: "transition-complete" });
+      await expectCompleted(this);
+    });
+
+    it(operation + " keeps the account eligible for retry after the final account write fails", async function () {
+      const user = await prepare(this);
+      failCommitOnce(userKey.user(user.uid));
+      const error = await transition(user, { lastSession: "transition-complete" })
+        .then(() => null, err => err);
+      expect(error.message).toBe("Temporary write failure");
+      const pending = await getUser(user.uid);
+      expect(pending.isDisabled).toBe(!targetDisabled);
+      for (const blog of this.blogs) {
+        expect((await getBlog({ id: blog.id })).isDisabled).toBe(targetDisabled);
+      }
+      await transition(pending, { lastSession: "transition-complete" });
+      await expectCompleted(this);
+    });
+  });
+});


### PR DESCRIPTION
Acknowledge subscription webhooks only after the persistence callback succeeds, and return retryable errors when provider retrieval or storage fails. PayPal retrieval and JSON parsing now stay within the awaited promise chain, with HTTP/response validation and a 15-second request/body deadline.

Account enable/disable transitions update blogs before committing the final account flag. A failed blog or final account write therefore leaves the transition eligible for webhook retry. Unchanged accounts retain the existing guard so active subscription events do not re-enable deliberately disabled individual blogs.

Validation: standard test runner with isolated Redis 6.2.14 passed 4 fault-injection availability specifications, 12 focused webhook specifications, and 7 Stripe HTTP integration specifications (seed 14396). Cases cover delayed persistence, provider failures, malformed responses, timeouts, failures in both transition directions, final account-write failure, retry completion, and deliberate per-blog disablement. No live payment-provider mutation was performed.

The transition ordering makes partial failures retryable; it is not an atomic transaction across user and blog records. Notification side effects are not deduplicated by this change.
