### PR TITLE
Add regression tests for externalLinks, imageCaption, and zoom plugins

### DIFF
--- a/app/build/plugins/externalLinks/tests.js
+++ b/app/build/plugins/externalLinks/tests.js
@@ -1,0 +1,82 @@
+const cheerio = require("cheerio");
+const { render } = require("./index.js");
+
+const runTest = (html, options) => {
+  return new Promise((resolve, reject) => {
+    const $ = cheerio.load(html);
+    render(
+      $,
+      function (err) {
+        if (err) return reject(err);
+        resolve($.html());
+      },
+      options
+    );
+  });
+};
+
+const options = {
+  domain: "example.com",
+  baseURL: "https://example.com",
+};
+
+describe("externalLinks plugin", function () {
+  it("adds target=_blank to links pointing to other hosts", async () => {
+    const html = '<a href="https://other.com/page">link</a>';
+    const output = await runTest(html, options);
+    expect(output).toContain('target="_blank"');
+  });
+
+  it("does not touch links to the site's own domain", async () => {
+    const html = '<a href="https://example.com/page">link</a>';
+    const output = await runTest(html, options);
+    expect(output).not.toContain("target=");
+  });
+
+  it("does not touch links to the site's baseURL host", async () => {
+    const html = '<a href="https://example.com/other">link</a>';
+    const output = await runTest(html, options);
+    expect(output).not.toContain("target=");
+  });
+
+  it("does not touch links to the raw options.domain value", async () => {
+    const html = '<a href="https://example.com/">link</a>';
+    const output = await runTest(html, options);
+    expect(output).not.toContain("target=");
+  });
+
+  it("does not touch relative links, which have no host", async () => {
+    const html = '<a href="/about">link</a>';
+    const output = await runTest(html, options);
+    expect(output).not.toContain("target=");
+  });
+
+  it("does not touch links with no href attribute", async () => {
+    const html = "<a>link</a>";
+    const output = await runTest(html, options);
+    expect(output).not.toContain("target=");
+  });
+
+  it("ignores unparseable href values instead of throwing", async () => {
+    const html = '<a href="http://[invalid">link</a>';
+    const output = await runTest(html, options);
+    expect(output).not.toContain("target=");
+  });
+
+  it("handles multiple links independently", async () => {
+    const html =
+      '<a href="https://other.com/a">a</a><a href="https://example.com/b">b</a><a href="https://another.com/c">c</a>';
+    const output = await runTest(html, options);
+    const $ = cheerio.load(output);
+    const links = $("a");
+    expect($(links[0]).attr("target")).toBe("_blank");
+    expect($(links[1]).attr("target")).toBeUndefined();
+    expect($(links[2]).attr("target")).toBe("_blank");
+  });
+
+  it("skips processing without throwing when options can't be parsed", async () => {
+    const html = '<a href="https://other.com/page">link</a>';
+    const output = await runTest(html, { domain: null, baseURL: null });
+    expect(output).not.toContain("target=");
+  });
+});

--- a/app/build/plugins/imageCaption/tests.js
+++ b/app/build/plugins/imageCaption/tests.js
@@ -1,0 +1,102 @@
+const cheerio = require("cheerio");
+const { render } = require("./index.js");
+
+const runTest = (html) => {
+  return new Promise((resolve, reject) => {
+    const $ = cheerio.load(html);
+    render($, function (err) {
+      if (err) return reject(err);
+      resolve($.html());
+    });
+  });
+};
+
+describe("imageCaption plugin", function () {
+  it("adds a caption from the title attribute", async () => {
+    const html = '<img src="a.jpg" title="A title">';
+    const output = await runTest(html);
+    expect(output).toContain('<span class="caption">A title</span>');
+  });
+
+  it("adds a caption from the alt attribute when there is no title", async () => {
+    const html = '<img src="a.jpg" alt="Alt text">';
+    const output = await runTest(html);
+    expect(output).toContain('<span class="caption">Alt text</span>');
+  });
+
+  it("prefers the title attribute over the alt attribute", async () => {
+    const html = '<img src="a.jpg" title="Title" alt="Alt">';
+    const output = await runTest(html);
+    expect(output).toContain('<span class="caption">Title</span>');
+    expect(output).not.toContain('<span class="caption">Alt</span>');
+  });
+
+  it("does nothing when there is no title or alt attribute", async () => {
+    const html = '<img src="a.jpg">';
+    const output = await runTest(html);
+    expect(output).not.toContain("caption");
+  });
+
+  it("ignores emoji images even if they have alt text", async () => {
+    const html = '<img class="emoji" src="a.png" alt=":smile:">';
+    const output = await runTest(html);
+    expect(output).not.toContain("caption");
+  });
+
+  it("wraps the parent .image element rather than the img itself", async () => {
+    const html = '<div class="image"><img src="a.jpg" alt="Alt text"></div>';
+    const output = await runTest(html);
+    expect(output).toContain(
+      '<div class="image"><img src="a.jpg" alt="Alt text"></div><span class="caption">Alt text</span>'
+    );
+  });
+
+  it("inserts the caption directly after the img when there's no .image parent", async () => {
+    const html = '<p><img src="a.jpg" alt="Alt text"></p>';
+    const output = await runTest(html);
+    expect(output).toContain(
+      '<img src="a.jpg" alt="Alt text"><span class="caption">Alt text</span>'
+    );
+  });
+
+  it("does not caption an image inside a paragraph with other text", async () => {
+    const html = '<p>Some text <img src="a.jpg" alt="Alt text"></p>';
+    const output = await runTest(html);
+    expect(output).not.toContain("caption");
+  });
+
+  it("does caption an image whose siblings are only whitespace text", async () => {
+    const html = '<p>\n  <img src="a.jpg" alt="Alt text">\n</p>';
+    const output = await runTest(html);
+    expect(output).toContain('<span class="caption">Alt text</span>');
+  });
+
+  it("allows sibling elements with the caption class", async () => {
+    const html =
+      '<p><img src="a.jpg" alt="Alt text"><span class="caption">Existing</span></p>';
+    const output = await runTest(html);
+    expect(output).toContain('<span class="caption">Alt text</span>');
+  });
+
+  it("allows sibling img elements without blocking the caption", async () => {
+    const html =
+      '<p><img src="a.jpg" alt="First"><img src="b.jpg" alt="Second"></p>';
+    const output = await runTest(html);
+    expect(output).toContain('<span class="caption">First</span>');
+    expect(output).toContain('<span class="caption">Second</span>');
+  });
+
+  it("escapes HTML-sensitive characters found in the alt text", async () => {
+    const html = '<img src="a.jpg" alt="Tom & Jerry">';
+    const output = await runTest(html);
+    expect(output).toContain('<span class="caption">Tom &amp; Jerry</span>');
+  });
+
+  it("handles multiple images in the document independently", async () => {
+    const html =
+      '<img src="a.jpg" title="First"><img src="b.jpg" title="Second">';
+    const output = await runTest(html);
+    expect(output).toContain('<span class="caption">First</span>');
+    expect(output).toContain('<span class="caption">Second</span>');
+  });
+});

--- a/app/build/plugins/zoom/tests.js
+++ b/app/build/plugins/zoom/tests.js
@@ -1,0 +1,90 @@
+const cheerio = require("cheerio");
+const { render } = require("./index.js");
+
+const runTest = (html) => {
+  return new Promise((resolve, reject) => {
+    const $ = cheerio.load(html);
+    render($, function (err) {
+      if (err) return reject(err);
+      resolve($.html());
+    });
+  });
+};
+
+describe("zoom plugin", function () {
+  it("marks a wide image with a width attribute for zoom", async () => {
+    const html = '<img src="a.jpg" width="500">';
+    const output = await runTest(html);
+    expect(output).toContain('data-action="zoom"');
+  });
+
+  it("marks a wide image with a data-width attribute for zoom", async () => {
+    const html = '<img src="a.jpg" data-width="500">';
+    const output = await runTest(html);
+    expect(output).toContain('data-action="zoom"');
+  });
+
+  it("does not mark a narrow image for zoom", async () => {
+    const html = '<img src="a.jpg" width="200">';
+    const output = await runTest(html);
+    expect(output).not.toContain("data-action");
+  });
+
+  it("does not mark an image exactly at the minimum width", async () => {
+    const html = '<img src="a.jpg" width="320">';
+    const output = await runTest(html);
+    expect(output).not.toContain("data-action");
+  });
+
+  it("marks an image one pixel wider than the minimum width", async () => {
+    const html = '<img src="a.jpg" width="321">';
+    const output = await runTest(html);
+    expect(output).toContain('data-action="zoom"');
+  });
+
+  it("does not mark an image with no width attribute", async () => {
+    const html = '<img src="a.jpg">';
+    const output = await runTest(html);
+    expect(output).not.toContain("data-action");
+  });
+
+  it("does not mark an image with a non-numeric width", async () => {
+    const html = '<img src="a.jpg" width="notanumber">';
+    const output = await runTest(html);
+    expect(output).not.toContain("data-action");
+  });
+
+  it("does not mark an image nested inside a link", async () => {
+    const html = '<a href="/x"><img src="a.jpg" width="500"></a>';
+    const output = await runTest(html);
+    expect(output).not.toContain("data-action");
+  });
+
+  it("does not mark an image whose src explicitly opts out with zoom=false", async () => {
+    const html = '<img src="a.jpg?zoom=false" width="500">';
+    const output = await runTest(html);
+    expect(output).not.toContain("data-action");
+  });
+
+  it("marks an image with an unrelated query string", async () => {
+    const html = '<img src="a.jpg?foo=bar" width="500">';
+    const output = await runTest(html);
+    expect(output).toContain('data-action="zoom"');
+  });
+
+  it("does not throw when the image has no src attribute", async () => {
+    const html = '<img width="500">';
+    const output = await runTest(html);
+    expect(output).not.toContain("data-action");
+  });
+
+  it("handles multiple images independently", async () => {
+    const html =
+      '<img src="a.jpg" width="500"><img src="b.jpg" width="100">';
+    const output = await runTest(html);
+    const $ = cheerio.load(output);
+    const images = $("img");
+    expect($(images[0]).attr("data-action")).toBe("zoom");
+    expect($(images[1]).attr("data-action")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `tests.js` for `app/build/plugins/externalLinks`, `app/build/plugins/imageCaption`, and `app/build/plugins/zoom` — none had test coverage before.
- Cover the main render paths plus edge cases: unparseable URLs/hosts, missing attributes, emoji images, images without paragraph siblings, min-width boundary, `zoom=false` query opt-out, and images nested in links.

## Test plan
- [x] `npm test app/build/plugins/externalLinks` — 9 specs, 0 failures, 100% line coverage on `index.js`
- [x] `npm test app/build/plugins/imageCaption` — 13 specs, 0 failures, 100% line coverage on `index.js`
- [x] `npm test app/build/plugins/zoom` — 12 specs, 0 failures, 100% line coverage on `index.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)