### PR TITLE
Fix Google Drive delete not propagating to remote

### DIFF
--- a/app/clients/google-drive/remove.js
+++ b/app/clients/google-drive/remove.js
@@ -9,6 +9,8 @@ module.exports = async function remove(blogID, path, callback) {
     clfdate() + " Google Drive: Remove:" + blogID + ":" + path + ":";
 
   try {
+    if (path[0] !== "/") path = "/" + path;
+
     const { serviceAccountId, folderId } = await database.blog.get(blogID);
     const drive = await createDriveClient(serviceAccountId);
     const { getByPath, remove } = database.folder(folderId, blogID);


### PR DESCRIPTION
## Summary
- Removing a file on the dashboard for a Google Drive-connected blog deleted the local copy but silently failed to delete the remote file, causing it to reappear on the next sync. Affected both regular files and Google Docs.
- Root cause: `app/clients/google-drive/remove.js` looked up the file's Drive `fileId` via `getByPath(path)` without normalizing `path` to have a leading `/`. Path→id mappings are always stored with a leading slash, so the lookup missed, `fileId` came back `undefined`, and the code logged a warning and skipped `drive.files.delete(...)` — only the local file was removed.
- `write.js` already normalizes the path the same way (`if (path[0] !== "/") path = "/" + path;`), which is why dashboard uploads worked correctly while deletes did not.
- Fix: apply the same leading-slash normalization in `remove.js` before doing the path lookup.

## Test plan
- [x] Confirmed locally against the running Docker stack that deleting a file on the dashboard for a Google Drive-connected blog now removes it from Drive (verified it no longer reappears on next sync).
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)