### PR TITLE
Fix flaky proxy cacher test (nginx temp-file race)

### DIFF
--- a/proxy/tests/util/setup.js
+++ b/proxy/tests/util/setup.js
@@ -148,6 +148,12 @@ module.exports = configFile => {
     this.listCache = async function listCache ({ watch = true } = {}) {
       const files = [];
 
+      // With use_temp_path=off nginx writes in-progress responses to a
+      // numbered temp file inside this same tree before renaming it to its
+      // final 32-char md5 hash name; skip temp files so a listCache() call
+      // racing an in-flight write can't return partial/garbled content.
+      const CACHE_FILENAME = /^[0-9a-f]{32}$/;
+
       const list = async function (dir) {
         const stat = await fs.stat(dir);
         if (stat.isDirectory()) {
@@ -155,7 +161,7 @@ module.exports = configFile => {
           for (const child of children) {
             await list(dir + "/" + child);
           }
-        } else {
+        } else if (CACHE_FILENAME.test(basename(dir))) {
           files.push(dir);
         }
       };


### PR DESCRIPTION
## Summary
- The proxy CI run linked here failed intermittently: https://github.com/davidmerfield/blot/actions/runs/34636589898/job/103385911138
- Root cause: `proxy_cache_path` is configured with `use_temp_path=off` ([http.conf:42](proxy/config/http.conf#L42)), so nginx writes an in-progress response to a numbered temp file directly inside the cache directory tree, then atomically renames it to its final 32-char md5 hash filename.
- `listCache()` in `proxy/tests/util/setup.js` did a raw recursive directory listing and returned whatever file it found first — occasionally the still-being-written temp file — so the test read partial/garbled content instead of the completed cache file (seen as `Expected 13 to be 12` and garbage line content in the failed run).
- Fix: filter `listCache()` results to only files whose basename matches nginx's actual cache filename format (`/^[0-9a-f]{32}$/`), skipping transient temp files.

## Test plan
- [x] Pushed to CI; watching the `proxy` job on this PR to confirm the flake is gone.