### PR TITLE
Fix invalid custom domain showing success message instead of error

### DIFF
--- a/app/dashboard/site/domain/index.js
+++ b/app/dashboard/site/domain/index.js
@@ -74,7 +74,7 @@ Domain.route('/')
     })
     .post(async (req, res) => {
         const blogID = req.blog.id;
-        const domainInput = req.body.domain;
+        const domainInput = typeof req.body.domain === 'string' ? req.body.domain : '';
         const { hostname } = parse(domainInput);
 
         if (req.body.handle) {

--- a/app/dashboard/site/domain/index.js
+++ b/app/dashboard/site/domain/index.js
@@ -87,12 +87,16 @@ Domain.route('/')
         }
 
         if (!hostname) {
-            await updateDomain(blogID, '');
-            // Clear the domain error from the session
-            delete req.session[`${blogID}:domainError`];
-            delete req.session[`${blogID}:domainWarning`];
-            req.session.save();
-            return res.message(res.locals.base + '/domain', 'Domain removed');
+            if (!domainInput || !domainInput.trim()) {
+                await updateDomain(blogID, '');
+                // Clear the domain error from the session
+                delete req.session[`${blogID}:domainError`];
+                delete req.session[`${blogID}:domainWarning`];
+                req.session.save();
+                return res.message(res.locals.base + '/domain', 'Domain removed');
+            }
+
+            return res.message(res.locals.base + '/domain/custom', new Error('Please enter a valid domain'));
         }
 
         // Remove the existing domain if it is set and differs from the new one


### PR DESCRIPTION
## Summary
- Entering an unparseable custom domain (e.g. `not a domain`, `foo..com`, `!!!`) caused `tldts.parse()` to return a `null` hostname, which fell into the same code branch as an intentionally empty field and silently removed the domain, redirecting to `/domain` with "Domain removed".
- Now only an actually-empty input triggers removal; any other unparseable input redirects to `/domain/custom` with a proper validation error ("Please enter a valid domain").

## Test plan
- [ ] Visit `/domain/custom`, submit an invalid domain like `not a domain`, confirm an error message appears on `/domain/custom` and the existing domain (if any) is untouched.
- [ ] Confirm clearing the domain field and submitting still redirects to `/domain` with "Domain removed".
- [ ] Confirm adding a valid domain still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)