### PR TITLE
Cache verified Drive content to detect same-size edits efficiently

### DIFF
--- a/TODO
+++ b/TODO
@@ -4,9 +4,7 @@ Resolve cloudflare fail2ban config drift
 
 Google Drive:
 - Fix bug with shared drive folders for [Chuck](https://mail.google.com/mail/u/0/#inbox/FMfcgzQfBkLKSVzvjZLRSCpRJwcKBPlf)
-- Add sync check
-  - [ ] Same-size content edits to regular files are never re-downloaded (sync.js only compares size, not content). Needs a scalable content-verification design that doesn't rehash every unchanged file on every sync (e.g. checksum stored at download time). See PR #1804 for a rejected attempt.
-- Fix bug with Google Docs when disconnecting a site from Google Drive on Blot then reconnecting the site to Google Drive. 
+- Fix bug with Google Docs when disconnecting a site from Google Drive on Blot then reconnecting the site to Google Drive.
 - Improve sync efficieny with option to target a specific folder or file first (Track ids in database) and tell [Chuck](https://mail.google.com/mail/u/0/#inbox/FMfcgzQfBspgLdtHcrTZqRcPTJFNzBbd) maybe use touch metadata method to force syncs periodically for hot files?
 - Improve html output for google docs and tell [Chuck](https://mail.google.com/mail/u/0/#inbox/FMfcgzQfBQFmTvLKzPkJrgsBTWZmQJWS)
   Issue: <p><img><br><img></p> should be <p><img></p><p><img></p>

--- a/app/clients/google-drive/README
+++ b/app/clients/google-drive/README
@@ -184,12 +184,19 @@ HTML templates for user-facing pages:
 - Recursively walks the remote folder tree.
 - For each remote file/folder:
   - If missing locally, downloads it or creates a directory.
-  - If present but out-of-date (different size or mod time), re-downloads.
+  - If present but out-of-date, verifies local content and downloads only when needed.
   - For Google Docs, uses modification time for comparison (no MD5).
-  - For regular files, uses file size.
+  - For regular files with a remote MD5, compares a previously verified checksum and local stat fingerprint. The fingerprint includes device, inode, size, and nanosecond modification/change times; replacements and same-size writes invalidate it even when modification time is restored.
+  - Verification metadata is fetched with one Redis HMGET per directory and stored separately from path metadata, scoped to the blog as well as the Drive folder. An unchanged warm file causes no content reads. Directory listing and stat work still scale with total file count.
+  - Regular files without a remote MD5 use size and modification time as a metadata fallback. Google-app behavior is unchanged.
+  - Checksums are recorded only after stable before/after stat checks around hashing and a successful rebuild. Downloaded temporary files are verified before publication; failed post-publication verification still triggers a rebuild but does not populate the cache.
   - Stream downloads are published only after the destination writer finishes; failed partial downloads are removed.
 - For each local file/folder not present remotely, deletes it (unless it matches an ignore pattern).
 - Updates the folder metadata database with new mappings.
+
+**Migrating existing folders:** Equal-size files without verification records are warmed incrementally, at most 32 files and 64 MiB per sync. A single larger file may run alone so it is not permanently excluded. A persistent cursor follows sorted depth-first paths and advances even when verification fails, preventing a failing prefix from starving later files. Deferred counts appear in sync progress. Warming includes a one-time verification and rebuild for each migrated file before its successful result is cached. Those files retain the previous size-only behavior until a subsequent sync verifies them; a manual resync can advance the migration. Missing/different-size files and changes to previously verified files are handled immediately. A full cursor wrap can defer earlier failed files until the next run.
+
+Manual resync preserves verified records and its cursor while rebuilding path mappings, then prunes orphaned records in Redis batches after a successful traversal. Ordinary resets and removals clear the appropriate verification data. Verification and cursors are blog-specific; the preexisting remote ID/path mapping remains Drive-folder-specific.
 
 ### Write/Remove/Disconnect
 

--- a/app/clients/google-drive/database/folder.js
+++ b/app/clients/google-drive/database/folder.js
@@ -2,10 +2,10 @@ const client = require("models/client");
 
 const PREFIX = require("./prefix");
 
-function folder(folderId) {
+function folder(folderId, blogID) {
 
   if (!(this instanceof folder)) {
-    return new folder(folderId);
+    return new folder(folderId, blogID);
   }
 
   if (!folderId) {
@@ -15,7 +15,44 @@ function folder(folderId) {
   // Redis keys
   this.key = `${PREFIX}${folderId}:folder`; // ID ↔ Path mapping
   this.reverseKey = `${PREFIX}${folderId}:path`; // Path ↔ ID mapping
+  this.contentKey = `${PREFIX}${folderId}:verified-content${blogID ? ":" + blogID : ""}`;
   this.metadataKey = `${PREFIX}${folderId}:metadata`; // File metadata
+
+  this.migrationCursorKey = `${this.contentKey}:cursor`;
+  this.getMigrationCursor = async () => (await client.get(this.migrationCursorKey)) || "";
+  this.setMigrationCursor = async (path) => client.set(this.migrationCursorKey, path);
+
+  // Content verification is independent of mutable metadata written by set().
+  // Fetch a directory in one Redis request, rather than one request per file.
+  this.getVerifiedContents = async (ids) => {
+    if (!ids.length) return [];
+    return (await client.hmGet(this.contentKey, ids)).map(value => {
+      try {
+        const record = value && JSON.parse(value);
+        return record && [record.path, record.checksum, record.fingerprint]
+          .every(field => typeof field === "string" && field.length) ? record : null;
+      } catch (_) { return null; }
+    });
+  };
+
+  this.setVerifiedContent = async (id, value) => {
+    await client.hSet(this.contentKey, id, JSON.stringify(value));
+  };
+
+  // Only manual mapping resets need this cleanup. Scan in batches so old
+  // verified IDs removed while mappings were absent do not accumulate forever.
+  this.pruneVerifiedContents = async () => {
+    let cursor = "0";
+    do {
+      const page = await client.hScan(this.contentKey, cursor, { COUNT: 256 });
+      cursor = page.cursor;
+      const ids = page.entries.map(entry => entry.field);
+      if (!ids.length) continue;
+      const paths = await client.hmGet(this.key, ids);
+      const removed = ids.filter((id, i) => !paths[i]);
+      if (removed.length) await client.hDel(this.contentKey, removed);
+    } while (cursor !== "0");
+  };
 
   // Set a mapping (ID → Path) and store metadata
   this.set = async (id, path, metadata = {}) => {
@@ -39,6 +76,7 @@ function folder(folderId) {
     if (previousId && previousId !== id) {
       // Remove the old mapping for the previous ID
       multi.hDel(this.key, previousId);
+      multi.hDel(this.contentKey, previousId);
     }
 
     // Add the new ID ↔ Path mapping
@@ -178,6 +216,7 @@ function folder(folderId) {
         ) {
           multi.hDel(this.key, currentId); // Delete ID ↔ Path mapping
           multi.hDel(this.reverseKey, currentPath); // Delete Path ↔ ID mapping
+          multi.hDel(this.contentKey, currentId);
           multi.hDel(this.metadataKey, currentId); // Delete metadata
           removedPaths.push(currentPath);
         }
@@ -191,11 +230,15 @@ function folder(folderId) {
   };
 
   // Reset all mappings and metadata
-  this.reset = async () => {
+  this.reset = async ({ preserveVerifiedContent = false } = {}) => {
     const multi = client.multi();
     multi.del(this.key);
     multi.del(this.reverseKey);
     multi.del(this.metadataKey);
+    if (!preserveVerifiedContent) {
+      multi.del(this.contentKey);
+      multi.del(this.migrationCursorKey);
+    }
     await multi.exec();
   };
 

--- a/app/clients/google-drive/database/tests/verified-content.js
+++ b/app/clients/google-drive/database/tests/verified-content.js
@@ -1,0 +1,72 @@
+const folderModule = require("../folder");
+const client = require("models/client");
+const prefix = require("../prefix");
+describe("Drive verified-content storage", function() {
+  const record = {
+    path: "/file.txt",
+    checksum: "md5",
+    fingerprint: "disk-stat"
+  };
+  let folder;
+  beforeEach(function() {
+    folder = folderModule("cache-test", "blog-a");
+  });
+  afterEach(async function() {
+    const keys = await client.keys(prefix + "cache-test*");
+    if (keys.length) await client.del(keys);
+  });
+  it("batch reads verification independently of metadata writes", async function() {
+    await folder.set("file", "/file.txt", {
+      modifiedTime: "old"
+    });
+    await folder.setVerifiedContent("file", record);
+    await folder.set("file", "/file.txt", {
+      modifiedTime: "new"
+    });
+    const batch = spyOn(client, "hmGet").and.callThrough();
+    expect(await folder.getVerifiedContents(["file", "missing"])).toEqual([record, null]);
+    expect(batch.calls.count()).toBe(1);
+  });
+  it("keeps local fingerprints and migration cursors separate for shared remote folders", async function() {
+    const other = folderModule("cache-test", "blog-b");
+    await folder.setVerifiedContent("file", record);
+    await other.setVerifiedContent("file", {
+      ...record,
+      fingerprint: "other-disk"
+    });
+    await folder.setMigrationCursor("/z");
+    await other.setMigrationCursor("/a");
+    expect(await folder.getVerifiedContents(["file"])).toEqual([record]);
+    expect((await other.getVerifiedContents(["file"]))[0].fingerprint).toBe("other-disk");
+    expect(await folder.getMigrationCursor()).toBe("/z");
+    expect(await other.getMigrationCursor()).toBe("/a");
+  });
+  it("clears verification when files are removed or reset normally", async function() {
+    await folder.set("file", "/file.txt");
+    await folder.setVerifiedContent("file", record);
+    await folder.remove("file");
+    expect(await folder.getVerifiedContents(["file"])).toEqual([null]);
+    await folder.setVerifiedContent("file", record);
+    await folder.setMigrationCursor("/z");
+    await folder.reset();
+    expect(await folder.getVerifiedContents(["file"])).toEqual([null]);
+    expect(await folder.getMigrationCursor()).toBe("");
+  });
+  it("preserves warm records across mapping resync and prunes removed IDs afterward", async function() {
+    await folder.set("file", "/file.txt");
+    await folder.setVerifiedContent("file", record);
+    await folder.setVerifiedContent("removed", {
+      ...record,
+      path: "/removed.txt"
+    });
+    await folder.setMigrationCursor("/z");
+    await folder.reset({
+      preserveVerifiedContent: true
+    });
+    expect(await folder.getVerifiedContents(["file"])).toEqual([record]);
+    expect(await folder.getMigrationCursor()).toBe("/z");
+    await folder.set("file", "/file.txt");
+    await folder.pruneVerifiedContents();
+    expect(await folder.getVerifiedContents(["file", "removed"])).toEqual([record, null]);
+  });
+});

--- a/app/clients/google-drive/disconnect.js
+++ b/app/clients/google-drive/disconnect.js
@@ -2,8 +2,17 @@ const Blog = require("models/blog");
 const database = require("./database");
 
 module.exports = async (blogID, callback) => {
-  
+
+    // Capture the folderId before deleting the account record, otherwise
+    // the verified-content cache and migration cursor for this blog's
+    // Drive folder become unreachable and leak in Redis permanently.
+    const account = await database.blog.get(blogID);
+
     await database.blog.delete(blogID);
+
+    if (account?.folderId) {
+        await database.folder(account.folderId, blogID).reset();
+    }
 
     Blog.set(blogID, { client: "" }, async function (err) {
         callback();

--- a/app/clients/google-drive/remove.js
+++ b/app/clients/google-drive/remove.js
@@ -11,7 +11,7 @@ module.exports = async function remove(blogID, path, callback) {
   try {
     const { serviceAccountId, folderId } = await database.blog.get(blogID);
     const drive = await createDriveClient(serviceAccountId);
-    const { getByPath, remove } = database.folder(folderId);
+    const { getByPath, remove } = database.folder(folderId, blogID);
 
     console.log(prefix(), "Removing from local folder");
     const pathOnBlot = localPath(blogID, path);

--- a/app/clients/google-drive/serviceAccount/hotDocPoller.js
+++ b/app/clients/google-drive/serviceAccount/hotDocPoller.js
@@ -439,7 +439,7 @@ class HotDocPoller {
     const { done, folder } = await establishSyncLock(item.blogID);
     try {
       const drive = await this.getDrive(item.serviceAccountId);
-      const folderDb = database.folder(item.folderId);
+      const folderDb = database.folder(item.folderId, item.blogID);
       const path = await folderDb.get(item.fileId);
 
       if (!path) {
@@ -495,6 +495,13 @@ class HotDocPoller {
 
         if (result?.updated && folder?.update) {
           await folder.update(path);
+        }
+
+        if (result?.verifiedContent) {
+          await folderDb.setVerifiedContent(file.data.id, {
+            path,
+            ...result.verifiedContent,
+          });
         }
 
         if (result?.updated !== true) {

--- a/app/clients/google-drive/sync/resetFromDrive.js
+++ b/app/clients/google-drive/sync/resetFromDrive.js
@@ -6,10 +6,10 @@ module.exports = async (blogID, publish, update) => {
   update = update || function () {};
 
   const account = await database.blog.get(blogID);
-  const { reset } = database.folder(account.folderId);
+  const { reset, pruneVerifiedContents } = database.folder(account.folderId, blogID);
 
   // reset the database state of the folder
-  await reset();
+  await reset({ preserveVerifiedContent: true });
 
-  await sync(blogID, publish, update);
+  if (await sync(blogID, publish, update)) await pruneVerifiedContents();
 };

--- a/app/clients/google-drive/sync/resetToDrive.js
+++ b/app/clients/google-drive/sync/resetToDrive.js
@@ -21,7 +21,7 @@ module.exports = async (blogID, publish, options = {}) => {
   const { folderId, serviceAccountId } = account;
   const drive = await createDriveClient(serviceAccountId);
   const checkWeCanContinue = CheckWeCanContinue(blogID, account);
-  const { reset, set } = database.folder(folderId);
+  const { reset, set } = database.folder(folderId, blogID);
   const progress = options.publishSyncProgress
     ? {
         current: 0,

--- a/app/clients/google-drive/sync/sync.js
+++ b/app/clients/google-drive/sync/sync.js
@@ -1,3 +1,5 @@
+const migrationBudget = require("./util/migrationBudget");
+const comparePaths = require("./util/comparePaths");
 const fs = require("fs-extra");
 const { join } = require("path");
 const localPath = require("helper/localPath");
@@ -37,7 +39,13 @@ module.exports = async function sync(blogID, publish, update) {
   }
 
   const drive = await createDriveClient(serviceAccountId);
-  const { getByPath, set, remove } = database.folder(folderId);
+  const { getByPath, set, remove, getVerifiedContents, setVerifiedContent,
+    getMigrationCursor, setMigrationCursor } = database.folder(folderId, blogID);
+  const migrationCursor = await getMigrationCursor();
+  const canMigrate = migrationBudget();
+  let lastMigrated = migrationCursor;
+  let migrationExhausted = false;
+  let deferred = 0;
   const checkWeCanContinue = CheckWeCanContinue(blogID, account);
   const progress = createProgress(
     await countLocalFiles(localPath(blogID, "/")),
@@ -93,7 +101,12 @@ module.exports = async function sync(blogID, publish, update) {
 
     // We handle file name deduplication and the mapping of
     // google docs to .gdoc files here.
-    const remoteContents = transformDriveItems(driveItems);
+    const remoteContents = transformDriveItems(driveItems)
+      .sort((a, b) => comparePaths(a.name, b.name));
+    const regularFiles = remoteContents.filter(item =>
+      !item.isDirectory && !item.mimeType.startsWith("application/vnd.google-apps."));
+    const verifiedRecords = await getVerifiedContents(regularFiles.map(item => item.id));
+    const verifiedById = new Map(regularFiles.map((item, i) => [item.id, verifiedRecords[i]]));
 
     for (const { name, isDirectory: isLocalDirectory } of localContents) {
       const path = join(dir, name);
@@ -160,24 +173,31 @@ module.exports = async function sync(blogID, publish, update) {
           "application/vnd.google-apps."
         );
 
-        // NOTE: for regular files this only compares size, not content.
-        // A same-size content edit will not be re-downloaded. This is a
-        // known gap — see TODO "Add sync check" under Google Drive.
-        //
-        // Do NOT "fix" this by hashing every local file's contents on
-        // every sync (e.g. `: false`, forcing download()'s MD5 check to
-        // always run) without also solving the cost problem: that
-        // recomputes a checksum from disk for every unchanged file on
-        // every sync, which does not scale for blogs with many files.
-        // We moved away from exactly that approach once already, see
-        // b618509. Any fix here needs to keep sync cost proportional to
-        // the number of *changed* files, e.g. by comparing against a
-        // checksum stored at download time instead of rehashing live.
-        // See PR #1804 for a rejected attempt and further discussion.
+        const cached = verifiedById.get(id);
+        const verified = cached && cached.path === path &&
+          cached.checksum === md5Checksum && cached.fingerprint &&
+          cached.fingerprint === existsLocally?.fingerprint;
         const identical = isGoogleAppFile
-          ? truncateToSecond(existsLocally?.modifiedTime) ===
-            truncateToSecond(modifiedTime)
-          : existsLocally?.size === size;
+          ? truncateToSecond(existsLocally?.modifiedTime) === truncateToSecond(modifiedTime)
+          : md5Checksum
+            ? Boolean(verified)
+            : existsLocally?.size === size &&
+              truncateToSecond(existsLocally?.modifiedTime) === truncateToSecond(modifiedTime);
+
+        // Warm old equal-size files incrementally, without turning the first
+        // sync after deployment into a complete content scan. A persistent
+        // cursor advances on attempts, including failures, for fair retries.
+        const legacy = !isGoogleAppFile && md5Checksum && !cached &&
+          existsLocally && !existsLocally.isDirectory && existsLocally.size === size;
+        if (legacy) {
+          if (comparePaths(path, migrationCursor) <= 0 || migrationExhausted || !canMigrate(size)) {
+            if (comparePaths(path, migrationCursor) > 0) migrationExhausted = true;
+            deferred++;
+            progress.publishThrottled("Verification deferred", path);
+            continue;
+          }
+          lastMigrated = path;
+        }
 
         if (!existsLocally || !identical) {
           await checkWeCanContinue();
@@ -221,7 +241,14 @@ module.exports = async function sync(blogID, publish, update) {
               publish("Skipped oversized Google Doc", path);
             }
 
-            if (result?.updated) await update(path);
+            // A previous rebuild/cache-store may have failed after publication.
+            // Rebuild before recording verification, even if bytes now match.
+            if (result?.updated || (!isGoogleAppFile && result?.verifiedContent)) {
+              await update(path);
+            }
+            if (!isGoogleAppFile && result?.verifiedContent) {
+              await setVerifiedContent(id, { path, ...result.verifiedContent });
+            }
           } catch (err) {
             publish("Download failed", path);
             console.error("Download failed for", path, err);
@@ -253,8 +280,14 @@ module.exports = async function sync(blogID, publish, update) {
 
   try {
     await walk("/", folderId);
-    progress.finish("Finished processing folder");
+    await setMigrationCursor(migrationExhausted ? lastMigrated : "");
+    progress.finish(deferred
+      ? `Finished processing folder (${deferred} content verifications deferred)`
+      : "Finished processing folder");
+    return true;
   } catch (err) {
+    if (lastMigrated !== migrationCursor) await setMigrationCursor(lastMigrated);
     publish("Sync failed", err.message);
+    return false;
   }
 };

--- a/app/clients/google-drive/sync/sync.js
+++ b/app/clients/google-drive/sync/sync.js
@@ -104,7 +104,8 @@ module.exports = async function sync(blogID, publish, update) {
     const remoteContents = transformDriveItems(driveItems)
       .sort((a, b) => comparePaths(a.name, b.name));
     const regularFiles = remoteContents.filter(item =>
-      !item.isDirectory && !item.mimeType.startsWith("application/vnd.google-apps."));
+      !item.isDirectory && !item.mimeType.startsWith("application/vnd.google-apps.") &&
+      item.md5Checksum);
     const verifiedRecords = await getVerifiedContents(regularFiles.map(item => item.id));
     const verifiedById = new Map(regularFiles.map((item, i) => [item.id, verifiedRecords[i]]));
 

--- a/app/clients/google-drive/sync/util/comparePaths.js
+++ b/app/clients/google-drive/sync/util/comparePaths.js
@@ -1,0 +1,9 @@
+// Same ordering as the sorted depth-first directory walk (not locale-dependent).
+module.exports = function comparePaths(a, b) {
+  const left = a.split("/");
+  const right = b.split("/");
+  for (let i = 0; i < Math.min(left.length, right.length); i++) {
+    if (left[i] !== right[i]) return left[i] < right[i] ? -1 : 1;
+  }
+  return left.length - right.length;
+};

--- a/app/clients/google-drive/sync/util/localReaddir.js
+++ b/app/clients/google-drive/sync/util/localReaddir.js
@@ -1,4 +1,4 @@
-const getmd5Checksum = require("clients/google-drive/util/md5Checksum");
+const fingerprint = require("../../util/contentFingerprint");
 const fs = require("fs-extra");
 const { join } = require("path");
 
@@ -8,17 +8,18 @@ const localreaddir = async (dir) => {
   return Promise.all(
     contents.map(async (name) => {
       const path = join(dir, name);
-      const stat = await fs.stat(path);
+      const stat = await fs.stat(path, { bigint: true });
 
       // Convert the modification time to an ISO string
       const modifiedTime = stat.mtime.toISOString();
       const isDirectory = stat.isDirectory();
-      const size = stat.size;
+      const size = Number(stat.size);
 
       return {
         name,
         isDirectory,
         size,
+        fingerprint: fingerprint(stat),
         modifiedTime: isDirectory ? undefined : modifiedTime,
       };
     })

--- a/app/clients/google-drive/sync/util/migrationBudget.js
+++ b/app/clients/google-drive/sync/util/migrationBudget.js
@@ -1,0 +1,12 @@
+// Bound the one-time warming of legacy folders. One file larger than the byte
+// allowance may run alone so large files cannot remain unverified forever.
+module.exports = function migrationBudget() {
+  let files = 0;
+  let bytes = 0;
+  return size => {
+    if (files >= 32 || (files > 0 && bytes + size > 64 * 1024 * 1024)) return false;
+    files++;
+    bytes += size;
+    return true;
+  };
+};

--- a/app/clients/google-drive/tests/cached-sync.js
+++ b/app/clients/google-drive/tests/cached-sync.js
@@ -1,0 +1,208 @@
+const fs = require("fs");
+const vm = require("vm");
+
+function harness(count = 1) {
+  const records = new Map();
+  const files = Array.from({
+    length: count
+  }, (_, i) => ({
+    id: String(i),
+    name: String(i).padStart(4, "0") + ".txt",
+    size: 4,
+    mimeType: "text/plain",
+    modifiedTime: "2026-01-01T00:00:00Z",
+    md5Checksum: "md5"
+  }));
+  const local = files.map(file => ({
+    ...file,
+    fingerprint: "local-" + file.id
+  }));
+  let cursor = "";
+  const state = {
+    files,
+    local,
+    records,
+    downloads: [],
+    batches: [],
+    updates: [],
+    failDownload: false,
+    failUpdate: false,
+    failStore: false
+  };
+  const stubs = {
+    "fs-extra": {},
+    "helper/localPath": (_, path) => path,
+    "../database": {
+      blog: {
+        get: async () => ({
+          folderId: "folder",
+          folderName: "folder",
+          serviceAccountId: "service"
+        })
+      },
+      folder: () => ({
+        getByPath: async () => null,
+        set: async () => {},
+        remove: async () => {},
+        getMigrationCursor: async () => cursor,
+        setMigrationCursor: async value => {
+          cursor = value;
+        },
+        getVerifiedContents: async ids => {
+          state.batches.push(ids);
+          return ids.map(id => records.get(id));
+        },
+        setVerifiedContent: async (id, value) => {
+          if (state.failStore) throw Error("cache unavailable");
+          records.set(id, value);
+        },
+      })
+    },
+    "../util/download": async (blog, drive, path, remote) => {
+      state.downloads.push(remote.id);
+      if (state.failDownload) throw Error("unavailable");
+      if (!remote.md5Checksum) return {
+        updated: true
+      };
+      return {
+        updated: false,
+        verifiedContent: {
+          checksum: remote.md5Checksum,
+          fingerprint: local.find(file => file.id === remote.id).fingerprint
+        }
+      };
+    },
+    "../serviceAccount/createDriveClient": async () => ({
+      files: {
+        get: async () => ({
+          data: {
+            name: "folder"
+          }
+        })
+      }
+    }),
+    "../util/checkWeCanContinue": () => async () => {},
+    "clients/util/shouldIgnoreFile": () => false,
+    "clients/util/resyncProgress": {
+      countLocalFiles: async () => count,
+      createProgress: () => ({
+        publish() {},
+        publishThrottled() {},
+        discover() {},
+        finish(message) {
+          state.finished = message;
+        }
+      })
+    },
+    "./util/driveReaddir": async () => files,
+    "./util/localReaddir": async () => local,
+    "./util/transformDriveItems": require("../sync/util/transformDriveItems"),
+    "./util/truncateToSecond": require("../sync/util/truncateToSecond"),
+    "./util/migrationBudget": require("../sync/util/migrationBudget"),
+    "./util/comparePaths": require("../sync/util/comparePaths"),
+  };
+  const module = {
+    exports: {}
+  };
+  vm.runInNewContext(fs.readFileSync(require.resolve("../sync/sync"), "utf8"), {
+    module,
+    exports: module.exports,
+    console: {
+      log() {},
+      error() {}
+    },
+    require: name => name in stubs ? stubs[name] : require(name),
+  });
+  state.run = () => module.exports("blog", () => {}, async path => {
+    state.updates.push(path);
+    if (state.failUpdate) throw Error("build failed");
+  });
+  state.warm = () => files.forEach(file => records.set(file.id, {
+    path: "/" + file.name,
+    checksum: file.md5Checksum,
+    fingerprint: "local-" + file.id
+  }));
+  return state;
+}
+describe("Drive verified content cache", function() {
+  it("skips 1000 unchanged files without content reads and batches the directory lookup", async function() {
+    const h = harness(1000);
+    h.warm();
+    expect(await h.run()).toBe(true);
+    expect(h.downloads).toEqual([]);
+    expect(h.updates).toEqual([]);
+    expect(h.finished).toBe("Finished processing folder");
+    expect(h.batches.length).toBe(1);
+    expect(h.batches[0].length).toBe(1000);
+  });
+  it("verifies same-size remote edits and local replacements", async function() {
+    const h = harness(3);
+    h.warm();
+    h.files[0].md5Checksum = "new";
+    h.local[1].fingerprint = "replaced";
+    expect(await h.run()).toBe(true);
+    expect(h.downloads).toEqual(["0", "1"]);
+    expect(h.records.get("0").checksum).toBe("new");
+  });
+  it("bounds legacy migration and advances beyond a repeatedly failing prefix", async function() {
+    const h = harness(70);
+    h.failDownload = true;
+    expect(await h.run()).toBe(true);
+    expect(h.downloads).toEqual(Array.from({
+      length: 32
+    }, (_, i) => String(i)));
+    expect(h.finished).toContain("deferred");
+    h.downloads = [];
+    expect(await h.run()).toBe(true);
+    expect(h.downloads).toEqual(Array.from({
+      length: 32
+    }, (_, i) => String(i + 32)));
+    h.downloads = [];
+    expect(await h.run()).toBe(true);
+    expect(h.downloads).toEqual(["64", "65", "66", "67", "68", "69"]);
+    h.failDownload = false;
+    h.downloads = [];
+    expect(await h.run()).toBe(true);
+    expect(h.downloads[0]).toBe("0");
+  });
+  it("stops at the byte limit and eventually verifies an oversized file alone", async function() {
+    const h = harness(3);
+    [40, 80, 1].forEach((size, i) => {
+      h.files[i].size = size * 1024 * 1024;
+      h.local[i].size = h.files[i].size;
+    });
+    expect(await h.run()).toBe(true);
+    expect(h.downloads).toEqual(["0"]);
+    h.downloads = [];
+    expect(await h.run()).toBe(true);
+    expect(h.downloads).toEqual(["1"]);
+    h.downloads = [];
+    expect(await h.run()).toBe(true);
+    expect(h.downloads).toEqual(["2"]);
+  });
+  it("rebuilds again after failed update or cache persistence, then warms", async function() {
+    const h = harness();
+    h.failUpdate = true;
+    expect(await h.run()).toBe(true);
+    expect(h.records.size).toBe(0);
+    h.failUpdate = false;
+    h.failStore = true;
+    expect(await h.run()).toBe(true);
+    expect(h.records.size).toBe(0);
+    h.failStore = false;
+    expect(await h.run()).toBe(true);
+    expect(h.records.size).toBe(1);
+    expect(h.updates.length).toBe(3);
+    expect(await h.run()).toBe(true);
+    expect(h.updates.length).toBe(3);
+  });
+  it("uses metadata for unchanged files with no remote checksum", async function() {
+    const h = harness();
+    delete h.files[0].md5Checksum;
+    expect(await h.run()).toBe(true);
+    expect(h.downloads).toEqual([]);
+    h.files[0].modifiedTime = "2026-01-02T00:00:00Z";
+    expect(await h.run()).toBe(true);
+    expect(h.downloads).toEqual(["0"]);
+  });
+});

--- a/app/clients/google-drive/tests/content-verification.js
+++ b/app/clients/google-drive/tests/content-verification.js
@@ -1,0 +1,74 @@
+const fs = require("fs-extra");
+const os = require("os");
+const { join } = require("path");
+const crypto = require("crypto");
+const vm = require("vm");
+const verify = require("../util/verifyContent");
+const fingerprint = require("../util/contentFingerprint");
+const checksum = require("../util/md5Checksum");
+const digest = value => crypto.createHash("md5").update(value).digest("hex");
+
+describe("Drive verified content on disk", function () {
+  let directory, filename;
+  beforeEach(async function () {
+    directory = await fs.mkdtemp(join(os.tmpdir(), "drive-verification-"));
+    filename = join(directory, "entry.txt");
+    await fs.writeFile(filename, "aaaa");
+  });
+  afterEach(async function () { await fs.remove(directory); });
+
+  it("binds a matching checksum to the actual file fingerprint", async function () {
+    expect(await verify(filename, digest("aaaa"))).toEqual({
+      checksum: digest("aaaa"),
+      fingerprint: fingerprint(await fs.stat(filename, { bigint: true })),
+    });
+  });
+
+  it("invalidates same-size edits even when the old modification time is restored", async function () {
+    const original = await verify(filename, digest("aaaa"));
+    const stat = await fs.stat(filename);
+    await fs.writeFile(filename, "bbbb");
+    await fs.utimes(filename, stat.atime, stat.mtime);
+    expect(await verify(filename, digest("aaaa"))).toBeNull();
+    const changed = await verify(filename, digest("bbbb"));
+    expect(changed.fingerprint).not.toBe(original.fingerprint);
+  });
+
+  it("invalidates replacement by a different inode with identical bytes", async function () {
+    const original = await verify(filename, digest("aaaa"));
+    const stat = await fs.stat(filename);
+    const replacement = join(directory, "replacement.txt");
+    await fs.writeFile(replacement, "aaaa");
+    await fs.utimes(replacement, stat.atime, stat.mtime);
+    await fs.rename(replacement, filename);
+    const replaced = await verify(filename, digest("aaaa"));
+    expect(replaced.checksum).toBe(original.checksum);
+    expect(replaced.fingerprint).not.toBe(original.fingerprint);
+  });
+
+  it("declines verification if the file changes while its checksum is being established", async function () {
+    const module = { exports: {} };
+    const racingChecksum = async path => {
+      const result = await checksum(path);
+      const stat = await fs.stat(path);
+      await fs.writeFile(path, "bbbb");
+      await fs.utimes(path, stat.atime, stat.mtime);
+      return result;
+    };
+    vm.runInNewContext(fs.readFileSync(require.resolve("../util/verifyContent"), "utf8"), {
+      module,
+      require: name => ({
+        "fs-extra": fs,
+        "./contentFingerprint": fingerprint,
+        "./md5Checksum": racingChecksum,
+      })[name],
+    });
+    expect(await module.exports(filename, digest("aaaa"))).toBeNull();
+  });
+
+  it("does not certify a missing file, directory, or absent remote checksum", async function () {
+    expect(await verify(join(directory, "missing"), digest("aaaa"))).toBeNull();
+    expect(await verify(directory, digest("aaaa"))).toBeNull();
+    expect(await verify(filename, undefined)).toBeNull();
+  });
+});

--- a/app/clients/google-drive/tests/disconnect.js
+++ b/app/clients/google-drive/tests/disconnect.js
@@ -1,0 +1,61 @@
+const fs = require("fs");
+const vm = require("vm");
+
+function load(stubs) {
+  const module = { exports: {} };
+  vm.runInNewContext(fs.readFileSync(require.resolve("../disconnect"), "utf8"), {
+    module,
+    exports: module.exports,
+    require: name => Object.prototype.hasOwnProperty.call(stubs, name) ? stubs[name] : require(name),
+  });
+  return module.exports;
+}
+
+describe("Drive disconnect", function() {
+  it("resets the folder's verified-content cache and cursor, scoped to the blog", async function() {
+    let resetArgs = null;
+    const disconnect = load({
+      "models/blog": {
+        set(blogID, data, callback) { callback(); },
+      },
+      "./database": {
+        blog: {
+          get: async () => ({ folderId: "folder-1", serviceAccountId: "account" }),
+          delete: async () => {},
+        },
+        folder: (folderId, blogID) => ({
+          reset: async (options) => {
+            resetArgs = { folderId, blogID, options };
+          },
+        }),
+      },
+    });
+
+    await new Promise(resolve => disconnect("blog-1", resolve));
+
+    expect(resetArgs).toEqual({ folderId: "folder-1", blogID: "blog-1", options: undefined });
+  });
+
+  it("does not try to reset a folder when the blog had none", async function() {
+    let folderCalled = false;
+    const disconnect = load({
+      "models/blog": {
+        set(blogID, data, callback) { callback(); },
+      },
+      "./database": {
+        blog: {
+          get: async () => null,
+          delete: async () => {},
+        },
+        folder: () => {
+          folderCalled = true;
+          return { reset: async () => {} };
+        },
+      },
+    });
+
+    await new Promise(resolve => disconnect("blog-1", resolve));
+
+    expect(folderCalled).toBe(false);
+  });
+});

--- a/app/clients/google-drive/tests/download-completion.js
+++ b/app/clients/google-drive/tests/download-completion.js
@@ -2,59 +2,135 @@ const assert = require("assert");
 // Exercise the real downloader with controlled streams and no Drive account.
 const fs = require("fs");
 const vm = require("vm");
-const { Readable, Writable, PassThrough } = require("stream");
+const {
+  Readable,
+  Writable,
+  PassThrough
+} = require("stream");
+
 function load(stubs) {
-  const module = { exports: {} };
+  const module = {
+    exports: {}
+  };
   vm.runInNewContext(fs.readFileSync(require.resolve("../util/download"), "utf8"), {
-    module, exports: module.exports, Buffer, console,
+    module,
+    exports: module.exports,
+    Buffer,
+    console,
     require: name => Object.prototype.hasOwnProperty.call(stubs, name) ? stubs[name] : require(name),
   });
   return module.exports;
 }
-describe("Drive download completion", function () {
-  let moved, removed, source, writer, finishWrite, download;
-  beforeEach(function () {
+describe("Drive download completion", function() {
+  let moved, removed, source, writer, finishWrite, download, mismatchTemp, failAfterPublish;
+  beforeEach(function() {
     finishWrite = undefined;
+    mismatchTemp = false;
+    failAfterPublish = false;
     moved = false;
     removed = false;
     source = Readable.from([Buffer.from("new contents")]);
-    writer = new Writable({ write(chunk, encoding, callback) { finishWrite = callback; } });
+    writer = new Writable({
+      write(chunk, encoding, callback) {
+        finishWrite = callback;
+      }
+    });
     download = load({
       "fs-extra": {
         createWriteStream: () => writer,
-        move: async () => { moved = true; },
-        remove: async () => { removed = true; },
+        move: async () => {
+          moved = true;
+        },
+        remove: async () => {
+          removed = true;
+        },
         utimes: async () => {},
       },
       "helper/localPath": () => "/test-blog/file.txt",
-      "colors/safe": { green: x => x },
+      "colors/safe": {
+        green: x => x
+      },
       debug: () => () => {},
       "helper/tempDir": () => "/test-temp",
       "helper/guid": () => "download",
-      "../util/md5Checksum": async () => "old",
-      config: {}, "helper/hash": () => {}, cheerio: {}, yauzl: {},
-      "../serviceAccount/hotDocPoller": {}, "../database": {},
+      "./verifyContent": async filename => {
+        if (filename.startsWith("/test-temp")) return mismatchTemp ? null : {
+          checksum: "new",
+          fingerprint: "verified"
+        };
+        if (moved && failAfterPublish) throw Error("stat failed after publication");
+        return moved ? {
+          checksum: "new",
+          fingerprint: "verified"
+        } : null;
+      },
+      config: {},
+      "helper/hash": () => {},
+      cheerio: {},
+      yauzl: {},
+      "../serviceAccount/hotDocPoller": {},
+      "../database": {},
     });
   });
+
   function start() {
-    return download("blog", { files: { get: async () => ({ data: source }) } }, "/file.txt", {
-      id: "file", mimeType: "text/plain", md5Checksum: "new", modifiedTime: "2026-01-01T00:00:00Z",
+    return download("blog", {
+      files: {
+        get: async () => ({
+          data: source
+        })
+      }
+    }, "/file.txt", {
+      id: "file",
+      mimeType: "text/plain",
+      md5Checksum: "new",
+      modifiedTime: "2026-01-01T00:00:00Z",
     });
   }
   async function writing() {
     while (!finishWrite) await new Promise(resolve => setImmediate(resolve));
   }
-  it("publishes only after the destination finishes", async function () {
+  it("publishes only after the destination finishes", async function() {
     let resolved = false;
-    const pending = start().then(result => { resolved = true; return result; });
+    const pending = start().then(result => {
+      resolved = true;
+      return result;
+    });
     await writing();
     expect(moved).toBe(false);
     expect(resolved).toBe(false);
     finishWrite();
-    expect(await pending).toEqual({ updated: true });
+    expect(await pending).toEqual({
+      updated: true,
+      verifiedContent: {
+        checksum: "new",
+        fingerprint: "verified"
+      }
+    });
     expect(moved).toBe(true);
   });
-  it("rejects a late writer failure and cleans up without publishing", async function () {
+  it("does not publish media whose bytes disagree with the listed checksum", async function() {
+    mismatchTemp = true;
+    const pending = start();
+    const rejected = assert.rejects(pending, /does not match/);
+    await writing();
+    finishWrite();
+    await rejected;
+    expect(moved).toBe(false);
+    expect(removed).toBe(true);
+  });
+  it("still requests a rebuild when post-publication verification fails", async function() {
+    failAfterPublish = true;
+    const pending = start();
+    await writing();
+    finishWrite();
+    expect(await pending).toEqual({
+      updated: true,
+      verifiedContent: null
+    });
+    expect(moved).toBe(true);
+  });
+  it("rejects a late writer failure and cleans up without publishing", async function() {
     const pending = start();
     const rejection = assert.rejects(pending, /disk full/);
     await writing();
@@ -64,7 +140,7 @@ describe("Drive download completion", function () {
     expect(removed).toBe(true);
     expect(source.destroyed).toBe(true);
   });
-  it("rejects a source failure and cleans up", async function () {
+  it("rejects a source failure and cleans up", async function() {
     source = new PassThrough();
     source.write("partial");
     const pending = start();
@@ -78,20 +154,47 @@ describe("Drive download completion", function () {
   });
 });
 
-describe("Drive download checksum optimization", function () {
-  it("does not request content when the local checksum matches", async function () {
+describe("Drive download checksum optimization", function() {
+  it("does not request content when the local checksum matches", async function() {
     let requested = false;
     const download = load({
-      "fs-extra": {}, "helper/localPath": () => "/test-blog/file.txt",
-      "colors/safe": {green:x=>x}, debug:()=>()=>{},
-      "helper/tempDir":()=>"/test-temp", "helper/guid":()=>"download",
-      "../util/md5Checksum":async()=>"same", config:{}, "helper/hash":()=>{},
-      cheerio:{}, yauzl:{}, "../serviceAccount/hotDocPoller":{}, "../database":{},
+      "fs-extra": {},
+      "helper/localPath": () => "/test-blog/file.txt",
+      "colors/safe": {
+        green: x => x
+      },
+      debug: () => () => {},
+      "helper/tempDir": () => "/test-temp",
+      "helper/guid": () => "download",
+      "./verifyContent": async () => ({
+        checksum: "same",
+        fingerprint: "verified"
+      }),
+      config: {},
+      "helper/hash": () => {},
+      cheerio: {},
+      yauzl: {},
+      "../serviceAccount/hotDocPoller": {},
+      "../database": {},
     });
-    const result = await download("blog", {files:{get:async()=>{requested=true;}}}, "/file.txt", {
-      id:"file", mimeType:"text/plain", md5Checksum:"same",
+    const result = await download("blog", {
+      files: {
+        get: async () => {
+          requested = true;
+        }
+      }
+    }, "/file.txt", {
+      id: "file",
+      mimeType: "text/plain",
+      md5Checksum: "same",
     });
-    expect(result).toEqual({updated:false});
+    expect(result).toEqual({
+      updated: false,
+      verifiedContent: {
+        checksum: "same",
+        fingerprint: "verified"
+      }
+    });
     expect(requested).toBe(false);
   });
 });

--- a/app/clients/google-drive/util/contentFingerprint.js
+++ b/app/clients/google-drive/util/contentFingerprint.js
@@ -1,0 +1,8 @@
+// Nanosecond stat fields keep the cache sensitive to same-size writes whose
+// timestamps fall within the same millisecond, as well as file replacement.
+module.exports = function contentFingerprint(stat) {
+  if (!stat || !stat.isFile()) return null;
+  const fields = [stat.dev, stat.ino, stat.size, stat.mtimeNs, stat.ctimeNs];
+  if (fields.some(value => value === undefined)) return null;
+  return fields.map(String).join(":");
+};

--- a/app/clients/google-drive/util/download.js
+++ b/app/clients/google-drive/util/download.js
@@ -6,7 +6,7 @@ const { join, dirname } = require("path");
 const debug = require("debug")("blot:clients:google-drive:download");
 const tempDir = require("helper/tempDir")();
 const guid = require("helper/guid");
-const computeMd5Checksum = require("../util/md5Checksum");
+const verifyContent = require("./verifyContent");
 const config = require("config");
 const hash = require("helper/hash");
 const cheerio = require("cheerio");
@@ -332,14 +332,14 @@ module.exports = async (
         return resolve({ updated: false });
       }
 
-      const existingMd5Checksum = await computeMd5Checksum(pathOnBlot);
+      const verifiedContent = await verifyContent(pathOnBlot, md5Checksum);
 
-      if (existingMd5Checksum && md5Checksum === existingMd5Checksum) {
+      if (verifiedContent) {
         debug("DOWNLOAD file skipped because md5Checksum matches");
         debug("      path:", path);
-        debug("   locally:", existingMd5Checksum);
+        debug("   locally:", verifiedContent.checksum);
         debug("    remote:", md5Checksum);
-        return resolve({ updated: false });
+        return resolve({ updated: false, verifiedContent });
       }
 
       debug("DOWNLOAD file");
@@ -405,6 +405,9 @@ module.exports = async (
       // Source end can precede the final disk write. Pipeline waits for the
       // destination and destroys both streams on error before we publish.
       await streamToFile(data, tempPath);
+      if (md5Checksum && !(await verifyContent(tempPath, md5Checksum))) {
+        throw new Error("Downloaded content does not match the listed Drive checksum");
+      }
       await fs.move(tempPath, pathOnBlot, { overwrite: true });
       try {
         const mtime = new Date(modifiedTime);
@@ -412,7 +415,10 @@ module.exports = async (
       } catch (e) {
         debug("Error setting mtime", e);
       }
-      settle(() => resolve({ updated: true }));
+      // Publication has succeeded. A concurrent local write (or stat failure)
+      // must not suppress the caller's rebuild; simply decline to cache it.
+      const verified = await verifyContent(pathOnBlot, md5Checksum).catch(() => null);
+      settle(() => resolve({ updated: true, verifiedContent: verified }));
     } catch (e) {
       debug("download error", e);
       await fs.remove(tempPath).catch(() => {});

--- a/app/clients/google-drive/util/verifyContent.js
+++ b/app/clients/google-drive/util/verifyContent.js
@@ -1,0 +1,26 @@
+const fs = require("fs-extra");
+const fingerprint = require("./contentFingerprint");
+const checksum = require("./md5Checksum");
+
+module.exports = async function verifyContent(filename, expected) {
+  if (!expected) return null;
+  let before;
+  try {
+    before = fingerprint(await fs.stat(filename, { bigint: true }));
+  } catch (err) {
+    if (err.code === "ENOENT" || err.code === "ENOTDIR") return null;
+    throw err;
+  }
+  if (!before) return null;
+  const actual = await checksum(filename);
+  let after;
+  try {
+    after = fingerprint(await fs.stat(filename, { bigint: true }));
+  } catch (err) {
+    if (err.code === "ENOENT" || err.code === "ENOTDIR") return null;
+    throw err;
+  }
+  return actual === expected && before === after
+    ? { checksum: actual, fingerprint: after }
+    : null;
+};


### PR DESCRIPTION
Follow-up to #1804 and David's review of #1791. The previous proposal made every regular file reach a full local hash on every sync. This approach caches a successfully verified result and skips content reads for unchanged files.

For example, an edit that changes a four-byte file to different four-byte contents now invalidates the saved Drive checksum, even if its modification time is unchanged. An unchanged file whose checksum and local fingerprint still match does not enter the downloader.

### How verification stays valid

- Store verified checksum + local path + stat fingerprint separately from ordinary Drive metadata. The fingerprint includes device, inode, size, and nanosecond modification/change times, so a local replacement or same-size write invalidates the entry even if mtime is restored.
- Compare against Drive's checksum already supplied by directory listing. Read verification records in one HMGET per directory, scoped to the local blog so two blogs sharing a remote folder do not overwrite each other's fingerprints.
- Establish checksums with before/after stat checks. Verify downloaded temporary content before publication, and record the cache only after verification and the update callback succeed. Post-publication verification failure still schedules the update but does not certify the file; failed update/cache writes remain retryable.
- Preserve verified records during manual mapping resync, then prune orphaned IDs in batches. Normal reset/removal clears the relevant cache. Google-app handling is preserved; regular files without a remote checksum use size + modification-time fallback.

### Cost and migration tradeoff

Warm syncs still enumerate files and stat them; this does not make the whole sync proportional only to changed files. It removes unchanged-file content reads and avoids a new verification lookup round trip per file. Changed files incur verification reads, and Redis stores an additional record per verified file.

Existing equal-size files without records are verified and rebuilt gradually: up to 32 files / 64 MiB per sync, with one oversized file allowed to run alone. A persistent cursor advances on failed attempts so a failing prefix cannot monopolize migration. Progress reports deferred verification. Those legacy same-size edits can remain undetected until a later sync reaches them; manual resync advances the cursor. These limits and the one-time rebuild cost are documented for review rather than claiming immediate full-library verification.

### Validation

The standard Google Drive suite passed **104 active specifications**, with **1 existing disabled provider specification**, using isolated Redis 6.2.14 (seed 14396). The 17 standalone filesystem/sync/download specifications also passed.

Coverage includes:
- 1,000 unchanged files: successful sync, one batched verification-cache lookup, zero downloader/verification calls, and zero updates.
- Same-size remote changes and local replacements; real filesystem edits with restored mtime; a write racing checksum verification.
- A repeatedly failing 70-file migration advancing in bounded batches, byte limits, and eventual progress for an oversized file.
- Corrupt downloaded content rejected before publication, post-publication verification failure, and retry after update/cache-persistence failures.
- Real Redis batching, per-blog isolation, removal/reset behavior, and pruning after mapping resync.

The large-folder case is a deterministic operation-count regression test, not a live Drive latency benchmark. No production Drive account or deployed multi-worker setup was exercised. Filesystem fingerprints are a cache invalidation mechanism under normal filesystem semantics, not a sandbox against hostile concurrent filesystem mutation.
