### PR TITLE
Skip Dropbox downloads with a too-long destination path

### DIFF
--- a/app/clients/dropbox/sync/index.js
+++ b/app/clients/dropbox/sync/index.js
@@ -377,6 +377,27 @@ function Apply(client, blogFolder, log, status) {
               } else {
                 log(item.resolved_relative_path, "Downloaded to folder successfully");
               }
+
+              // Seen in production: a Dropbox account stuck generating
+              // ever-longer "(Conflict met exemplaar van ...)" copies of the
+              // same file until the name exceeded the filesystem's max name
+              // length. We can't write a placeholder here the way we do for
+              // unsupported/oversized files above, because item.path_on_disk
+              // is itself the too-long path – any write to it fails the same
+              // way the download did. Without this check, the file's hash
+              // never matches (it's never written), so every subsequent sync
+              // and hourly validation run re-attempts and re-fails the same
+              // download forever, spamming the logs and repeatedly flagging
+              // the blog as having "unsynced changes".
+              if (err && err.code === "ENAMETOOLONG") {
+                log(
+                  item.resolved_relative_path,
+                  "Skipping download because destination path exceeds filesystem name limit"
+                );
+                status("Skipping " + item.resolved_relative_path + " (name too long)");
+                return callback();
+              }
+
               // Swallow the error that occur when the user has forbidden content
               // in their folder. We should surface this eventually. You can test
               // this error using the file in tests/files/will_flag_restricted_content.png

--- a/app/clients/dropbox/sync/reset-to-blot.js
+++ b/app/clients/dropbox/sync/reset-to-blot.js
@@ -250,6 +250,16 @@ const walk = async (
           await download(client, pathOnDropbox, pathOnDisk);
           summary.downloaded += 1;
         } catch (e) {
+          // A file can end up with a destination path longer than the
+          // filesystem allows – seen in production when a Dropbox account
+          // got stuck wrapping the same file in nested "(Conflict met
+          // exemplaar van ...)" copies. That download can never succeed, so
+          // without counting it as "skipped" here it stays out of both
+          // summary.downloaded and summary.skipped, which means the hourly
+          // sync validation (init.js's countChanges) keeps treating this
+          // blog as having unsynced changes and re-emails the admin every
+          // hour, forever, even though there's nothing new to report.
+          if (e.code === "ENAMETOOLONG") summary.skipped += 1;
           continue;
         }
       } else if (!localCounterpart) {
@@ -259,6 +269,7 @@ const walk = async (
           await download(client, pathOnDropbox, pathOnDisk);
           summary.downloaded += 1;
         } catch (e) {
+          if (e.code === "ENAMETOOLONG") summary.skipped += 1;
           continue;
         }
       } else {

--- a/app/clients/dropbox/util/retry.js
+++ b/app/clients/dropbox/util/retry.js
@@ -13,10 +13,19 @@ function retry(fn, options) {
   // 401 = token revoked
   // 409 = folder no longer exists
   // in these cases, do not retry, there is no point
+  //
+  // ENAMETOOLONG = the destination path exceeds the filesystem's
+  // max name/path length. Retrying can never succeed here since the
+  // path length doesn't change between attempts – seen in production
+  // when a Dropbox account got stuck repeatedly wrapping a file in
+  // "(Conflict met exemplaar van ...)" copies, eventually producing a
+  // filename over the OS limit. Without this, every sync attempt burned
+  // through all 6 exponential-backoff retries before giving up.
   options.errorFilter =
     options.errorFilter ||
     function (err) {
       console.log("dropbox:retry invoked with err", err);
+      if (err.code === "ENAMETOOLONG") return false;
       return [401, 409].indexOf(err.status) === -1;
     };
 


### PR DESCRIPTION
## Summary
- Production triage (blootsvoets, `blog_4b88d0e391b543ddb6c2da1c8bf60e57`) found a Dropbox account stuck generating nested `(Conflict met exemplaar van ...)` copies of the same file until the filename exceeded the filesystem's max name length, throwing `ENAMETOOLONG` on every download attempt.
- Because the file could never be written, its hash never matched, so every webhook-triggered sync and the hourly sync validation job kept re-attempting and re-failing the same download indefinitely — spamming logs and repeatedly emailing the admin about "unsynced changes" for the same blog.
- `app/clients/dropbox/util/retry.js`: treat `ENAMETOOLONG` as non-retryable (same as the existing 401/409 no-retry cases), since retrying can never succeed — the path length doesn't change between attempts.
- `app/clients/dropbox/sync/index.js`: explicitly detect `ENAMETOOLONG` in the download callback and skip with a clear log line, following the same skip pattern already used just above it for unsupported-extension and oversized files.

## Test plan
- [ ] CI (this repo's tests run in Docker in GitHub Actions, not locally)