### PR TITLE
Fix flaky rename test by making entry titles collision-proof

### DIFF
--- a/app/sync/tests/renames.js
+++ b/app/sync/tests/renames.js
@@ -169,8 +169,11 @@ describe("update", function () {
     var ghostPath = ctx.fake.path(".txt");
     var ghostNewPath = ctx.fake.path(".txt");
 
-    var content = ctx.fake.file();
-    var ghostContent = ctx.fake.file();
+    // Unique titles avoid a permalink collision between these two entries,
+    // which would otherwise get a "-2" suffix and break checkRename's
+    // exact permalink-reuse assertion.
+    var content = ctx.fake.file({ title: ctx.fake.random.uuid() });
+    var ghostContent = ctx.fake.file({ title: ctx.fake.random.uuid() });
     var ghostEntryID;
 
     ctx.writeAndSync(path, content, function (err) {


### PR DESCRIPTION
## Summary

Investigating a flaky failure in [PR #1787's CI run](https://github.com/davidmerfield/blot/actions/runs/34617370656/job/103322625930) (`update skips missing deleted-entry records while detecting renames`), even though that PR only touches benchmark tooling and never touches `app/sync` or entry/URL code.

The failure was:
```
Failed: checking entry /Practical/THX/PCI/Music/content/application.txt
url [expected] /ut
    [returned] /ut-2
```

Root cause: this test creates two entries in the same blog (`content` and `ghostContent`) via `fake.file()`, whose default title comes from `faker.lorem.word()` — a small, finite word pool. When both entries happen to draw the same title, their permalinks collide, and the second one gets disambiguated with a `-2` suffix. `checkRename()`'s helper asserts the renamed entry keeps the *exact* permalink of the entry it replaces, so a collision between these two unrelated entries broke the assertion.

## Fix

Give `content` and `ghostContent` unique titles (`ctx.fake.random.uuid()`) so their permalinks can never collide with each other, regardless of which random words faker happens to draw.

Scoped this fix to just the one flaky test — the other tests in `renames.js` only ever create a single random title per blog per test run, so they aren't exposed to this collision.

## Test plan

- [x] Read through `app/models/entry/_setUrl.js` to confirm slug/permalink collisions are scoped per-blog and produce a `-2`..`-4` suffix retry, matching the observed failure
- [ ] CI (per repo convention, relying on GitHub Actions runners rather than local Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)