### PR TITLE
Hide sync progress bar under dashboard folder

### DIFF
--- a/app/views/dashboard/folder/folder.css
+++ b/app/views/dashboard/folder/folder.css
@@ -52,11 +52,22 @@
     overflow: hidden;
   }
 
+  /* Progress UI is suppressed for the folder footer in sync_status.js;
+     keep the line compact even if has-progress is present. */
   .sync-status.has-progress {
     display: flex;
-    height: auto;
-    overflow: visible;
-    width: 100%;
+    height: 1.5em;
+    overflow: hidden;
+    width: auto;
+  }
+
+  .sync-status.has-progress .sync-status-progress,
+  .sync-status.has-progress .sync-status-progress-label {
+    display: none;
+  }
+
+  .sync-status.has-progress .sync-status-icon {
+    display: inline;
   }
 
   .sync-status .sync-status-body {

--- a/app/views/js/sync_status.js
+++ b/app/views/js/sync_status.js
@@ -78,10 +78,13 @@ function renderSyncStatusMessage(message) {
   var visibleMessage = shortenSyncingFilename(parsed.text);
   var progressBar = q(".sync-status-progress-bar");
   var progressLabel = q(".sync-status-progress-label");
+  // Folder footer stays a single compact status line. Drive/iCloud syncs still
+  // emit "(n/m) ..." messages; show the text, but never expand into a bar here.
+  var hideProgress = !!statusContainer.closest(".status-link");
 
   statusText.innerText = visibleMessage;
 
-  if (parsed.hasProgress) {
+  if (parsed.hasProgress && !hideProgress) {
     var roundedPercent = Math.round(Math.max(0, Math.min(100, parsed.percent)));
 
     statusContainer.classList.add("has-progress");


### PR DESCRIPTION
## Summary
- Folder footer sync status no longer expands into a progress bar when clients emit `(n/m) …` messages (e.g. Google Drive tree walks).
- Status text and synced/syncing/error icons still update; progress UI remains available on other dashboard surfaces (client settings, imports).
- Folder CSS keeps the footer compact if `has-progress` is present as a fallback.

## Test plan
- [ ] Open a Google Drive site dashboard folder while a sync with `(n/m)` statuses is running — footer shows text + spinner, not a bar or “% complete”
- [ ] Confirm “Synced” still renders with the green check in the folder footer after sync finishes
- [ ] On `/client` (or import) pages that use sync-status with progress, the bar still appears when appropriate
- [ ] Subfolder views that include the same status-link footer behave the same as the root folder


Made with [Cursor](https://cursor.com)