### PR TITLE
Overwrite coverage artifact on job rerun to fix stale coverage-report failures

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -365,6 +365,12 @@ jobs:
           include-hidden-files: true
           if-no-files-found: warn
           retention-days: 7
+          # A re-run of this job (e.g. after a flaky failure) reuses the same
+          # workflow run, so without this the previous attempt's artifact of
+          # the same name sticks around too. coverage-report then downloads
+          # both copies into one folder and nyc chokes on the stale/partial
+          # one. Overwriting keeps only the latest attempt's coverage.
+          overwrite: true
 
   coverage-report:
     needs: [setup-tests, test]


### PR DESCRIPTION
## Summary
- Re-running a flaky `test` shard job (e.g. [attempt 1 of `test (proxy, 1/1)`](https://github.com/davidmerfield/blot/actions/runs/34636589898/job/103385911138) failed, [attempt 2](https://github.com/davidmerfield/blot/actions/runs/34636589898/job/103388006781) succeeded) uploads a new `coverage-<suite>-<shard>` artifact with the same name as the failed attempt's — GitHub Actions doesn't delete the old one, so both persist under the identical name in the same run.
- `coverage-report`'s `download-artifact` step matches `coverage-*` and downloaded **both** copies into one folder (23 raw files from 19 shards instead of 19), and the stale/partial file from the failed attempt broke `nyc report`:
  ```
  Invalid file coverage object, missing keys, found:lines,statements,functions,branches,branchesTrue
  ##[error]Process completed with exit code 1.
  ```
  (seen in [this coverage-report run](https://github.com/davidmerfield/blot/actions/runs/34636589898/job/103388378655))
- Fix: pass `overwrite: true` to the coverage artifact upload so a job rerun replaces the previous attempt's artifact instead of leaving a duplicate around.

## Test plan
- [ ] Push and let `node.yml` run on this PR
- [ ] Manually re-run one `test` shard job and confirm `coverage-report` still succeeds afterward