### PR TITLE
Bound blog render caches by byte size, not just item count

### DIFF
--- a/app/blog/render/full-view-cache.js
+++ b/app/blog/render/full-view-cache.js
@@ -5,6 +5,12 @@ var LRUCache = require("lru-cache").LRUCache;
 // plus blog.cacheID which changes whenever render-relevant blog data changes.
 var fullViewCache = new LRUCache({
   max: 1000,
+  // Bound by bytes too: unbounded-size views (large templates/partials)
+  // shouldn't be able to fill the cache's memory budget on their own.
+  maxSize: 20 * 1024 * 1024,
+  sizeCalculation: function (value) {
+    return JSON.stringify(value).length;
+  },
 });
 
 function cloneDeep(value) {

--- a/app/blog/render/retrieve/popular_tags.js
+++ b/app/blog/render/retrieve/popular_tags.js
@@ -4,6 +4,11 @@ var LRUCache = require("lru-cache").LRUCache;
 // Safe cache key includes blog/cache identity and query pagination options.
 var popularTagsCache = new LRUCache({
   max: 1000,
+  // Bound by bytes too, for consistency with the other render-path caches.
+  maxSize: 5 * 1024 * 1024,
+  sizeCalculation: function (value) {
+    return JSON.stringify(value).length;
+  },
 });
 
 function cloneDeep(value) {

--- a/app/blog/render/retrieve/posts.js
+++ b/app/blog/render/retrieve/posts.js
@@ -9,6 +9,12 @@ const { sortEntries } = getTemplateSortOptions;
 
 const postsCache = new LRUCache({
   max: 1000,
+  // Bound by bytes, not just item count: a single tag-heavy blog paginating
+  // through hundreds of distinct tags can otherwise fill all 1000 slots with
+  // large payloads (up to 500 full entries each) and starve every other
+  // blog sharing this process's memory.
+  maxSize: 100 * 1024 * 1024,
+  sizeCalculation: (value) => JSON.stringify(value).length,
 });
 
 function cloneDeep(value) {


### PR DESCRIPTION
## Summary
- Overnight triage of 35 prod container restarts (mostly `blot-container-yellow`, some `blot-container-blue`) traced them to repeated V8 heap exhaustion (`FATAL ERROR: ... JavaScript heap out of memory`), not a Linux/cgroup OOM kill — see `dmesg`/`kills` showed nothing since 2026-09-10.
- Crashes only hit containers that render blogs (yellow always, blue when picking up blog traffic as failover); the pure dashboard/site container (green) never crashed — pointing at `app/blog`'s render-path caches rather than a general Node issue.
- `postsCache` ([app/blog/render/retrieve/posts.js](app/blog/render/retrieve/posts.js)), `fullViewCache` ([app/blog/render/full-view-cache.js](app/blog/render/full-view-cache.js)), and `popularTagsCache` ([app/blog/render/retrieve/popular_tags.js](app/blog/render/retrieve/popular_tags.js)) are shared, process-wide `LRUCache`s capped only by entry count (`max: 1000`), with no byte-size limit.
- A tag-heavy site being crawled across hundreds of distinct `/tagged/<slug>` pages (nashp.com — the site from #1806) fills the shared `postsCache` with many large payloads (up to 500 full entries per page, deep-cloned, including full rendered HTML per entry) that never get evicted until the 1000-item count cap is hit. That starves memory for every other blog sharing the same Node process.

## Fix
Add `maxSize` + `sizeCalculation` to all three caches so a handful of heavy entries can't dominate the shared memory budget regardless of item count:
- `postsCache`: 100MB (holds the largest payloads — full entry pages)
- `fullViewCache`: 20MB
- `popularTagsCache`: 5MB

## Test plan
- [ ] CI test suite (pushed for GitHub Actions to run — Docker-based suite, not run locally)
- [ ] Watch prod restart counts for `blot-container-yellow`/`blot-container-blue` after deploy — should drop from the ~35/10h baseline observed overnight

🤖 Generated with [Claude Code](https://claude.com/claude-code)