### PR TITLE
Address code review follow-ups from PR #1818

### DIFF
--- a/app/clients/dropbox/sync/index.js
+++ b/app/clients/dropbox/sync/index.js
@@ -384,11 +384,13 @@ function Apply(client, blogFolder, log, status) {
               // length. We can't write a placeholder here the way we do for
               // unsupported/oversized files above, because item.path_on_disk
               // is itself the too-long path – any write to it fails the same
-              // way the download did. Without this check, the file's hash
-              // never matches (it's never written), so every subsequent sync
-              // and hourly validation run re-attempts and re-fails the same
-              // download forever, spamming the logs and repeatedly flagging
-              // the blog as having "unsynced changes".
+              // way the download did. This only changes the log/status line;
+              // the file is still never written, so its hash still never
+              // matches and every subsequent webhook/hourly walk still calls
+              // download() again. download() now checks the path length
+              // before contacting Dropbox (see util/download.js), so at
+              // least this no longer burns 6 retries or fetches the file
+              // over the network first.
               if (err && err.code === "ENAMETOOLONG") {
                 log(
                   item.resolved_relative_path,

--- a/app/clients/dropbox/sync/reset-to-blot.js
+++ b/app/clients/dropbox/sync/reset-to-blot.js
@@ -177,18 +177,35 @@ const walk = async (
     if (isDotfileOrDotfolder(pathOnBlot)) continue;
 
     if (remoteItem.is_directory) {
+      let mkdirFailed = false;
+
       if (localCounterpart && !localCounterpart.is_directory) {
         progress.publish("Removing", pathOnBlot);
         await fs.remove(pathOnDisk);
         summary.removed += 1;
         publish("Creating directory", pathOnDisk);
-        await fs.mkdir(pathOnDisk);
-        summary.createdDirs += 1;
+        try {
+          await fs.mkdir(pathOnDisk);
+          summary.createdDirs += 1;
+        } catch (e) {
+          if (e.code !== "ENAMETOOLONG") throw e;
+          summary.skipped += 1;
+          mkdirFailed = true;
+        }
       } else if (!localCounterpart) {
         publish("Creating directory", pathOnBlot);
-        await fs.mkdir(pathOnDisk);
-        summary.createdDirs += 1;
+        try {
+          await fs.mkdir(pathOnDisk);
+          summary.createdDirs += 1;
+        } catch (e) {
+          if (e.code !== "ENAMETOOLONG") throw e;
+          summary.skipped += 1;
+          mkdirFailed = true;
+        }
       }
+
+      // Can't walk a directory that was never created.
+      if (mkdirFailed) continue;
 
       await walk(
         blogID,
@@ -253,12 +270,11 @@ const walk = async (
           // A file can end up with a destination path longer than the
           // filesystem allows – seen in production when a Dropbox account
           // got stuck wrapping the same file in nested "(Conflict met
-          // exemplaar van ...)" copies. That download can never succeed, so
-          // without counting it as "skipped" here it stays out of both
-          // summary.downloaded and summary.skipped, which means the hourly
-          // sync validation (init.js's countChanges) keeps treating this
-          // blog as having unsynced changes and re-emails the admin every
-          // hour, forever, even though there's nothing new to report.
+          // exemplaar van ...)" copies. That download can never succeed.
+          // countChanges() (init.js) only looks at downloaded/removed/
+          // createdDirs, so this was never counted as an unsynced change
+          // either way; recording it as "skipped" here is just for
+          // visibility in logs/summaries, not to affect the hourly email.
           if (e.code === "ENAMETOOLONG") summary.skipped += 1;
           continue;
         }

--- a/app/clients/dropbox/util/constants.js
+++ b/app/clients/dropbox/util/constants.js
@@ -18,11 +18,11 @@ const NAME_MAX_BYTES = 255;
 const PATH_MAX_BYTES = 4096;
 
 const exceedsFilesystemPathLimits = (destination = "") => {
-  const basename = path.basename(destination);
-  return (
-    Buffer.byteLength(basename, "utf8") > NAME_MAX_BYTES ||
-    Buffer.byteLength(destination, "utf8") > PATH_MAX_BYTES
-  );
+  if (Buffer.byteLength(destination, "utf8") > PATH_MAX_BYTES) return true;
+
+  return destination
+    .split(path.sep)
+    .some((component) => Buffer.byteLength(component, "utf8") > NAME_MAX_BYTES);
 };
 
 module.exports = {

--- a/app/clients/dropbox/util/constants.js
+++ b/app/clients/dropbox/util/constants.js
@@ -1,4 +1,5 @@
 const shouldIgnoreFile = require("clients/util/shouldIgnoreFile");
+const path = require("path");
 
 const UNSUPPORTED_FILE_EXTENSIONS = [".paper"];
 
@@ -9,9 +10,25 @@ const hasUnsupportedExtension = (filePath = "") => {
   );
 };
 
+// ext4 (and most Linux filesystems) reject any path component over 255
+// bytes and any full path over 4096 bytes with ENAMETOOLONG. Checking this
+// locally lets us skip a destination we already know is unwriteable instead
+// of downloading the file from Dropbox first and failing on the write.
+const NAME_MAX_BYTES = 255;
+const PATH_MAX_BYTES = 4096;
+
+const exceedsFilesystemPathLimits = (destination = "") => {
+  const basename = path.basename(destination);
+  return (
+    Buffer.byteLength(basename, "utf8") > NAME_MAX_BYTES ||
+    Buffer.byteLength(destination, "utf8") > PATH_MAX_BYTES
+  );
+};
+
 module.exports = {
   MAX_FILE_SIZE: 100 * 1024 * 1024, // 100 MB
   UNSUPPORTED_FILE_EXTENSIONS,
   hasUnsupportedExtension,
   isDotfileOrDotfolder: shouldIgnoreFile,
+  exceedsFilesystemPathLimits,
 };

--- a/app/clients/dropbox/util/download.js
+++ b/app/clients/dropbox/util/download.js
@@ -7,7 +7,11 @@ const retry = require("./retry");
 const callOnce = require("helper/callOnce");
 
 const TIMEOUT = 30 * 1000; // 30 seconds
-const { MAX_FILE_SIZE, hasUnsupportedExtension } = require("./constants");
+const {
+  MAX_FILE_SIZE,
+  hasUnsupportedExtension,
+  exceedsFilesystemPathLimits,
+} = require("./constants");
 
 async function download(client, source, destination, callback) {
   const id = uuid();
@@ -16,6 +20,20 @@ async function download(client, source, destination, callback) {
   let timedOut = false;
 
   console.log(prefix(), source, "->", destination);
+
+  // The destination path can never become writeable between attempts, so
+  // check it locally before fetching anything from Dropbox. Without this,
+  // we'd download the full file every time only to fail on fs.outputFile.
+  if (exceedsFilesystemPathLimits(destination)) {
+    console.log(
+      prefix(),
+      "destination exceeds filesystem name/path limit, skipping download",
+      destination
+    );
+    const err = new Error("Destination path exceeds filesystem limit");
+    err.code = "ENAMETOOLONG";
+    return callback(err);
+  }
 
   const timeout = setTimeout(function () {
     timedOut = true;


### PR DESCRIPTION
## Summary
Follow-ups from the review of #1818 (Dropbox ENAMETOOLONG handling), verified against the code:

- Check destination path/basename length locally before calling Dropbox in `download()`, so a too-long destination fails fast instead of downloading the full file and then failing on the write.
- Catch `ENAMETOOLONG` on `fs.mkdir` in `reset-to-blot.js`'s `walk()` (both call sites), counting it as skipped instead of throwing out of the hourly validation walk uncaught.
- Fix comments in `sync/index.js` and `reset-to-blot.js` that overclaimed the original fix stopped the hash-mismatch retry loop or was needed to keep `countChanges()` from flagging the blog as unsynced — it never was, since `countChanges()` never counted `skipped` or uncounted failed downloads either way.

Test coverage for `retry.js` intentionally left out of scope per request.

## Test plan
- [x] `node --check` on all four edited files
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)