### PR TITLE
Install bash in test image for redis service-overrides test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,6 +135,11 @@ RUN node -e "require('sharp'); console.log('sharp loads against libvips ' + requ
 RUN apk add --no-cache chromium nss freetype harfbuzz ttf-freefont
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
+# config/redis/scripts/install-service-overrides.sh is written for the bash
+# that ships on the production EC2 host and its test spawns it with `bash`
+# directly - Alpine's base image only has busybox `sh`, so add the real thing.
+RUN apk add --no-cache bash
+
 # Configure git so the git client doesn't complain
 RUN git config --global --add safe.directory /usr/src/app \
  && git config --global user.email "you@example.com" \


### PR DESCRIPTION
## Summary
- The `config/redis` test job added in 2f689f5e4 spawns `config/redis/scripts/install-service-overrides.sh` via `execFile("bash", ...)`, but the Alpine-based `dev` image built by the root `Dockerfile` only has busybox `sh` — no `bash` binary — so the job failed in CI with `spawn bash ENOENT` (https://github.com/davidmerfield/blot/actions/runs/34634975061/job/103381225488).
- Add `bash` to the `dev` (test) Docker stage so the test can actually run the script it's exercising. `install-service-overrides.sh` and `setup.sh` already assume bash (they run on the production EC2 host, which has it) — this only affects the CI test image, not production.

## Test plan
- [ ] CI: `test (config/redis, 1/1)` passes on this PR