### PR TITLE
Retry deploy health check's curl probe before failing

### DIFF
--- a/scripts/deploy/util/checkHealth.js
+++ b/scripts/deploy/util/checkHealth.js
@@ -1,5 +1,7 @@
 const HEALTH_CHECK_TIMEOUT = 180; // 3 minutes
 const HEALTH_CHECK_INTERVAL = 15; // 15 seconds
+const CURL_RETRY_ATTEMPTS = 3;
+const CURL_RETRY_DELAY = 3; // seconds
 const MAX_PORT = 65535;
 
 const sshCommand = require("./sshCommand");
@@ -44,9 +46,37 @@ module.exports = async function checkHealth(containerName, containerPort) {
           `Container is healthy according to docker, running second health check...`
         );
 
-        await sshCommand(
-          `curl --fail --max-time 10 http://localhost:${containerPort}/health || exit 1`
-        );
+        // Docker reporting "healthy" doesn't guarantee the very next curl
+        // lands cleanly - a single transient blip (e.g. contention while a
+        // sibling container is also coming up) can fail one attempt even
+        // though the app is genuinely up. Retry a few times before giving
+        // up and triggering a rollback.
+        let curlError;
+        let reachable = false;
+        for (let attempt = 1; attempt <= CURL_RETRY_ATTEMPTS; attempt++) {
+          try {
+            await sshCommand(
+              `curl --fail --max-time 10 http://localhost:${containerPort}/health`
+            );
+            reachable = true;
+            break;
+          } catch (error) {
+            curlError = error;
+            if (attempt < CURL_RETRY_ATTEMPTS) {
+              console.log(
+                `Health check curl attempt ${attempt} failed, retrying...`
+              );
+              await new Promise((resolve) =>
+                setTimeout(resolve, CURL_RETRY_DELAY * 1000)
+              );
+            }
+          }
+        }
+
+        if (!reachable) {
+          throw curlError;
+        }
+
         console.log(`Container is healthy and accessible.`);
 
         return true;


### PR DESCRIPTION
## Summary
- Yesterday's deploy (run [34639535279](https://github.com/davidmerfield/blot/actions/runs/34639535279/job/103395561431)) failed on the green container: Docker's own `HEALTHCHECK` reported `healthy`, but the deploy script's single follow-up `curl http://localhost:PORT/health` got 0 bytes back and timed out after 10s, which triggered a rollback and failed the job.
- Blue had deployed the same image seconds earlier without issue, and a manual re-run of the same commit ([34641647767](https://github.com/davidmerfield/blot/actions/runs/34641647767)) succeeded immediately — pointing to a transient blip (likely resource contention starting a second heavy container right after the first) rather than a real app failure.
- `checkHealth.js`'s final curl check now retries up to 3 times with a short delay before giving up, so a one-off blip doesn't fail the whole deploy and trigger an unnecessary rollback. It still fails/rolls back if the container is genuinely unresponsive across all attempts.

## Test plan
- [ ] Merge and watch the next deploy run for the retry log line (`Health check curl attempt N failed, retrying...`) if a blip occurs again
- [ ] Confirm a genuinely broken container (bad image) still fails and rolls back as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)