### PR TITLE
Fix flaky cacher spec: nginx cache header byte can equal newline

### DIFF
--- a/config/openresty/tests/basic.js
+++ b/config/openresty/tests/basic.js
@@ -16,22 +16,30 @@ describe("cacher", function () {
 
     expect(files.length).toBe(1);
 
-    const contents = await fs.readFile(files[0], "utf-8");
+    const buffer = await fs.readFile(files[0]);
+    // The file starts with nginx's fixed-size binary cache header
+    // (ngx_http_file_cache_header_t). Its raw bytes include a timestamp, so
+    // it occasionally contains a '\n' (0x0A) byte, which used to shift every
+    // line index below and made this spec flaky. Slice from the "KEY: "
+    // marker so we only split the guaranteed plain-text metadata/headers/
+    // body into lines.
+    const keyIndex = buffer.indexOf("KEY: ");
+    const contents = buffer.slice(keyIndex).toString("utf-8");
     // we trim because the lines end with '\r'
     const lines = contents.split("\n").map(l => l.trim());
 
-    expect(lines.length).toBe(12);
-    expect(lines[1]).toBe("KEY: " + this.origin + "/");
-    expect(lines[2]).toBe("HTTP/1.1 200 OK");
-    expect(lines[3]).toBe("X-Powered-By: Express");
-    expect(lines[4]).toBe("Content-Type: text/html; charset=utf-8");
-    expect(lines[5]).toBe("Content-Length: 11");
-    expect(lines[6]).toMatch(/^ETag: /);
-    expect(lines[7]).toMatch(/^Date: /);
-    expect(lines[8]).toBe("Connection: keep-alive");
-    expect(lines[9]).toBe("Keep-Alive: timeout=5");
+    expect(lines.length).toBe(11);
+    expect(lines[0]).toBe("KEY: " + this.origin + "/");
+    expect(lines[1]).toBe("HTTP/1.1 200 OK");
+    expect(lines[2]).toBe("X-Powered-By: Express");
+    expect(lines[3]).toBe("Content-Type: text/html; charset=utf-8");
+    expect(lines[4]).toBe("Content-Length: 11");
+    expect(lines[5]).toMatch(/^ETag: /);
+    expect(lines[6]).toMatch(/^Date: /);
+    expect(lines[7]).toBe("Connection: keep-alive");
+    expect(lines[8]).toBe("Keep-Alive: timeout=5");
 
-    expect(lines[11]).toBe("Hello Node!");
+    expect(lines[10]).toBe("Hello Node!");
 
     // if we retry the request, the header 'cache-hit' should be set
     const cachedResponse = await fetch(this.origin);

--- a/proxy/tests/basic.js
+++ b/proxy/tests/basic.js
@@ -16,22 +16,30 @@ describe("cacher", function () {
 
     expect(files.length).toBe(1);
 
-    const contents = await fs.readFile(files[0], "utf-8");
+    const buffer = await fs.readFile(files[0]);
+    // The file starts with nginx's fixed-size binary cache header
+    // (ngx_http_file_cache_header_t). Its raw bytes include a timestamp, so
+    // it occasionally contains a '\n' (0x0A) byte, which used to shift every
+    // line index below and made this spec flaky. Slice from the "KEY: "
+    // marker so we only split the guaranteed plain-text metadata/headers/
+    // body into lines.
+    const keyIndex = buffer.indexOf("KEY: ");
+    const contents = buffer.slice(keyIndex).toString("utf-8");
     // we trim because the lines end with '\r'
     const lines = contents.split("\n").map(l => l.trim());
 
-    expect(lines.length).toBe(12);
-    expect(lines[1]).toBe("KEY: " + this.origin + "/");
-    expect(lines[2]).toBe("HTTP/1.1 200 OK");
-    expect(lines[3]).toBe("X-Powered-By: Express");
-    expect(lines[4]).toBe("Content-Type: text/html; charset=utf-8");
-    expect(lines[5]).toBe("Content-Length: 11");
-    expect(lines[6]).toMatch(/^ETag: /);
-    expect(lines[7]).toMatch(/^Date: /);
-    expect(lines[8]).toBe("Connection: keep-alive");
-    expect(lines[9]).toBe("Keep-Alive: timeout=5");
+    expect(lines.length).toBe(11);
+    expect(lines[0]).toBe("KEY: " + this.origin + "/");
+    expect(lines[1]).toBe("HTTP/1.1 200 OK");
+    expect(lines[2]).toBe("X-Powered-By: Express");
+    expect(lines[3]).toBe("Content-Type: text/html; charset=utf-8");
+    expect(lines[4]).toBe("Content-Length: 11");
+    expect(lines[5]).toMatch(/^ETag: /);
+    expect(lines[6]).toMatch(/^Date: /);
+    expect(lines[7]).toBe("Connection: keep-alive");
+    expect(lines[8]).toBe("Keep-Alive: timeout=5");
 
-    expect(lines[11]).toBe("Hello Node!");
+    expect(lines[10]).toBe("Hello Node!");
 
     // if we retry the request, the header 'cache-hit' should be set
     const cachedResponse = await fetch(this.origin);


### PR DESCRIPTION
## Summary

Investigating the failing `test (proxy, 1/1)` check on [PR #1809](https://github.com/davidmerfield/blot/pull/1809), the spec failure is unrelated to that PR's diff (it only touches `app/blog` and `app/request-logger.js`; this spec exercises a plain Express fixture server through the openresty proxy cache). The same failure signature — cascading index shifts starting with "Expected 13 to be 12" — has shown up on other unrelated branches too (e.g. `test (config/openresty, 1/1)` on an earlier commit of that same PR), confirming it's a pre-existing flake, not a regression from any one PR.

## Root cause

nginx's on-disk cache file begins with a fixed-size binary header (`ngx_http_file_cache_header_t`) that embeds a raw Unix timestamp. `proxy/tests/basic.js` and `config/openresty/tests/basic.js` (duplicate copies) read the whole cache file as UTF-8 and split it on `"\n"`, then check header/body content by fixed line index. Whenever a timestamp byte happens to equal `0x0A`, the split produces one extra "line", shifting every later index down by one and failing the spec with garbled comparisons.

## Fix

Read the file as a `Buffer`, locate the `"KEY: "` marker (the first guaranteed plain-text line), and slice from there before splitting into lines. This drops the binary header from the split entirely, so its bytes can no longer be mistaken for a newline.

## Testing

- `node -c` on both modified spec files
- Will confirm via CI on this PR