### PR TITLE
Retry Docker builds on transient registry auth failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,24 +59,25 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       # Per-arch registry cache. Keeps layers hot on each native runner.
+      # Wrapped in a retry: base-image pulls occasionally fail with a Docker
+      # Hub auth/network blip ("connection reset by peer" fetching an oauth
+      # token) that has nothing to do with the build itself.
       - name: Build ${{ env.PUSH_IMAGES == 'true' && 'and push' || '(local only)' }} (${{ matrix.arch }})
         id: build
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@v3
         with:
-          context: .
-          target: prod
-          platforms: ${{ matrix.platform }}          # native, no QEMU
-          # Fork PRs cannot push to GHCR - build locally and load into the
-          # runner's Docker so the health check below still has an image.
-          push: ${{ env.PUSH_IMAGES == 'true' }}
-          load: ${{ env.PUSH_IMAGES != 'true' }}
-          tags: |
-            ${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ matrix.arch }}
-          cache-from: |
-            type=registry,ref=${{ env.IMAGE_NAME }}:cache-${{ matrix.arch }}
-          # Registry cache export needs write access, which fork PRs lack -
-          # skip it there rather than fail the build.
-          cache-to: ${{ env.PUSH_IMAGES == 'true' && format('type=registry,ref={0}:cache-{1},mode=max', env.IMAGE_NAME, matrix.arch) || '' }}
+          action: docker/build-push-action@v6
+          attempt_limit: 2
+          attempt_delay: 10000
+          with: |
+            context: .
+            target: prod
+            platforms: ${{ matrix.platform }}
+            push: ${{ env.PUSH_IMAGES == 'true' }}
+            load: ${{ env.PUSH_IMAGES != 'true' }}
+            tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ matrix.arch }}
+            cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:cache-${{ matrix.arch }}
+            cache-to: ${{ env.PUSH_IMAGES == 'true' && format('type=registry,ref={0}:cache-{1},mode=max', env.IMAGE_NAME, matrix.arch) || '' }}
 
       - name: Verify health check (${{ matrix.arch }})
         env:
@@ -178,22 +179,23 @@ jobs:
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Wrapped in a retry: base-image pulls occasionally fail with a Docker
+      # Hub auth/network blip ("connection reset by peer" fetching an oauth
+      # token) that has nothing to do with the build itself.
       - name: Build ${{ env.PUSH_IMAGES == 'true' && 'and push' || '(local only)' }} airlock (${{ matrix.arch }})
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@v3
         with:
-          context: config/airlock
-          platforms: ${{ matrix.platform }}
-          # Fork PRs cannot push to GHCR - build locally and load into the
-          # runner's Docker so the egress-filter check below still has an image.
-          push: ${{ env.PUSH_IMAGES == 'true' }}
-          load: ${{ env.PUSH_IMAGES != 'true' }}
-          tags: |
-            ${{ env.AIRLOCK_IMAGE_NAME }}:${{ github.sha }}-${{ matrix.arch }}
-          cache-from: |
-            type=registry,ref=${{ env.AIRLOCK_IMAGE_NAME }}:cache-${{ matrix.arch }}
-          # Registry cache export needs write access, which fork PRs lack -
-          # skip it there rather than fail the build.
-          cache-to: ${{ env.PUSH_IMAGES == 'true' && format('type=registry,ref={0}:cache-{1},mode=max', env.AIRLOCK_IMAGE_NAME, matrix.arch) || '' }}
+          action: docker/build-push-action@v6
+          attempt_limit: 2
+          attempt_delay: 10000
+          with: |
+            context: config/airlock
+            platforms: ${{ matrix.platform }}
+            push: ${{ env.PUSH_IMAGES == 'true' }}
+            load: ${{ env.PUSH_IMAGES != 'true' }}
+            tags: ${{ env.AIRLOCK_IMAGE_NAME }}:${{ github.sha }}-${{ matrix.arch }}
+            cache-from: type=registry,ref=${{ env.AIRLOCK_IMAGE_NAME }}:cache-${{ matrix.arch }}
+            cache-to: ${{ env.PUSH_IMAGES == 'true' && format('type=registry,ref={0}:cache-{1},mode=max', env.AIRLOCK_IMAGE_NAME, matrix.arch) || '' }}
 
       - name: Verify egress filter (${{ matrix.arch }})
         env:


### PR DESCRIPTION
## Summary
- Investigated two commits flagged as possible master test flakes: [572464ef9](https://github.com/davidmerfield/blot/commit/572464ef912ba374b53b8291f37e353d005d0636) (#1824) and [daa014161](https://github.com/davidmerfield/blot/commit/daa0141619f8be5d016785d6c95746c519514ba6) (#1813). Both were confirmed as infra flakes unrelated to the code changes in those PRs.
- The `build-airlock` job's failure was a Docker Hub network blip while fetching an oauth token to pull `alpine:3.20` (`connection reset by peer`) — nothing to do with the openresty rule changes in #1824.
- This PR wraps the `docker/build-push-action` steps in `build` and `build-airlock` with `Wandalen/wretry.action` (2 attempts) so a single transient registry failure doesn't fail the whole workflow run.
- The `node` test job's flake (PR #1813, `app/dashboard` shard) was left alone per request — it's a one-off resource-contention symptom (`fetch failed`, CSRF/302 mismatches), not something worth adding blanket retries around given those tests write real state to Redis/disk.

## Test plan
- [ ] Confirm `build` and `build-airlock` jobs pass on this PR's own CI run
- [ ] Confirm workflow YAML is valid (checked locally with `python3 -c "import yaml; yaml.safe_load(...)"`)