### PR TITLE
Clamp allEntries/archives to 500 most recent entries (experiment)

### DIFF
--- a/app/blog/README
+++ b/app/blog/README
@@ -111,11 +111,11 @@ Each file in this directory is a named retriever. The retrieve system (`render/r
 |---|---|---|
 | `active` | `active.js` | Lambda that returns `"active"` if the current URL matches `this.url` or `this.slug`. |
 | `absolute_urls` / `absoluteURLs` | `absolute_urls.js` | Lambda that rewrites relative `href`/`src` attributes to absolute URLs. Used in RSS feeds. |
-| `all_entries` / `allEntries` | `all_entries.js` | All published entries for the blog, capped at `MAX_ENTRIES` (`lib/limits.js`, currently 500) most recent entries. |
+| `all_entries` / `allEntries` | `all_entries.js` | All published entries for the blog, capped at `MAX_ENTRIES` (`lib/limits.js`, currently 1000) most recent entries. |
 | `all_tags` / `allTags` | `all_tags.js` | All tags, sorted alphabetically, with entry counts. |
 | `app_css` / `appCSS` / `plugin_css` | `app_css.js` | Concatenated CSS from enabled blog plugins. |
 | `app_js` / `appJS` / `plugin_js` | `app_js.js` | Concatenated JS from enabled blog plugins. |
-| `archives` | `archives.js` | Entries grouped by year and month (for archive views), capped at `MAX_ENTRIES` (`lib/limits.js`, currently 500) most recent entries. |
+| `archives` | `archives.js` | Entries grouped by year and month (for archive views), capped at `MAX_ENTRIES` (`lib/limits.js`, currently 1000) most recent entries. |
 | `asset` | `asset.js` | Single asset lookup by path. |
 | `avatar_url` | `avatar_url.js` | URL for the blog's avatar image. |
 | `cdn` | `cdn.js` | Lambda/string for CDN URL generation. Used as `{{#cdn}}/path{{/cdn}}` (section) or `{{cdn}}` (origin string). Skips CDN rewriting on preview subdomains. |

--- a/app/blog/README
+++ b/app/blog/README
@@ -111,11 +111,11 @@ Each file in this directory is a named retriever. The retrieve system (`render/r
 |---|---|---|
 | `active` | `active.js` | Lambda that returns `"active"` if the current URL matches `this.url` or `this.slug`. |
 | `absolute_urls` / `absoluteURLs` | `absolute_urls.js` | Lambda that rewrites relative `href`/`src` attributes to absolute URLs. Used in RSS feeds. |
-| `all_entries` / `allEntries` | `all_entries.js` | All published entries for the blog. |
+| `all_entries` / `allEntries` | `all_entries.js` | All published entries for the blog, capped at `MAX_ENTRIES` (`lib/limits.js`, currently 500) most recent entries. |
 | `all_tags` / `allTags` | `all_tags.js` | All tags, sorted alphabetically, with entry counts. |
 | `app_css` / `appCSS` / `plugin_css` | `app_css.js` | Concatenated CSS from enabled blog plugins. |
 | `app_js` / `appJS` / `plugin_js` | `app_js.js` | Concatenated JS from enabled blog plugins. |
-| `archives` | `archives.js` | All entries grouped by year and month (for archive views). |
+| `archives` | `archives.js` | Entries grouped by year and month (for archive views), capped at `MAX_ENTRIES` (`lib/limits.js`, currently 500) most recent entries. |
 | `asset` | `asset.js` | Single asset lookup by path. |
 | `avatar_url` | `avatar_url.js` | URL for the blog's avatar image. |
 | `cdn` | `cdn.js` | Lambda/string for CDN URL generation. Used as `{{#cdn}}/path{{/cdn}}` (section) or `{{cdn}}` (origin string). Skips CDN rewriting on preview subdomains. |

--- a/app/blog/lib/limits.js
+++ b/app/blog/lib/limits.js
@@ -5,7 +5,13 @@
 // enough to block the shared Node event loop and OOM the process.
 //
 // This is a breaking change for templates that rely on allEntries/archives
-// listing every single post on very large blogs - it is an experiment to
-// see whether clamping resolves the pathological behaviour before investing
-// in a precomputed archive index.
-module.exports.MAX_ENTRIES = 500;
+// listing every single post on very large blogs. A production Redis scan
+// found the biggest blogs run to ~4,600 entries and nashp.com (the blog that
+// actually triggered #1806) sits at ~800 - 1000 covers that with headroom
+// while still bounding the most extreme blogs. This clamp is a stopgap, not
+// a fix: it doesn't help a blog like anchor.com, whose problem is huge
+// individual entries rather than entry count. See issue #1806 for the real
+// fix in progress (a precomputed archives index + re-enabling field-narrowed
+// hash reads) and the longer-term plan to migrate archive-style templates to
+// a paginated {{#posts}} pattern.
+module.exports.MAX_ENTRIES = 1000;

--- a/app/blog/lib/limits.js
+++ b/app/blog/lib/limits.js
@@ -1,0 +1,11 @@
+// Hard cap on how many entries the archives and allEntries template tags
+// fetch. Without it, large blogs (nashp.com had ~800 entries at the time of
+// issue #1806) load and synchronously process every entry on every request
+// to /archives, which under aggressive bot crawling was serialized/slow
+// enough to block the shared Node event loop and OOM the process.
+//
+// This is a breaking change for templates that rely on allEntries/archives
+// listing every single post on very large blogs - it is an experiment to
+// see whether clamping resolves the pathological behaviour before investing
+// in a precomputed archive index.
+module.exports.MAX_ENTRIES = 500;

--- a/app/blog/render/retrieve/all_entries.js
+++ b/app/blog/render/retrieve/all_entries.js
@@ -3,6 +3,7 @@ const projectEntryFields = require("./helpers/projectEntryFields");
 const entryFieldList = require("./helpers/entryFieldList");
 const withEntryFields = require("../../lib/withEntryFields");
 const asRetriever = require("../../lib/asRetriever");
+const { MAX_ENTRIES } = require("../../lib/limits");
 
 async function allEntries(req, res) {
   const keys = ["allEntries", "all_entries"];
@@ -10,11 +11,11 @@ async function allEntries(req, res) {
 
   let allEntriesList;
   if (!fields) {
-    allEntriesList = await getAll(req.blog.id);
+    allEntriesList = await getAll(req.blog.id, { limit: MAX_ENTRIES });
   } else {
     allEntriesList = await withEntryFields(
-      () => getAll(req.blog.id, { fields }),
-      () => getAll(req.blog.id)
+      () => getAll(req.blog.id, { fields, limit: MAX_ENTRIES }),
+      () => getAll(req.blog.id, { limit: MAX_ENTRIES })
     );
   }
 

--- a/app/blog/render/retrieve/archives.js
+++ b/app/blog/render/retrieve/archives.js
@@ -6,17 +6,18 @@ const withEntryFields = require("../../lib/withEntryFields");
 const moment = require("moment");
 require("moment-timezone");
 const asRetriever = require("../../lib/asRetriever");
+const { MAX_ENTRIES } = require("../../lib/limits");
 
 async function archives(req, res) {
   const fields = entryFieldList(req.retrieve, ["archives"]);
 
   let allEntries;
   if (!fields) {
-    allEntries = await getAll(req.blog.id);
+    allEntries = await getAll(req.blog.id, { limit: MAX_ENTRIES });
   } else {
     allEntries = await withEntryFields(
-      () => getAll(req.blog.id, { fields }),
-      () => getAll(req.blog.id)
+      () => getAll(req.blog.id, { fields, limit: MAX_ENTRIES }),
+      () => getAll(req.blog.id, { limit: MAX_ENTRIES })
     );
   }
 

--- a/app/models/entries/README
+++ b/app/models/entries/README
@@ -90,6 +90,7 @@ Retrieves one or more named lists in a single call.
 Retrieves all entries including deleted ones (reads from the `all` list). Returns skinny entry objects by default (`options.skinny` defaults to `true`).
 
 - `options.fields` — optional array of entry property names, forwarded to `Entry.get`. When `config.redis.readEntriesFromHash` is on this narrows the read to just those fields (plus `id`) from each entry's Redis hash instead of the whole entry, which keeps list/archive pages from loading every entry's rendered HTML; while it is off `Entry.get` ignores it. Undefined means "whole entry". See `app/blog/render/retrieve/helpers/entryFieldList.js` for how the render pipeline derives this from template retrieve metadata.
+- `options.limit` — optional number. When set, returns at most this many of the most recently published entries instead of the entire `all` list. Undefined means "no limit". See `app/blog/lib/limits.js` for the cap the `allEntries`/`archives` template tags pass.
 - `callback(entries)` — array of `Entry` instances.
 
 ### `getAllIDs(blogID, callback)`

--- a/app/models/entries/index.js
+++ b/app/models/entries/index.js
@@ -120,7 +120,12 @@ module.exports = (function () {
     // entry info when getting every entry
     if (options.skinny === undefined) options.skinny = true;
 
-    return getRange(blogID, 0, -1, options, callback);
+    // options.limit caps the number of (most recent) entries returned,
+    // instead of the entire "all" list. See app/blog/lib/limits.js for why
+    // the render pipeline passes this.
+    var end = options.limit ? options.limit - 1 : -1;
+
+    return getRange(blogID, 0, end, options, callback);
   }
 
   function get(blogID, options, callback) {

--- a/app/models/entries/tests.js
+++ b/app/models/entries/tests.js
@@ -959,7 +959,7 @@ describe("entries", function () {
   describe("getAll with a limit", function () {
     it("returns only the N most recently published entries", async function (done) {
       const blogID = this.blog.id;
-      const key = `blog:${blogID}:all`;
+      const key = `blog:${blogID}:entries`;
 
       await redis.zAdd(key, [
         { score: 1, value: "id1" },
@@ -979,7 +979,7 @@ describe("entries", function () {
 
     it("returns every entry when no limit is given", async function (done) {
       const blogID = this.blog.id;
-      const key = `blog:${blogID}:all`;
+      const key = `blog:${blogID}:entries`;
 
       await redis.zAdd(key, [
         { score: 1, value: "id1" },

--- a/app/models/entries/tests.js
+++ b/app/models/entries/tests.js
@@ -955,4 +955,50 @@ describe("entries", function () {
       });
     });
   });
+
+  describe("getAll with a limit", function () {
+    it("returns only the N most recently published entries", async function (done) {
+      const blogID = this.blog.id;
+      const key = `blog:${blogID}:all`;
+
+      await redis.zAdd(key, [
+        { score: 1, value: "id1" },
+        { score: 2, value: "id2" },
+        { score: 3, value: "id3" },
+      ]);
+
+      spyOn(Entry, "get").and.callFake((blogID, ids, callback) => {
+        callback(ids.map((id) => buildEntry(id, { id })));
+      });
+
+      Entries.getAll(blogID, { limit: 2 }, function (entries) {
+        expect(entries.map((entry) => entry.id)).toEqual(["id3", "id2"]);
+        done();
+      });
+    });
+
+    it("returns every entry when no limit is given", async function (done) {
+      const blogID = this.blog.id;
+      const key = `blog:${blogID}:all`;
+
+      await redis.zAdd(key, [
+        { score: 1, value: "id1" },
+        { score: 2, value: "id2" },
+        { score: 3, value: "id3" },
+      ]);
+
+      spyOn(Entry, "get").and.callFake((blogID, ids, callback) => {
+        callback(ids.map((id) => buildEntry(id, { id })));
+      });
+
+      Entries.getAll(blogID, function (entries) {
+        expect(entries.map((entry) => entry.id)).toEqual([
+          "id3",
+          "id2",
+          "id1",
+        ]);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Experiment for #1806: on large, heavily-crawled blogs (nashp.com had ~800 entries), the `archives` and `allEntries` template tags load and synchronously process every entry in the blog on every request, with no caching or precomputed index. Under bot crawling this can block the shared Node event loop long enough to OOM the process (see issue for the full investigation).

This PR clamps both retrievers to the 500 most recently published entries:

- `Entries.getAll(blogID, options, callback)` (`app/models/entries/index.js`) gains an opt-in `options.limit` — when set, it returns only the N most recent entries (the underlying sorted set is already stored most-recent-first) instead of the entire `all` list.
- `allEntries` / `archives` (`app/blog/render/retrieve/{all_entries,archives}.js`) now pass `limit: MAX_ENTRIES` (500, defined in the new `app/blog/lib/limits.js`).
- Other `getAll` callers (e.g. site export in `app/dashboard/site/export.js`) are unaffected, since `limit` is opt-in and defaults to unlimited.

## Is this the right fix?

This doesn't eliminate the recompute cost per request (archives still groups whatever it fetches from scratch on every request), but it bounds the worst case, which is the immediate goal. The issue also floats a precomputed/incrementally-maintained archive index as the more thorough fix — that's a bigger change and not what this PR attempts.

**This is a breaking change**: on a blog with more than 500 posts, `allEntries`/`archives` will now silently stop listing everything past the 500 most recent. Flagging that explicitly since it's a real behavior change for large blogs, not just a perf tweak — happy to gate it behind a flag, land it as-is for the experiment, or take a different approach if you'd rather validate the perf impact before making it live everywhere.

## Test plan

- [ ] Added unit tests for `Entries.getAll`'s new `limit` option (`app/models/entries/tests.js`)
- [ ] Existing `allEntries`/`archives` retriever tests continue to pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)