### PR TITLE
Block AWS/GCP credential and AI tool config scanning paths in openresty

### DIFF
--- a/config/openresty/conf/blot-blogs.conf
+++ b/config/openresty/conf/blot-blogs.conf
@@ -92,9 +92,46 @@ location ~* (\.aws/|\.azure/|\.kube/config) {
   return 444;
 }
 
+# GCloud CLI credential directory (not covered by the .aws/.azure/.kube
+# rule above), plus bare AWS/GCP/Google credential filenames scanners try
+# at the root. Anchored to the full filename so this doesn't catch content.
+location ~* (^|/)\.gcloud/ {
+  limit_req zone=bots;
+  return 444;
+}
+
+location ~* (^|/)(aws[-_]credentials|aws\.json|gcp\.json|google\.json)$ {
+  limit_req zone=bots;
+  return 444;
+}
+
+# Generic credential/token/key JSON files
+location ~* (^|/)(keys|tokens|api[-_]keys|\.auth)\.json$ {
+  limit_req zone=bots;
+  return 444;
+}
+
 # AI coding agent config/credential files (can contain API keys). Scanners
 # have started probing for these alongside the older cloud credential dirs.
 location ~* (^|/)(\.?mcp\.json$|\.codex/|\.continue/|\.windsurf/|\.anthropic/|\.openai/|\.hermes/|opencode/auth\.json$) {
+  limit_req zone=bots;
+  return 444;
+}
+
+# More AI coding agent/assistant config directories and filenames scanners
+# probe for (Claude Desktop, Cursor, Codeium/Windsurf, generic ai/llm/mcp
+# config names) — can contain API keys.
+location ~* (^|/)claude_desktop_config\.json$ {
+  limit_req zone=bots;
+  return 444;
+}
+
+location ~* (^|/)\.(cursor|codeium)/ {
+  limit_req zone=bots;
+  return 444;
+}
+
+location ~* (^|/)(ai|ai_config|llm|llm_config|mcp_config)\.json$ {
   limit_req zone=bots;
   return 444;
 }


### PR DESCRIPTION
## Summary

The user's pasted log sample showed scanner traffic on `color.davidtorcivia.com` sequentially probing for cloud credential and AI-tool config files, all returning 404 (not yet blocked at the openresty layer):

| Pattern | Example paths from log |
|---|---|
| AWS credential filenames | `/aws-credentials`, `/aws_credentials`, `/aws.json` |
| GCloud CLI credential dir | `/.gcloud/credentials`, `/.gcloud/credentials.json` |
| Bare GCP/Google config | `/gcp.json`, `/google.json` |
| Generic key/token JSON | `/keys.json`, `/tokens.json`, `/api_keys.json`, `/.auth.json` |
| Claude Desktop config | `/claude_desktop_config.json` |
| Cursor / Codeium dirs | `/.cursor/config.json`, `/.cursor/settings.json`, `/.codeium/settings.json`, `/.codeium/windsurf/mcp_config.json` |
| Generic AI/LLM/MCP config | `/ai.json`, `/ai_config.json`, `/llm.json`, `/llm_config.json`, `/mcp_config.json` |

None of these were caught by existing rules — the closest existing rules only cover `.aws/`, `.azure/`, `.kube/config` directories and a narrower set of named service-account/firebase/gcp-*/google-* JSON filenames, plus `.mcp.json` (not `mcp_config.json`) and `.codex/`/`.continue/`/`.windsurf/`/`.anthropic/`/`.openai/` dirs (not `.cursor/`/`.codeium/`).

All new patterns are anchored to full filenames or directory segments (`(^|/)...$` or `(^|/).../`) rather than bare substrings, so they won't catch legitimate blog post slugs (e.g. a hypothetical post mentioning "aws" or "ai" in its title is untouched — only the exact `aws.json`/`ai.json` filename matches).

These are all `return 444` since credential/config-scanning paths have no plausible legitimate use on a Blot blog.

Other entries in the pasted log (200s on real blog posts, a 301 redirect, a 400 on `/413`, unrelated blot subdomain 404s like `/robots.txt`, `/search`, `/.well-known/nodeinfo`) are normal traffic or already-handled cases and were left alone.

## Test plan
- [x] Validated new `location` block syntax against `openresty/openresty:alpine` in Docker (`openresty -t` passes)
- [ ] CI / deploy will confirm the mustache template still builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)