### PR TITLE
iCloud: fail closed on an unconfirmed directory listing (stops silent unpublishing)

### DIFF
--- a/app/clients/icloud/macserver/routes/readdir.js
+++ b/app/clients/icloud/macserver/routes/readdir.js
@@ -38,10 +38,45 @@ export default async (req, res) => {
   // otherwise, files or subdirectories may be missing. if this stops working
   // you can use brctl monitor -p [path] to force iCloud to sync the directory
   // listing (this will not download the files, just the list of contents)
+  // `ls` (brctl/ls.js) does NOT throw on failure: it returns null when the
+  // directory does not exist, when brctl's download times out, or on any
+  // unexpected error. Previously its return value was discarded and we fell
+  // through to fs.readdir regardless, so a transient timeout produced a
+  // PARTIAL listing served as a 200. The caller (sync/fromiCloud) then
+  // treated every file missing from that partial list as deleted remotely
+  // and removed Blot's local copy - silently unpublishing real posts.
+  let listing = null;
   try {
-    await ls(dirPath);
+    listing = await ls(dirPath);
   } catch (error) {
     console.error(clfdate(), "Error listing directory:", dirPath, error);
+  }
+
+  if (listing === null || listing === undefined) {
+    // Distinguish a directory that is genuinely gone (a legitimate remote
+    // deletion - let it flow through the ENOENT -> 404 path below, as before)
+    // from one that exists but whose contents iCloud has not materialised.
+    // Only the latter is a partial listing, and for it we FAIL CLOSED: the
+    // error makes remoteReaddir throw, which aborts that sync pass before its
+    // deletion loop runs, and the sync is simply retried later. A failed sync
+    // is recoverable; a deleted post is not.
+    let exists = true;
+    try {
+      await fs.stat(dirPath);
+    } catch (error) {
+      if (error.code === "ENOENT") exists = false;
+    }
+
+    if (exists) {
+      console.error(
+        clfdate(),
+        "Refusing to serve unconfirmed (possibly partial) listing:",
+        dirPath
+      );
+      return res
+        .status(503)
+        .send("Directory listing unavailable: iCloud has not synced it yet");
+    }
   }
 
   let files = [];

--- a/app/clients/icloud/macserver/routes/readdir.js
+++ b/app/clients/icloud/macserver/routes/readdir.js
@@ -52,7 +52,7 @@ export default async (req, res) => {
     console.error(clfdate(), "Error listing directory:", dirPath, error);
   }
 
-  if (listing === null || listing === undefined) {
+  if (listing === null) {
     // Distinguish a directory that is genuinely gone (a legitimate remote
     // deletion - let it flow through the ENOENT -> 404 path below, as before)
     // from one that exists but whose contents iCloud has not materialised.

--- a/app/clients/icloud/sync/tests/fromiCloud.js
+++ b/app/clients/icloud/sync/tests/fromiCloud.js
@@ -111,4 +111,30 @@ describe("icloud fromiCloud sync", function () {
     expect(summary.skipped).toBe(1);
     expect(summary.placeholdersCreated).toBe(1);
   });
+
+  it("does not remove local files when remoteReaddir fails (partial/unconfirmed listing)", async () => {
+    const localFile = localPath(blogID, join("/", "post.txt"));
+    await fs.outputFile(localFile, "hello world");
+
+    mockModule(remoteRecursiveListPath, async () => {});
+    mockModule(remoteReaddirPath, async () => {
+      throw new Error("Directory listing unavailable: iCloud has not synced it yet");
+    });
+    mockModule(checkWeCanContinuePath, () => async () => {});
+    mockModule(databasePath, { store: async () => {} });
+
+    const fromiCloud = require(fromiCloudPath);
+    const published = [];
+    const summary = await fromiCloud(
+      blogID,
+      (...args) => published.push(args.join(" ")),
+      async () => {}
+    );
+
+    const stat = await fs.stat(localFile);
+
+    expect(stat.isFile()).toBe(true);
+    expect(summary.removed).toBe(0);
+    expect(published.some((line) => line.includes("Sync failed"))).toBe(true);
+  });
 });


### PR DESCRIPTION
Hi, it's Claude (Fable 5.1; Effort: Low). This one isn't from the security report — it's a data-integrity bug I'd rate as the scariest thing left in the tree for a platform whose promise is "your folder is your blog": **a transient iCloud timeout can silently unpublish real posts.**

### The bug
`brctl/ls.js` doesn't throw on failure — it **returns `null`** when the directory is missing, when `brctl download` times out, or on any unexpected error. `macserver/routes/readdir.js` discarded that return value and fell through to `fs.readdir` regardless, so a timeout produced a **partial** listing served as a `200` (your own comment at line 37 notes the listing "may be missing" files without a successful `ls`).

`sync/fromiCloud.js` then treats every local file absent from that partial list as *deleted remotely*: `fs.remove` + `update(path)` → the post is unpublished from the live blog. It comes back on the next successful sync, but in between the site is silently missing content, and this runs on the hourly / daily / startup resync paths — so it's a recurring, invisible outage after a routine `brctl` hiccup.

### The fix
Check the `ls` result. When it's `null`, `stat` the directory to tell two cases apart:
- **genuinely gone** (`ENOENT`) → still flows through the existing `404` path, so legitimate remote deletions keep working exactly as before;
- **exists but unconfirmed** (iCloud hasn't materialised it) → return `503`.

The `503` makes `remoteReaddir` throw, which aborts that sync pass *before* its deletion loop runs; the sync simply retries on the next schedule. A failed sync is recoverable — a deleted post is not.

### Notes
- Success path is byte-for-byte unchanged (a real listing is a non-null string). I compare `=== null`, not falsy, so an empty-but-valid listing isn't misclassified.
- A non-`ENOENT` `stat` error also fails closed (can't confirm → don't delete).
- `toiCloud` is only ever called with `skipDeletions: true`, so this never reached the user's iCloud source files — but `remoteDelete` is a loaded gun if deletions are ever enabled, since the same partial-listing bug would then wipe their originals. Worth keeping in mind.
- Not run against a live Mac; ESM syntax-checked and control-flow-traced. No existing test encoded the old behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
